### PR TITLE
agents: add interim testing skill helper

### DIFF
--- a/.agent/skills/rsyslog_commit/SKILL.md
+++ b/.agent/skills/rsyslog_commit/SKILL.md
@@ -18,11 +18,33 @@ This skill standardizes the final step of the development workflow: committing a
 ### 1. Pre-Commit Checklist
 - **Code Style**: Run `bash devtools/format-code.sh` IF any `.c` or `.h` files were modified. This is mandatory for C source changes.
 - **Python Style**: If Python files changed and `pycodestyle` is installed, run `devtools/format-python.sh <changed-python-files>`. Use `devtools/format-python.sh --fix <changed-python-files>` only when you intentionally want `autopep8` rewrites. If the tools are missing, suggest installing them (`sudo apt-get install -y pycodestyle python3-autopep8` on Debian/Ubuntu) but do not block unrelated build or test validation. The shared 120-column style configuration lives in `setup.cfg`; review `autopep8` output carefully for legacy Python-2-style scripts.
-- **Optional Local Linters**: Before opening or updating a PR, run useful diff-scoped linters when installed: `shellcheck` for changed `*.sh`, `hadolint` for changed Dockerfiles, `trivy config` for changed infrastructure/config files, and `jscpd` for larger changed source/test sets. Guard each command with `command -v`; if a tool is missing, suggest installing it but do not block unrelated build or test validation. Do not run `cppcheck` routinely unless requested; it is too noisy for the rsyslog tree.
-- **Validation**: Ensure `make -j$(nproc) check TESTS=""` passes and relevant tests are run.
+- **Local Preflight Linters**: Before heavier validation or opening/updating a
+  PR, run useful diff-scoped linters when installed: `shellcheck` for changed
+  `*.sh`, `checkbashisms -p` for changed scripts that claim POSIX `sh`
+  portability, `devtools/format-python.sh --check-if-available` for changed
+  Python, `actionlint` and pinned `zizmor` for changed workflows, `hadolint`
+  for changed Dockerfiles, `trivy config` for changed infrastructure/config
+  files, and `jscpd` for larger changed source/test sets. Guard optional
+  commands with `command -v`; if a tool is missing, suggest installing it but
+  do not block unrelated build or test validation. On Debian/Ubuntu,
+  `checkbashisms` is provided by `devscripts`. Do not run `cppcheck` routinely
+  unless requested; it is too noisy for the rsyslog tree.
+- **Validation**: Ensure the relevant build/test path passed. For PR-ready
+  implementation work, prefer the local container-testing skill's change-gated
+  validation over unconditional full-suite local runs.
   - **Multi-Pass AI Audit**: Run the `/audit` workflow for a rigorous, persona-based review (Memory, Concurrency, Standards) using the project's canned prompts.
-  - **Local Cubic**: Run local Cubic review when `cubic` is installed and reachable. Hosted Cubic/Gemini PR comments are additional review feedback, not a substitute for local Cubic.
-  - **Container Gate**: For implementation changes, run the `rsyslog_local_container_testing` skill's full ordered local container sequence when container tooling is available. Focused `run-ci.sh TEST=...` commands are targeted container tests, not full local container validation unless that skill explicitly permits the reduced lane.
+  - **Local Cubic**: Run local Cubic review for code changes when `cubic` is
+    installed and reachable. Skip Cubic for documentation-only changes. For
+    tests, workflows, build tooling, and mixed changes, use Cubic when the
+    change is non-trivial, behavior-affecting, security-sensitive, or large.
+    Hosted Cubic/Gemini PR comments are additional review feedback, not a
+    substitute for local Cubic where local Cubic applies.
+  - **Container Gate**: For implementation changes, run the
+    `rsyslog_local_container_testing` skill's PR-ready change-gated local
+    container sequence when container tooling is available. Focused
+    `run-ci.sh TEST=...` commands are targeted container tests, not PR-ready
+    local container validation unless that skill explicitly permits the reduced
+    lane.
   - **Mock Smoke Check**: If you added or renamed test files, run `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)` as a final distribution check.
   - **Note**: If you already successfully built and tested your changes immediately *before* formatting, you do NOT need to re-run the build/test cycle. Formatting is a normalization step and does not affect functionality.
 

--- a/.agent/skills/rsyslog_doc/SKILL.md
+++ b/.agent/skills/rsyslog_doc/SKILL.md
@@ -61,7 +61,15 @@ Every documentation page must include:
 - **Required Keys**: `support_status`, `maturity_level`, `primary_contact`, `last_reviewed`.
 
 ### 4. Validation
-- **Build Docs**: Run `./doc/tools/build-doc-linux.sh --clean --format html`.
+- **Build Docs**: For rendered user-facing documentation changes under
+  `doc/source/**`, or Sphinx support files that affect that tree, run a
+  high-concurrency HTML build:
+  `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"`.
+  Add `--strict` for larger, structural, navigation-heavy, or warning-sensitive
+  documentation edits.
+- Internal docs that are not rendered into the user manual, such as `doc/ai/**`,
+  repository agent guides, and skill files, do not require a Sphinx docs build
+  unless they also change rendered Sphinx inputs.
 - **json-formatter**: Run `make -j16 json-formatter` to update the RAG knowledge base.
 - **Mermaid**: Ensure Mermaid diagrams have a blank line after the directive and quoted labels.
 

--- a/.agent/skills/rsyslog_local_container_testing/SKILL.md
+++ b/.agent/skills/rsyslog_local_container_testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rsyslog_local_container_testing
-description: Mirror rsyslog run_checks.yml container validation locally, including the clang static analyzer job followed by the Ubuntu 26.04 run-ci.sh check run, service-skip validation, clean-tree rules, and container path caveats.
+description: Mirror rsyslog run_checks.yml container validation locally, including Cubic review where applicable, the clang static analyzer job, the change-gated Ubuntu 26.04 run-ci.sh check run, service-skip validation, clean-tree rules, and container path caveats.
 ---
 
 # rsyslog_local_container_testing
@@ -8,9 +8,10 @@ description: Mirror rsyslog run_checks.yml container validation locally, includi
 Use this skill when validating rsyslog implementation changes through local dev
 containers, and treat it as the final pre-finish gate when Docker, Podman, or
 equivalent container tooling is available. Local container validation should
-mirror the relevant GitHub Actions container jobs instead of inventing a
-parallel local-only flow. If container tooling is unavailable, report that
-limitation explicitly rather than silently substituting a weaker gate.
+mirror the relevant GitHub Actions container jobs, including their relevance
+gates, instead of inventing a parallel local-only flow. If container tooling is
+unavailable, report that limitation explicitly rather than silently
+substituting a weaker gate.
 
 ## When To Use
 
@@ -31,11 +32,71 @@ to catch the failures that otherwise cost a full GitHub Actions turnaround and
 follow-up babysitting cycle, without cloning the entire CI matrix for every
 small patch.
 
+Start with the repository helper:
+
+```sh
+devtools/local-validation-plan.sh
+```
+
+The default mode classifies the current local diff and prints the recommended
+validation path. It includes committed branch changes, staged and unstaged
+tracked edits, and untracked files. This is important because PR work is often
+validated before everything is committed.
+
+When you want deterministic execution instead of a checklist, use:
+
+```sh
+devtools/local-validation-plan.sh --run
+```
+
+`--run` executes the selected path and exits on the first required failure.
+Optional local linters still remain tool-presence guarded, so missing optional
+developer tools do not turn a documentation or tooling-only change into a
+container validation failure.
+
+Before starting any heavy local validation, run the relevant cheap local checks
+that are available in the environment. These checks should be diff-scoped and
+tool-presence guarded:
+
+- changed shell scripts: `shellcheck`
+- changed scripts with a POSIX `sh` shebang: `checkbashisms -p`; on
+  Debian/Ubuntu install it with `sudo apt-get install -y devscripts`. Do not
+  run it as a full-testbench gate by default, because many tests intentionally
+  use Bash-oriented testbench conventions. Keep this check diff-scoped so
+  runtime stays proportional to the changed files.
+- changed Python files: `devtools/format-python.sh --check-if-available`
+- changed GitHub Actions workflows: `actionlint` and pinned `zizmor`
+- changed Dockerfiles: `hadolint`
+- changed infrastructure/config files: `trivy config` on the changed paths or
+  smallest relevant directory
+- larger source/test PRs: `jscpd` as an advisory duplication check
+- changed C sources or headers: `devtools/format-code.sh`
+
+Do not run `cppcheck` routinely unless a maintainer explicitly asks for it; it
+is too noisy for routine rsyslog PR validation.
+
+- **Agent-documentation and skill-only changes**. If the diff is limited to
+  `AGENTS.md`, `AGENTS.local.md`, `.agent/skills/**`, or `.codex/skills/**`,
+  do not run the Ubuntu 26.04 container check or static analyzer merely because
+  validation instructions changed. Validate these edits with normal text review,
+  Markdown/link sanity checks where available, and a small command dry-run only
+  when the edited instructions include command snippets whose syntax is
+  uncertain. If the agent-doc change also edits code, testbench files,
+  workflows, build files, or scripts, validate those touched areas normally.
+- **User-facing documentation changes**. If the diff changes rendered
+  user-facing docs, such as `doc/source/**` or Sphinx support files that affect
+  that tree, do not run the Ubuntu 26.04 runtime check just because docs
+  changed. Instead run a high-concurrency docs build:
+  `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"`.
+  Use `--strict` for larger, structural, or navigation-heavy documentation
+  edits. Internal docs that are not rendered into the user manual, such as
+  `doc/ai/**`, repository agent guides, and skill files, do not require this
+  docs build unless they also change rendered Sphinx inputs.
 - **Tier 1: default PR-ready gate for code or testbench changes**. Run the
-  existing static-analyzer pass and Ubuntu 26.04 `devtools/run-ci.sh` check.
-  This is the normal local confidence gate for C, parser, module, runtime,
-  `tests/*.sh`, `diag.sh`, `Makefile.am`, `configure.ac`, and
-  `run_checks.yml` changes.
+  local Cubic review when applicable, the existing static-analyzer pass, and a
+  change-gated Ubuntu 26.04 `devtools/run-ci.sh` check. This is the normal
+  local confidence gate for C, parser, module, runtime, `tests/*.sh`,
+  `diag.sh`, `Makefile.am`, `configure.ac`, and `run_checks.yml` changes.
 - **Tier 2: compile portability gate for non-trivial C/header changes**. Add
   the two build-only compile lanes from `run_checks.yml`:
   `clang21-ndebug` and `gcc15-gnu23-debug`. Use this when a change touches
@@ -47,26 +108,109 @@ small patch.
   `ubuntu_26_san` for memory, parser, string, JSON, property, and bounds work;
   `ubuntu_26_tsan` for threading, queue, action lifecycle, or lock-order work;
   `ubuntu_26_imtcp_no_epoll` for imtcp and network input changes;
-  `i386_CI` for integer width, pointer size, serialization, and ABI-sensitive
-  work; `ubuntu_22_distcheck` or `kafka_distcheck_CI` for dist, autotools,
+  `ubuntu_22_distcheck` or `kafka_distcheck_CI` for dist, autotools,
   packaging, or Kafka Makefile changes.
 
 Keep macOS, full distro matrix, package builds, and service-backed matrix jobs
 as CI-owned by default. Run them locally only when the change directly targets
 that area and the local host can reproduce the required environment.
 
+Keep i386 and Ubuntu 24 regular runtime coverage cloud-only by default. Run
+them locally only when reproducing a lane-specific failure, validating their
+workflow/container, or when a maintainer explicitly asks for that local lane.
+
+Normal PR-ready local validation is change-gated. It must not force the full
+test suite by default. Force full coverage only for daily, weekly, release,
+flake-campaign, maintainer-requested, or relevance-gate validation work.
+
+## Local Capacity Knobs
+
+Use the local machine's configured capacity for broad local checks instead of
+hard-coding this host's current limit into instructions. Unknown machines should
+default conservatively:
+
+```sh
+: "${RSYSLOG_LOCAL_CHECK_JOBS:=10}"
+: "${RSYSLOG_LOCAL_BUILD_JOBS:=10}"
+export CI_MAKE_OPT="-j${RSYSLOG_LOCAL_BUILD_JOBS}"
+export CI_MAKE_CHECK_OPT="-j${RSYSLOG_LOCAL_CHECK_JOBS}"
+```
+
+`RSYSLOG_LOCAL_CHECK_JOBS` is the normal local `make check` concurrency gauge.
+It should be set by the user or machine profile, for example in `.bashrc`.
+Deflake and overload experiments are prompt-driven and must use explicit
+one-off `-jN` values instead of changing this normal validation knob.
+
+## Cubic Review
+
+Run the local `cubic` CLI as an AI review gate when it applies. Cubic is a small
+local shim that forwards the review request to the configured cloud AI service,
+so it can normally run in parallel with the local static analyzer.
+
+- **Docs-only changes**: do not run Cubic.
+- **Code changes (`*.c`, `*.h`, grammar/parser/runtime/module logic)**: always
+  run Cubic when the command is installed and reachable.
+- **Test-only changes**: run Cubic for non-trivial test logic, timing/sync
+  changes, helper changes, or broad testbench behavior.
+- **Workflow, build, and tooling changes**: run Cubic when the change is
+  non-trivial, behavior-affecting, security-sensitive, or large. Use
+  `actionlint`, pinned `zizmor`, and the relevant local linters as the primary
+  deterministic checks for workflow syntax/security.
+- **Mixed or large changes**: run Cubic.
+
+Hosted Cubic or Gemini PR comments are useful additional feedback, but they do
+not replace local Cubic for code changes and do not replace local analyzer,
+build, or container checks.
+
+## Extended Lane Triggers
+
+Use extended lanes to target a plausible failure mode that the default
+change-gated Ubuntu 26.04 check would not expose. Do not add lanes by habit.
+
+- **Compile portability lanes (`clang21-ndebug`, `gcc15-gnu23-debug`)**:
+  run for shared header changes, configure/build/autotools changes,
+  compiler-sensitive C changes, macro/inline helper changes, generated C paths,
+  debug/no-debug sensitive code, GNU23/C standard sensitivity, or broad C
+  changes where one normal compiler is weak evidence.
+- **SAN (`ubuntu_26_san`)**: run for parser, string, buffer, JSON, property,
+  length accounting, allocation, ownership, malformed-input, crash,
+  undefined-behavior, or security-adjacent changes.
+- **TSAN (`ubuntu_26_tsan`)**: run for queues, actions, worker lifecycle,
+  shutdown, retry, timers, locks, atomics, condition variables, shared state,
+  readiness/polling/synchronization test changes, and all changes to
+  `runtime/wti.*` or `runtime/wtp.*`.
+- **imtcp poll/select (`ubuntu_26_imtcp_no_epoll`)**: run when touching imtcp
+  behavior that could differ between epoll and poll/select mode.
+- **Distribution checks (`ubuntu_22_distcheck`, mock distcheck, or
+  `kafka_distcheck_CI`)**: run when adding, renaming, or deleting files/tests,
+  changing `Makefile.am`, `configure.ac`, `m4`, packaging lists, generated
+  artifacts, or Kafka build/test plumbing.
+- **Service-specific lanes**: run only when directly relevant to the touched
+  module, tests, helpers, build plumbing, or relevance logic. This includes
+  Kafka, Elasticsearch, VictoriaLogs/omhttp, MySQL/libdbi, imfile, and similar
+  focused families. For imjournal, local runtime tests are normally not
+  representative unless the host has a usable journal environment; document the
+  limitation and rely on CI/static checks when local runtime coverage is not
+  practical.
+- **i386 and Ubuntu 24**: leave cloud-only by default. Use local runs only for
+  lane-specific reproduction, explicit 32-bit ABI/width work, dependency or
+  Ubuntu-LTS package behavior, or workflow/container changes in those lanes.
+
 ## Preferred Order
 
-For the full final gate, run two container validations for broad local
-confidence. Mirror these
+For the PR-ready final gate, run Cubic where applicable and two container
+validations for broad local confidence. Mirror these
 `.github/workflows/run_checks.yml` paths:
 
-1. The `clang static analyzer` job's container command.
-2. The Ubuntu 26.04 `devtools/run-ci.sh` check run, only after the analyzer run
-   is clean or its findings are understood.
+1. Local Cubic review and the `clang static analyzer` job's container command.
+   These can run in parallel when the agent harness supports parallel commands.
+2. The change-gated Ubuntu 26.04 `devtools/run-ci.sh` check run, only after the
+   analyzer and Cubic results are clean or their findings are understood.
 
-This ordered pair is what "full local container validation" means in agent
-status reports. A focused `devtools/run-ci.sh TEST=...` or build-only
+This sequence is what "PR-ready local container validation" means in agent
+status reports. It is intentionally not an unconditional full-suite run; it
+must use the same conservative change-gating and service-relevance model as
+regular PR CI. A focused `devtools/run-ci.sh TEST=...` or build-only
 `TESTS=""` container command is useful supplemental evidence, but it is only a
 targeted container test unless this skill explicitly calls that reduced lane
 acceptable for the touched area. Hosted CI, including hosted Cubic/Gemini
@@ -93,6 +237,22 @@ rm -f tests/runtime_unit_gss_token_util \
 ```
 
 Skip this only for an immediate rerun with unchanged settings.
+
+If a previous container run left generated files owned by root or by an
+unexpected container UID, `make distclean` may print permission errors or the
+next `autoreconf` may fail while opening `autom4te.cache`. In that case,
+normalize ownership and writable bits in the throwaway worktree before cleaning
+again:
+
+```sh
+sudo chown -R "$(id -u):$(id -g)" .
+chmod -R u+rwX,go+rwX .
+make distclean || true
+```
+
+Use this only for local validation worktrees where the generated build output is
+not part of the intended diff. Re-check `git status --short` afterwards and
+remove only untracked build products or logs, not source changes.
 
 Container configure runs leave generated Makefiles with absolute paths from
 inside the container, such as `/rsyslog/missing`. Reconfigure on the host before
@@ -167,43 +327,63 @@ devtools/devcontainer.sh --rm make -j20
 
 ## Run 2: run_checks.yml Ubuntu 26.04 Check
 
-Use the same `devtools/run-ci.sh` path as CI. On this host, use `-j80`.
-For full Valgrind-capable check runs, set a non-sanitizer compiler and CFLAGS;
-ASAN-instrumented binaries are not suitable for Valgrind tests.
+Use the same `devtools/run-ci.sh` path as CI, with local concurrency from
+`RSYSLOG_LOCAL_BUILD_JOBS` and `RSYSLOG_LOCAL_CHECK_JOBS`. For Valgrind-capable
+check runs, set a non-sanitizer compiler and CFLAGS; ASAN-instrumented binaries
+are not suitable for Valgrind tests.
 
-For service-skip validation with an irrelevant fake change set:
+For PR-ready validation with the actual changed-file set, apply the default
+service relevance suppressions before entering the container. Local validation
+normally happens before committing, so include committed branch changes,
+staged/unstaged tracked changes, and untracked files. Clean generated build
+state first so untracked build products do not pollute the relevance decision:
 
 ```sh
+make distclean || true
+: "${RSYSLOG_LOCAL_CHECK_JOBS:=10}"
+: "${RSYSLOG_LOCAL_BUILD_JOBS:=10}"
+export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04'
+export RSYSLOG_CONTAINER_UID=''
+export RSYSLOG_TESTBENCH_CHANGED_FILES="$({
+  git diff --name-only origin/main...HEAD
+  git diff --name-only HEAD
+  git ls-files --others --exclude-standard
+} | sort -u)"
+export CC='gcc'
+export CFLAGS='-g'
+export CI_CONFIGURE_CACHE=1
+export CI_MAKE_OPT="-j${RSYSLOG_LOCAL_BUILD_JOBS}"
+export CI_MAKE_CHECK_OPT="-j${RSYSLOG_LOCAL_CHECK_JOBS}"
+export CI_CHECK_CMD='check'
+export VERBOSE=1
+. devtools/apply-service-relevance.sh
+rsyslog_apply_default_pr_service_suppressions
 /usr/bin/time -p env \
-RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
-RSYSLOG_TESTBENCH_CHANGED_FILES='doc/README.md' \
-CC='clang-21' \
-CFLAGS='-g' \
-CI_MAKE_OPT='-j80' \
-CI_MAKE_CHECK_OPT='-j80' \
-CI_CHECK_CMD='check' \
 devtools/devcontainer.sh --rm devtools/run-ci.sh
 ```
 
-This run intentionally leaves locally available service test families enabled
-unless the CI-equivalent configure path disables them. For an irrelevant fake
-change set, MySQL, libdbi, and Kafka should appear in the test list but skip via
-`tests/diag.sh` before service startup. This validates the in-test gate that
-local container users rely on.
+For service-skip validation with an irrelevant fake change set, set
+`RSYSLOG_TESTBENCH_CHANGED_FILES` to a representative path such as
+`doc/README.md` before sourcing `devtools/apply-service-relevance.sh`.
 
-For a faster build-only smoke check, set `CI_MAKE_CHECK_OPT='-j80 TESTS='`.
-This is useful for intermediate feedback, but it does not satisfy the full
-final validation gate.
+For a faster build-only smoke check, set:
+
+```sh
+CI_MAKE_CHECK_OPT="-j${RSYSLOG_LOCAL_CHECK_JOBS} TESTS="
+```
+
+This is useful for intermediate feedback, but it does not satisfy the PR-ready
+validation gate.
 
 Do not replace this run with a focused `TEST=...` lane just because the PR has a
-single new test. The full run validates the CI configure path, generated state,
-service relevance filters, and broad testbench integration.
+single new test. The change-gated broad run validates the CI configure path,
+generated state, service relevance filters, and broad testbench integration.
 
 ## Optional Tier 3: Risk-Triggered Specialist Lanes
 
 Run these only when the changed area justifies the extra local time. The command
-shape should stay close to `run_checks.yml`; record deviations in the final
-status.
+shape should stay close to `run_checks.yml`; use the trigger table above and
+record deviations in the final status.
 
 - **Memory-sensitive changes**: mirror `ubuntu_26_san` with `clang-21`,
   AddressSanitizer, UndefinedBehaviorSanitizer, disabled Valgrind, and the same
@@ -211,18 +391,56 @@ status.
   segfault-related work.
 - **Threading changes**: mirror `ubuntu_26_tsan` with `clang-21`,
   ThreadSanitizer, `--security-opt seccomp=unconfined`, and the CI TSAN
-  suppressions. Use for queues, worker lifecycle, action shutdown, locks, and
-  shared state.
+  suppressions. Use for queues, worker lifecycle, action shutdown, locks,
+  shared state, and all changes to `runtime/wti.*` or `runtime/wtp.*`.
 - **imtcp select-mode changes**: mirror `ubuntu_26_imtcp_no_epoll` when touching
   imtcp behavior that could differ between epoll and poll/select.
-- **32-bit or ABI-sensitive changes**: mirror `i386_CI` when changing integer
-  sizes, pointer casts, serialization, protocol framing, or disk/state formats.
+- **32-bit or ABI-sensitive changes**: rely on hosted i386 CI by default.
+  Mirror `i386_CI` locally only when reproducing an i386-only failure, changing
+  the i386 workflow/container, or when a maintainer explicitly requests local
+  32-bit validation.
 - **Distribution or build-system changes**: mirror `ubuntu_22_distcheck` for
   general dist/autotools risk, and `kafka_distcheck_CI` for Kafka build/test
   plumbing.
 
 Do not run these by habit. The expected value is highest when the lane is tied
 to the changed subsystem or to a specific failure mode seen during babysitting.
+
+## Limited Local Environment Fallback
+
+Some agents, workstations, and external contributor environments have limited
+tooling. Web Agents commonly lack Docker/Podman, but the same situation can
+happen on developer machines, locked-down CI shells, fresh containers, or
+systems without optional linters. These environments are supported: missing
+local tools are coverage gaps, not local workflow blockers. In that
+environment:
+
+- Prefer `devtools/local-validation-plan.sh` in default plan mode when a local
+  checkout and shell are available. It can classify the change without starting
+  containers.
+- Use `devtools/local-validation-plan.sh --run` only when the selected class is
+  runnable without containers, such as agent-doc-only, internal-doc-only,
+  local-validation-tooling, or rendered-docs when the docs toolchain exists. Do
+  not use a no-container `--run` result as substitute evidence for code,
+  testbench, workflow, or focused container-test changes.
+- Run every available applicable local check, such as diff-scoped linters,
+  `actionlint`, pinned `zizmor`, Python style checks, shell syntax checks,
+  documentation builds, host builds, focused host-side tests, and any
+  repository scripts that work without containers. Missing one optional tool
+  does not justify skipping other checks that are present.
+- Inspect the changed files, `run_checks.yml`, and service relevance rules to
+  identify the CI lanes that should cover the change.
+- Do not claim PR-ready container validation. State clearly that container
+  validation is unavailable in the current environment.
+- Provide the exact local container lanes or hosted CI lanes that a container
+  capable agent should run next.
+- Missing local tools such as `shellcheck`, `checkbashisms`, `actionlint`,
+  `zizmor`, `hadolint`, `trivy`, `jscpd`, `pycodestyle`, Cubic, Docker, or
+  Podman are not fatal by themselves. Report the missing checks and continue
+  with all deterministic checks that are available and relevant.
+- For code changes, still run or request Cubic according to the Cubic rules
+  when the local CLI is available. If Cubic is unavailable, report that as a
+  separate AI-review limitation.
 
 ## Service Relevance
 

--- a/.agent/skills/rsyslog_test/SKILL.md
+++ b/.agent/skills/rsyslog_test/SKILL.md
@@ -179,6 +179,19 @@ if command -v shellcheck >/dev/null 2>&1; then
     '*.sh' | xargs -0 -r shellcheck -S warning
 fi
 
+if command -v checkbashisms >/dev/null 2>&1; then
+  git diff --name-only --diff-filter=ACMR upstream/main...HEAD -- '*.sh' |
+    while IFS= read -r f; do
+      case "$(head -n1 "$f")" in
+      '#!/bin/sh'|'#!/usr/bin/sh'|'#!/usr/bin/env sh')
+        checkbashisms -p "$f"
+        ;;
+      esac
+    done
+else
+  echo "info: checkbashisms is in Debian/Ubuntu package devscripts"
+fi
+
 if command -v hadolint >/dev/null 2>&1; then
   git diff -z --name-only --diff-filter=ACMR upstream/main...HEAD -- \
     '*Dockerfile*' 'Dockerfile' | xargs -0 -r hadolint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ after formatting if you already validated the code immediately before.
 
 - Runtime container definitions live in `packaging/docker/rsyslog`.
 - Local GitHub Actions-style validation commands for the Ubuntu 26.04 dev
-  container, `-j80` check runs, clang static analyzer, disabled external
+  container, local concurrency knobs, clang static analyzer, disabled external
   services, and Docker storage cleanup are documented in the
   [`rsyslog_local_container_testing`](.agent/skills/rsyslog_local_container_testing/SKILL.md)
   skill. AI agents should use that skill when running or planning this
@@ -76,37 +76,68 @@ after formatting if you already validated the code immediately before.
 
 ## Required Final Validation Gate
 
-For implementation tasks, AI agents MUST treat full local container validation
-as the final validation gate when container tooling is available.
+For implementation tasks, AI agents MUST treat PR-ready local container
+validation as the final validation gate when container tooling is available.
 
+- Start by running `devtools/local-validation-plan.sh` to classify the local
+  diff. Use `devtools/local-validation-plan.sh --run` when you want the helper
+  to execute the selected validation path and fail on the first required error.
+  The helper includes committed branch changes, staged/unstaged tracked changes,
+  and untracked files, so it is safer than manually inspecting only
+  `origin/main...HEAD` during active local work.
+- Agent-documentation and skill-only edits, limited to files such as
+  `AGENTS.md`, `AGENTS.local.md`, `.agent/skills/**`, or `.codex/skills/**`,
+  do not require a full local CI container run or static analyzer. Validate
+  them with text review, targeted command-snippet checks when useful, and the
+  relevant documentation/style checks. If the same change also touches code,
+  tests, workflows, build files, or scripts, validate those touched areas via
+  the container-testing skill.
+- User-facing documentation edits that affect rendered Sphinx docs under
+  `doc/source/**`, or Sphinx support files for that tree, should run a
+  high-concurrency docs build instead of local runtime CI:
+  `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"`.
+  Internal agent, skill, and AI-maintenance docs that are not rendered into the
+  user manual do not require this docs build unless they also change rendered
+  Sphinx inputs.
 - If Docker or Podman is available and usable, run the
   [`rsyslog_local_container_testing`](.agent/skills/rsyslog_local_container_testing/SKILL.md)
-  skill's full local validation before reporting the task complete.
-- Full local container validation means the skill's ordered full sequence,
-  including the static analyzer and Ubuntu 26.04 `run-ci.sh` check run. Focused
-  container tests are useful targeted evidence, but they are not the full gate
-  unless the skill explicitly allows the reduced lane for the touched area.
+  skill's PR-ready local validation before reporting the task complete.
+- PR-ready local container validation means the skill's ordered
+  change-gated sequence: local Cubic where applicable, the Ubuntu 26.04 static
+  analyzer, and the Ubuntu 26.04 `run-ci.sh` check run using the same relevance
+  gates as regular PR CI. Focused container tests are useful targeted evidence,
+  but they are not the final gate unless the skill explicitly allows the
+  reduced lane for the touched area.
 - Use the skill's configured CI-equivalent dev image, including Docker Hub dev
   images when appropriate. Use a locally built image only when validating that
   local image or the runtime container produced by the task.
-- Run local Cubic validation when `cubic` is installed and reachable. Hosted
-  Cubic or Gemini PR comments are additional review feedback, not substitutes
-  for local Cubic or local container validation.
+- Run local Cubic validation for code changes when `cubic` is installed and
+  reachable. Do not run Cubic for documentation-only changes. For tests,
+  workflow, build, and other non-code changes, use Cubic when the change is
+  non-trivial, behavior-affecting, security-sensitive, or large. Hosted Cubic
+  or Gemini PR comments are additional review feedback, not substitutes for
+  local Cubic or local container validation.
+- Agents should honor local machine capacity knobs when running broad local
+  checks: `RSYSLOG_LOCAL_CHECK_JOBS` for `make check` concurrency and
+  `RSYSLOG_LOCAL_BUILD_JOBS` for build concurrency, both defaulting to `10`
+  when unset. Deflake or overload experiments must use explicit prompt-provided
+  `-jN` values instead of changing these defaults.
 - Relax expensive or service-backed lanes only for the narrow touched-area
   cases documented in the container-testing skill, and record the rationale.
 - If Docker or Podman is not installed, not running, lacks required
   permissions, or the required image cannot be obtained, state that exact
   blocker in the final response.
-- If full local container validation is skipped or blocked, list the targeted
-  validation that was run instead and explicitly mark the work as **not fully
-  container-validated**.
+- If PR-ready local container validation is skipped or blocked, list the
+  targeted validation that was run instead and explicitly mark the work as
+  **not fully container-validated**.
 - Do not describe implementation work as fully validated or complete unless
-  full local container validation passed, or the user explicitly accepted the
-  reduced validation scope after the blocker was reported.
+  PR-ready local container validation passed, or the user explicitly accepted
+  the reduced validation scope after the blocker was reported.
 - Session ledgers and final summaries for PR work must distinguish fully
-  container-validated work from targeted container-tested-only work. Include the
-  local Cubic status, hosted AI review status, image tag and ID, exact commands,
-  lane relaxations, and pass/fail results.
+  PR-ready container-validated work from targeted container-tested-only work.
+  Include the local Cubic status, hosted AI review status, image tag and ID,
+  exact commands, local concurrency values, lane relaxations, and pass/fail
+  results.
 
 ## Context Discovery (Subtree Guides)
 
@@ -161,12 +192,12 @@ Each major subtree contains a specialized `AGENTS.md` that points to area-specif
   changes that touch print statements, exception syntax, imports, or line
   continuations.
 
-## Optional Local Linter Passes
+## Local Preflight Linters
 
 CodeFactor and CI provide centralized lint feedback, but agents SHOULD run
-useful local linters on the PR diff when the tools are already installed. These
-checks are advisory local validation: if a tool is missing, suggest installing
-it and continue with the normal build/test flow.
+useful local linters on the PR diff before heavier validation when the tools are
+already installed. These checks are advisory local validation: if a tool is
+missing, suggest installing it and continue with the normal build/test flow.
 
 Use a freshly fetched upstream base when computing changed files:
 
@@ -178,6 +209,16 @@ git fetch upstream main --prune
   `command -v shellcheck >/dev/null && git diff -z --name-only
   --diff-filter=ACMR upstream/main...HEAD -- '*.sh' | xargs -0 -r
   shellcheck -S warning`
+- For changed scripts with a POSIX `sh` shebang, run `checkbashisms` when
+  installed. On Debian/Ubuntu it is provided by `devscripts`
+  (`sudo apt-get install -y devscripts`). Do not use full-tree
+  `checkbashisms` as a routine gate for the testbench; many tests intentionally
+  use Bash-oriented testbench conventions. Prefer checking changed files that
+  claim `/bin/sh` portability so runtime stays proportional to the PR delta:
+  `command -v checkbashisms >/dev/null && git diff --name-only
+  --diff-filter=ACMR upstream/main...HEAD -- '*.sh' | while IFS= read -r f;
+  do case "$(head -n1 "$f")" in '#!/bin/sh'|'#!/usr/bin/sh'|'#!/usr/bin/env sh')
+  checkbashisms -p "$f";; esac; done`
 - For changed Dockerfiles, run `hadolint` when installed:
   `command -v hadolint >/dev/null && git diff -z --name-only
   --diff-filter=ACMR upstream/main...HEAD -- '*Dockerfile*' 'Dockerfile' |
@@ -191,6 +232,35 @@ git fetch upstream main --prune
 Do not add `cppcheck` to the routine local PR checklist for this repository
 unless a maintainer explicitly asks for it; it has historically produced too
 much low-value noise on the rsyslog code base.
+
+## Limited Local Environments
+
+Agents, workstations, and external contributor environments without Docker or
+Podman access, including Web Agents, must still do the best deterministic
+validation available in their current configuration. We must support those
+environments: missing local tools are coverage gaps, not local workflow
+blockers. Run every applicable diff-scoped linter, syntax check, static check,
+documentation build, host build, or focused host-side test that is available
+and relevant to the change. Inspect the CI configuration and changed files, and
+identify the hosted or local-container lanes that should cover anything the
+current environment cannot run. Do not claim PR-ready container validation when
+containers are unavailable; state the limitation and the exact lane a
+container-capable agent or hosted CI should run next.
+
+`devtools/local-validation-plan.sh` is still useful in these environments when
+the repository checkout and basic shell tools are available: run it in default
+plan mode to classify the change. Use `--run` only for classifications whose
+selected checks can actually run without containers, such as agent-doc-only,
+internal-doc-only, local-validation-tooling, or rendered-docs when the docs
+toolchain is available. For code, testbench, workflow, or focused container
+test classifications, a no-container agent should report the recommended lanes
+instead of trying to replace them with weaker local evidence.
+
+Missing optional tools such as `shellcheck`, `checkbashisms`, `actionlint`,
+`zizmor`, `hadolint`, `trivy`, `jscpd`, `pycodestyle`, Cubic, Docker, or
+Podman are not fatal by themselves. Record which checks could not run, run the
+available applicable subset, and name the missing checks or container lanes
+that still need coverage.
 
 ## GitHub Actions Validation
 

--- a/devtools/local-validation-plan.sh
+++ b/devtools/local-validation-plan.sh
@@ -1,0 +1,427 @@
+#!/bin/sh
+#
+# Local validation dispatcher for AI and human-assisted rsyslog development.
+#
+# The helper has two modes:
+#   - default: classify the current diff and print the validation plan
+#   - --run: execute that plan and stop at the first required failure
+#
+# The changed-file set intentionally combines committed branch changes,
+# staged/unstaged tracked changes, and untracked files. This avoids the common
+# local-testing mistake where an agent validates only HEAD..base while the real
+# patch still has uncommitted edits.
+#
+# Keep this script portable POSIX sh. It is meant to run on lean developer and
+# container images, including Alpine-style environments where Bash may be
+# absent. Optional diff-scoped tools such as shellcheck, checkbashisms, Cubic,
+# and pycodestyle-backed formatters must not make this helper fail merely
+# because they are unavailable; print a warning and continue. A validation tool
+# that exists but reports a real finding still fails normally. Do not run
+# full-tree shell portability scans here: they are slower and noisy for
+# Bash-owned testbench scripts.
+set -eu
+
+mode=plan
+base_ref="${RSYSLOG_LOCAL_VALIDATION_BASE:-origin/main}"
+
+usage() {
+	cat <<'EOF'
+usage: devtools/local-validation-plan.sh [--run] [--base REF]
+
+Print, or with --run execute, the local validation workflow for the current
+diff. The changed-file set includes committed branch changes, staged and
+unstaged tracked changes, and untracked files. Generated build products should
+be cleaned before using this helper.
+
+Environment knobs:
+  RSYSLOG_LOCAL_VALIDATION_BASE  Base ref for committed branch changes (default: origin/main)
+  RSYSLOG_LOCAL_BUILD_JOBS       Local build concurrency (default: 10)
+  RSYSLOG_LOCAL_CHECK_JOBS       Local make check concurrency (default: 10)
+  RSYSLOG_LOCAL_DOC_JOBS         Local Sphinx doc build jobs (default: nproc)
+
+The --run mode exits on the first validation finding from a tool that actually
+runs. Missing local tools produce warnings, not failures; hosted CI or a fuller
+local environment must cover the skipped plumbing.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--run)
+		mode=run
+		shift
+		;;
+	--base)
+		if [ "$#" -lt 2 ]; then
+			echo "error: --base requires an argument" >&2
+			exit 2
+		fi
+		base_ref="$2"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "error: unknown argument: $1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+done
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+tmp_changed="$(mktemp)"
+tmp_shell="$(mktemp)"
+tmp_python="$(mktemp)"
+tmp_c="$(mktemp)"
+cleanup() {
+	rm -f "$tmp_changed" "$tmp_shell" "$tmp_python" "$tmp_c"
+}
+trap cleanup EXIT
+
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+	echo "error: base ref '$base_ref' is not available; fetch it or pass --base" >&2
+	exit 2
+fi
+
+{
+	git diff --name-only --diff-filter=d "$base_ref"...HEAD
+	git diff --name-only --diff-filter=d HEAD
+	git ls-files --others --exclude-standard
+} | sort -u > "$tmp_changed"
+
+if [ ! -s "$tmp_changed" ]; then
+	echo "No local changes detected relative to $base_ref."
+	exit 0
+fi
+
+matches_any() {
+	pattern="$1"
+	grep -Eq "$pattern" "$tmp_changed"
+}
+
+matches_only() {
+	pattern="$1"
+	! grep -Evq "$pattern" "$tmp_changed"
+}
+
+has_rendered_docs=0
+has_workflow=0
+has_build=0
+has_testbench_plumbing=0
+has_test_shell_only=0
+has_c=0
+has_runtime_ci=0
+
+if matches_any '^(doc/source/|doc/Makefile\.am$|doc/tools/|doc/requirements\.txt$|doc/source/conf\.py$)'; then
+	has_rendered_docs=1
+fi
+if matches_any '^\.github/workflows/'; then
+	has_workflow=1
+fi
+if matches_any '(^|/)Makefile\.am$|^configure\.ac$|^m4/'; then
+	has_build=1
+fi
+if matches_any '^tests/(diag\.sh|Makefile\.am|[^/]+\.[ch]$|helpers/|unit/)'; then
+	has_testbench_plumbing=1
+fi
+if matches_only '^tests/[^/]+\.sh$'; then
+	has_test_shell_only=1
+fi
+if matches_any '\.(c|h)$'; then
+	has_c=1
+fi
+
+if matches_any '^((runtime|grammar|tools|plugins|contrib|compat)/|tests/|[^/]+\.(c|h)$|configure\.ac$|Makefile\.am$|m4/|\.github/workflows/run_checks\.yml$)'; then
+	has_runtime_ci=1
+fi
+
+agent_docs_only=0
+if matches_only '(^|/)AGENTS(\.local)?\.md$|^\.agent/skills/|^\.codex/skills/'; then
+	agent_docs_only=1
+fi
+
+internal_docs_only=0
+if [ "$has_rendered_docs" -eq 0 ] && matches_only '(^|/)AGENTS(\.local)?\.md$|^\.agent/skills/|^\.codex/skills/|^doc/ai/|^doc/security/|^doc/README\.md$|^doc/AGENTS\.md$|^doc/BUILDS_README\.md$|^doc/STRATEGY\.md$|^doc/IMPLEMENTATION_PLAN\.md$'; then
+	internal_docs_only=1
+fi
+
+validation_tooling_only=0
+if [ "$has_rendered_docs" -eq 0 ] && matches_only '(^|/)AGENTS(\.local)?\.md$|^\.agent/skills/|^\.codex/skills/|^doc/ai/|^doc/security/|^doc/README\.md$|^doc/AGENTS\.md$|^doc/BUILDS_README\.md$|^doc/STRATEGY\.md$|^doc/IMPLEMENTATION_PLAN\.md$|^devtools/(local-validation-plan\.sh|check-test-antipatterns\.sh|format-code\.sh|format-python\.sh|list-git-changed-c-h-files\.sh)$'; then
+	validation_tooling_only=1
+fi
+
+grep -E '\.sh$' "$tmp_changed" > "$tmp_shell" || true
+grep -E '\.py$' "$tmp_changed" > "$tmp_python" || true
+grep -E '\.(c|h)$' "$tmp_changed" > "$tmp_c" || true
+
+classification=general
+if [ "$agent_docs_only" -eq 1 ]; then
+	classification=agent-doc-only
+elif [ "$internal_docs_only" -eq 1 ]; then
+	classification=internal-doc-only
+elif [ "$validation_tooling_only" -eq 1 ]; then
+	classification=local-validation-tooling
+elif [ "$has_rendered_docs" -eq 1 ] && [ "$has_runtime_ci" -eq 0 ] && [ "$has_workflow" -eq 0 ] && [ "$has_build" -eq 0 ]; then
+	classification=rendered-docs
+elif [ "$has_test_shell_only" -eq 1 ]; then
+	classification=test-shell-only
+elif [ "$has_testbench_plumbing" -eq 1 ]; then
+	classification=testbench-plumbing
+elif [ "$has_c" -eq 1 ] || [ "$has_build" -eq 1 ] || [ "$has_workflow" -eq 1 ] || [ "$has_runtime_ci" -eq 1 ]; then
+	classification=code-or-ci
+fi
+
+nproc_jobs() {
+	if command -v nproc >/dev/null 2>&1; then
+		nproc
+	else
+		getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1
+	fi
+}
+
+doc_jobs="${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc_jobs)}"
+build_jobs="${RSYSLOG_LOCAL_BUILD_JOBS:-10}"
+check_jobs="${RSYSLOG_LOCAL_CHECK_JOBS:-10}"
+
+print_plan() {
+	echo "Local validation classification: $classification"
+	echo "Base ref: $base_ref"
+	echo
+	echo "Changed files:"
+	sed 's/^/  /' "$tmp_changed"
+	echo
+	echo "Recommended validation:"
+	case "$classification" in
+	agent-doc-only | internal-doc-only)
+		echo "  - Text review and command-snippet sanity checks as needed."
+		echo "  - No runtime container CI, static analyzer, or Sphinx build required."
+		;;
+	local-validation-tooling)
+		echo "  - Shell/Python style checks for changed tooling."
+		echo "  - Dry-run this helper against representative diffs where practical."
+		echo "  - No runtime container CI unless the tooling change affects CI/container execution."
+		;;
+	rendered-docs)
+		echo "  - ./doc/tools/build-doc-linux.sh --clean --format html --jobs \"$doc_jobs\""
+		echo "  - Add --strict for larger or structural documentation edits."
+		;;
+	test-shell-only)
+		echo "  - shellcheck changed tests if shellcheck is installed."
+		echo "  - Focused container test with CI_MAKE_CHECK_TESTS set to changed tests."
+		echo "  - Add broad Ubuntu 26.04 run if the test changes timing, ports, process lifecycle, or shared behavior."
+		;;
+	testbench-plumbing | code-or-ci | general)
+		echo "  - Available cheap diff-scoped linters."
+		echo "  - Cubic where applicable."
+		echo "  - Ubuntu 26.04 static analyzer for C/testbench/code changes."
+		echo "  - Change-gated Ubuntu 26.04 run-ci.sh check."
+		;;
+	esac
+}
+
+run_shellcheck() {
+	if [ ! -s "$tmp_shell" ]; then
+		return 0
+	fi
+	if command -v shellcheck >/dev/null 2>&1; then
+		while IFS= read -r file; do
+			shellcheck -S warning "$file"
+		done < "$tmp_shell"
+	else
+		echo "warning: shellcheck not installed; skipping shell lint" >&2
+	fi
+	if command -v checkbashisms >/dev/null 2>&1; then
+		while IFS= read -r file; do
+			read -r first_line < "$file" || first_line=
+			case "$first_line" in
+			'#!/bin/sh' | '#!/usr/bin/sh' | '#!/usr/bin/env sh')
+				checkbashisms -p "$file"
+				;;
+			esac
+		done < "$tmp_shell"
+	else
+		echo "warning: checkbashisms not installed; skipping POSIX shell portability lint" >&2
+	fi
+}
+
+run_python_style() {
+	if [ ! -s "$tmp_python" ]; then
+		return 0
+	fi
+	if [ -x devtools/format-python.sh ]; then
+		while IFS= read -r file; do
+			devtools/format-python.sh --check-if-available "$file"
+		done < "$tmp_python"
+	else
+		echo "warning: devtools/format-python.sh missing or not executable; skipping Python style check" >&2
+	fi
+}
+
+run_format_code_check() {
+	if [ ! -s "$tmp_c" ]; then
+		return 0
+	fi
+	if [ -x devtools/format-code.sh ]; then
+		devtools/format-code.sh --git-changed
+	else
+		echo "warning: devtools/format-code.sh missing or not executable; skipping C format check" >&2
+	fi
+}
+
+run_docs_build() {
+	if [ ! -x ./doc/tools/build-doc-linux.sh ]; then
+		echo "warning: doc/tools/build-doc-linux.sh missing or not executable; skipping docs build" >&2
+		echo "warning: this run is not docs-validated; use hosted CI or a fuller local environment" >&2
+		return 0
+	fi
+	./doc/tools/build-doc-linux.sh --clean --format html --jobs "$doc_jobs"
+}
+
+have_container_tooling() {
+	if ! command -v docker >/dev/null 2>&1; then
+		echo "warning: docker not installed; skipping selected local container validation lane" >&2
+		echo "warning: this run is not fully container-validated; use hosted CI or a container-capable agent" >&2
+		return 1
+	fi
+	return 0
+}
+
+run_distclean_if_available() {
+	if command -v make >/dev/null 2>&1; then
+		make distclean || true
+	else
+		echo "warning: make not installed; skipping distclean before container lane" >&2
+	fi
+}
+
+run_timed_env() {
+	if [ -x /usr/bin/time ]; then
+		/usr/bin/time -p env "$@"
+	else
+		echo "warning: /usr/bin/time missing; running without runtime measurement" >&2
+		env "$@"
+	fi
+}
+
+have_devcontainer_script() {
+	if [ -x devtools/devcontainer.sh ]; then
+		return 0
+	fi
+	echo "warning: devtools/devcontainer.sh missing or not executable; skipping container lane" >&2
+	echo "warning: this run is not fully container-validated; use hosted CI or a fuller local environment" >&2
+	return 1
+}
+
+run_cubic_if_available() {
+	case "$classification" in
+	agent-doc-only | internal-doc-only | rendered-docs)
+		return 0
+		;;
+	esac
+	if command -v cubic >/dev/null 2>&1; then
+		cubic review --print-logs --base HEAD
+	else
+		echo "warning: cubic not installed; skipping local Cubic review" >&2
+	fi
+}
+
+run_static_analyzer() {
+	have_container_tooling || return 0
+	have_devcontainer_script || return 0
+	run_distclean_if_available
+	rm -rf scan-build-report clang-analyzer.log
+	run_timed_env \
+		RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
+		SCAN_BUILD='scan-build' \
+		SCAN_BUILD_CC='clang' \
+		SCAN_BUILD_REPORT_DIR='scan-build-report' \
+		CI_MAKE_OPT='-j20' \
+		DOCKER_RUN_EXTRA_OPTS='-e SCAN_BUILD -e SCAN_BUILD_CC -e SCAN_BUILD_REPORT_DIR' \
+		RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--disable-elasticsearch --disable-elasticsearch-tests --disable-imkafka --disable-omkafka --disable-kafka-tests --disable-mysql --disable-mysql-tests' \
+		devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh
+}
+
+run_change_gated_ubuntu26() {
+	have_container_tooling || return 0
+	have_devcontainer_script || return 0
+	if ! command -v bash >/dev/null 2>&1; then
+		echo "warning: bash not installed; skipping service relevance setup and container lane" >&2
+		echo "warning: this run is not fully container-validated; use hosted CI or a fuller local environment" >&2
+		return 0
+	fi
+	run_distclean_if_available
+	export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04'
+	export RSYSLOG_CONTAINER_UID=''
+	export RSYSLOG_TESTBENCH_CHANGED_FILES
+	RSYSLOG_TESTBENCH_CHANGED_FILES="$(cat "$tmp_changed")"
+	export CC='gcc'
+	export CFLAGS='-g'
+	export CI_CONFIGURE_CACHE=1
+	export CI_MAKE_OPT="-j${build_jobs}"
+	export CI_MAKE_CHECK_OPT="-j${check_jobs}"
+	export CI_CHECK_CMD='check'
+	export VERBOSE=1
+	run_timed_env bash -c \
+		'. devtools/apply-service-relevance.sh && rsyslog_apply_default_pr_service_suppressions && exec devtools/devcontainer.sh --rm devtools/run-ci.sh'
+}
+
+run_focused_test_shell() {
+	tests="$(grep -E '^tests/[^/]+\.sh$' "$tmp_changed" | sed 's#^tests/##' | tr '\n' ' ')"
+	if [ -z "$tests" ]; then
+		return 0
+	fi
+	have_container_tooling || return 0
+	have_devcontainer_script || return 0
+	run_distclean_if_available
+	export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04'
+	export RSYSLOG_CONTAINER_UID=''
+	export CC='gcc'
+	export CFLAGS='-g'
+	export CI_CONFIGURE_CACHE=1
+	export CI_MAKE_OPT="-j${build_jobs}"
+	export CI_MAKE_CHECK_OPT="-j${check_jobs}"
+	export CI_MAKE_CHECK_TESTS="$tests"
+	export CI_CHECK_CMD='check'
+	export VERBOSE=1
+	run_timed_env devtools/devcontainer.sh --rm devtools/run-ci.sh
+}
+
+print_plan
+
+if [ "$mode" = plan ]; then
+	exit 0
+fi
+
+echo
+echo "Executing local validation plan..."
+run_shellcheck
+run_python_style
+run_format_code_check
+git diff --check "$base_ref"...HEAD
+git diff --cached --check
+git diff --check
+
+case "$classification" in
+agent-doc-only | internal-doc-only)
+	echo "Validation complete: documentation/instruction-only change."
+	;;
+local-validation-tooling)
+	echo "Validation complete: local validation tooling checks passed."
+	;;
+rendered-docs)
+	run_docs_build
+	;;
+test-shell-only)
+	run_focused_test_shell
+	;;
+testbench-plumbing | code-or-ci | general)
+	run_cubic_if_available
+	run_static_analyzer
+	run_change_gated_ubuntu26
+	;;
+esac


### PR DESCRIPTION
## Summary

This is the first in-repository PoC for the interim local testing skill/workflow.
It adds a helper and updates the agent guidance so agents, maintainers, Web Agents,
and external contributors have one deterministic starting point for local validation.

Changes:

- add `devtools/local-validation-plan.sh`
- classify the current local delta before choosing validation
- include committed branch changes, staged/unstaged tracked edits, and untracked files
- support `--run` for deterministic execution of the selected available checks
- keep shell/Python checks diff-scoped
- run `checkbashisms -p` only for changed scripts that claim POSIX `sh` portability
- warn and continue when local tools are missing, including Docker/Podman, Cubic, shellcheck, checkbashisms, formatter helpers, or docs/container plumbing
- document limited local environments so missing local tools are treated as coverage gaps, not workflow blockers

## Why

The local validation workflow had grown beyond a reliable text-only checklist.
Agents could easily test only committed diffs while leaving uncommitted edits
unvalidated, run too much for docs-only work, or hard-fail external contributors
who lack Docker or optional linters.

This PoC makes the expected validation path discoverable and executable while
preserving support for constrained local environments.

## Validation

- `shellcheck -S warning devtools/local-validation-plan.sh`
- `checkbashisms -p devtools/local-validation-plan.sh`
- `sh -n devtools/local-validation-plan.sh`
- `dash -n devtools/local-validation-plan.sh`
- `./devtools/local-validation-plan.sh --run --base origin/main`
- `git diff --check origin/main...HEAD`
