### PR TITLE
imptcp: harden auto compression probe

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1452,21 +1452,19 @@ static int compressionAutoDetect(const uchar *const buf, const size_t len, sbool
 
     probe.next_in = (Bytef *)buf;
     probe.avail_in = len;
-    do {
-        probe.next_out = out;
-        probe.avail_out = sizeof(out);
-        zRet = inflate(&probe, Z_SYNC_FLUSH);
-        if (sizeof(out) - probe.avail_out != 0 || zRet == Z_STREAM_END) {
-            *pIsCompressed = 1;
-            inflateEnd(&probe);
-            return 1;
-        }
-        if (zRet != Z_OK && zRet != Z_BUF_ERROR) {
-            *pIsCompressed = 0;
-            inflateEnd(&probe);
-            return 1;
-        }
-    } while (probe.avail_out == 0);
+    probe.next_out = out;
+    probe.avail_out = sizeof(out);
+    zRet = inflate(&probe, Z_SYNC_FLUSH);
+    if (sizeof(out) - probe.avail_out != 0 || zRet == Z_STREAM_END) {
+        *pIsCompressed = 1;
+        inflateEnd(&probe);
+        return 1;
+    }
+    if (zRet != Z_OK && zRet != Z_BUF_ERROR) {
+        *pIsCompressed = 0;
+        inflateEnd(&probe);
+        return 1;
+    }
 
     inflateEnd(&probe);
     if (len >= COMPRESS_AUTO_MAX_SNIFF_BYTES) {

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -119,7 +119,8 @@ DEFobjCurrIf(glbl) DEFobjCurrIf(net) DEFobjCurrIf(prop) DEFobjCurrIf(datetime) D
  * or COMPRESS_NEVER so the hot path stays branch-free.
  */
 #define COMPRESS_STREAM_AUTO 3
-#define COMPRESS_AUTO_SNIFF_BYTES 2
+#define COMPRESS_AUTO_MIN_SNIFF_BYTES 2
+#define COMPRESS_AUTO_MAX_SNIFF_BYTES 4096
 
 /* config settings */
 typedef struct configSettings_s {
@@ -301,8 +302,8 @@ struct ptcpsess_s {
     z_stream zstrm; /* zip stream to use for tcp compression */
     uint8_t compressionMode;
     uint8_t compressionAutoDetectPending; /* AUTO mode: still sniffing? */
-    uint8_t compressionAutoDetectLen; /* bytes buffered for sniffing (0..COMPRESS_AUTO_SNIFF_BYTES) */
-    uchar compressionAutoDetectBuf[COMPRESS_AUTO_SNIFF_BYTES];
+    size_t compressionAutoDetectLen; /* bytes buffered while AUTO mode is still ambiguous */
+    uchar compressionAutoDetectBuf[COMPRESS_AUTO_MAX_SNIFF_BYTES];
     int iMsg; /* index of next char to store in msg */
     int iCurrLine; /* 2nd char of current line in regex framing mode */
     int bAtStrtOfFram; /* are we at the very beginning of a new frame? */
@@ -1405,24 +1406,31 @@ finalize_it:
     RETiRet;
 }
 
-/* AUTO mode: inspect the first COMPRESS_AUTO_SNIFF_BYTES bytes of the
- * session and decide whether the peer is sending a zlib stream
- * (RFC 1950) or plain syslog. The probe is restricted to byte 0 == 0x78
- * (CMF: deflate, default 32 KiB window - what rsyslog's omfwd always
- * emits via deflateInit()). A plain syslog frame never starts with 'x'
- * (must be ASCII digit for octet-counted framing or '<' for
- * non-transparent framing), so the test is conclusive for any
- * rsyslog-to-rsyslog deployment and for every standard 3rd-party syslog
- * sender we know of.
+/* AUTO mode: inspect the session start and decide whether the peer is
+ * sending a zlib stream (RFC 1950) or plain syslog. The two-byte zlib
+ * header is only a candidate marker: imptcp also accepts octet-stuffed
+ * plain frames that begin with arbitrary bytes. To avoid routing such
+ * plaintext to inflate(), keep buffering candidate streams until a
+ * throw-away inflate probe either produces syslog bytes (compressed) or
+ * reports invalid zlib data (plain).
  *
  * Returns:
  *   1  - decision taken; *pIsCompressed reflects the verdict
  *   0  - not enough bytes yet; caller must wait for more data
  */
 static int compressionAutoDetect(const uchar *const buf, const size_t len, sbool *const pIsCompressed) {
-    if (len < COMPRESS_AUTO_SNIFF_BYTES) {
+    unsigned cmf;
+    unsigned flg;
+    z_stream probe;
+    uchar out[4096];
+    int zRet;
+
+    if (len < COMPRESS_AUTO_MIN_SNIFF_BYTES) {
         return 0;
     }
+    cmf = buf[0];
+    flg = buf[1];
+
     /* RFC 1950 zlib stream header:
      *   - CMF byte: low nibble = 8 (deflate); we additionally require
      *     the full byte to be 0x78 (window bits 15) which is what every
@@ -1430,14 +1438,42 @@ static int compressionAutoDetect(const uchar *const buf, const size_t len, sbool
      *   - FLG byte: (CMF*256 + FLG) % 31 == 0; FDICT (bit 5) == 0 since
      *     omfwd does not use a preset dictionary.
      */
-    const unsigned cmf = buf[0];
-    const unsigned flg = buf[1];
-    if (cmf == 0x78 && ((cmf << 8) + flg) % 31u == 0u && (flg & 0x20u) == 0u) {
-        *pIsCompressed = 1;
-    } else {
+    if (cmf != 0x78 || ((cmf << 8) + flg) % 31u != 0u || (flg & 0x20u) != 0u) {
         *pIsCompressed = 0;
+        return 1;
     }
-    return 1;
+
+    memset(&probe, 0, sizeof(probe));
+    zRet = inflateInit(&probe);
+    if (zRet != Z_OK) {
+        *pIsCompressed = 0;
+        return 1;
+    }
+
+    probe.next_in = (Bytef *)buf;
+    probe.avail_in = len;
+    do {
+        probe.next_out = out;
+        probe.avail_out = sizeof(out);
+        zRet = inflate(&probe, Z_SYNC_FLUSH);
+        if (sizeof(out) - probe.avail_out != 0 || zRet == Z_STREAM_END) {
+            *pIsCompressed = 1;
+            inflateEnd(&probe);
+            return 1;
+        }
+        if (zRet != Z_OK && zRet != Z_BUF_ERROR) {
+            *pIsCompressed = 0;
+            inflateEnd(&probe);
+            return 1;
+        }
+    } while (probe.avail_out == 0);
+
+    inflateEnd(&probe);
+    if (len >= COMPRESS_AUTO_MAX_SNIFF_BYTES) {
+        *pIsCompressed = 1;
+        return 1;
+    }
+    return 0;
 }
 
 static rsRetVal DataRcvd(ptcpsess_t *pThis, char *pData, size_t iLen) {
@@ -1446,9 +1482,10 @@ static rsRetVal DataRcvd(ptcpsess_t *pThis, char *pData, size_t iLen) {
     ATOMIC_ADD_uint64(&pThis->pLstn->rcvdBytes, &pThis->pLstn->mut_rcvdBytes, iLen);
 
     if (pThis->compressionAutoDetectPending) {
-        /* buffer up to COMPRESS_AUTO_SNIFF_BYTES bytes spanning reads */
+        /* Buffer session-start bytes until a zlib-looking prefix is proven
+         * compressed or rejected as plaintext. */
         sbool bIsCompressed = 0;
-        while (pThis->compressionAutoDetectLen < COMPRESS_AUTO_SNIFF_BYTES && iLen > 0) {
+        while (pThis->compressionAutoDetectLen < COMPRESS_AUTO_MAX_SNIFF_BYTES && iLen > 0) {
             pThis->compressionAutoDetectBuf[pThis->compressionAutoDetectLen++] = (uchar)*pData;
             ++pData;
             --iLen;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1243,6 +1243,7 @@ TESTS_IMPTCP = \
 	imptcp-NUL.sh \
 	imptcp-NUL-rawmsg.sh \
 	imptcp-stream-compression-auto.sh \
+	imptcp-stream-compression-auto-zlib-prefix-plain.sh \
 	rscript_random.sh \
 	rscript_hash32.sh \
 	rscript_hash64.sh \

--- a/tests/imptcp-stream-compression-auto-zlib-prefix-plain.sh
+++ b/tests/imptcp-stream-compression-auto-zlib-prefix-plain.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Regression test for imptcp compression.mode="stream:auto" when a plain
+# octet-stuffed session starts with bytes that also look like a zlib header
+# (ASCII "x^"). The oracle is that the line reaches omfile and a second
+# line on the same connection is accepted; before the fix AUTO locked the
+# session into the compressed path and closed it on zlib Z_DATA_ERROR.
+#
+# Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+
+if ! command -v python3 >/dev/null 2>&1; then
+	echo "SKIP: python3 is unavailable"
+	skip_test
+fi
+
+generate_conf
+add_conf '
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp" port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+      compression.mode="stream:auto")
+
+*.* action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
+
+python3 - <<'PY'
+import os
+import socket
+
+port = int(os.environ["TCPFLOOD_PORT"])
+payload = b"x^plain accepted by stream:auto\nsecond write after probe\n"
+with socket.create_connection(("127.0.0.1", port), timeout=10) as sock:
+    sock.sendall(payload)
+PY
+
+wait_file_lines "$RSYSLOG_OUT_LOG" 2
+shutdown_when_empty
+wait_shutdown
+
+content_check "x^plain accepted by stream:auto" "$RSYSLOG_OUT_LOG"
+content_check "second write after probe" "$RSYSLOG_OUT_LOG"
+exit_test


### PR DESCRIPTION
### Motivation

- Fix misclassification in `compression.mode="stream:auto"` where two-byte zlib-looking prefixes could permanently route a plaintext session to the compressed path and cause the session to be closed on zlib errors.  
- Ensure an imptcp listener that must accept both compressed and plain peers can tolerate plaintext sessions whose first bytes happen to match a zlib header.

### Description

- Replace the single fixed sniff window with a bounded probe window by introducing `COMPRESS_AUTO_MIN_SNIFF_BYTES` (2) and `COMPRESS_AUTO_MAX_SNIFF_BYTES` (4096) and enlarge the per-session sniff buffer accordingly.  
- Rework `compressionAutoDetect()` so the two-byte zlib header is treated only as a candidate: when a candidate header is seen, a throw-away zlib `inflate()` probe is run on the buffered bytes (using a temporary `z_stream`) and the result is used to classify the session; the function returns `0` while the verdict is still ambiguous.  
- Update `DataRcvd()` to buffer ambiguous session-start bytes up to the bounded maximum, call the revised `compressionAutoDetect()`, lock `compressionMode` only after the probe returns a verdict, and re-inject the buffered bytes into either the compressed or uncompressed path as before.  
- Add a regression test `tests/imptcp-stream-compression-auto-zlib-prefix-plain.sh` (and register it in `tests/Makefile.am`) that verifies a plaintext octet-stuffed session beginning with ASCII `x^` is accepted and that subsequent writes on the same connection are processed.

### Testing

- Ran `./configure --enable-imptcp --enable-testbench --disable-impstats-push` and performed an incremental host build with `make -j${RSYSLOG_LOCAL_BUILD_JOBS:-10} check TESTS=""` which completed successfully.  
- Executed the relevant test scripts with `make check TESTS="imptcp-stream-compression-auto.sh imptcp-stream-compression-auto-zlib-prefix-plain.sh"` and both tests passed.  
- Ran `devtools/check-test-antipatterns.sh` on the new test and `shellcheck -S warning` against the new test script with no failures.  
- Ran the repository local validation helper `devtools/local-validation-plan.sh --base HEAD --run`; available local checks completed, but full container-style validation (Cubic / Docker / Podman lanes and the Ubuntu 26.04 analyzer container runs) was not available in this environment and should be exercised in CI or by a container-capable reviewer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1865d03d788332ba34c13c9cac1e57)