### PR TITLE
tests: retry omfwd one-target flake wrappers

### DIFF
--- a/tests/omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh
+++ b/tests/omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh
@@ -1,3 +1,36 @@
 #!/bin/bash
+# This wrapper retries the shared target-failure skeleton once more when TCP
+# timing races trigger the known omfwd load-balancer flake. The second attempt
+# keeps the same forced receiver-close scenario and bounded-loss oracle; it
+# only avoids failing the suite on one unlucky reconnect timing window.
+: "${srcdir:=.}"
+
 export OMFWD_IOBUF_SIZE=1000 # triggers edge cases
-. ${srcdir:-.}/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh
+skeleton="$srcdir/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh"
+max_attempts=2
+attempt=1
+result=1
+
+while [ "$attempt" -le "$max_attempts" ]; do
+    if [ "$attempt" -gt 1 ]; then
+        echo "Retrying omfwd 1-byte target-failure test (attempt $attempt of $max_attempts) to mitigate TCP buffer timing races."
+    fi
+
+    if [ "$attempt" -lt "$max_attempts" ]; then
+        TESTBENCH_SUPPRESS_FAIL_MARKER=YES "$skeleton"
+    else
+        "$skeleton"
+    fi
+    result=$?
+    if [ "$result" -eq 0 ]; then
+        if [ "$attempt" -gt 1 ]; then
+            echo "omfwd 1-byte target-failure test passed on retry."
+        fi
+        exit 0
+    fi
+
+    attempt=$((attempt + 1))
+done
+
+echo "omfwd 1-byte target-failure test failed after $max_attempts attempts."
+exit "$result"

--- a/tests/omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh
+++ b/tests/omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh
@@ -3,7 +3,7 @@
 # timing races trigger the known omfwd load-balancer flake. The second attempt
 # keeps the same forced receiver-close scenario and bounded-loss oracle; it
 # only avoids failing the suite on one unlucky reconnect timing window.
-: "${srcdir:=.}"
+export srcdir="${srcdir:=.}"
 
 export OMFWD_IOBUF_SIZE=1000 # triggers edge cases
 skeleton="$srcdir/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh"
@@ -17,9 +17,9 @@ while [ "$attempt" -le "$max_attempts" ]; do
     fi
 
     if [ "$attempt" -lt "$max_attempts" ]; then
-        TESTBENCH_SUPPRESS_FAIL_MARKER=YES "$skeleton"
+        TESTBENCH_SUPPRESS_FAIL_MARKER=YES bash "$skeleton"
     else
-        "$skeleton"
+        bash "$skeleton"
     fi
     result=$?
     if [ "$result" -eq 0 ]; then

--- a/tests/omfwd-lb-1target-retry-1_byte_buf.sh
+++ b/tests/omfwd-lb-1target-retry-1_byte_buf.sh
@@ -3,7 +3,7 @@
 # trigger the known omfwd load-balancer flake. The second attempt keeps the
 # same 1-byte-buffer scenario; it only avoids failing the suite on one unlucky
 # receiver-close/reconnect timing window.
-: "${srcdir:=.}"
+export srcdir="${srcdir:=.}"
 
 export OMFWD_IOBUF_SIZE=10 # triggers edge cases
 skeleton="$srcdir/omfwd-lb-1target-retry-test_skeleton.sh"
@@ -17,9 +17,9 @@ while [ "$attempt" -le "$max_attempts" ]; do
     fi
 
     if [ "$attempt" -lt "$max_attempts" ]; then
-        TESTBENCH_SUPPRESS_FAIL_MARKER=YES "$skeleton"
+        TESTBENCH_SUPPRESS_FAIL_MARKER=YES bash "$skeleton"
     else
-        "$skeleton"
+        bash "$skeleton"
     fi
     result=$?
     if [ "$result" -eq 0 ]; then

--- a/tests/omfwd-lb-1target-retry-1_byte_buf.sh
+++ b/tests/omfwd-lb-1target-retry-1_byte_buf.sh
@@ -1,3 +1,36 @@
 #!/bin/bash
+# This wrapper retries the shared skeleton once more when TCP timing races
+# trigger the known omfwd load-balancer flake. The second attempt keeps the
+# same 1-byte-buffer scenario; it only avoids failing the suite on one unlucky
+# receiver-close/reconnect timing window.
+: "${srcdir:=.}"
+
 export OMFWD_IOBUF_SIZE=10 # triggers edge cases
-. ${srcdir:-.}/omfwd-lb-1target-retry-test_skeleton.sh
+skeleton="$srcdir/omfwd-lb-1target-retry-test_skeleton.sh"
+max_attempts=2
+attempt=1
+result=1
+
+while [ "$attempt" -le "$max_attempts" ]; do
+    if [ "$attempt" -gt 1 ]; then
+        echo "Retrying omfwd 1-byte load-balancer test (attempt $attempt of $max_attempts) to mitigate TCP buffer timing races."
+    fi
+
+    if [ "$attempt" -lt "$max_attempts" ]; then
+        TESTBENCH_SUPPRESS_FAIL_MARKER=YES "$skeleton"
+    else
+        "$skeleton"
+    fi
+    result=$?
+    if [ "$result" -eq 0 ]; then
+        if [ "$attempt" -gt 1 ]; then
+            echo "omfwd 1-byte load-balancer test passed on retry."
+        fi
+        exit 0
+    fi
+
+    attempt=$((attempt + 1))
+done
+
+echo "omfwd 1-byte load-balancer test failed after $max_attempts attempts."
+exit "$result"


### PR DESCRIPTION
## Summary
- retry the two omfwd 1-byte-buffer one-target wrappers once, matching the existing full-buffer mitigation pattern
- keep the shared skeleton scenarios and final failure marker behavior unchanged
- document the retry as a timing-flake mitigation for https://github.com/rsyslog/rsyslog/issues/6308

## Validation
- shellcheck -S warning tests/omfwd-lb-1target-retry-1_byte_buf.sh tests/omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh tests/omfwd-lb-1target-retry-full_buf.sh tests/omfwd-lb-1target-retry-test_skeleton.sh tests/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh
- devtools/check-test-antipatterns.sh tests/omfwd-lb-1target-retry-1_byte_buf.sh tests/omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh
- git diff --check
- ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --disable-elasticsearch --disable-elasticsearch-tests --disable-kafka-tests --disable-imkafka --disable-omkafka --disable-mysql --disable-mysql-tests
- make -j$(nproc) check TESTS=""
- cd tests && taskset -c 0 ./omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh && ./omfwd-lb-1target-retry-1_byte_buf.sh && ./omfwd-lb-1target-retry-full_buf.sh
- make check TESTS="omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh omfwd-lb-1target-retry-1_byte_buf.sh omfwd-lb-1target-retry-full_buf.sh"
- make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)
- local Cubic: blocked by policy reviewer because it would send unpublished local diff to external service
- Docker image: rsyslog/rsyslog_dev_base_ubuntu:26.04, image id sha256:0261050851cd52e531d6b11d840563bd603d4af23b2a3728e09c040772c64276
- static analyzer container: PASS, scan-build no bugs found
- focused Ubuntu 26.04 container: PASS, 2/2 changed tests
- broad change-gated Ubuntu 26.04 container: PASS, 1289 total, 1262 pass, 27 skip, 0 fail

Refs https://github.com/rsyslog/rsyslog/issues/6308