### PR TITLE
mmdblookup: avoid shutdown crash after open failure

### DIFF
--- a/plugins/mmdblookup/mmdblookup.c
+++ b/plugins/mmdblookup/mmdblookup.c
@@ -69,6 +69,7 @@ typedef struct wrkrInstanceData {
     instanceData *pData;
     MMDB_s mmdb;
     pthread_mutex_t mmdbMutex;
+    sbool mmdb_mutex_initialized;
     sbool mmdb_is_open;
 } wrkrInstanceData_t;
 
@@ -168,10 +169,19 @@ ENDcreateInstance
 
 BEGINcreateWrkrInstance
     CODESTARTcreateWrkrInstance;
+    pWrkrData->mmdb_mutex_initialized = 0;
+    pWrkrData->mmdb_is_open = 0;
+    CHKiConcCtrl(pthread_mutex_init(&pWrkrData->mmdbMutex, NULL));
+    pWrkrData->mmdb_mutex_initialized = 1;
     CHKiRet(open_mmdb(pData->pszMmdbFile, &pWrkrData->mmdb));
     pWrkrData->mmdb_is_open = 1;
-    CHKiConcCtrl(pthread_mutex_init(&pWrkrData->mmdbMutex, NULL));
 finalize_it:
+    if (iRet != RS_RET_OK) {
+        if (pWrkrData->mmdb_is_open) close_mmdb(&pWrkrData->mmdb);
+        if (pWrkrData->mmdb_mutex_initialized) pthread_mutex_destroy(&pWrkrData->mmdbMutex);
+        free(pWrkrData);
+        pWrkrData = NULL;
+    }
 ENDcreateWrkrInstance
 
 
@@ -199,7 +209,10 @@ BEGINfreeWrkrInstance
     CODESTARTfreeWrkrInstance;
     if (pWrkrData->mmdb_is_open) close_mmdb(&pWrkrData->mmdb);
     pWrkrData->mmdb_is_open = 0;
-    pthread_mutex_destroy(&pWrkrData->mmdbMutex);
+    if (pWrkrData->mmdb_mutex_initialized) {
+        pthread_mutex_destroy(&pWrkrData->mmdbMutex);
+        pWrkrData->mmdb_mutex_initialized = 0;
+    }
 ENDfreeWrkrInstance
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1460,6 +1460,7 @@ TESTS_MMJSONTRANSFORM_MMJSONPARSE = \
 	data_pipeline-qradar.sh
 
 TESTS_MMDBLOOKUP = \
+    mmdb-open-missing.sh \
     mmdb.sh \
     mmdb-space.sh \
     mmdb-container.sh \
@@ -1468,6 +1469,7 @@ TESTS_MMDBLOOKUP = \
     mmdb-multilevel.sh
 
 TESTS_MMDBLOOKUP_VALGRIND = \
+    mmdb-open-missing-vg.sh \
     mmdb-vg.sh \
     mmdb-multilevel-vg.sh
 

--- a/tests/mmdb-open-missing-vg.sh
+++ b/tests/mmdb-open-missing-vg.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Valgrind companion for GitHub issue #4024. The missing-database path used to
+# leave a partially-created worker instance behind, which could crash only after
+# shutdown cleanup. Running the same scenario under Valgrind makes that oracle
+# explicit for CI.
+script_dir=$(dirname "$0")
+: ${srcdir:=.}
+export USE_VALGRIND="YES"
+export RS_TESTBENCH_VALGRIND_EXTRA_OPTS="$RS_TESTBENCH_VALGRIND_EXTRA_OPTS --suppressions=$srcdir/libmaxmindb.supp"
+. "$script_dir/mmdb-open-missing.sh"

--- a/tests/mmdb-open-missing.sh
+++ b/tests/mmdb-open-missing.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Regression test for GitHub issue #4024. A missing mmdbfile must suspend the
+# mmdblookup action with a clear diagnostic instead of leaving a half-created
+# worker instance that can later crash while rsyslog shuts down.
+. ${srcdir:=.}/diag.sh init
+require_plugin mmdblookup
+
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%$!iplocation%\n")
+
+module(load="../plugins/mmdblookup/.libs/mmdblookup")
+module(load="../plugins/mmnormalize/.libs/mmnormalize")
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
+
+ruleset(name="testing") {
+	action(type="mmnormalize" rulebase="'$srcdir'/mmdb.rb")
+	action(type="mmdblookup"
+	       mmdbfile="'$RSYSLOG_DYNNAME'.missing.mmdb"
+	       key="$!ip"
+	       fields="city"
+	       action.resumeRetryCount="0")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}'
+
+startup
+tcpflood -m 1 -j "202.106.0.20\ "
+shutdown_when_empty
+wait_shutdown
+
+check_not_present "Segmentation fault" "${RSYSLOG_DYNNAME}.started"
+content_check "maxminddb error: cannot open database file" "${RSYSLOG_DYNNAME}.started"
+exit_test


### PR DESCRIPTION
## Summary
- clean up partially-created mmdblookup worker instances when opening the MaxMind database fails
- keep the worker slot NULL on create failure so shutdown does not try to remove worker data without an owning action
- add normal and Valgrind regression tests for a missing mmdbfile

Fixes https://github.com/rsyslog/rsyslog/issues/4024

## Validation
- ./tests/mmdb-open-missing.sh
- ./tests/mmdb-open-missing-vg.sh
- ./tests/mmdb.sh
- ./tests/mmdb-multilevel-vg.sh
- devtools/check-test-antipatterns.sh tests/mmdb-open-missing.sh tests/mmdb-open-missing-vg.sh
- shellcheck -S warning tests/mmdb-open-missing.sh tests/mmdb-open-missing-vg.sh
- bash devtools/format-code.sh
- make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)
- local Cubic: blocked by approval reviewer because it would send unpublished diff to an external service
- Docker image: rsyslog/rsyslog_dev_base_ubuntu:26.04, sha256:0261050851cd52e531d6b11d840563bd603d4af23b2a3728e09c040772c64276
- Ubuntu 26.04 static analyzer container: passed, no bugs found
- Ubuntu 26.04 change-gated run-ci container: passed, 1291 total / 1264 pass / 27 skip / 0 fail
- Ubuntu 26.04 sanitizer run-ci container: passed, 1096 total / 1069 pass / 27 skip / 0 fail

## Lane Notes
- Default run-ci relevance kept service families enabled because tests/Makefile.am changed; no service-family relaxation was applied.
- Sanitizer lane used the run_checks.yml ubuntu_26_san settings, which disable Valgrind/libfaketime and Kafka/Elasticsearch tests as part of that lane.
- TSAN not run: this patch changes error-path resource cleanup in one module worker instance, not shared runtime concurrency behavior; Valgrind and ASAN/UBSAN covered the crash/memory path.