### PR TITLE
mmexternal: fix single-instance reply handling

### DIFF
--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -75,6 +75,16 @@ mmjsonrewrite:
   notes:
     - Expands dotted JSON property names into nested containers per message.
 
+mmexternal:
+  paths: ["plugins/mmexternal/"]
+  requires_serialization: true
+  locks:
+    - type: mutex
+      field: pData.mut
+  notes:
+    - Default mode keeps one child process context per worker.
+    - forceSingleInstance shares one child context in pData and serializes helper access with pData.mut.
+
 omotel:
   paths: ["plugins/omotel/"]
   requires_serialization: false
@@ -104,4 +114,3 @@ imfifo:
     - Reads log messages line-by-line from local POSIX named pipes (FIFOs).
     - Utilizes non-blocking poll() loops with a 100ms timeout to ensure clean and immediate shutdown.
     - Uses O_RDWR opening technique to keep a dummy writer in the daemon itself to avoid startup hangs and EOF reopening loops.
-

--- a/plugins/mmexternal/mmexternal.c
+++ b/plugins/mmexternal/mmexternal.c
@@ -49,15 +49,33 @@ MODULE_TYPE_OUTPUT;
 MODULE_TYPE_NOKEEP;
 MODULE_CNFNAME("mmexternal")
 
+/* Concurrency & Locking
+ * ---------------------
+ * By default each worker owns a private helper process context, so helper
+ * pipes, response buffers, and debug-output fds stay in worker-local state.
+ * When forceSingleInstance="on", pData owns one shared helper context and
+ * pData->mut serializes startup, request/response exchange, and shutdown.
+ */
+
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA;
 
+typedef struct childProcessCtx_s {
+	pid_t pid; /* pid of currently running process */
+	int fdOutput; /* debug output fd (-1 if closed) */
+	int fdPipeOut; /* file descriptor to write to */
+	int fdPipeIn; /* fd we receive messages from the program (if we want to) */
+	int bIsRunning; /* is binary currently running? 0-no, 1-yes */
+	char *respBuf; /* buffer to read external plugin's response */
+	size_t maxLenRespBuf; /* current maximum length of response buffer */
+} childProcessCtx_t;
+
 typedef struct _instanceData {
-    uchar *szBinary; /* name of binary to call */
-    char **aParams; /* Optional Parameters for binary command */
-    int iParams; /* Holds the count of parameters if set*/
-    int bForceSingleInst; /* only a single wrkr instance of program permitted? */
+	uchar *szBinary; /* name of binary to call */
+	char **aParams; /* Optional Parameters for binary command */
+	int iParams; /* Holds the count of parameters if set*/
+	int bForceSingleInst; /* only a single wrkr instance of program permitted? */
     int inputProp; /* what to provide as input to the external program? */
 #define INPUT_MSG 0
 #define INPUT_RAWMSG 1
@@ -65,28 +83,33 @@ typedef struct _instanceData {
     int outputMode; /* what to expect from the external program? */
 #define OUTPUT_JSON 0
 #define OUTPUT_NONE 1
-    long responseTimeout; /* milliseconds to wait for JSON response, 0 means forever */
-    uchar *outputFileName; /* name of file for std[out/err] or NULL if to discard */
-    pthread_mutex_t mut; /* make sure only one instance is active */
+	long responseTimeout; /* milliseconds to wait for JSON response, 0 means forever */
+	uchar *outputFileName; /* name of file for std[out/err] or NULL if to discard */
+	pthread_mutex_t mut; /* make sure only one instance is active */
+	childProcessCtx_t *pSingleChildCtx; /* shared child process state when forceSingleInstance=on */
 } instanceData;
 
 typedef struct wrkrInstanceData {
-    instanceData *pData;
-    pid_t pid; /* pid of currently running process */
-    int fdOutput; /* it's fd (-1 if closed) */
-    int fdPipeOut; /* file descriptor to write to */
-    int fdPipeIn; /* fd we receive messages from the program (if we want to) */
-    int bIsRunning; /* is binary currently running? 0-no, 1-yes */
-    char *respBuf; /* buffer to read exernal plugin's response */
-    int maxLenRespBuf; /* (current) maximum length of response buffer */
-    int lenRespBuf; /* actual nbr of chars in response buffer */
-    int idxRespBuf; /* last char read from response buffer */
+	instanceData *pData;
+	childProcessCtx_t *pChildCtx; /* child process context (shared or per-worker) */
 } wrkrInstanceData_t;
 
 typedef struct configSettings_s {
     uchar *szBinary; /* name of binary to call */
 } configSettings_t;
 static configSettings_t cs;
+
+static rsRetVal allocChildCtx(childProcessCtx_t **const ppChildCtx);
+static void freeChildCtx(childProcessCtx_t *const pChildCtx);
+static void terminateChild(instanceData *__restrict__ const pData,
+			   childProcessCtx_t *__restrict__ const pChildCtx,
+			   const long timeoutMs);
+static rsRetVal cleanupChild(instanceData *pData, childProcessCtx_t *pChildCtx);
+static rsRetVal openPipe(instanceData *pData, childProcessCtx_t *pChildCtx);
+static rsRetVal tryRestart(instanceData *pData, childProcessCtx_t *pChildCtx);
+static rsRetVal processProgramReply(instanceData *__restrict__ const pData,
+				    childProcessCtx_t *__restrict__ const pChildCtx,
+				    smsg_t *const pMsg);
 
 
 /* tables for interfacing with the v6 config system */
@@ -113,15 +136,13 @@ BEGINcreateInstance
 ENDcreateInstance
 
 BEGINcreateWrkrInstance
-    CODESTARTcreateWrkrInstance;
-    pWrkrData->fdPipeIn = -1;
-    pWrkrData->fdPipeOut = -1;
-    pWrkrData->fdOutput = -1;
-    pWrkrData->bIsRunning = 0;
-    pWrkrData->respBuf = NULL;
-    pWrkrData->maxLenRespBuf = 0;
-    pWrkrData->lenRespBuf = 0;
-    pWrkrData->idxRespBuf = 0;
+	CODESTARTcreateWrkrInstance;
+	pWrkrData->pChildCtx = NULL;
+	if (pWrkrData->pData->bForceSingleInst) {
+		pWrkrData->pChildCtx = pWrkrData->pData->pSingleChildCtx;
+	} else {
+		iRet = allocChildCtx(&pWrkrData->pChildCtx);
+	}
 ENDcreateWrkrInstance
 
 
@@ -132,22 +153,33 @@ ENDisCompatibleWithFeature
 
 
 BEGINfreeInstance
-    int i;
-    CODESTARTfreeInstance;
-    pthread_mutex_destroy(&pData->mut);
-    free(pData->szBinary);
-    free(pData->outputFileName);
-    if (pData->aParams != NULL) {
-        for (i = 0; i < pData->iParams; i++) {
-            free(pData->aParams[i]);
-        }
-        free(pData->aParams);
-    }
+	int i;
+	CODESTARTfreeInstance;
+	if (pData->pSingleChildCtx != NULL) {
+		if (pData->pSingleChildCtx->bIsRunning) {
+			terminateChild(pData, pData->pSingleChildCtx, 1000);
+		}
+		freeChildCtx(pData->pSingleChildCtx);
+	}
+	free(pData->szBinary);
+	free(pData->outputFileName);
+	if (pData->aParams != NULL) {
+		for (i = 0; i < pData->iParams; i++) {
+			free(pData->aParams[i]);
+		}
+		free(pData->aParams);
+	}
+	pthread_mutex_destroy(&pData->mut);
 ENDfreeInstance
 
 BEGINfreeWrkrInstance
-    CODESTARTfreeWrkrInstance;
-    free(pWrkrData->respBuf);
+	CODESTARTfreeWrkrInstance;
+	if (!pWrkrData->pData->bForceSingleInst && pWrkrData->pChildCtx != NULL) {
+		if (pWrkrData->pChildCtx->bIsRunning) {
+			terminateChild(pWrkrData->pData, pWrkrData->pChildCtx, 1000);
+		}
+		freeChildCtx(pWrkrData->pChildCtx);
+	}
 ENDfreeWrkrInstance
 
 
@@ -165,87 +197,114 @@ ENDtryResume
  * best effort to write the message but do *not* try very
  * hard to handle errors. -- rgerhards, 2014-01-16
  */
-static void writeOutputDebug(wrkrInstanceData_t *__restrict__ const pWrkrData,
-                             const char *__restrict__ const buf,
-                             const ssize_t lenBuf) {
-    char errStr[1024];
-    ssize_t r;
+static void writeOutputDebug(instanceData *__restrict__ const pData,
+			     childProcessCtx_t *__restrict__ const pChildCtx,
+			     const char *__restrict__ const buf,
+			     const ssize_t lenBuf) {
+	char errStr[1024];
+	ssize_t r;
 
-    if (pWrkrData->pData->outputFileName == NULL) goto done;
+	if (pData->outputFileName == NULL) goto done;
 
-    if (pWrkrData->fdOutput == -1) {
-        pWrkrData->fdOutput = open((char *)pWrkrData->pData->outputFileName, O_WRONLY | O_APPEND | O_CREAT, 0600);
-        if (pWrkrData->fdOutput == -1) {
-            DBGPRINTF("mmexternal: error opening output file %s: %s\n", pWrkrData->pData->outputFileName,
-                      rs_strerror_r(errno, errStr, sizeof(errStr)));
-            goto done;
-        }
-    }
+	if (pChildCtx->fdOutput == -1) {
+		pChildCtx->fdOutput = open((char *)pData->outputFileName, O_WRONLY | O_APPEND | O_CREAT, 0600);
+		if (pChildCtx->fdOutput == -1) {
+			DBGPRINTF("mmexternal: error opening output file %s: %s\n", pData->outputFileName,
+				  rs_strerror_r(errno, errStr, sizeof(errStr)));
+			goto done;
+		}
+	}
 
-    r = write(pWrkrData->fdOutput, buf, (size_t)lenBuf);
-    if (r != lenBuf) {
-        DBGPRINTF(
-            "mmexternal: problem writing output file %s: bytes "
-            "requested %lld, written %lld, msg: %s\n",
-            pWrkrData->pData->outputFileName, (long long)lenBuf, (long long)r,
-            rs_strerror_r(errno, errStr, sizeof(errStr)));
-    }
+	r = write(pChildCtx->fdOutput, buf, (size_t)lenBuf);
+	if (r != lenBuf) {
+		DBGPRINTF(
+			"mmexternal: problem writing output file %s: bytes "
+			"requested %lld, written %lld, msg: %s\n",
+			pData->outputFileName, (long long)lenBuf, (long long)r,
+			rs_strerror_r(errno, errStr, sizeof(errStr)));
+	}
 done:
-    return;
+	return;
 }
 
 
-static void waitForChildExit(wrkrInstanceData_t *__restrict__ const pWrkrData, const long timeoutMs) {
-    int status;
-    int ret = -1;
-    long counter;
+static rsRetVal allocChildCtx(childProcessCtx_t **const ppChildCtx) {
+	DEFiRet;
 
-    counter = timeoutMs / 10;
-    while ((ret = waitpid(pWrkrData->pid, &status, WNOHANG)) == 0 && counter > 0) {
-        srSleep(0, 10000);
-        --counter;
-    }
+	CHKmalloc(*ppChildCtx = calloc(1, sizeof(childProcessCtx_t)));
+	(*ppChildCtx)->fdOutput = -1;
+	(*ppChildCtx)->fdPipeOut = -1;
+	(*ppChildCtx)->fdPipeIn = -1;
 
-    if (ret == 0) {
-        if (kill(pWrkrData->pid, SIGKILL) == -1) {
-            LogError(errno, RS_RET_SYS_ERR, "mmexternal: could not send SIGKILL to child process");
-            return;
-        }
-        ret = waitpid(pWrkrData->pid, &status, 0);
-    }
-
-    /* waitpid may fail with ECHILD if rsyslogd's main loop already reaped the child. */
-    if (ret == pWrkrData->pid) {
-        glblReportChildProcessExit(runConf, pWrkrData->pData->szBinary, pWrkrData->pid, status);
-    }
+finalize_it:
+	RETiRet;
 }
 
 
-static void closeWrkrPipes(wrkrInstanceData_t *__restrict__ const pWrkrData) {
-    if (pWrkrData->fdOutput != -1) {
-        close(pWrkrData->fdOutput);
-        pWrkrData->fdOutput = -1;
-    }
-    if (pWrkrData->fdPipeIn != -1) {
-        close(pWrkrData->fdPipeIn);
-        pWrkrData->fdPipeIn = -1;
-    }
-    if (pWrkrData->fdPipeOut != -1) {
-        close(pWrkrData->fdPipeOut);
-        pWrkrData->fdPipeOut = -1;
-    }
+static void freeChildCtx(childProcessCtx_t *const pChildCtx) {
+	if (pChildCtx == NULL) {
+		return;
+	}
+	free(pChildCtx->respBuf);
+	free(pChildCtx);
 }
 
 
-static void terminateChild(wrkrInstanceData_t *__restrict__ const pWrkrData, const long timeoutMs) {
-    if (pWrkrData->bIsRunning == 0) return;
+static void waitForChildExit(instanceData *__restrict__ const pData,
+			     childProcessCtx_t *__restrict__ const pChildCtx,
+			     const long timeoutMs) {
+	int status;
+	int ret = -1;
+	long counter;
 
-    if (kill(pWrkrData->pid, SIGTERM) == -1) {
-        LogError(errno, RS_RET_SYS_ERR, "mmexternal: could not send SIGTERM to child process");
-    }
-    closeWrkrPipes(pWrkrData);
-    waitForChildExit(pWrkrData, timeoutMs);
-    pWrkrData->bIsRunning = 0;
+	counter = timeoutMs / 10;
+	while ((ret = waitpid(pChildCtx->pid, &status, WNOHANG)) == 0 && counter > 0) {
+		srSleep(0, 10000);
+		--counter;
+	}
+
+	if (ret == 0) {
+		if (kill(pChildCtx->pid, SIGKILL) == -1) {
+			LogError(errno, RS_RET_SYS_ERR, "mmexternal: could not send SIGKILL to child process");
+			return;
+		}
+		ret = waitpid(pChildCtx->pid, &status, 0);
+	}
+
+	/* waitpid may fail with ECHILD if rsyslogd's main loop already reaped the child. */
+	if (ret == pChildCtx->pid) {
+		glblReportChildProcessExit(runConf, pData->szBinary, pChildCtx->pid, status);
+	}
+}
+
+
+static void closeChildPipes(childProcessCtx_t *__restrict__ const pChildCtx) {
+	if (pChildCtx->fdOutput != -1) {
+		close(pChildCtx->fdOutput);
+		pChildCtx->fdOutput = -1;
+	}
+	if (pChildCtx->fdPipeIn != -1) {
+		close(pChildCtx->fdPipeIn);
+		pChildCtx->fdPipeIn = -1;
+	}
+	if (pChildCtx->fdPipeOut != -1) {
+		close(pChildCtx->fdPipeOut);
+		pChildCtx->fdPipeOut = -1;
+	}
+}
+
+
+static void terminateChild(instanceData *__restrict__ const pData,
+			   childProcessCtx_t *__restrict__ const pChildCtx,
+			   const long timeoutMs) {
+	if (pChildCtx->bIsRunning == 0) return;
+
+	if (kill(pChildCtx->pid, SIGTERM) == -1) {
+		LogError(errno, RS_RET_SYS_ERR, "mmexternal: could not send SIGTERM to child process");
+	}
+	closeChildPipes(pChildCtx);
+	waitForChildExit(pData, pChildCtx, timeoutMs);
+	pChildCtx->bIsRunning = 0;
 }
 
 
@@ -257,72 +316,111 @@ static void terminateChild(wrkrInstanceData_t *__restrict__ const pWrkrData, con
  * things quite a bit simpler. So don't think the simple code does
  * not handle those border-cases that are describe to cannot exist!
  */
-static rsRetVal processProgramReply(wrkrInstanceData_t *__restrict__ const pWrkrData, smsg_t *const pMsg) {
-    DEFiRet;
-    char errStr[1024];
-    ssize_t r;
-    int numCharsRead;
-    char *newptr;
-    struct pollfd fdToPoll[1];
+static rsRetVal processProgramReply(instanceData *__restrict__ const pData,
+				    childProcessCtx_t *__restrict__ const pChildCtx,
+				    smsg_t *const pMsg) {
+	DEFiRet;
+	char errStr[1024];
+	ssize_t r;
+	size_t numCharsRead;
+	size_t newSize;
+	size_t maxResponseSize;
+	char *newptr;
+	struct pollfd fdToPoll[1];
 
-    if (pWrkrData->pData->outputMode == OUTPUT_NONE) {
-        FINALIZE;
-    }
+	if (pData->outputMode == OUTPUT_NONE) {
+		FINALIZE;
+	}
 
-    numCharsRead = 0;
-    fdToPoll[0].fd = pWrkrData->fdPipeIn;
-    fdToPoll[0].events = POLLIN;
-    do {
-        if (pWrkrData->maxLenRespBuf < numCharsRead + 256) { /* 256 to permit at least a decent read */
-            pWrkrData->maxLenRespBuf += 4096;
-            if ((newptr = realloc(pWrkrData->respBuf, pWrkrData->maxLenRespBuf)) == NULL) {
-                DBGPRINTF("mmexternal: error realloc responseBuf: %s\n", rs_strerror_r(errno, errStr, sizeof(errStr)));
-                /* emergency - fake no update */
-                memcpy(pWrkrData->respBuf, "{}\n", sizeof("{}\n"));
-                numCharsRead = 3;
-                break;
-            }
-            pWrkrData->respBuf = newptr;
-        }
-        if (pWrkrData->pData->responseTimeout > 0) {
-            const int pollRet = poll(fdToPoll, 1, pWrkrData->pData->responseTimeout);
-            if (pollRet == -1) {
-                if (errno == EINTR) continue;
-                LogError(errno, RS_RET_SYS_ERR, "mmexternal: error polling for response from program");
-                ABORT_FINALIZE(RS_RET_SYS_ERR);
-            } else if (pollRet == 0) {
-                LogMsg(0, RS_RET_TIMED_OUT, LOG_WARNING,
-                       "mmexternal: program '%s' (pid %ld) did not respond within timeout (%ld ms); "
-                       "will be restarted and current message skipped",
-                       pWrkrData->pData->szBinary, (long)pWrkrData->pid, pWrkrData->pData->responseTimeout);
-                terminateChild(pWrkrData, 1000);
-                FINALIZE;
-            }
-        }
-        r = read(pWrkrData->fdPipeIn, pWrkrData->respBuf + numCharsRead, pWrkrData->maxLenRespBuf - numCharsRead - 1);
-        if (r > 0) {
-            numCharsRead += r;
-            pWrkrData->respBuf[numCharsRead] = '\0'; /* space reserved in read! */
-        } else {
-            /* emergency - fake no update */
-            memcpy(pWrkrData->respBuf, "{}\n", sizeof("{}\n"));
-            numCharsRead = 3;
-        }
-        if (Debug && r == -1) {
-            DBGPRINTF("mmexternal: error reading from external program: %s\n",
-                      rs_strerror_r(errno, errStr, sizeof(errStr)));
-        }
-    } while (pWrkrData->respBuf[numCharsRead - 1] != '\n');
+	numCharsRead = 0;
+	maxResponseSize = (size_t)glblGetMaxLine(runConf);
+	if (maxResponseSize < 256) {
+		maxResponseSize = 256;
+	}
+	fdToPoll[0].fd = pChildCtx->fdPipeIn;
+	fdToPoll[0].events = POLLIN;
+	do {
+		if (pChildCtx->maxLenRespBuf < numCharsRead + 256) { /* 256 to permit at least a decent read */
+			newSize = pChildCtx->maxLenRespBuf;
+			if (newSize == 0) {
+				newSize = 4096;
+			}
+			while (newSize < numCharsRead + 256 && newSize < maxResponseSize) {
+				newSize += 4096;
+			}
+			if (newSize > maxResponseSize) {
+				newSize = maxResponseSize;
+			}
+			if (newSize < numCharsRead + 256) {
+				LogMsg(0, RS_RET_ERR, LOG_WARNING,
+				       "mmexternal: program '%s' (pid %ld) returned a response longer than maxMessageSize "
+				       "(%zu bytes); will be restarted and current message skipped",
+				       pData->szBinary, (long)pChildCtx->pid, maxResponseSize);
+				terminateChild(pData, pChildCtx, 1000);
+				FINALIZE;
+			}
+			if ((newptr = realloc(pChildCtx->respBuf, newSize)) == NULL) {
+				LogError(errno, RS_RET_OUT_OF_MEMORY,
+					 "mmexternal: could not grow response buffer for program '%s'; "
+					 "will restart helper and skip current message",
+					 pData->szBinary);
+				terminateChild(pData, pChildCtx, 1000);
+				FINALIZE;
+			}
+			pChildCtx->respBuf = newptr;
+			pChildCtx->maxLenRespBuf = newSize;
+		}
+		if (pData->responseTimeout > 0) {
+			const int pollRet = poll(fdToPoll, 1, pData->responseTimeout);
+			if (pollRet == -1) {
+				if (errno == EINTR) continue;
+				LogError(errno, RS_RET_SYS_ERR, "mmexternal: error polling for response from program");
+				ABORT_FINALIZE(RS_RET_SYS_ERR);
+			} else if (pollRet == 0) {
+				LogMsg(0, RS_RET_TIMED_OUT, LOG_WARNING,
+				       "mmexternal: program '%s' (pid %ld) did not respond within timeout (%ld ms); "
+				       "will be restarted and current message skipped",
+				       pData->szBinary, (long)pChildCtx->pid, pData->responseTimeout);
+				terminateChild(pData, pChildCtx, 1000);
+				FINALIZE;
+			}
+		}
+		r = read(pChildCtx->fdPipeIn, pChildCtx->respBuf + numCharsRead, pChildCtx->maxLenRespBuf - numCharsRead - 1);
+		if (r > 0) {
+			numCharsRead += r;
+			pChildCtx->respBuf[numCharsRead] = '\0'; /* space reserved in read! */
+		} else if (r == 0) {
+			LogMsg(0, RS_RET_READ_ERR, LOG_WARNING,
+			       "mmexternal: program '%s' (pid %ld) terminated while returning a response; "
+			       "will be restarted and current message skipped",
+			       pData->szBinary, (long)pChildCtx->pid);
+			cleanupChild(pData, pChildCtx);
+			FINALIZE;
+		} else if (errno == EINTR) {
+			continue;
+		} else {
+			LogError(errno, RS_RET_READ_ERR,
+				 "mmexternal: error reading response from program '%s'; "
+				 "will restart helper and skip current message",
+				 pData->szBinary);
+			terminateChild(pData, pChildCtx, 1000);
+			FINALIZE;
+		}
+		if (Debug && r == -1) {
+			DBGPRINTF("mmexternal: error reading from external program: %s\n",
+				  rs_strerror_r(errno, errStr, sizeof(errStr)));
+		}
+	} while (pChildCtx->respBuf[numCharsRead - 1] != '\n');
 
-    writeOutputDebug(pWrkrData, pWrkrData->respBuf, numCharsRead);
-    /* strip LF, which is not part of the JSON message but framing */
-    pWrkrData->respBuf[numCharsRead - 1] = '\0';
-    iRet = MsgSetPropsViaJSON(pMsg, (uchar *)pWrkrData->respBuf);
-    if (iRet != RS_RET_OK) {
-        LogError(0, iRet, "mmexternal: invalid reply '%s' from program '%s'", pWrkrData->respBuf,
-                 pWrkrData->pData->szBinary);
-        iRet = RS_RET_OK;
-    }
+	writeOutputDebug(pData, pChildCtx, pChildCtx->respBuf, (ssize_t)numCharsRead);
+	/* strip LF, which is not part of the JSON message but framing */
+	pChildCtx->respBuf[numCharsRead - 1] = '\0';
+	iRet = MsgSetPropsViaJSON(pMsg, (uchar *)pChildCtx->respBuf);
+	if (iRet != RS_RET_OK) {
+		LogError(0, iRet, "mmexternal: invalid reply '%s' from program '%s'", pChildCtx->respBuf,
+			 pData->szBinary);
+		iRet = RS_RET_OK;
+	}
 
 finalize_it:
     RETiRet;
@@ -335,9 +433,9 @@ finalize_it:
  * rsyslog will never see it except as script output. Do NOT
  * use dbgprintf() or LogError() and friends.
  */
-static void __attribute__((noreturn)) execBinary(wrkrInstanceData_t *pWrkrData,
-                                                 const int fdStdin,
-                                                 const int fdStdOutErr) {
+static void __attribute__((noreturn)) execBinary(instanceData *pData,
+						 const int fdStdin,
+						 const int fdStdOutErr) {
     int i;
     int fdDevNull = -1;
     struct sigaction sigAct;
@@ -386,15 +484,15 @@ static void __attribute__((noreturn)) execBinary(wrkrInstanceData_t *pWrkrData,
     alarm(0);
 
     /* finally exec child */
-    execve((char *)pWrkrData->pData->szBinary, pWrkrData->pData->aParams, newenviron);
+	execve((char *)pData->szBinary, pData->aParams, newenviron);
 
     /* we should never reach this point, but if we do, we complain and terminate */
     char errstr[1024];
     char errbuf[2048];
     rs_strerror_r(errno, errstr, sizeof(errstr));
     errstr[sizeof(errstr) - 1] = '\0';
-    const size_t lenbuf = snprintf(errbuf, sizeof(errbuf), "mmexternal: failed to execute binary '%s': %s\n",
-                                   pWrkrData->pData->szBinary, errstr);
+	const size_t lenbuf = snprintf(errbuf, sizeof(errbuf), "mmexternal: failed to execute binary '%s': %s\n",
+				       pData->szBinary, errstr);
     errbuf[sizeof(errbuf) - 1] = '\0';
     if (write(2, errbuf, lenbuf) != (ssize_t)lenbuf) {
         /* just keep static analyzers happy... */
@@ -407,12 +505,12 @@ static void __attribute__((noreturn)) execBinary(wrkrInstanceData_t *pWrkrData,
 /* creates a pipe and starts program, uses pipe as stdin for program.
  * rgerhards, 2009-04-01
  */
-static rsRetVal openPipe(wrkrInstanceData_t *pWrkrData) {
-    int pipestdin[2];
-    int pipestdout[2];
-    int useOutputPipe = pWrkrData->pData->outputMode != OUTPUT_NONE;
-    pid_t cpid;
-    DEFiRet;
+static rsRetVal openPipe(instanceData *pData, childProcessCtx_t *pChildCtx) {
+	int pipestdin[2];
+	int pipestdout[2];
+	int useOutputPipe = pData->outputMode != OUTPUT_NONE;
+	pid_t cpid;
+	DEFiRet;
 
     if (pipe(pipestdin) == -1) {
         ABORT_FINALIZE(RS_RET_ERR_CREAT_PIPE);
@@ -421,76 +519,76 @@ static rsRetVal openPipe(wrkrInstanceData_t *pWrkrData) {
         ABORT_FINALIZE(RS_RET_ERR_CREAT_PIPE);
     }
 
-    DBGPRINTF("mmexternal: executing program '%s' with '%d' parameters\n", pWrkrData->pData->szBinary,
-              pWrkrData->pData->iParams);
+	DBGPRINTF("mmexternal: executing program '%s' with '%d' parameters\n", pData->szBinary,
+		  pData->iParams);
 
-    /* final sanity check */
-    assert(pWrkrData->pData->szBinary != NULL);
-    assert(pWrkrData->pData->aParams != NULL);
+	/* final sanity check */
+	assert(pData->szBinary != NULL);
+	assert(pData->aParams != NULL);
 
     /* NO OUTPUT AFTER FORK! */
     cpid = fork();
-    if (cpid == -1) {
-        ABORT_FINALIZE(RS_RET_ERR_FORK);
-    }
-    pWrkrData->pid = cpid;
+	if (cpid == -1) {
+		ABORT_FINALIZE(RS_RET_ERR_FORK);
+	}
+	pChildCtx->pid = cpid;
 
-    if (cpid == 0) {
-        /* we are now the child, just exec the binary. */
-        close(pipestdin[1]); /* close those pipe "ports" that */
-        if (useOutputPipe) {
-            close(pipestdout[0]); /* we don't need */
-            execBinary(pWrkrData, pipestdin[0], pipestdout[1]);
-        } else {
-            execBinary(pWrkrData, pipestdin[0], -1);
-        }
+	if (cpid == 0) {
+		/* we are now the child, just exec the binary. */
+		close(pipestdin[1]); /* close those pipe "ports" that */
+		if (useOutputPipe) {
+			close(pipestdout[0]); /* we don't need */
+			execBinary(pData, pipestdin[0], pipestdout[1]);
+		} else {
+			execBinary(pData, pipestdin[0], -1);
+		}
         /*NO CODE HERE - WILL NEVER BE REACHED!*/
     }
 
-    DBGPRINTF("mmexternal: child has pid %d\n", (int)cpid);
-    if (useOutputPipe) {
-        pWrkrData->fdPipeIn = pipestdout[0];
-        close(pipestdout[1]);
-    }
-    close(pipestdin[0]);
-    pWrkrData->pid = cpid;
-    pWrkrData->fdPipeOut = pipestdin[1];
-    pWrkrData->bIsRunning = 1;
+	DBGPRINTF("mmexternal: child has pid %d\n", (int)cpid);
+	if (useOutputPipe) {
+		pChildCtx->fdPipeIn = pipestdout[0];
+		close(pipestdout[1]);
+	}
+	close(pipestdin[0]);
+	pChildCtx->pid = cpid;
+	pChildCtx->fdPipeOut = pipestdin[1];
+	pChildCtx->bIsRunning = 1;
 finalize_it:
-    RETiRet;
+	RETiRet;
 }
 
 
 /* clean up after a terminated child
  */
-static rsRetVal cleanup(wrkrInstanceData_t *pWrkrData) {
-    int status;
-    int ret;
-    DEFiRet;
+static rsRetVal cleanupChild(instanceData *pData, childProcessCtx_t *pChildCtx) {
+	int status;
+	int ret;
+	DEFiRet;
 
-    assert(pWrkrData->bIsRunning == 1);
-    ret = waitpid(pWrkrData->pid, &status, 0);
+	assert(pChildCtx->bIsRunning == 1);
+	ret = waitpid(pChildCtx->pid, &status, 0);
 
-    /* waitpid will fail with errno == ECHILD if the child process has already
-       been reaped by the rsyslogd main loop (see rsyslogd.c) */
-    if (ret == pWrkrData->pid) {
-        glblReportChildProcessExit(runConf, pWrkrData->pData->szBinary, pWrkrData->pid, status);
-    }
+	/* waitpid will fail with errno == ECHILD if the child process has already
+	   been reaped by the rsyslogd main loop (see rsyslogd.c) */
+	if (ret == pChildCtx->pid) {
+		glblReportChildProcessExit(runConf, pData->szBinary, pChildCtx->pid, status);
+	}
 
-    closeWrkrPipes(pWrkrData);
-    pWrkrData->bIsRunning = 0;
-    RETiRet;
+	closeChildPipes(pChildCtx);
+	pChildCtx->bIsRunning = 0;
+	RETiRet;
 }
 
 
 /* try to restart the binary when it has stopped.
  */
-static rsRetVal tryRestart(wrkrInstanceData_t *pWrkrData) {
-    DEFiRet;
-    assert(pWrkrData->bIsRunning == 0);
+static rsRetVal tryRestart(instanceData *pData, childProcessCtx_t *pChildCtx) {
+	DEFiRet;
+	assert(pChildCtx->bIsRunning == 0);
 
-    iRet = openPipe(pWrkrData);
-    RETiRet;
+	iRet = openPipe(pData, pChildCtx);
+	RETiRet;
 }
 
 /* write to pipe
@@ -498,62 +596,64 @@ static rsRetVal tryRestart(wrkrInstanceData_t *pWrkrData) {
  * may block (and this not be acceptable), the action should be run on its
  * own action queue.
  */
-static rsRetVal callExtProg(wrkrInstanceData_t *__restrict__ const pWrkrData, smsg_t *__restrict__ const pMsg) {
-    int lenWritten;
-    int lenWrite;
-    int writeOffset;
+static rsRetVal callExtProg(instanceData *__restrict__ const pData,
+			    childProcessCtx_t *__restrict__ const pChildCtx,
+			    smsg_t *__restrict__ const pMsg) {
+	int lenWritten;
+	int lenWrite;
+	int writeOffset;
     int i_iov;
     struct iovec iov[2];
     int bFreeInputstr = 1; /* we must only free if it does not point to msg-obj mem! */
     const uchar *inputstr = NULL; /* string to be processed by external program */
     DEFiRet;
 
-    if (pWrkrData->pData->inputProp == INPUT_MSG) {
-        inputstr = getMSG(pMsg);
-        lenWrite = getMSGLen(pMsg);
-        bFreeInputstr = 0;
-    } else if (pWrkrData->pData->inputProp == INPUT_RAWMSG) {
-        getRawMsg(pMsg, (uchar **)&inputstr, &lenWrite);
-        bFreeInputstr = 0;
-    } else {
+	if (pData->inputProp == INPUT_MSG) {
+		inputstr = getMSG(pMsg);
+		lenWrite = getMSGLen(pMsg);
+		bFreeInputstr = 0;
+	} else if (pData->inputProp == INPUT_RAWMSG) {
+		getRawMsg(pMsg, (uchar **)&inputstr, &lenWrite);
+		bFreeInputstr = 0;
+	} else {
         inputstr = msgGetJSONMESG(pMsg);
         lenWrite = strlen((const char *)inputstr);
     }
 
-    writeOffset = 0;
-    do {
-        DBGPRINTF("mmexternal: writing to prog (fd %d, offset %d): %s\n", pWrkrData->fdPipeOut, (int)writeOffset,
-                  inputstr);
+	writeOffset = 0;
+	do {
+		DBGPRINTF("mmexternal: writing to prog (fd %d, offset %d): %s\n", pChildCtx->fdPipeOut, (int)writeOffset,
+			  inputstr);
         i_iov = 0;
         if (writeOffset < lenWrite) {
             iov[0].iov_base = (char *)inputstr + writeOffset;
             iov[0].iov_len = lenWrite - writeOffset;
             ++i_iov;
-        }
-        iov[i_iov].iov_base = (void *)"\n";
-        iov[i_iov].iov_len = 1;
-        lenWritten = writev(pWrkrData->fdPipeOut, iov, i_iov + 1);
-        if (lenWritten == -1) {
-            switch (errno) {
-                case EPIPE:
-                    LogMsg(0, RS_RET_ERR_WRITE_PIPE, LOG_WARNING,
-                           "mmexternal: program '%s' (pid %ld) terminated; will be restarted",
-                           pWrkrData->pData->szBinary, (long)pWrkrData->pid);
-                    CHKiRet(cleanup(pWrkrData));
-                    CHKiRet(tryRestart(pWrkrData));
-                    writeOffset = 0;
-                    break;
-                default:
+		}
+		iov[i_iov].iov_base = (void *)"\n";
+		iov[i_iov].iov_len = 1;
+		lenWritten = writev(pChildCtx->fdPipeOut, iov, i_iov + 1);
+		if (lenWritten == -1) {
+			switch (errno) {
+				case EPIPE:
+					LogMsg(0, RS_RET_ERR_WRITE_PIPE, LOG_WARNING,
+					       "mmexternal: program '%s' (pid %ld) terminated; will be restarted",
+					       pData->szBinary, (long)pChildCtx->pid);
+					CHKiRet(cleanupChild(pData, pChildCtx));
+					CHKiRet(tryRestart(pData, pChildCtx));
+					writeOffset = 0;
+					break;
+				default:
                     LogError(errno, RS_RET_ERR_WRITE_PIPE, "mmexternal: error sending message to program");
                     ABORT_FINALIZE(RS_RET_ERR_WRITE_PIPE);
                     break;
             }
-        } else {
-            writeOffset += lenWritten;
-        }
-    } while (lenWritten != lenWrite + 1);
+		} else {
+			writeOffset += lenWritten;
+		}
+	} while (lenWritten != lenWrite + 1);
 
-    CHKiRet(processProgramReply(pWrkrData, pMsg));
+	CHKiRet(processProgramReply(pData, pChildCtx, pMsg));
 
 finalize_it:
     /* we need to free json input strings, only. All others point to memory
@@ -569,18 +669,21 @@ finalize_it:
 BEGINdoAction_NoStrings
     smsg_t **ppMsg = (smsg_t **)pMsgData;
     smsg_t *pMsg = ppMsg[0];
-    instanceData *pData;
-    CODESTARTdoAction;
-    pData = pWrkrData->pData;
-    if (pData->bForceSingleInst) pthread_mutex_lock(&pData->mut);
-    if (pWrkrData->bIsRunning == 0) {
-        openPipe(pWrkrData);
-    }
+	instanceData *pData;
+	childProcessCtx_t *pChildCtx;
+	CODESTARTdoAction;
+	pData = pWrkrData->pData;
+	pChildCtx = pWrkrData->pChildCtx;
+	if (pData->bForceSingleInst) pthread_mutex_lock(&pData->mut);
+	if (pChildCtx->bIsRunning == 0) {
+		CHKiRet(openPipe(pData, pChildCtx));
+	}
 
-    iRet = callExtProg(pWrkrData, pMsg);
+	iRet = callExtProg(pData, pChildCtx, pMsg);
 
-    if (iRet != RS_RET_OK) iRet = RS_RET_SUSPENDED;
-    if (pData->bForceSingleInst) pthread_mutex_unlock(&pData->mut);
+finalize_it:
+	if (iRet != RS_RET_OK) iRet = RS_RET_SUSPENDED;
+	if (pData->bForceSingleInst) pthread_mutex_unlock(&pData->mut);
 ENDdoAction
 
 
@@ -589,10 +692,11 @@ static void setInstParamDefaults(instanceData *pData) {
     pData->aParams = NULL;
     pData->outputFileName = NULL;
     pData->iParams = 0;
-    pData->bForceSingleInst = 0;
-    pData->inputProp = INPUT_MSG;
-    pData->outputMode = OUTPUT_JSON;
-    pData->responseTimeout = 0;
+	pData->bForceSingleInst = 0;
+	pData->inputProp = INPUT_MSG;
+	pData->outputMode = OUTPUT_JSON;
+	pData->responseTimeout = 0;
+	pData->pSingleChildCtx = NULL;
 }
 
 
@@ -618,8 +722,8 @@ BEGINnewActInst
             CHKmalloc(pData->outputFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "responsetimeout")) {
             pData->responseTimeout = pvals[i].val.d.n;
-        } else if (!strcmp(actpblk.descr[i].name, "forcesingleinstance")) {
-            pData->bForceSingleInst = (int)pvals[i].val.d.n;
+		} else if (!strcmp(actpblk.descr[i].name, "forcesingleinstance")) {
+			pData->bForceSingleInst = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "interface.input")) {
             inputCStr = es_str2cstr(pvals[i].val.d.estr, NULL);
             CHKmalloc(inputCStr);
@@ -648,10 +752,13 @@ BEGINnewActInst
             }
         } else {
             DBGPRINTF("mmexternal: program error, non-handled param '%s'\n", actpblk.descr[i].name);
-        }
-    }
+		}
+	}
+	if (pData->bForceSingleInst) {
+		CHKiRet(allocChildCtx(&pData->pSingleChildCtx));
+	}
 
-    CHKiRet(OMSRsetEntry(*ppOMSR, 0, NULL, OMSR_TPL_AS_MSG));
+	CHKiRet(OMSRsetEntry(*ppOMSR, 0, NULL, OMSR_TPL_AS_MSG));
     DBGPRINTF("mmexternal: bForceSingleInst %d\n", pData->bForceSingleInst);
     DBGPRINTF("mmexternal: interface.input '%s', mode %d\n", inputCStr == NULL ? "msg" : inputCStr, pData->inputProp);
     DBGPRINTF("mmexternal: interface.output '%s', mode %d, responseTimeout %ld\n",

--- a/plugins/mmexternal/mmexternal.c
+++ b/plugins/mmexternal/mmexternal.c
@@ -62,20 +62,20 @@ MODULE_CNFNAME("mmexternal")
 DEF_OMOD_STATIC_DATA;
 
 typedef struct childProcessCtx_s {
-	pid_t pid; /* pid of currently running process */
-	int fdOutput; /* debug output fd (-1 if closed) */
-	int fdPipeOut; /* file descriptor to write to */
-	int fdPipeIn; /* fd we receive messages from the program (if we want to) */
-	int bIsRunning; /* is binary currently running? 0-no, 1-yes */
-	char *respBuf; /* buffer to read external plugin's response */
-	size_t maxLenRespBuf; /* current maximum length of response buffer */
+    pid_t pid; /* pid of currently running process */
+    int fdOutput; /* debug output fd (-1 if closed) */
+    int fdPipeOut; /* file descriptor to write to */
+    int fdPipeIn; /* fd we receive messages from the program (if we want to) */
+    int bIsRunning; /* is binary currently running? 0-no, 1-yes */
+    char *respBuf; /* buffer to read external plugin's response */
+    size_t maxLenRespBuf; /* current maximum length of response buffer */
 } childProcessCtx_t;
 
 typedef struct _instanceData {
-	uchar *szBinary; /* name of binary to call */
-	char **aParams; /* Optional Parameters for binary command */
-	int iParams; /* Holds the count of parameters if set*/
-	int bForceSingleInst; /* only a single wrkr instance of program permitted? */
+    uchar *szBinary; /* name of binary to call */
+    char **aParams; /* Optional Parameters for binary command */
+    int iParams; /* Holds the count of parameters if set*/
+    int bForceSingleInst; /* only a single wrkr instance of program permitted? */
     int inputProp; /* what to provide as input to the external program? */
 #define INPUT_MSG 0
 #define INPUT_RAWMSG 1
@@ -83,15 +83,15 @@ typedef struct _instanceData {
     int outputMode; /* what to expect from the external program? */
 #define OUTPUT_JSON 0
 #define OUTPUT_NONE 1
-	long responseTimeout; /* milliseconds to wait for JSON response, 0 means forever */
-	uchar *outputFileName; /* name of file for std[out/err] or NULL if to discard */
-	pthread_mutex_t mut; /* make sure only one instance is active */
-	childProcessCtx_t *pSingleChildCtx; /* shared child process state when forceSingleInstance=on */
+    long responseTimeout; /* milliseconds to wait for JSON response, 0 means forever */
+    uchar *outputFileName; /* name of file for std[out/err] or NULL if to discard */
+    pthread_mutex_t mut; /* make sure only one instance is active */
+    childProcessCtx_t *pSingleChildCtx; /* shared child process state when forceSingleInstance=on */
 } instanceData;
 
 typedef struct wrkrInstanceData {
-	instanceData *pData;
-	childProcessCtx_t *pChildCtx; /* child process context (shared or per-worker) */
+    instanceData *pData;
+    childProcessCtx_t *pChildCtx; /* child process context (shared or per-worker) */
 } wrkrInstanceData_t;
 
 typedef struct configSettings_s {
@@ -102,14 +102,14 @@ static configSettings_t cs;
 static rsRetVal allocChildCtx(childProcessCtx_t **const ppChildCtx);
 static void freeChildCtx(childProcessCtx_t *const pChildCtx);
 static void terminateChild(instanceData *__restrict__ const pData,
-			   childProcessCtx_t *__restrict__ const pChildCtx,
-			   const long timeoutMs);
+                           childProcessCtx_t *__restrict__ const pChildCtx,
+                           const long timeoutMs);
 static rsRetVal cleanupChild(instanceData *pData, childProcessCtx_t *pChildCtx);
 static rsRetVal openPipe(instanceData *pData, childProcessCtx_t *pChildCtx);
 static rsRetVal tryRestart(instanceData *pData, childProcessCtx_t *pChildCtx);
 static rsRetVal processProgramReply(instanceData *__restrict__ const pData,
-				    childProcessCtx_t *__restrict__ const pChildCtx,
-				    smsg_t *const pMsg);
+                                    childProcessCtx_t *__restrict__ const pChildCtx,
+                                    smsg_t *const pMsg);
 
 
 /* tables for interfacing with the v6 config system */
@@ -136,13 +136,13 @@ BEGINcreateInstance
 ENDcreateInstance
 
 BEGINcreateWrkrInstance
-	CODESTARTcreateWrkrInstance;
-	pWrkrData->pChildCtx = NULL;
-	if (pWrkrData->pData->bForceSingleInst) {
-		pWrkrData->pChildCtx = pWrkrData->pData->pSingleChildCtx;
-	} else {
-		iRet = allocChildCtx(&pWrkrData->pChildCtx);
-	}
+    CODESTARTcreateWrkrInstance;
+    pWrkrData->pChildCtx = NULL;
+    if (pWrkrData->pData->bForceSingleInst) {
+        pWrkrData->pChildCtx = pWrkrData->pData->pSingleChildCtx;
+    } else {
+        iRet = allocChildCtx(&pWrkrData->pChildCtx);
+    }
 ENDcreateWrkrInstance
 
 
@@ -153,33 +153,33 @@ ENDisCompatibleWithFeature
 
 
 BEGINfreeInstance
-	int i;
-	CODESTARTfreeInstance;
-	if (pData->pSingleChildCtx != NULL) {
-		if (pData->pSingleChildCtx->bIsRunning) {
-			terminateChild(pData, pData->pSingleChildCtx, 1000);
-		}
-		freeChildCtx(pData->pSingleChildCtx);
-	}
-	free(pData->szBinary);
-	free(pData->outputFileName);
-	if (pData->aParams != NULL) {
-		for (i = 0; i < pData->iParams; i++) {
-			free(pData->aParams[i]);
-		}
-		free(pData->aParams);
-	}
-	pthread_mutex_destroy(&pData->mut);
+    int i;
+    CODESTARTfreeInstance;
+    if (pData->pSingleChildCtx != NULL) {
+        if (pData->pSingleChildCtx->bIsRunning) {
+            terminateChild(pData, pData->pSingleChildCtx, 1000);
+        }
+        freeChildCtx(pData->pSingleChildCtx);
+    }
+    free(pData->szBinary);
+    free(pData->outputFileName);
+    if (pData->aParams != NULL) {
+        for (i = 0; i < pData->iParams; i++) {
+            free(pData->aParams[i]);
+        }
+        free(pData->aParams);
+    }
+    pthread_mutex_destroy(&pData->mut);
 ENDfreeInstance
 
 BEGINfreeWrkrInstance
-	CODESTARTfreeWrkrInstance;
-	if (!pWrkrData->pData->bForceSingleInst && pWrkrData->pChildCtx != NULL) {
-		if (pWrkrData->pChildCtx->bIsRunning) {
-			terminateChild(pWrkrData->pData, pWrkrData->pChildCtx, 1000);
-		}
-		freeChildCtx(pWrkrData->pChildCtx);
-	}
+    CODESTARTfreeWrkrInstance;
+    if (!pWrkrData->pData->bForceSingleInst && pWrkrData->pChildCtx != NULL) {
+        if (pWrkrData->pChildCtx->bIsRunning) {
+            terminateChild(pWrkrData->pData, pWrkrData->pChildCtx, 1000);
+        }
+        freeChildCtx(pWrkrData->pChildCtx);
+    }
 ENDfreeWrkrInstance
 
 
@@ -198,113 +198,112 @@ ENDtryResume
  * hard to handle errors. -- rgerhards, 2014-01-16
  */
 static void writeOutputDebug(instanceData *__restrict__ const pData,
-			     childProcessCtx_t *__restrict__ const pChildCtx,
-			     const char *__restrict__ const buf,
-			     const ssize_t lenBuf) {
-	char errStr[1024];
-	ssize_t r;
+                             childProcessCtx_t *__restrict__ const pChildCtx,
+                             const char *__restrict__ const buf,
+                             const ssize_t lenBuf) {
+    char errStr[1024];
+    ssize_t r;
 
-	if (pData->outputFileName == NULL) goto done;
+    if (pData->outputFileName == NULL) goto done;
 
-	if (pChildCtx->fdOutput == -1) {
-		pChildCtx->fdOutput = open((char *)pData->outputFileName, O_WRONLY | O_APPEND | O_CREAT, 0600);
-		if (pChildCtx->fdOutput == -1) {
-			DBGPRINTF("mmexternal: error opening output file %s: %s\n", pData->outputFileName,
-				  rs_strerror_r(errno, errStr, sizeof(errStr)));
-			goto done;
-		}
-	}
+    if (pChildCtx->fdOutput == -1) {
+        pChildCtx->fdOutput = open((char *)pData->outputFileName, O_WRONLY | O_APPEND | O_CREAT, 0600);
+        if (pChildCtx->fdOutput == -1) {
+            DBGPRINTF("mmexternal: error opening output file %s: %s\n", pData->outputFileName,
+                      rs_strerror_r(errno, errStr, sizeof(errStr)));
+            goto done;
+        }
+    }
 
-	r = write(pChildCtx->fdOutput, buf, (size_t)lenBuf);
-	if (r != lenBuf) {
-		DBGPRINTF(
-			"mmexternal: problem writing output file %s: bytes "
-			"requested %lld, written %lld, msg: %s\n",
-			pData->outputFileName, (long long)lenBuf, (long long)r,
-			rs_strerror_r(errno, errStr, sizeof(errStr)));
-	}
+    r = write(pChildCtx->fdOutput, buf, (size_t)lenBuf);
+    if (r != lenBuf) {
+        DBGPRINTF(
+            "mmexternal: problem writing output file %s: bytes "
+            "requested %lld, written %lld, msg: %s\n",
+            pData->outputFileName, (long long)lenBuf, (long long)r, rs_strerror_r(errno, errStr, sizeof(errStr)));
+    }
 done:
-	return;
+    return;
 }
 
 
 static rsRetVal allocChildCtx(childProcessCtx_t **const ppChildCtx) {
-	DEFiRet;
+    DEFiRet;
 
-	CHKmalloc(*ppChildCtx = calloc(1, sizeof(childProcessCtx_t)));
-	(*ppChildCtx)->fdOutput = -1;
-	(*ppChildCtx)->fdPipeOut = -1;
-	(*ppChildCtx)->fdPipeIn = -1;
+    CHKmalloc(*ppChildCtx = calloc(1, sizeof(childProcessCtx_t)));
+    (*ppChildCtx)->fdOutput = -1;
+    (*ppChildCtx)->fdPipeOut = -1;
+    (*ppChildCtx)->fdPipeIn = -1;
 
 finalize_it:
-	RETiRet;
+    RETiRet;
 }
 
 
 static void freeChildCtx(childProcessCtx_t *const pChildCtx) {
-	if (pChildCtx == NULL) {
-		return;
-	}
-	free(pChildCtx->respBuf);
-	free(pChildCtx);
+    if (pChildCtx == NULL) {
+        return;
+    }
+    free(pChildCtx->respBuf);
+    free(pChildCtx);
 }
 
 
 static void waitForChildExit(instanceData *__restrict__ const pData,
-			     childProcessCtx_t *__restrict__ const pChildCtx,
-			     const long timeoutMs) {
-	int status;
-	int ret = -1;
-	long counter;
+                             childProcessCtx_t *__restrict__ const pChildCtx,
+                             const long timeoutMs) {
+    int status;
+    int ret = -1;
+    long counter;
 
-	counter = timeoutMs / 10;
-	while ((ret = waitpid(pChildCtx->pid, &status, WNOHANG)) == 0 && counter > 0) {
-		srSleep(0, 10000);
-		--counter;
-	}
+    counter = timeoutMs / 10;
+    while ((ret = waitpid(pChildCtx->pid, &status, WNOHANG)) == 0 && counter > 0) {
+        srSleep(0, 10000);
+        --counter;
+    }
 
-	if (ret == 0) {
-		if (kill(pChildCtx->pid, SIGKILL) == -1) {
-			LogError(errno, RS_RET_SYS_ERR, "mmexternal: could not send SIGKILL to child process");
-			return;
-		}
-		ret = waitpid(pChildCtx->pid, &status, 0);
-	}
+    if (ret == 0) {
+        if (kill(pChildCtx->pid, SIGKILL) == -1) {
+            LogError(errno, RS_RET_SYS_ERR, "mmexternal: could not send SIGKILL to child process");
+            return;
+        }
+        ret = waitpid(pChildCtx->pid, &status, 0);
+    }
 
-	/* waitpid may fail with ECHILD if rsyslogd's main loop already reaped the child. */
-	if (ret == pChildCtx->pid) {
-		glblReportChildProcessExit(runConf, pData->szBinary, pChildCtx->pid, status);
-	}
+    /* waitpid may fail with ECHILD if rsyslogd's main loop already reaped the child. */
+    if (ret == pChildCtx->pid) {
+        glblReportChildProcessExit(runConf, pData->szBinary, pChildCtx->pid, status);
+    }
 }
 
 
 static void closeChildPipes(childProcessCtx_t *__restrict__ const pChildCtx) {
-	if (pChildCtx->fdOutput != -1) {
-		close(pChildCtx->fdOutput);
-		pChildCtx->fdOutput = -1;
-	}
-	if (pChildCtx->fdPipeIn != -1) {
-		close(pChildCtx->fdPipeIn);
-		pChildCtx->fdPipeIn = -1;
-	}
-	if (pChildCtx->fdPipeOut != -1) {
-		close(pChildCtx->fdPipeOut);
-		pChildCtx->fdPipeOut = -1;
-	}
+    if (pChildCtx->fdOutput != -1) {
+        close(pChildCtx->fdOutput);
+        pChildCtx->fdOutput = -1;
+    }
+    if (pChildCtx->fdPipeIn != -1) {
+        close(pChildCtx->fdPipeIn);
+        pChildCtx->fdPipeIn = -1;
+    }
+    if (pChildCtx->fdPipeOut != -1) {
+        close(pChildCtx->fdPipeOut);
+        pChildCtx->fdPipeOut = -1;
+    }
 }
 
 
 static void terminateChild(instanceData *__restrict__ const pData,
-			   childProcessCtx_t *__restrict__ const pChildCtx,
-			   const long timeoutMs) {
-	if (pChildCtx->bIsRunning == 0) return;
+                           childProcessCtx_t *__restrict__ const pChildCtx,
+                           const long timeoutMs) {
+    if (pChildCtx->bIsRunning == 0) return;
 
-	if (kill(pChildCtx->pid, SIGTERM) == -1) {
-		LogError(errno, RS_RET_SYS_ERR, "mmexternal: could not send SIGTERM to child process");
-	}
-	closeChildPipes(pChildCtx);
-	waitForChildExit(pData, pChildCtx, timeoutMs);
-	pChildCtx->bIsRunning = 0;
+    if (kill(pChildCtx->pid, SIGTERM) == -1) {
+        LogError(errno, RS_RET_SYS_ERR, "mmexternal: could not send SIGTERM to child process");
+    }
+    closeChildPipes(pChildCtx);
+    waitForChildExit(pData, pChildCtx, timeoutMs);
+    pChildCtx->bIsRunning = 0;
 }
 
 
@@ -317,110 +316,104 @@ static void terminateChild(instanceData *__restrict__ const pData,
  * not handle those border-cases that are describe to cannot exist!
  */
 static rsRetVal processProgramReply(instanceData *__restrict__ const pData,
-				    childProcessCtx_t *__restrict__ const pChildCtx,
-				    smsg_t *const pMsg) {
-	DEFiRet;
-	char errStr[1024];
-	ssize_t r;
-	size_t numCharsRead;
-	size_t newSize;
-	size_t maxResponseSize;
-	char *newptr;
-	struct pollfd fdToPoll[1];
+                                    childProcessCtx_t *__restrict__ const pChildCtx,
+                                    smsg_t *const pMsg) {
+    DEFiRet;
+    ssize_t r;
+    size_t numCharsRead;
+    size_t newSize;
+    size_t maxResponseSize;
+    char *newptr;
+    struct pollfd fdToPoll[1];
 
-	if (pData->outputMode == OUTPUT_NONE) {
-		FINALIZE;
-	}
+    if (pData->outputMode == OUTPUT_NONE) {
+        FINALIZE;
+    }
 
-	numCharsRead = 0;
-	maxResponseSize = (size_t)glblGetMaxLine(runConf);
-	if (maxResponseSize < 256) {
-		maxResponseSize = 256;
-	}
-	fdToPoll[0].fd = pChildCtx->fdPipeIn;
-	fdToPoll[0].events = POLLIN;
-	do {
-		if (pChildCtx->maxLenRespBuf < numCharsRead + 256) { /* 256 to permit at least a decent read */
-			newSize = pChildCtx->maxLenRespBuf;
-			if (newSize == 0) {
-				newSize = 4096;
-			}
-			while (newSize < numCharsRead + 256 && newSize < maxResponseSize) {
-				newSize += 4096;
-			}
-			if (newSize > maxResponseSize) {
-				newSize = maxResponseSize;
-			}
-			if (newSize < numCharsRead + 256) {
-				LogMsg(0, RS_RET_ERR, LOG_WARNING,
-				       "mmexternal: program '%s' (pid %ld) returned a response longer than maxMessageSize "
-				       "(%zu bytes); will be restarted and current message skipped",
-				       pData->szBinary, (long)pChildCtx->pid, maxResponseSize);
-				terminateChild(pData, pChildCtx, 1000);
-				FINALIZE;
-			}
-			if ((newptr = realloc(pChildCtx->respBuf, newSize)) == NULL) {
-				LogError(errno, RS_RET_OUT_OF_MEMORY,
-					 "mmexternal: could not grow response buffer for program '%s'; "
-					 "will restart helper and skip current message",
-					 pData->szBinary);
-				terminateChild(pData, pChildCtx, 1000);
-				FINALIZE;
-			}
-			pChildCtx->respBuf = newptr;
-			pChildCtx->maxLenRespBuf = newSize;
-		}
-		if (pData->responseTimeout > 0) {
-			const int pollRet = poll(fdToPoll, 1, pData->responseTimeout);
-			if (pollRet == -1) {
-				if (errno == EINTR) continue;
-				LogError(errno, RS_RET_SYS_ERR, "mmexternal: error polling for response from program");
-				ABORT_FINALIZE(RS_RET_SYS_ERR);
-			} else if (pollRet == 0) {
-				LogMsg(0, RS_RET_TIMED_OUT, LOG_WARNING,
-				       "mmexternal: program '%s' (pid %ld) did not respond within timeout (%ld ms); "
-				       "will be restarted and current message skipped",
-				       pData->szBinary, (long)pChildCtx->pid, pData->responseTimeout);
-				terminateChild(pData, pChildCtx, 1000);
-				FINALIZE;
-			}
-		}
-		r = read(pChildCtx->fdPipeIn, pChildCtx->respBuf + numCharsRead, pChildCtx->maxLenRespBuf - numCharsRead - 1);
-		if (r > 0) {
-			numCharsRead += r;
-			pChildCtx->respBuf[numCharsRead] = '\0'; /* space reserved in read! */
-		} else if (r == 0) {
-			LogMsg(0, RS_RET_READ_ERR, LOG_WARNING,
-			       "mmexternal: program '%s' (pid %ld) terminated while returning a response; "
-			       "will be restarted and current message skipped",
-			       pData->szBinary, (long)pChildCtx->pid);
-			cleanupChild(pData, pChildCtx);
-			FINALIZE;
-		} else if (errno == EINTR) {
-			continue;
-		} else {
-			LogError(errno, RS_RET_READ_ERR,
-				 "mmexternal: error reading response from program '%s'; "
-				 "will restart helper and skip current message",
-				 pData->szBinary);
-			terminateChild(pData, pChildCtx, 1000);
-			FINALIZE;
-		}
-		if (Debug && r == -1) {
-			DBGPRINTF("mmexternal: error reading from external program: %s\n",
-				  rs_strerror_r(errno, errStr, sizeof(errStr)));
-		}
-	} while (pChildCtx->respBuf[numCharsRead - 1] != '\n');
+    numCharsRead = 0;
+    maxResponseSize = (size_t)glblGetMaxLine(runConf);
+    if (maxResponseSize < 256) {
+        maxResponseSize = 256;
+    }
+    fdToPoll[0].fd = pChildCtx->fdPipeIn;
+    fdToPoll[0].events = POLLIN;
+    do {
+        if (pChildCtx->maxLenRespBuf < numCharsRead + 256) { /* 256 to permit at least a decent read */
+            newSize = pChildCtx->maxLenRespBuf;
+            if (newSize == 0) {
+                newSize = 4096;
+            }
+            while (newSize < numCharsRead + 256 && newSize < maxResponseSize) {
+                newSize += 4096;
+            }
+            if (newSize > maxResponseSize) {
+                newSize = maxResponseSize;
+            }
+            if (newSize < numCharsRead + 256) {
+                LogMsg(0, RS_RET_ERR, LOG_WARNING,
+                       "mmexternal: program '%s' (pid %ld) returned a response longer than maxMessageSize "
+                       "(%zu bytes); will be restarted and current message skipped",
+                       pData->szBinary, (long)pChildCtx->pid, maxResponseSize);
+                terminateChild(pData, pChildCtx, 1000);
+                FINALIZE;
+            }
+            if ((newptr = realloc(pChildCtx->respBuf, newSize)) == NULL) {
+                LogError(errno, RS_RET_OUT_OF_MEMORY,
+                         "mmexternal: could not grow response buffer for program '%s'; "
+                         "will restart helper and skip current message",
+                         pData->szBinary);
+                terminateChild(pData, pChildCtx, 1000);
+                FINALIZE;
+            }
+            pChildCtx->respBuf = newptr;
+            pChildCtx->maxLenRespBuf = newSize;
+        }
+        if (pData->responseTimeout > 0) {
+            const int pollRet = poll(fdToPoll, 1, pData->responseTimeout);
+            if (pollRet == -1) {
+                if (errno == EINTR) continue;
+                LogError(errno, RS_RET_SYS_ERR, "mmexternal: error polling for response from program");
+                ABORT_FINALIZE(RS_RET_SYS_ERR);
+            } else if (pollRet == 0) {
+                LogMsg(0, RS_RET_TIMED_OUT, LOG_WARNING,
+                       "mmexternal: program '%s' (pid %ld) did not respond within timeout (%ld ms); "
+                       "will be restarted and current message skipped",
+                       pData->szBinary, (long)pChildCtx->pid, pData->responseTimeout);
+                terminateChild(pData, pChildCtx, 1000);
+                FINALIZE;
+            }
+        }
+        r = read(pChildCtx->fdPipeIn, pChildCtx->respBuf + numCharsRead, pChildCtx->maxLenRespBuf - numCharsRead - 1);
+        if (r > 0) {
+            numCharsRead += r;
+            pChildCtx->respBuf[numCharsRead] = '\0'; /* space reserved in read! */
+        } else if (r == 0) {
+            LogMsg(0, RS_RET_READ_ERR, LOG_WARNING,
+                   "mmexternal: program '%s' (pid %ld) terminated while returning a response; "
+                   "will be restarted and current message skipped",
+                   pData->szBinary, (long)pChildCtx->pid);
+            cleanupChild(pData, pChildCtx);
+            FINALIZE;
+        } else if (errno == EINTR) {
+            continue;
+        } else {
+            LogError(errno, RS_RET_READ_ERR,
+                     "mmexternal: error reading response from program '%s'; "
+                     "will restart helper and skip current message",
+                     pData->szBinary);
+            terminateChild(pData, pChildCtx, 1000);
+            FINALIZE;
+        }
+    } while (numCharsRead == 0 || pChildCtx->respBuf[numCharsRead - 1] != '\n');
 
-	writeOutputDebug(pData, pChildCtx, pChildCtx->respBuf, (ssize_t)numCharsRead);
-	/* strip LF, which is not part of the JSON message but framing */
-	pChildCtx->respBuf[numCharsRead - 1] = '\0';
-	iRet = MsgSetPropsViaJSON(pMsg, (uchar *)pChildCtx->respBuf);
-	if (iRet != RS_RET_OK) {
-		LogError(0, iRet, "mmexternal: invalid reply '%s' from program '%s'", pChildCtx->respBuf,
-			 pData->szBinary);
-		iRet = RS_RET_OK;
-	}
+    writeOutputDebug(pData, pChildCtx, pChildCtx->respBuf, (ssize_t)numCharsRead);
+    /* strip LF, which is not part of the JSON message but framing */
+    pChildCtx->respBuf[numCharsRead - 1] = '\0';
+    iRet = MsgSetPropsViaJSON(pMsg, (uchar *)pChildCtx->respBuf);
+    if (iRet != RS_RET_OK) {
+        LogError(0, iRet, "mmexternal: invalid reply '%s' from program '%s'", pChildCtx->respBuf, pData->szBinary);
+        iRet = RS_RET_OK;
+    }
 
 finalize_it:
     RETiRet;
@@ -433,9 +426,7 @@ finalize_it:
  * rsyslog will never see it except as script output. Do NOT
  * use dbgprintf() or LogError() and friends.
  */
-static void __attribute__((noreturn)) execBinary(instanceData *pData,
-						 const int fdStdin,
-						 const int fdStdOutErr) {
+static void __attribute__((noreturn)) execBinary(instanceData *pData, const int fdStdin, const int fdStdOutErr) {
     int i;
     int fdDevNull = -1;
     struct sigaction sigAct;
@@ -484,15 +475,15 @@ static void __attribute__((noreturn)) execBinary(instanceData *pData,
     alarm(0);
 
     /* finally exec child */
-	execve((char *)pData->szBinary, pData->aParams, newenviron);
+    execve((char *)pData->szBinary, pData->aParams, newenviron);
 
     /* we should never reach this point, but if we do, we complain and terminate */
     char errstr[1024];
     char errbuf[2048];
     rs_strerror_r(errno, errstr, sizeof(errstr));
     errstr[sizeof(errstr) - 1] = '\0';
-	const size_t lenbuf = snprintf(errbuf, sizeof(errbuf), "mmexternal: failed to execute binary '%s': %s\n",
-				       pData->szBinary, errstr);
+    const size_t lenbuf =
+        snprintf(errbuf, sizeof(errbuf), "mmexternal: failed to execute binary '%s': %s\n", pData->szBinary, errstr);
     errbuf[sizeof(errbuf) - 1] = '\0';
     if (write(2, errbuf, lenbuf) != (ssize_t)lenbuf) {
         /* just keep static analyzers happy... */
@@ -506,11 +497,11 @@ static void __attribute__((noreturn)) execBinary(instanceData *pData,
  * rgerhards, 2009-04-01
  */
 static rsRetVal openPipe(instanceData *pData, childProcessCtx_t *pChildCtx) {
-	int pipestdin[2];
-	int pipestdout[2];
-	int useOutputPipe = pData->outputMode != OUTPUT_NONE;
-	pid_t cpid;
-	DEFiRet;
+    int pipestdin[2];
+    int pipestdout[2];
+    int useOutputPipe = pData->outputMode != OUTPUT_NONE;
+    pid_t cpid;
+    DEFiRet;
 
     if (pipe(pipestdin) == -1) {
         ABORT_FINALIZE(RS_RET_ERR_CREAT_PIPE);
@@ -519,76 +510,75 @@ static rsRetVal openPipe(instanceData *pData, childProcessCtx_t *pChildCtx) {
         ABORT_FINALIZE(RS_RET_ERR_CREAT_PIPE);
     }
 
-	DBGPRINTF("mmexternal: executing program '%s' with '%d' parameters\n", pData->szBinary,
-		  pData->iParams);
+    DBGPRINTF("mmexternal: executing program '%s' with '%d' parameters\n", pData->szBinary, pData->iParams);
 
-	/* final sanity check */
-	assert(pData->szBinary != NULL);
-	assert(pData->aParams != NULL);
+    /* final sanity check */
+    assert(pData->szBinary != NULL);
+    assert(pData->aParams != NULL);
 
     /* NO OUTPUT AFTER FORK! */
     cpid = fork();
-	if (cpid == -1) {
-		ABORT_FINALIZE(RS_RET_ERR_FORK);
-	}
-	pChildCtx->pid = cpid;
+    if (cpid == -1) {
+        ABORT_FINALIZE(RS_RET_ERR_FORK);
+    }
+    pChildCtx->pid = cpid;
 
-	if (cpid == 0) {
-		/* we are now the child, just exec the binary. */
-		close(pipestdin[1]); /* close those pipe "ports" that */
-		if (useOutputPipe) {
-			close(pipestdout[0]); /* we don't need */
-			execBinary(pData, pipestdin[0], pipestdout[1]);
-		} else {
-			execBinary(pData, pipestdin[0], -1);
-		}
+    if (cpid == 0) {
+        /* we are now the child, just exec the binary. */
+        close(pipestdin[1]); /* close those pipe "ports" that */
+        if (useOutputPipe) {
+            close(pipestdout[0]); /* we don't need */
+            execBinary(pData, pipestdin[0], pipestdout[1]);
+        } else {
+            execBinary(pData, pipestdin[0], -1);
+        }
         /*NO CODE HERE - WILL NEVER BE REACHED!*/
     }
 
-	DBGPRINTF("mmexternal: child has pid %d\n", (int)cpid);
-	if (useOutputPipe) {
-		pChildCtx->fdPipeIn = pipestdout[0];
-		close(pipestdout[1]);
-	}
-	close(pipestdin[0]);
-	pChildCtx->pid = cpid;
-	pChildCtx->fdPipeOut = pipestdin[1];
-	pChildCtx->bIsRunning = 1;
+    DBGPRINTF("mmexternal: child has pid %d\n", (int)cpid);
+    if (useOutputPipe) {
+        pChildCtx->fdPipeIn = pipestdout[0];
+        close(pipestdout[1]);
+    }
+    close(pipestdin[0]);
+    pChildCtx->pid = cpid;
+    pChildCtx->fdPipeOut = pipestdin[1];
+    pChildCtx->bIsRunning = 1;
 finalize_it:
-	RETiRet;
+    RETiRet;
 }
 
 
 /* clean up after a terminated child
  */
 static rsRetVal cleanupChild(instanceData *pData, childProcessCtx_t *pChildCtx) {
-	int status;
-	int ret;
-	DEFiRet;
+    int status;
+    int ret;
+    DEFiRet;
 
-	assert(pChildCtx->bIsRunning == 1);
-	ret = waitpid(pChildCtx->pid, &status, 0);
+    assert(pChildCtx->bIsRunning == 1);
+    ret = waitpid(pChildCtx->pid, &status, 0);
 
-	/* waitpid will fail with errno == ECHILD if the child process has already
-	   been reaped by the rsyslogd main loop (see rsyslogd.c) */
-	if (ret == pChildCtx->pid) {
-		glblReportChildProcessExit(runConf, pData->szBinary, pChildCtx->pid, status);
-	}
+    /* waitpid will fail with errno == ECHILD if the child process has already
+       been reaped by the rsyslogd main loop (see rsyslogd.c) */
+    if (ret == pChildCtx->pid) {
+        glblReportChildProcessExit(runConf, pData->szBinary, pChildCtx->pid, status);
+    }
 
-	closeChildPipes(pChildCtx);
-	pChildCtx->bIsRunning = 0;
-	RETiRet;
+    closeChildPipes(pChildCtx);
+    pChildCtx->bIsRunning = 0;
+    RETiRet;
 }
 
 
 /* try to restart the binary when it has stopped.
  */
 static rsRetVal tryRestart(instanceData *pData, childProcessCtx_t *pChildCtx) {
-	DEFiRet;
-	assert(pChildCtx->bIsRunning == 0);
+    DEFiRet;
+    assert(pChildCtx->bIsRunning == 0);
 
-	iRet = openPipe(pData, pChildCtx);
-	RETiRet;
+    iRet = openPipe(pData, pChildCtx);
+    RETiRet;
 }
 
 /* write to pipe
@@ -597,63 +587,63 @@ static rsRetVal tryRestart(instanceData *pData, childProcessCtx_t *pChildCtx) {
  * own action queue.
  */
 static rsRetVal callExtProg(instanceData *__restrict__ const pData,
-			    childProcessCtx_t *__restrict__ const pChildCtx,
-			    smsg_t *__restrict__ const pMsg) {
-	int lenWritten;
-	int lenWrite;
-	int writeOffset;
+                            childProcessCtx_t *__restrict__ const pChildCtx,
+                            smsg_t *__restrict__ const pMsg) {
+    int lenWritten;
+    int lenWrite;
+    int writeOffset;
     int i_iov;
     struct iovec iov[2];
     int bFreeInputstr = 1; /* we must only free if it does not point to msg-obj mem! */
     const uchar *inputstr = NULL; /* string to be processed by external program */
     DEFiRet;
 
-	if (pData->inputProp == INPUT_MSG) {
-		inputstr = getMSG(pMsg);
-		lenWrite = getMSGLen(pMsg);
-		bFreeInputstr = 0;
-	} else if (pData->inputProp == INPUT_RAWMSG) {
-		getRawMsg(pMsg, (uchar **)&inputstr, &lenWrite);
-		bFreeInputstr = 0;
-	} else {
+    if (pData->inputProp == INPUT_MSG) {
+        inputstr = getMSG(pMsg);
+        lenWrite = getMSGLen(pMsg);
+        bFreeInputstr = 0;
+    } else if (pData->inputProp == INPUT_RAWMSG) {
+        getRawMsg(pMsg, (uchar **)&inputstr, &lenWrite);
+        bFreeInputstr = 0;
+    } else {
         inputstr = msgGetJSONMESG(pMsg);
         lenWrite = strlen((const char *)inputstr);
     }
 
-	writeOffset = 0;
-	do {
-		DBGPRINTF("mmexternal: writing to prog (fd %d, offset %d): %s\n", pChildCtx->fdPipeOut, (int)writeOffset,
-			  inputstr);
+    writeOffset = 0;
+    do {
+        DBGPRINTF("mmexternal: writing to prog (fd %d, offset %d): %s\n", pChildCtx->fdPipeOut, (int)writeOffset,
+                  inputstr);
         i_iov = 0;
         if (writeOffset < lenWrite) {
             iov[0].iov_base = (char *)inputstr + writeOffset;
             iov[0].iov_len = lenWrite - writeOffset;
             ++i_iov;
-		}
-		iov[i_iov].iov_base = (void *)"\n";
-		iov[i_iov].iov_len = 1;
-		lenWritten = writev(pChildCtx->fdPipeOut, iov, i_iov + 1);
-		if (lenWritten == -1) {
-			switch (errno) {
-				case EPIPE:
-					LogMsg(0, RS_RET_ERR_WRITE_PIPE, LOG_WARNING,
-					       "mmexternal: program '%s' (pid %ld) terminated; will be restarted",
-					       pData->szBinary, (long)pChildCtx->pid);
-					CHKiRet(cleanupChild(pData, pChildCtx));
-					CHKiRet(tryRestart(pData, pChildCtx));
-					writeOffset = 0;
-					break;
-				default:
+        }
+        iov[i_iov].iov_base = (void *)"\n";
+        iov[i_iov].iov_len = 1;
+        lenWritten = writev(pChildCtx->fdPipeOut, iov, i_iov + 1);
+        if (lenWritten == -1) {
+            switch (errno) {
+                case EPIPE:
+                    LogMsg(0, RS_RET_ERR_WRITE_PIPE, LOG_WARNING,
+                           "mmexternal: program '%s' (pid %ld) terminated; will be restarted", pData->szBinary,
+                           (long)pChildCtx->pid);
+                    CHKiRet(cleanupChild(pData, pChildCtx));
+                    CHKiRet(tryRestart(pData, pChildCtx));
+                    writeOffset = 0;
+                    break;
+                default:
                     LogError(errno, RS_RET_ERR_WRITE_PIPE, "mmexternal: error sending message to program");
                     ABORT_FINALIZE(RS_RET_ERR_WRITE_PIPE);
                     break;
             }
-		} else {
-			writeOffset += lenWritten;
-		}
-	} while (lenWritten != lenWrite + 1);
+        } else {
+            writeOffset += lenWritten;
+        }
+    } while (lenWritten != lenWrite + 1);
 
-	CHKiRet(processProgramReply(pData, pChildCtx, pMsg));
+    CHKiRet(processProgramReply(pData, pChildCtx, pMsg));
 
 finalize_it:
     /* we need to free json input strings, only. All others point to memory
@@ -669,21 +659,21 @@ finalize_it:
 BEGINdoAction_NoStrings
     smsg_t **ppMsg = (smsg_t **)pMsgData;
     smsg_t *pMsg = ppMsg[0];
-	instanceData *pData;
-	childProcessCtx_t *pChildCtx;
-	CODESTARTdoAction;
-	pData = pWrkrData->pData;
-	pChildCtx = pWrkrData->pChildCtx;
-	if (pData->bForceSingleInst) pthread_mutex_lock(&pData->mut);
-	if (pChildCtx->bIsRunning == 0) {
-		CHKiRet(openPipe(pData, pChildCtx));
-	}
+    instanceData *pData;
+    childProcessCtx_t *pChildCtx;
+    CODESTARTdoAction;
+    pData = pWrkrData->pData;
+    pChildCtx = pWrkrData->pChildCtx;
+    if (pData->bForceSingleInst) pthread_mutex_lock(&pData->mut);
+    if (pChildCtx->bIsRunning == 0) {
+        CHKiRet(openPipe(pData, pChildCtx));
+    }
 
-	iRet = callExtProg(pData, pChildCtx, pMsg);
+    iRet = callExtProg(pData, pChildCtx, pMsg);
 
 finalize_it:
-	if (iRet != RS_RET_OK) iRet = RS_RET_SUSPENDED;
-	if (pData->bForceSingleInst) pthread_mutex_unlock(&pData->mut);
+    if (iRet != RS_RET_OK) iRet = RS_RET_SUSPENDED;
+    if (pData->bForceSingleInst) pthread_mutex_unlock(&pData->mut);
 ENDdoAction
 
 
@@ -692,11 +682,11 @@ static void setInstParamDefaults(instanceData *pData) {
     pData->aParams = NULL;
     pData->outputFileName = NULL;
     pData->iParams = 0;
-	pData->bForceSingleInst = 0;
-	pData->inputProp = INPUT_MSG;
-	pData->outputMode = OUTPUT_JSON;
-	pData->responseTimeout = 0;
-	pData->pSingleChildCtx = NULL;
+    pData->bForceSingleInst = 0;
+    pData->inputProp = INPUT_MSG;
+    pData->outputMode = OUTPUT_JSON;
+    pData->responseTimeout = 0;
+    pData->pSingleChildCtx = NULL;
 }
 
 
@@ -722,8 +712,8 @@ BEGINnewActInst
             CHKmalloc(pData->outputFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "responsetimeout")) {
             pData->responseTimeout = pvals[i].val.d.n;
-		} else if (!strcmp(actpblk.descr[i].name, "forcesingleinstance")) {
-			pData->bForceSingleInst = (int)pvals[i].val.d.n;
+        } else if (!strcmp(actpblk.descr[i].name, "forcesingleinstance")) {
+            pData->bForceSingleInst = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "interface.input")) {
             inputCStr = es_str2cstr(pvals[i].val.d.estr, NULL);
             CHKmalloc(inputCStr);
@@ -752,13 +742,13 @@ BEGINnewActInst
             }
         } else {
             DBGPRINTF("mmexternal: program error, non-handled param '%s'\n", actpblk.descr[i].name);
-		}
-	}
-	if (pData->bForceSingleInst) {
-		CHKiRet(allocChildCtx(&pData->pSingleChildCtx));
-	}
+        }
+    }
+    if (pData->bForceSingleInst) {
+        CHKiRet(allocChildCtx(&pData->pSingleChildCtx));
+    }
 
-	CHKiRet(OMSRsetEntry(*ppOMSR, 0, NULL, OMSR_TPL_AS_MSG));
+    CHKiRet(OMSRsetEntry(*ppOMSR, 0, NULL, OMSR_TPL_AS_MSG));
     DBGPRINTF("mmexternal: bForceSingleInst %d\n", pData->bForceSingleInst);
     DBGPRINTF("mmexternal: interface.input '%s', mode %d\n", inputCStr == NULL ? "msg" : inputCStr, pData->inputProp);
     DBGPRINTF("mmexternal: interface.output '%s', mode %d, responseTimeout %ld\n",

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -131,6 +131,8 @@ TESTS_DEFAULT = \
 	glbl_setenv.sh \
 	mmexternal-SegFault.sh \
 	mmexternal-interface-output-none.sh \
+	mmexternal-single-instance.sh \
+	mmexternal-response-too-long.sh \
 	mmexternal-response-timeout.sh \
 	nested-call-shutdown.sh \
 	dnscache-TTL-0.sh \
@@ -3187,6 +3189,8 @@ EXTRA_DIST += \
 	testsuites/mmexternal-SegFault-mm-python.py \
 	testsuites/mmexternal-hang-no-reply.sh \
 	testsuites/mmexternal-no-output.sh \
+	testsuites/mmexternal-single-instance-bin.sh \
+	testsuites/mmexternal-too-long-reply-bin.sh \
 	testsuites/mmsnareparse/sample-custom-pattern.data \
 	testsuites/mmsnareparse/sample-windows2022-security.data \
 	testsuites/mmsnareparse/sample-windows2025-security.data \

--- a/tests/mmexternal-response-too-long.sh
+++ b/tests/mmexternal-response-too-long.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Regression coverage for bounded mmexternal replies: a helper that emits an
+# oversized unterminated JSON line must be restarted before responseTimeout is
+# reached, and the queue must continue to the following action. The oracle
+# waits a short time for both downstream messages and checks that a second
+# helper instance handled the recovery message.
+
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/mmexternal/.libs/mmexternal")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+if $msg contains "too-long-message" then {
+	action(
+		type="mmexternal"
+		responseTimeout="30000"
+		binary="'${srcdir}'/testsuites/mmexternal-too-long-reply-bin.sh '$RSYSLOG_DYNNAME'.side '$RSYSLOG_DYNNAME'.state"
+	)
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+
+startup
+injectmsg literal "<13>Mar 10 01:00:00 host tag:too-long-message-1"
+injectmsg literal "<13>Mar 10 01:00:00 host tag:too-long-message-2"
+wait_file_lines "$RSYSLOG_OUT_LOG" 2 5
+shutdown_when_empty
+wait_shutdown
+
+content_check "too-long-message-1"
+content_check "too-long-message-2"
+
+start_count=$(grep -c '^Starting ' "$RSYSLOG_DYNNAME.side" | awk '{print $1}')
+recover_count=$(grep -c '^Recovered too-long-message-2$' "$RSYSLOG_DYNNAME.side" | awk '{print $1}')
+
+if (( start_count < 2 )); then
+	echo "expected helper restart, but start count was $start_count"
+	error_exit 1
+fi
+
+if (( recover_count != 1 )); then
+	echo "unexpected recovery count: $recover_count"
+	error_exit 1
+fi
+
+exit_test

--- a/tests/mmexternal-single-instance.sh
+++ b/tests/mmexternal-single-instance.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# This regression verifies that mmexternal forceSingleInstance="on" really
+# shares one helper across many workers. The oracle checks that the helper
+# writes exactly one Starting line, one Terminating line, and one Received line
+# per injected message while downstream omfile still receives every message.
+
+. ${srcdir:=.}/diag.sh init
+skip_platform "SunOS" "This test currently does not work on Solaris"
+export NUMMESSAGES=10000
+
+generate_conf
+add_conf '
+module(load="../plugins/mmexternal/.libs/mmexternal")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+:msg, contains, "msgnum:" {
+	action(
+		type="mmexternal"
+		binary="'$srcdir'/testsuites/mmexternal-single-instance-bin.sh '$RSYSLOG_DYNNAME'.side"
+		forceSingleInstance="on"
+		queue.type="LinkedList"
+		queue.workerThreads="10"
+		queue.size="5000"
+		queue.timeoutShutdown="30000"
+	)
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+
+start_count=$(grep -c '^Starting$' "$RSYSLOG_DYNNAME.side" | awk '{print $1}')
+term_count=$(grep -c '^Terminating$' "$RSYSLOG_DYNNAME.side" | awk '{print $1}')
+recv_count=$(grep -c '^Received .*msgnum:' "$RSYSLOG_DYNNAME.side" | awk '{print $1}')
+line_count=$(wc -l < "$RSYSLOG_OUT_LOG" | awk '{print $1}')
+
+if (( start_count != 1 )); then
+	echo "unexpected helper start count: $start_count"
+	error_exit 1
+fi
+
+if (( term_count != 1 )); then
+	echo "unexpected helper termination count: $term_count"
+	error_exit 1
+fi
+
+if (( recv_count != NUMMESSAGES )); then
+	echo "unexpected helper receive count: $recv_count (expected: $NUMMESSAGES)"
+	error_exit 1
+fi
+
+if (( line_count != NUMMESSAGES )); then
+	echo "unexpected output line count: $line_count (expected: $NUMMESSAGES)"
+	error_exit 1
+fi
+
+exit_test

--- a/tests/testsuites/mmexternal-single-instance-bin.sh
+++ b/tests/testsuites/mmexternal-single-instance-bin.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+outfile=$1
+
+echo "Starting" >> "$outfile"
+trap 'echo "Terminating" >> "$outfile"; exit 0' TERM INT
+
+while IFS= read -r line; do
+	echo "Received $line" >> "$outfile"
+	printf '{}\n'
+done
+
+echo "Terminating" >> "$outfile"

--- a/tests/testsuites/mmexternal-too-long-reply-bin.sh
+++ b/tests/testsuites/mmexternal-too-long-reply-bin.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+outfile=$1
+statefile=$2
+
+echo "Starting $$" >> "$outfile"
+
+if [ ! -e "$statefile" ]; then
+	: > "$statefile"
+	if IFS= read -r line; then
+		echo "Oversized $line" >> "$outfile"
+		printf '{"msg":"'
+		head -c 1200000 /dev/zero | tr '\0' 'A'
+		printf '"}'
+		sleep 30
+	fi
+else
+	while IFS= read -r line; do
+		echo "Recovered $line" >> "$outfile"
+		printf '{}\n'
+	done
+fi
+
+echo "Terminating $$" >> "$outfile"


### PR DESCRIPTION
## Summary

- make `forceSingleInstance` use one shared mmexternal helper across workers
- clean up shared and per-worker child state on teardown
- bound helper replies by the existing `maxMessageSize` limit and remove the realloc NULL-deref path
- add focused mmexternal regressions plus module-map locking notes

## Validation

- Passed: container clang static analyzer lane (`rsyslog/rsyslog_dev_base_ubuntu:26.04`, image `sha256:8edc2cda1e0d2b6f6eca70aaea24bb92db161a3bca5116418a9a6cc9fe5eecf6`)
- Passed: container TSAN lane
- Passed: container mock `make distcheck TEST_RUN_TYPE=MOCK-OK`
- Passed: local Cubic review (`issues: []`)
- Focused container reruns passed for `sndrcv_relp_tls`, `omprog-single-instance`, `omprog-single-instance-outfile`, `omprog-feedback-timeout`, and `omprog-restart-terminated` after unrelated flakes in full `run-ci.sh` runs

## Notes

- I intentionally left partial-write handling alone because separate work is already in flight for that area.
