### PR TITLE
mmjsontransform: fix dotted conflict ownership

### DIFF
--- a/plugins/mmjsontransform/mmjsontransform.c
+++ b/plugins/mmjsontransform/mmjsontransform.c
@@ -955,6 +955,7 @@ static rsRetVal jsontransformApplyPolicyRules(struct json_object *src,
             }
             jsontransformConflict_t insertConflict = {0, NULL};
             iRet = jsontransformInsertDotted(dest, targetKey, rewrittenValue, &insertConflict);
+            rewrittenValue = NULL;
             if (iRet != RS_RET_OK) {
                 jsontransformConflictCleanup(&insertConflict);
                 goto loop_finalize;
@@ -1190,8 +1191,8 @@ static rsRetVal jsontransformRewriteObject(struct json_object *src,
         }
         if (strchr(key, '.') != NULL) {
             iRet = jsontransformInsertDotted(dest, key, child, conflict);
-            if (iRet != RS_RET_OK) goto conflict;
             child = NULL;
+            if (iRet != RS_RET_OK) goto conflict;
             if (conflict != NULL && conflict->occurred) goto conflict;
             free(valueContext);
             valueContext = NULL;

--- a/tests/mmjsontransform-policy-basic.sh
+++ b/tests/mmjsontransform-policy-basic.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Validate mmjsontransform YAML policy rename/drop preprocessing, mode, and HUP reload.
+# Validate mmjsontransform YAML policy rename/drop preprocessing, mode, HUP reload,
+# and malformed dotted-key conflict handling without leaking or double-freeing values.
 . ${srcdir:=.}/diag.sh init
 
 policy_file="$RSYSLOG_DYNNAME.policy.yaml"
@@ -58,6 +59,13 @@ YAML
 issue_HUP
 tcpflood -m1 -M '"<166>Mar 10 01:00:00 host app: { \"usr\": \"carol\", \"debug\": true, \"ctx\": { \"old\": 3 } }"'
 
+# Regression coverage for conflict-path ownership: policy preprocessing passes
+# JSON values to dotted insertion, which consumes them even when malformed keys
+# such as a trailing-empty dotted path conflict.  The oracle is that rsyslogd
+# stays alive through shutdown, keeps the malformed message out of the output,
+# and logs the hierarchy conflict instead of double-freeing the input child.
+tcpflood -m1 -M '"<166>Mar 10 01:00:00 host app: { \"a.\": \"bad\" }"'
+
 shutdown_when_empty
 wait_shutdown
 
@@ -112,6 +120,11 @@ fi
 
 if ! grep -q "failed to reload policy file" "$RSYSLOG_DYNNAME.started"; then
     echo "FAIL: expected reload failure to be logged for invalid policy mode"
+    error_exit 1
+fi
+
+if ! grep -q "dotted path 'a.' ends with an empty segment" "$RSYSLOG_DYNNAME.started"; then
+    echo "FAIL: expected malformed dotted key conflict to be logged"
     error_exit 1
 fi
 


### PR DESCRIPTION
### Motivation

- Fix an ownership/cleanup mismatch in `mmjsontransform` where `jsontransformInsertDotted()` sometimes consumed the `value` but callers (policy preprocessing and rewrite paths) still `json_object_put()` the same object, causing double-free or leak paths for malformed dotted keys (e.g. `"a."`, `"a..b"`, or ordering cases that collide with scalar parents`).

### Description

- In `plugins/mmjsontransform/mmjsontransform.c` adjust the policy-processing caller so `rewrittenValue` is cleared immediately after handing it to `jsontransformInsertDotted()` to match the callee's ownership-transfer contract (`jsontransformApplyPolicyRules()` now sets `rewrittenValue = NULL` right after the insert handoff).
- Make the same immediate-handoff ordering in the normal unflatten rewrite path by clearing `child` immediately after calling `jsontransformInsertDotted()` to avoid callers later unconditionally putting an already-consumed object (`jsontransformRewriteObject()` updated accordingly).
- Extend `tests/mmjsontransform-policy-basic.sh` with a regression case that sends a malformed trailing-empty dotted key (`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18612ccaf88332adbb76225440ed6c)