### PR TITLE
template: reject invalid regex match selectors

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -3489,8 +3489,8 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg,
 
 #ifdef FEATURE_REGEXP
     /* Variables necessary for regular expression matching */
-    size_t nmatch = 10;
-    regmatch_t pmatch[10];
+    size_t nmatch = TPL_REGEX_MAX_MATCHES;
+    regmatch_t pmatch[TPL_REGEX_MAX_MATCHES];
 #endif
 
     *pbMustBeFreed = 0;

--- a/runtime/template.c
+++ b/runtime/template.c
@@ -785,6 +785,18 @@ static struct cnfparamblk pblkConstant = {
 
 #ifdef FEATURE_REGEXP
 DEFobjCurrIf(regexp) static int bFirstRegexpErrmsg = 1; /**< did we already do a "can't load regexp" error message? */
+
+static rsRetVal tplValidateRegexMatchSelector(struct template *const pTpl,
+                                              const char *const paramName,
+                                              const int selector) {
+    if (selector < 0 || selector >= TPL_REGEX_MAX_MATCHES) {
+        LogError(0, RS_RET_ERR, "template %s error: %s=%d is invalid (supported range 0..%d)",
+                 pTpl->pszName != NULL ? pTpl->pszName : "<unnamed>", paramName, selector, TPL_REGEX_MAX_MATCHES - 1);
+        return RS_RET_ERR;
+    }
+
+    return RS_RET_OK;
+}
 #endif
 
 /* helper to tplToString and strgen's, extends buffer */
@@ -2500,6 +2512,12 @@ static rsRetVal createPropertyTpe(struct template *pTpl, struct cnfobj *o) {
                  "specified - this is not possible, remove one");
         ABORT_FINALIZE(RS_RET_ERR);
     }
+#ifdef FEATURE_REGEXP
+    if (re_expr != NULL) {
+        CHKiRet(tplValidateRegexMatchSelector(pTpl, "regex.match", re_matchToUse));
+        CHKiRet(tplValidateRegexMatchSelector(pTpl, "regex.submatch", re_submatchToUse));
+    }
+#endif
 
     /* apply */
     CHKmalloc(pTpe = tpeConstruct(pTpl));
@@ -3028,6 +3046,7 @@ void tplDeleteNew(rsconf_t *conf) {
                     // No action needed for other cases
                     break;
             }
+            free(pTpeDel->fieldName);
             free(pTpeDel);
         }
         pTplDel = pTpl;

--- a/runtime/template.h
+++ b/runtime/template.h
@@ -100,7 +100,9 @@ enum tplRegexType {
     TPL_REGEX_ERE = 1 /* posix ERE */
 };
 
-    #include "msg.h"
+#define TPL_REGEX_MAX_MATCHES 10
+
+#include "msg.h"
 
 /* a specific parse entry */
 struct templateEntry {
@@ -123,8 +125,8 @@ struct templateEntry {
     #ifdef FEATURE_REGEXP
             regex_t re; /* APR: this is the regular expression */
             short has_regex;
-            short iMatchToUse; /* which match should be obtained (10 max) */
-            short iSubMatchToUse; /* which submatch should be obtained (10 max) */
+            short iMatchToUse; /* which match should be obtained (TPL_REGEX_MAX_MATCHES max) */
+            short iSubMatchToUse; /* which submatch should be obtained (TPL_REGEX_MAX_MATCHES max) */
             enum tplRegexType typeRegex;
             enum tlpRegexNoMatchType {
                 TPL_REGEX_NOMATCH_USE_DFLTSTR = 0,

--- a/runtime/template.h
+++ b/runtime/template.h
@@ -100,9 +100,9 @@ enum tplRegexType {
     TPL_REGEX_ERE = 1 /* posix ERE */
 };
 
-#define TPL_REGEX_MAX_MATCHES 10
+    #define TPL_REGEX_MAX_MATCHES 10
 
-#include "msg.h"
+    #include "msg.h"
 
 /* a specific parse entry */
 struct templateEntry {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,6 +17,10 @@ EXTRA_DIST = \
 TESTS_JSON_OMITIFZERO = json-omitifzero.sh json-omitifzero-subtree.sh json-whitespace.sh
 EXTRA_DIST += $(TESTS_JSON_OMITIFZERO)
 
+TESTS_TEMPLATE_REGEX_BOUNDS = template-regex-index-bounds.sh
+TESTS_TEMPLATE_REGEX_BOUNDS_LIBYAML = yaml-template-regex-index-bounds.sh
+EXTRA_DIST += $(TESTS_TEMPLATE_REGEX_BOUNDS) $(TESTS_TEMPLATE_REGEX_BOUNDS_LIBYAML)
+
 TESTS_IMFIFO = imfifo.sh imfifo-vg.sh yaml-imfifo.sh
 EXTRA_DIST += $(TESTS_IMFIFO)
 
@@ -188,6 +192,7 @@ TESTS_DEFAULT = \
 	template-pos-from-to-oversize-lowercase.sh \
 	template-pos-from-to-missing-jsonvar.sh \
 	template-const-jsonf.sh \
+	$(TESTS_TEMPLATE_REGEX_BOUNDS) \
 	template-topos-neg.sh \
 	fac_authpriv.sh \
 	fac_local0.sh \
@@ -625,6 +630,7 @@ TESTS_LIBYAML = \
 	yaml-statements-call.sh \
 	yaml-statements-unset.sh \
 	yaml-template-list.sh \
+	$(TESTS_TEMPLATE_REGEX_BOUNDS_LIBYAML) \
 	yaml-template-subtree.sh \
 	yaml-statements-reload-lookup.sh \
 	yaml-lookup-table-duplicate.sh

--- a/tests/template-regex-index-bounds.sh
+++ b/tests/template-regex-index-bounds.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Validate that list-template regex.match and regex.submatch values outside the
+# fixed regexec pmatch[] range are rejected during RainerScript config parsing.
+# Oracle: rsyslogd -N1 must fail for both configs and emit the specific range
+# validation message, so the runtime never reaches out-of-bounds match access.
+. ${srcdir:=.}/diag.sh init
+modpath="../runtime/.libs:../.libs"
+
+run_invalid_conf() {
+    local name="$1"
+    local config="$2"
+    local expect="$3"
+    local cfg="${RSYSLOG_DYNNAME}.${name}.conf"
+    local log="${RSYSLOG_DYNNAME}.${name}.log"
+
+    cat > "$cfg" <<RS_EOF
+$config
+RS_EOF
+
+    ../tools/rsyslogd -N1 -f "$cfg" -M"$modpath" > "$log" 2>&1
+    if [ $? -eq 0 ]; then
+        echo "FAIL: config check unexpectedly succeeded for $name"
+        cat "$log"
+        error_exit 1
+    fi
+
+    content_check "$expect" "$log"
+}
+
+run_invalid_conf "bad-submatch" \
+'template(name="bad_submatch" type="list") {
+  property(name="msg" regex.expression="(a)" regex.submatch="-1")
+}' \
+"template bad_submatch error: regex.submatch=-1 is invalid (supported range 0..9)"
+
+run_invalid_conf "bad-match" \
+'template(name="bad_match" type="list") {
+  property(name="msg" regex.expression="(a)" regex.match="10")
+}' \
+"template bad_match error: regex.match=10 is invalid (supported range 0..9)"
+
+exit_test

--- a/tests/yaml-template-regex-index-bounds.sh
+++ b/tests/yaml-template-regex-index-bounds.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Validate that YAML list-template regex.match and regex.submatch values outside
+# the fixed regexec pmatch[] range are rejected during config parsing.
+# Oracle: rsyslogd -N1 must fail for both YAML configs and log the same range
+# validation message as RainerScript, keeping both frontends in sync.
+. ${srcdir:=.}/diag.sh init
+require_yaml_support
+modpath="../runtime/.libs:../.libs"
+
+run_invalid_yaml() {
+    local name="$1"
+    local config="$2"
+    local expect="$3"
+    local cfg="${RSYSLOG_DYNNAME}.${name}.yaml"
+    local log="${RSYSLOG_DYNNAME}.${name}.log"
+
+    cat > "$cfg" <<YAML_EOF
+$config
+YAML_EOF
+
+    ../tools/rsyslogd -N1 -f "$cfg" -M"$modpath" > "$log" 2>&1
+    if [ $? -eq 0 ]; then
+        echo "FAIL: YAML config check unexpectedly succeeded for $name"
+        cat "$log"
+        error_exit 1
+    fi
+
+    content_check "$expect" "$log"
+}
+
+run_invalid_yaml "bad-submatch" \
+'version: 2
+templates:
+  - name: bad_submatch
+    type: list
+    elements:
+      - property:
+          name: msg
+          regex.expression: "(a)"
+          regex.submatch: "-1"' \
+"template bad_submatch error: regex.submatch=-1 is invalid (supported range 0..9)"
+
+run_invalid_yaml "bad-match" \
+'version: 2
+templates:
+  - name: bad_match
+    type: list
+    elements:
+      - property:
+          name: msg
+          regex.expression: "(a)"
+          regex.match: "10"' \
+"template bad_match error: regex.match=10 is invalid (supported range 0..9)"
+
+exit_test


### PR DESCRIPTION
## Summary
- reject out-of-range template `regex.match` and `regex.submatch` values during config parsing before runtime can index past `pmatch[]`
- reuse a shared `TPL_REGEX_MAX_MATCHES` limit in the runtime regex path
- free `fieldName` in `tplDeleteNew()` and add paired RainerScript/YAML regressions

## Why
This closes the first confirmed template security-hardening issue from the review and folds in the related reload cleanup fix while the same code is touched.

## Validation
- local Cubic review: no issues found
- Ubuntu 26.04 static analyzer container lane
- Ubuntu 26.04 change-gated `devtools/run-ci.sh`
- Ubuntu 26.04 mock `make distcheck TEST_RUN_TYPE=MOCK-OK -j10`
