### PR TITLE
agents: avoid local container UID trap

### DIFF
--- a/.agent/skills/rsyslog_local_container_testing/SKILL.md
+++ b/.agent/skills/rsyslog_local_container_testing/SKILL.md
@@ -224,6 +224,15 @@ normal local dev-container validation. When the task specifically validates a
 locally built runtime or dev image, use that locally built image/tag for the
 container-under-test and record its image ID.
 
+For normal local validation, do not set `RSYSLOG_CONTAINER_UID=''`. Leaving
+`RSYSLOG_CONTAINER_UID` unset lets `devtools/devcontainer.sh` run the container
+process as the host uid/gid and inject a matching passwd/group entry when
+needed. This prevents generated build products from being owned by the dev
+image's default user, which is often a different uid than the host checkout
+owner. Set `RSYSLOG_CONTAINER_UID=''` only when intentionally reproducing the
+exact GitHub Actions default-container-user behavior, and expect to normalize
+ownership afterwards.
+
 ## Clean Tree Rule
 
 Before switching compiler, sanitizer flags, configure options, container image,
@@ -295,7 +304,6 @@ For `clang21-ndebug`:
 make distclean || true
 /usr/bin/time -p env \
 RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
-RSYSLOG_CONTAINER_UID='' \
 CI_CONFIGURE_CACHE='1' \
 CC='clang-21' \
 CFLAGS='-g' \
@@ -303,7 +311,6 @@ RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-debug=no' \
 devtools/devcontainer.sh --rm devtools/run-configure.sh
 /usr/bin/time -p env \
 RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
-RSYSLOG_CONTAINER_UID='' \
 devtools/devcontainer.sh --rm make -j20
 ```
 
@@ -313,7 +320,6 @@ For `gcc15-gnu23-debug`:
 make distclean || true
 /usr/bin/time -p env \
 RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
-RSYSLOG_CONTAINER_UID='' \
 CI_CONFIGURE_CACHE='1' \
 CC='gcc-15' \
 CFLAGS='-g -std=gnu23' \
@@ -321,7 +327,6 @@ RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-debug=yes --disable-omamqp1' \
 devtools/devcontainer.sh --rm devtools/run-configure.sh
 /usr/bin/time -p env \
 RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
-RSYSLOG_CONTAINER_UID='' \
 devtools/devcontainer.sh --rm make -j20
 ```
 
@@ -343,7 +348,6 @@ make distclean || true
 : "${RSYSLOG_LOCAL_CHECK_JOBS:=10}"
 : "${RSYSLOG_LOCAL_BUILD_JOBS:=10}"
 export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04'
-export RSYSLOG_CONTAINER_UID=''
 export RSYSLOG_TESTBENCH_CHANGED_FILES="$({
   git diff --name-only origin/main...HEAD
   git diff --name-only HEAD
@@ -459,7 +463,6 @@ apply the same PR-style configure suppressions in local container runs:
 ```sh
 make distclean || true
 export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04'
-export RSYSLOG_CONTAINER_UID=''
 export RSYSLOG_TESTBENCH_CHANGED_FILES='runtime/lookup.c'
 export CC='gcc'
 export CFLAGS='-g'

--- a/devtools/local-validation-plan.sh
+++ b/devtools/local-validation-plan.sh
@@ -356,7 +356,6 @@ run_change_gated_ubuntu26() {
 	fi
 	run_distclean_if_available
 	export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04'
-	export RSYSLOG_CONTAINER_UID=''
 	export RSYSLOG_TESTBENCH_CHANGED_FILES
 	RSYSLOG_TESTBENCH_CHANGED_FILES="$(cat "$tmp_changed")"
 	export CC='gcc'
@@ -379,7 +378,6 @@ run_focused_test_shell() {
 	have_devcontainer_script || return 0
 	run_distclean_if_available
 	export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04'
-	export RSYSLOG_CONTAINER_UID=''
 	export CC='gcc'
 	export CFLAGS='-g'
 	export CI_CONFIGURE_CACHE=1


### PR DESCRIPTION
## Summary

This updates local validation so normal dev-container runs avoid creating build products owned by the dev image's default uid.

The root cause is that `RSYSLOG_CONTAINER_UID=''` disables `devtools/devcontainer.sh`'s existing host uid/gid mapping. On this host the Ubuntu 26.04 dev image default user is uid `1001`, while the checkout owner is uid `1000`, so generated files can become awkward to clean up after container validation.

## Changes

- Stop forcing `RSYSLOG_CONTAINER_UID=''` in `devtools/local-validation-plan.sh` for local Ubuntu 26.04 validation lanes.
- Document that local validation should leave `RSYSLOG_CONTAINER_UID` unset by default.
- Keep `RSYSLOG_CONTAINER_UID=''` reserved for intentional GitHub Actions default-container-user reproduction.

## Validation

- `shellcheck -S warning devtools/local-validation-plan.sh`
- `checkbashisms -p devtools/local-validation-plan.sh`
- `sh -n devtools/local-validation-plan.sh`
- `dash -n devtools/local-validation-plan.sh`
- `git diff --check`
- `devtools/local-validation-plan.sh --run`
