### PR TITLE
tests: cover imrelp TLS random disconnects

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1652,6 +1652,7 @@ TESTS_RELP_GNUTLS = \
          relp_tls_certificate_not_found.sh \
 	 omrelp_wrong_authmode.sh \
 	 imrelp-tls.sh \
+	 imrelp-tls-randconn-drop.sh \
 	 imrelp-tls-chainedcert.sh \
 	 imrelp-tls-mixed-chainedcert.sh \
 	 imrelp-tls-mixed-chainedcert2.sh

--- a/tests/imrelp-tls-randconn-drop.sh
+++ b/tests/imrelp-tls-randconn-drop.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# added 2026-05-28 by Codex, released under ASL 2.0
+#
+# Regression coverage for GitHub issue #4724. A RELP/TLS client using
+# tcpflood -D randomly closes connections while sending, which used to make
+# the imrelp receiver exit silently under flood load. The oracle is that
+# rsyslogd survives the broken client sessions and can still shut down through
+# the normal testbench path. Message sequence checks are intentionally not used:
+# random client-side disconnects can legitimately lose in-flight messages.
+. ${srcdir:=.}/diag.sh init
+require_plugin imrelp
+export NUMMESSAGES=50
+generate_conf
+add_conf '
+global(maxMessageSize="256k" net.enableDNS="off")
+main_queue(queue.type="Direct")
+
+module(load="../plugins/imrelp/.libs/imrelp")
+input(type="imrelp"
+      name="imrelp-tls-randconn-drop"
+      address="127.0.0.1"
+      port="0"
+      tls="on"
+      tls.cacert="'$srcdir'/tls-certs/ca.pem"
+      tls.mycert="'$srcdir'/tls-certs/cert.pem"
+      tls.myprivkey="'$srcdir'/tls-certs/key.pem"
+      tls.authmode="certvalid"
+      tls.permittedpeer="rsyslog"
+      maxDataSize="256k"
+      ruleset="discard_relp")
+
+ruleset(name="discard_relp") {
+	stop
+}
+'
+startup
+assign_single_tcp_listener_port TCPFLOOD_PORT
+tcpflood -D -l0.90 -Trelp-tls -acertvalid -p"$TCPFLOOD_PORT" -m"$NUMMESSAGES" \
+	-x "$srcdir/tls-certs/ca.pem" \
+	-z "$srcdir/tls-certs/key.pem" \
+	-Z "$srcdir/tls-certs/cert.pem" \
+	-Ersyslog \
+	-M "\"<134>1 2026-05-28T00:00:00Z tcpflood tcpflood - - Date is now 2026-05-28T00:00:00Z\"" \
+	>"$RSYSLOG_DYNNAME.tcpflood" 2>&1
+tcpflood_rc=$?
+cat -n "$RSYSLOG_DYNNAME.tcpflood"
+if [ "$tcpflood_rc" -ne 0 ]; then
+	printf 'tcpflood exited with rc=%s after the intentional random disconnects\n' "$tcpflood_rc"
+fi
+cat "$RSYSLOG_DYNNAME.tcpflood" "$RSYSLOG_DYNNAME.started" >"$RSYSLOG_DYNNAME.disconnect.log"
+content_check "session broken" "$RSYSLOG_DYNNAME.disconnect.log"
+
+check_rsyslog_active ""
+
+shutdown_when_empty
+wait_shutdown
+exit_test


### PR DESCRIPTION
## Summary
- add RELP/TLS regression coverage for issue #4724 using tcpflood -D random disconnects
- assert the imrelp receiver survives the broken client sessions and shuts down normally

Refs #4724.

## Validation
- ./tests/imrelp-tls-randconn-drop.sh
- make check TESTS='imrelp-tls-randconn-drop.sh'
- make check TESTS='imrelp-tls.sh sndrcv_relp_tls.sh imrelp-manyconn.sh'
- shellcheck -S warning tests/imrelp-tls-randconn-drop.sh
- git diff --check
- devtools/check-test-antipatterns.sh tests/imrelp-tls-randconn-drop.sh
- Ubuntu 26.04 static analyzer container: PASS, scan-build found no bugs
- Ubuntu 26.04 full run-ci container: PASS, 1290 total / 1263 pass / 27 skip / 0 fail / 0 error
- local Cubic: blocked by local approval policy for unpublished diff external review

Container image: rsyslog/rsyslog_dev_base_ubuntu:26.04 (sha256:0261050851cd52e531d6b11d840563bd603d4af23b2a3728e09c040772c64276).