### PR TITLE
template: guard NULL property rendering

### DIFF
--- a/runtime/template.c
+++ b/runtime/template.c
@@ -918,6 +918,12 @@ rsRetVal tplToString(struct template *__restrict__ const pTpl,
             bMustBeFreed = 0;
         } else if (pTpe->eEntryType == FIELD) {
             pVal = (uchar *)MsgGetProp(pMsg, pTpe, &pTpe->data.field.msgProp, &iLenVal, &bMustBeFreed, ttNow);
+            if (pVal == NULL) {
+                DBGPRINTF("template property evaluation returned NULL, using empty value\n");
+                pVal = UCHAR_CONSTANT("");
+                iLenVal = 0;
+                bMustBeFreed = 0;
+            }
             /* we now need to check if we should use SQL option. In this case,
              * we must go over the generated string and escape '\'' characters.
              * rgerhards, 2005-09-22: the option values below look somewhat misplaced,

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -182,6 +182,7 @@ TESTS_DEFAULT = \
         template-pure-json.sh \
         template-jsonf-nested.sh \
 	template-jsonf-trailing-backslash.sh \
+	template-missing-jsonvars-queue.sh \
 	template-pos-from-to.sh \
 	template-pos-from-to-lowercase.sh \
 	template-pos-from-to-oversize.sh \

--- a/tests/template-missing-jsonvars-queue.sh
+++ b/tests/template-missing-jsonvars-queue.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# added 2026-05-28 by AI agent; released under ASL 2.0
+# Reproduces the list-template shape from issue #3311: an action worker renders
+# several missing $! JSON fields after queueing. The oracle is exact output with
+# empty field values, proving the renderer neither crashes nor invents data.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+
+template(name="MTFW_CDR" type="list") {
+	constant(value="{\"ReportGeneratedTime\":\"")
+	property(name="$!field1")
+	constant(value=" +05:30\",\"Delivered Time\":\"")
+	property(name="$!field3")
+	constant(value=" +05:30\",\"Record Type\":\"")
+	property(name="$!field5")
+	constant(value="\",\"Delivery Status\":\"")
+	property(name="$!field17")
+	constant(value="\",\"Failure Reason\":\"")
+	property(name="$!field18")
+	constant(value="\",\"Failure Reason Type\":\"")
+	property(name="$!field19")
+	constant(value="\",\"Service Centre\":\"")
+	property(name="$!field53")
+	constant(value="\",\"Vendor\":\"TELEDNA\",\"Location\":\"NOIDA\"}\n")
+}
+
+local4.* action(type="omfile"
+	file="'$RSYSLOG_OUT_LOG'"
+	template="MTFW_CDR"
+	queue.type="LinkedList"
+	queue.filename="stats_ruleset"
+	queue.spoolDirectory="'${RSYSLOG_DYNNAME}'.spool"
+	queue.size="100"
+	queue.highWatermark="10"
+	queue.lowWatermark="5"
+	queue.saveOnShutdown="on"
+	queue.checkpointInterval="1")
+'
+
+startup
+injectmsg_literal '<167>1 2003-03-01T01:00:00.000Z hostname1 sender - tag [tcpflood@32473 MSGNUM="0"] data'
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='{"ReportGeneratedTime":" +05:30","Delivered Time":" +05:30","Record Type":"","Delivery Status":"","Failure Reason":"","Failure Reason Type":"","Service Centre":"","Vendor":"TELEDNA","Location":"NOIDA"}'
+cmp_exact
+exit_test


### PR DESCRIPTION
## Summary
- harden list-template rendering so an unexpected NULL property result is converted to an empty field before buffer copying
- add a regression test for issue #3311's queued list-template shape with missing `$!field*` JSON values

Fixes #3311.

## Validation
- PASS: `shellcheck -S warning tests/template-missing-jsonvars-queue.sh`
- PASS: `./tests/template-missing-jsonvars-queue.sh`
- PASS: `make check TESTS=template-missing-jsonvars-queue.sh`
- PASS: Ubuntu 26.04 static analyzer container, `rsyslog/rsyslog_dev_base_ubuntu:26.04`, image `sha256:0261050851cd52e531d6b11d840563bd603d4af23b2a3728e09c040772c64276`
- BLOCKED: local Cubic review was rejected by local policy because it would send the unpublished diff to an external service
- PARTIAL: Ubuntu 26.04 change-gated `run-ci.sh` container ran twice; both runs passed the new template test but failed the unrelated `sndrcv_tls_mbedtls_gnutlspriorityString_no_suite_in_common.sh` TLS priority-string test. A direct rerun of that failed test in the same container state passed, so this appears unrelated to the template change.

Relaxations/skips: none intentionally relaxed for the broad run; Kafka/Elasticsearch/MySQL and other service families were left enabled by the relevance helper because `tests/Makefile.am` changed.
