### PR TITLE
testbench: synchronize omfwd retry test

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1405,18 +1405,23 @@ assign_file_content() {
 # $2 is the instance name (1, 2)
 # $3, if set, is a file that releases minitcpsrv from bound/offline to listening
 # $4, if set, is a file minitcpsrv writes after listen() succeeds
+# $5, if set, is a file minitcpsrv writes after accept() succeeds
 start_minitcpsrvr() {
 	local instance=${2:-1}
 	local wait_listen_opt=""
 	local listen_ready_opt=""
+	local accept_ready_opt=""
 	if [ "${3:-}" != "" ]; then
 		wait_listen_opt="-w ${3:-}"
 	fi
 	if [ "${4:-}" != "" ]; then
 		listen_ready_opt="-L ${4:-}"
 	fi
+	if [ "${5:-}" != "" ]; then
+		accept_ready_opt="-A ${5:-}"
+	fi
 	./minitcpsrv -t127.0.0.1 -p 0 -P "$RSYSLOG_DYNNAME.minitcpsrvr_port$instance" \
-		-f "$1" $wait_listen_opt $listen_ready_opt $MINITCPSRV_EXTRA_OPTS &
+		-f "$1" $wait_listen_opt $listen_ready_opt $accept_ready_opt $MINITCPSRV_EXTRA_OPTS &
 	BGPROCESS=$!
 	MINITCPSRVR_PIDS="${MINITCPSRVR_PIDS:-} $BGPROCESS"
 	wait_file_exists "$RSYSLOG_DYNNAME.minitcpsrvr_port$instance"

--- a/tests/minitcpsrvr.c
+++ b/tests/minitcpsrvr.c
@@ -56,6 +56,7 @@ int targetPort = -1;
 char *portFileName = NULL;
 char *waitListenFileName = NULL;
 char *listenReadyFileName = NULL;
+char *acceptReadyFileName = NULL;
 size_t totalWritten = 0;
 int listen_fd, conn_fd, fd, file_fd, nfds, port = 8080;
 struct sockaddr_in server_addr;
@@ -71,7 +72,8 @@ static void errout(char *reason) {
 
 static void usage(void) {
     fprintf(stderr,
-            "usage: minitcpsrv [-R] [-w listenFile] [-L listenReadyFile] -t ip-addr -p port -P portFile -f outfile\n");
+            "usage: minitcpsrv [-R] [-w listenFile] [-L listenReadyFile] [-A acceptReadyFile] "
+            "-t ip-addr -p port -P portFile -f outfile\n");
     exit(1);
 }
 
@@ -86,6 +88,20 @@ static void writeListenReadyMarker(void) {
     ret = fprintf(fp, "listening\n");
     if (fclose(fp) != 0 || ret < 0) {
         errout(listenReadyFileName);
+    }
+}
+
+static void writeAcceptReadyMarker(void) {
+    FILE *fp;
+    int ret;
+
+    if (acceptReadyFileName == NULL) return;
+    if ((fp = fopen(acceptReadyFileName, "w")) == NULL) {
+        errout(acceptReadyFileName);
+    }
+    ret = fprintf(fp, "accepted\n");
+    if (fclose(fp) != 0 || ret < 0) {
+        errout(acceptReadyFileName);
     }
 }
 
@@ -203,10 +219,13 @@ int main(int argc, char *argv[]) {
     memset(fds, 0, sizeof(fds));
     memset(buffer_offs, 0, sizeof(buffer_offs));
 
-    while ((opt = getopt(argc, argv, "aB:D:L:Rt:p:P:f:s:S:w:")) != -1) {
+    while ((opt = getopt(argc, argv, "aA:B:D:L:Rt:p:P:f:s:S:w:")) != -1) {
         switch (opt) {
             case 'a':  // abort listener: act like the server has died (shutdown and re-open listen socket)
                 abortListener = 1;
+                break;
+            case 'A':
+                acceptReadyFileName = optarg;
                 break;
             case 'R':
                 useReusePort = 1;
@@ -302,6 +321,7 @@ int main(int argc, char *argv[]) {
                     perror("Accept failed");
                     continue;
                 }
+                writeAcceptReadyMarker();
 
                 fds[nfds].fd = conn_fd;
                 fds[nfds].events = POLLIN;

--- a/tests/omfwd-lb-2target-retry.sh
+++ b/tests/omfwd-lb-2target-retry.sh
@@ -3,10 +3,12 @@
 # unavailable during the first message batch. Phase 1 keeps target 2 bound but
 # not listening, so all initial messages must go to target 1. Phase 2 releases
 # target 2, waits until minitcpsrv has actually called listen(), then waits
-# until the configured target-pool retry interval has elapsed before injecting
-# another full batch. Before shutdown, the test waits until both receivers show
-# the expected exact line counts; this is the oracle that target 2 resumed and
-# the second batch was split evenly rather than still flowing only to target 1.
+# until the one-second pool retry interval is certainly eligible in omfwd's
+# whole-second timer model before injecting another full batch. After injection
+# the test waits for minitcpsrv to accept the retry connection. Before shutdown,
+# the test waits until both receivers show the expected exact line counts; this
+# is the oracle that target 2 resumed and the second batch was split evenly
+# rather than still flowing only to target 1.
 # Added 2024-02-24 by rgerhards. Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 generate_conf
@@ -16,10 +18,12 @@ export NUMMESSAGES=10000  # MUST be an EVEN number!
 # numbers
 TARGET2_LISTEN_RELEASE="$RSYSLOG_DYNNAME.minitcpsrvr2.listen"
 TARGET2_LISTEN_READY="$RSYSLOG_DYNNAME.minitcpsrvr2.ready"
+TARGET2_ACCEPT_READY="$RSYSLOG_DYNNAME.minitcpsrvr2.accepted"
 rm -f "$TARGET2_LISTEN_RELEASE"
 rm -f "$TARGET2_LISTEN_READY"
+rm -f "$TARGET2_ACCEPT_READY"
 start_minitcpsrvr $RSYSLOG_OUT_LOG  1
-start_minitcpsrvr $RSYSLOG2_OUT_LOG 2 "$TARGET2_LISTEN_RELEASE" "$TARGET2_LISTEN_READY"
+start_minitcpsrvr $RSYSLOG2_OUT_LOG 2 "$TARGET2_LISTEN_RELEASE" "$TARGET2_LISTEN_READY" "$TARGET2_ACCEPT_READY"
 
 # regular startup
 add_conf '
@@ -55,10 +59,15 @@ printf "\nSUCCESS for part 1 of the test\n\n"
 touch "$TARGET2_LISTEN_RELEASE"
 echo "waiting until the previously suspended pool member is listening"
 wait_file_exists "$TARGET2_LISTEN_READY"
-echo "waiting for one target-pool retry interval"
-$TESTTOOL_DIR/msleep 1200
+retry_ready_after=$(( $(date +%s) + 2 ))
+echo "waiting until the target-pool retry interval is eligible"
+while [ "$(date +%s)" -lt "$retry_ready_after" ]; do
+	$TESTTOOL_DIR/msleep 100
+done
 
 injectmsg $NUMMESSAGES $NUMMESSAGES
+echo "waiting until omfwd retries and reconnects the previously suspended pool member"
+wait_file_exists "$TARGET2_ACCEPT_READY"
 
 target2_expected=$(( NUMMESSAGES / 2 ))
 target1_expected=$(( NUMMESSAGES + target2_expected ))


### PR DESCRIPTION
## Summary

This fixes a synchronization bug in `omfwd-lb-2target-retry.sh` that showed up during the deflake campaign.

Changes:

- add an optional accept-ready marker to `minitcpsrvr`
- expose that marker through `start_minitcpsrvr`
- update the omfwd retry test to wait for omfwd's whole-second retry window and then wait until target 2 actually accepts the retry connection

## Why

The test already waited until target 2 had called `listen()`, but it still relied on a fixed sleep before assuming omfwd had retried and reconnected. Under heavy parallel test load that condition can be false even when the product behavior is correct.

The new marker keeps the test oracle tied to the behavior being tested: target 2 is unavailable for the first batch, then becomes usable, accepts a retry connection, and receives its expected share of the second batch.

## Validation

Post-rebase cheap checks:

- `shellcheck -S warning tests/omfwd-lb-2target-retry.sh`
- `checkbashisms -p tests/omfwd-lb-2target-retry.sh`
- `devtools/format-code.sh --git-changed`
- `git diff --check origin/main...HEAD`
- `devtools/local-validation-plan.sh --base origin/main`

Earlier local validation of the same patch before the final main refresh:

- targeted container run of `omfwd-lb-2target-retry.sh`: passed
- Ubuntu 26.04 static analyzer: passed
- broad change-gated Ubuntu 26.04 `run-ci.sh` check: passed
