### PR TITLE
imuxsock: handle embedded NUL datagrams safely

### DIFF
--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -1115,6 +1115,7 @@ static rsRetVal SubmitMsg(uchar *pRcv, int lenRcv, lstn_t *pLstn, struct ucred *
          */
         parser.SanitizeMsg(pMsg);
         lenMsg = pMsg->iLenRawMsg - offs; /* SanitizeMsg() may have changed the size */
+        parse = pMsg->pszRawMsg + offs;
         msgSetPRI(pMsg, pri);
         MsgSetAfterPRIOffs(pMsg, priValid ? offs + 1 : 0);
 
@@ -1644,7 +1645,7 @@ BEGINactivateCnfPrePrivDrop
         lstn_t *const listeners_new = realloc(listeners, (1 + nLstn) * sizeof(lstn_t));
         CHKmalloc(listeners_new);
         listeners = listeners_new;
-        for (i = 1; i < nLstn; ++i) {
+        for (i = 0; i <= nLstn; ++i) {
             listeners[i].sockName = NULL;
             listeners[i].fd = -1;
         }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -332,6 +332,7 @@ TESTS_DEFAULT = \
 	imuxsock_logger_err.sh \
 	imuxsock_logger_parserchain.sh \
 	imuxsock_annotate_large.sh \
+	imuxsock-NUL.sh \
 	imuxsock_traillf.sh \
 	imuxsock_ccmiddle.sh \
 	imuxsock_logger_syssock.sh \
@@ -531,6 +532,7 @@ TESTS_OSSL_WRONG_OPT = \
 	tcpflood_wrong_option_output.sh
 
 TESTS_DEFAULT_VALGRIND = \
+	imuxsock-NUL-vg.sh \
 	omusrmsg-noabort-vg.sh \
 	omfile_hup-vg.sh \
 	gzipwr_hup-vg.sh \

--- a/tests/imuxsock-NUL-vg.sh
+++ b/tests/imuxsock-NUL-vg.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Valgrind coverage for imuxsock-NUL.sh. The base test checks exact sanitized
+# output; this wrapper also detects the uninitialized-byte reads/writes reported
+# in issue #4941 without combining Valgrind with TSAN.
+export USE_VALGRIND="YES"
+if [ -z "${srcdir+x}" ] && [ ! -f ./diag.sh ] && [ -f "$(dirname "$0")/diag.sh" ]; then
+  cd "$(dirname "$0")" || exit 1
+fi
+. "${srcdir:=.}/imuxsock-NUL.sh"

--- a/tests/imuxsock-NUL.sh
+++ b/tests/imuxsock-NUL.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Regression test for issue #4941: an imuxsock datagram containing an embedded
+# NUL byte must be processed using the received datagram length, sanitized as
+# "#000", and written without leaking uninitialized bytes from the receive
+# buffer. The oracle is exact raw-message output after synchronized shutdown.
+. "${srcdir:=.}/diag.sh" init
+
+export NUMMESSAGES=1
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+
+generate_conf
+add_conf '
+module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")
+input(type="imuxsock" Socket="'$RSYSLOG_DYNNAME'-testbench_socket")
+
+template(name="outfmt" type="string" string="%rawmsg%\n")
+if $rawmsg startswith "<1>a" then action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+./syslog_caller -u "$RSYSLOG_DYNNAME-testbench_socket" -s 1 -m 1 -n
+shutdown_when_empty
+wait_shutdown
+content_check --regex '^<1>a#000b$'
+if [ "$(wc -l < "$RSYSLOG_OUT_LOG")" -ne 1 ]; then
+  echo "unexpected extra output generated, $RSYSLOG_OUT_LOG is:"
+  cat -n "$RSYSLOG_OUT_LOG"
+  error_exit 1
+fi
+exit_test

--- a/tests/syslog_caller.c
+++ b/tests/syslog_caller.c
@@ -9,6 +9,7 @@
  * -f message format to use
  * -u Unix datagram socket path
  * -L generated message length for Unix datagram mode
+ * -n send a short Unix datagram message with an embedded NUL byte
  * -w milliseconds to wait after sending messages
  *
  * Part of the testbench for rsyslog.
@@ -70,9 +71,22 @@ static void usage(void) {
  *
  * Returns the generated message length in bytes.
  */
-static size_t genRawMsg(char *buf, const size_t buflen, const int sev, const int iRun, const size_t msgLen) {
+static size_t genRawMsg(
+    char *buf, const size_t buflen, const int sev, const int iRun, const size_t msgLen, const int embeddedNul) {
     if (buflen == 0) return 0;
     buf[0] = '\0';
+
+    if (embeddedNul) {
+        const int n = snprintf(buf, buflen, "<%d>", sev % 8);
+        buf[buflen - 1] = '\0';
+        if (n < 0) return 0;
+        const size_t prefixLen = (size_t)n;
+        if (prefixLen >= buflen || buflen - prefixLen < 4) return prefixLen < buflen ? prefixLen : buflen - 1;
+        buf[prefixLen] = 'a';
+        buf[prefixLen + 1] = '\0';
+        buf[prefixLen + 2] = 'b';
+        return prefixLen + 3;
+    }
 
     if (msgLen > 0) {
         const int n = snprintf(buf, buflen, "<%d>", sev % 8);
@@ -99,7 +113,8 @@ static size_t genRawMsg(char *buf, const size_t buflen, const int sev, const int
  * iRun: message sequence number used by the generated text format.
  * msgLen: payload length for raw/fill mode; 0 uses formatted text mode.
  */
-static void sendRawUnix(const char *sockName, const int sev, const int iRun, const size_t msgLen) {
+static void sendRawUnix(
+    const char *sockName, const int sev, const int iRun, const size_t msgLen, const int embeddedNul) {
     int sock;
     struct sockaddr_un sa;
     char msgbuf[4096];
@@ -117,7 +132,7 @@ static void sendRawUnix(const char *sockName, const int sev, const int iRun, con
     sa.sun_family = AF_UNIX;
     strncpy(sa.sun_path, sockName, sizeof(sa.sun_path) - 1);
     sa.sun_path[sizeof(sa.sun_path) - 1] = '\0';
-    lenMsg = genRawMsg(msgbuf, sizeof(msgbuf), sev, iRun, msgLen);
+    lenMsg = genRawMsg(msgbuf, sizeof(msgbuf), sev, iRun, msgLen, embeddedNul);
     if (sendto(sock, msgbuf, lenMsg, 0, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
         perror("sendto");
         close(sock);
@@ -153,6 +168,7 @@ int main(int argc, char *argv[]) {
     const char *unixSockName = NULL;
     size_t msgLen = 0;
     int waitMs = 0;
+    int embeddedNul = 0;
 #ifdef HAVE_LIBLOGGING_STDLOG
     stdlog_channel_t logchan = NULL;
     const char *chandesc = "syslog:";
@@ -161,9 +177,9 @@ int main(int argc, char *argv[]) {
 
 #ifdef HAVE_LIBLOGGING_STDLOG
     stdlog_init(STDLOG_USE_DFLT_OPTS);
-    while ((opt = getopt(argc, argv, "m:s:C:f:u:L:w:")) != -1) {
+    while ((opt = getopt(argc, argv, "m:s:C:f:u:L:nw:")) != -1) {
 #else
-    while ((opt = getopt(argc, argv, "m:s:u:L:w:")) != -1) {
+    while ((opt = getopt(argc, argv, "m:s:u:L:nw:")) != -1) {
 #endif
         switch (opt) {
             case 's':
@@ -190,6 +206,9 @@ int main(int argc, char *argv[]) {
             case 'w':
                 waitMs = atoi(optarg);
                 break;
+            case 'n':
+                embeddedNul = 1;
+                break;
 #ifdef HAVE_LIBLOGGING_STDLOG
             case 'C':
                 chandesc = optarg;
@@ -211,7 +230,7 @@ int main(int argc, char *argv[]) {
 
     if (unixSockName != NULL) {
         for (i = 0; i < msgs; ++i) {
-            sendRawUnix(unixSockName, sev, i, msgLen);
+            sendRawUnix(unixSockName, sev, i, msgLen, embeddedNul);
             if (bRollingSev) sev++;
         }
         if (waitMs > 0) usleep((unsigned int)waitMs * 1000U);


### PR DESCRIPTION
## Summary
- fix imuxsock tag parsing after SanitizeMsg() expands embedded NUL bytes in raw messages
- initialize the reserved listener slot so cleanup does not read an uninitialized fd when sysSock.use="off"
- add normal and Valgrind regressions for an embedded-NUL Unix datagram

Closes https://github.com/rsyslog/rsyslog/issues/4941

## Validation
- local Cubic: blocked by local policy review because it would send unpublished diff to an external service
- shellcheck -S warning tests/imuxsock-NUL.sh tests/imuxsock-NUL-vg.sh
- devtools/check-test-antipatterns.sh tests/imuxsock-NUL.sh tests/imuxsock-NUL-vg.sh
- git diff --check
- bash devtools/format-code.sh --git-changed
- make -j${RSYSLOG_LOCAL_BUILD_JOBS:-10} check TESTS=""
- make check TESTS="imuxsock-NUL.sh imuxsock-NUL-vg.sh"
- make distcheck TEST_RUN_TYPE=MOCK-OK -j${RSYSLOG_LOCAL_BUILD_JOBS:-10}
- Docker image: rsyslog/rsyslog_dev_base_ubuntu:26.04, sha256:0261050851cd52e531d6b11d840563bd603d4af23b2a3728e09c040772c64276
- clang static analyzer container: RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 SCAN_BUILD=scan-build SCAN_BUILD_CC=clang SCAN_BUILD_REPORT_DIR=scan-build-report CI_MAKE_OPT=-j20 ... devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh, result: No bugs found
- Ubuntu 26.04 change-gated container: /usr/bin/time -p env devtools/devcontainer.sh --rm devtools/run-ci.sh, result: 1291 total, 1264 pass, 27 skip, 0 fail, real 586.41
- Ubuntu 26.04 ASAN/UBSAN container: clang-21 with ASAN/UBSAN, Valgrind disabled per sanitizer rules, result: 1096 total, 1069 pass, 27 skip, 0 fail, real 464.39

## Lane notes
- Used Docker Hub dev image as allowed for normal validation.
- TSAN was not run: this change is buffer/length and listener-slot initialization, not queue/thread/lifecycle synchronization.
- ASAN/UBSAN was run because this is crash/uninitialized-byte work.
