### PR TITLE
omfwd: avoid tcpclt leak on rebind

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -663,6 +663,7 @@ TESTS_IMTCP = \
 	imtcp-netns.sh \
 	imtcp-NUL.sh \
 	imtcp-NUL-rawmsg.sh \
+	omfwd-rebind-tcp.sh \
 	imtcp_incomplete_frame_at_end.sh \
 	imtcp-multiport.sh \
 	imtcp-bigmessage-octetcounting.sh \
@@ -683,7 +684,8 @@ TESTS_IMTCP_YAML = \
 	imtcp-persource-ratelimit.sh
 
 TESTS_IMTCP_VALGRIND = \
-	imtcp-octet-framing-too-long-vg.sh
+	imtcp-octet-framing-too-long-vg.sh \
+	omfwd-rebind-tcp-vg.sh
 
 TESTS_RATELIMIT = \
 	ratelimit_exclusivity.sh \

--- a/tests/omfwd-rebind-tcp-vg.sh
+++ b/tests/omfwd-rebind-tcp-vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Valgrind wrapper for omfwd-rebind-tcp.sh.  Keep the scenario in the base
+# test so the normal and Valgrind registrations exercise the same logic.
+export USE_VALGRIND="YES"
+. ${srcdir:=.}/omfwd-rebind-tcp.sh

--- a/tests/omfwd-rebind-tcp.sh
+++ b/tests/omfwd-rebind-tcp.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Verify that TCP rebind preserves forwarding while repeatedly tearing down
+# and reconnecting the target transport.  The tiny rebind interval forces the
+# rebind path for every message; the receiver sequence check proves all data
+# still arrives.  When sourced by the -vg wrapper, Valgrind is the oracle for
+# leaked rebind-side allocations.  This guards
+# https://github.com/rsyslog/rsyslog/issues/6663.
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=40
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+if $msg contains "msgnum:" then {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+startup
+
+export RCVR_PORT=$TCPFLOOD_PORT
+generate_conf 2
+add_conf '
+action(type="omfwd" target="127.0.0.1" protocol="tcp" port="'$RCVR_PORT'"
+       rebindinterval="1")
+' 2
+
+startup 2
+injectmsg2
+shutdown_when_empty 2
+wait_shutdown 2
+
+shutdown_when_empty
+wait_shutdown
+
+seq_check
+exit_test

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -1703,15 +1703,16 @@ BEGINcommitTransaction
     char namebuf[264]; /* 256 for FQDN, 5 for port and 3 for transport => 264 */
     CODESTARTcommitTransaction;
     /* if needed, rebind first. This ensure we can deliver to the rebound addresses.
-     * Note that rebind requires reconnect (TCP) or socket recreation (UDP) to the
-     * new targets. This is done by the poolTryResume(), which needs to be made in any case.
+     * Note that rebind requires reconnect (TCP) or socket recreation (UDP) to
+     * the new targets. DestructInstanceData() drops the transport state and
+     * poolTryResume() creates the next connection. The per-worker tcpclt
+     * objects stay valid across rebinds and must not be reallocated here.
      */
     if (pWrkrData->pData->iRebindInterval && (pWrkrData->nXmit++ >= pWrkrData->pData->iRebindInterval)) {
         dbgprintf("REBIND (sent %d, interval %d) - omfwd dropping target connection (as configured)\n",
                   pWrkrData->nXmit, pWrkrData->pData->iRebindInterval);
         pWrkrData->nXmit = 0; /* else we have an addtl wrap at 2^31-1 */
         DestructInstanceData(pWrkrData, 1);
-        initTCP(pWrkrData);
         LogMsg(0, RS_RET_PARAM_ERROR, LOG_WARNING, "omfwd: dropped connections due to configured rebind interval");
     }
 


### PR DESCRIPTION
## Summary
- keep per-worker tcpclt objects across configured omfwd TCP rebinds instead of re-running initTCP()
- add a Valgrind regression that forces repeated TCP rebind teardown/reconnect cycles

Closes https://github.com/rsyslog/rsyslog/issues/6663

## Validation
- ./autogen.sh
- ./configure --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --enable-imtcp --disable-elasticsearch --disable-elasticsearch-tests --disable-imkafka --disable-omkafka --disable-kafka-tests --disable-mysql --disable-mysql-tests
- make -j${RSYSLOG_LOCAL_BUILD_JOBS:-10} check TESTS=""
- ./tests/omfwd-rebind-tcp-vg.sh
- shellcheck -S warning tests/omfwd-rebind-tcp-vg.sh
- devtools/check-test-antipatterns.sh tests/omfwd-rebind-tcp-vg.sh
- git diff --check
- make check TESTS='omfwd-rebind-tcp-vg.sh'
- bash devtools/format-code.sh --git-changed
- Ubuntu 26.04 static analyzer container: PASS, scan-build: No bugs found
- Ubuntu 26.04 change-gated devcontainer run-ci: PASS, 1290 total / 1263 pass / 27 skip / 0 fail

## Local AI Review
- Local Cubic was attempted but blocked by the approval reviewer because it would send the unpublished diff to an external service.

## Container Details
- Image: rsyslog/rsyslog_dev_base_ubuntu:26.04
- Image ID: sha256:0261050851cd52e531d6b11d840563bd603d4af23b2a3728e09c040772c64276
- Relaxations: default PR service relevance was applied; service-backed lanes stayed enabled where the changed test registration made relevance conservative.