### PR TITLE
ci: enforce compile warning configure option

### DIFF
--- a/.github/scripts/debian_package_build.sh
+++ b/.github/scripts/debian_package_build.sh
@@ -51,6 +51,7 @@ install_prereqs() {
   apt-get update
   apt-get install -y --no-install-recommends \
     autoconf \
+    autoconf-archive \
     automake \
     autotools-dev \
     bison \
@@ -122,14 +123,13 @@ find_dist_tarball() {
 
   cd "$workspace"
 
-  local dist_tarball
-  dist_tarball="$(ls -1 rsyslog-*.tar.gz | head -1)"
-  if [ -z "$dist_tarball" ]; then
+  local dist_tarballs=(rsyslog-*.tar.gz)
+  if [ ${#dist_tarballs[@]} -eq 0 ] || [ ! -e "${dist_tarballs[0]}" ]; then
     echo "ERROR: make dist did not produce rsyslog-*.tar.gz" >&2
     return 1
   fi
 
-  printf '%s\n' "$dist_tarball"
+  printf '%s\n' "${dist_tarballs[0]}"
 }
 
 unpack_source_tree() {

--- a/.github/workflows/daily_focused_tests.yml
+++ b/.github/workflows/daily_focused_tests.yml
@@ -61,6 +61,7 @@ jobs:
           case "${{ matrix.lane }}" in
           'base')
             sudo apt-get install -y --no-install-recommends \
+              autoconf-archive \
               clang-tools \
               cmake \
               cmake-curses-gui \
@@ -129,6 +130,7 @@ jobs:
             ;;
           'journal')
             sudo apt-get install -y \
+              autoconf-archive \
               libestr-dev \
               libgcrypt20-dev \
               libglib2.0-dev \
@@ -219,7 +221,7 @@ jobs:
           'base')
             autoreconf -fvi
             ./configure \
-              --enable-compile-warning=error \
+              --enable-compile-warnings=error \
               --enable-clickhouse \
               --enable-clickhouse-tests=no \
               --disable-elasticsearch \
@@ -326,7 +328,7 @@ jobs:
             autoreconf -fvi
             ./configure \
               --cache-file=config.cache \
-              --enable-compile-warning=error \
+              --enable-compile-warnings=error \
               --enable-testbench \
               --enable-omstdout \
               --enable-imdiag \

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            autoconf-archive \
             libestr-dev \
             libglib2.0-dev \
             libgnutls28-dev \

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            autoconf-archive \
             libestr-dev \
             libglib2.0-dev \
             libgnutls28-dev \

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -839,7 +839,7 @@ jobs:
           dnf install -y epel-release
           dnf install -y mock dnf-utils
           echo "== Install build tools for autoreconf/configure/make dist =="
-          dnf install -y autoconf automake libtool gcc make flex bison
+          dnf install -y autoconf autoconf-archive automake libtool gcc make flex bison
           echo "== Add Adiscon repo and install configure deps (libestr, libfastjson for make dist) =="
           curl -fsSL -o /etc/pki/rpm-gpg/RPM-GPG-KEY-Adiscon https://download.adiscon.com/rpms/RPM-GPG-KEY-Adiscon
           {
@@ -933,6 +933,7 @@ jobs:
             libfastjson \
             docutils \
             autoconf \
+            autoconf-archive \
             automake \
             libtool
 
@@ -945,6 +946,7 @@ jobs:
             flex \
             bison \
             autoconf \
+            autoconf-archive \
             automake \
             libtool \
             pkg-config \
@@ -1397,6 +1399,126 @@ jobs:
           export VERBOSE=1
           devtools/devcontainer.sh --rm devtools/run-ci.sh
 
+  dev_container_definition_CI:
+    needs: [changes]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    name: dev container definition CI
+    steps:
+      - name: git checkout project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: fetch upstream (for changed-files diff)
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git remote add upstream "https://github.com/$GITHUB_REPOSITORY.git"
+          git fetch upstream "$BASE_REF"
+
+      - name: Check for dev container definition changes
+        id: dev_container_changes
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          sha: ${{ github.event.pull_request.head.sha }}
+          files: |
+            devtools/ci/Dockerfile*
+            packaging/docker/dev_env/**/Dockerfile*
+            packaging/docker/dev_env/**/setup-system.sh
+            packaging/docker/dev_env/**/build.sh
+            packaging/docker/dev_env/common/**
+            .github/workflows/run_checks.yml
+
+      - name: Build changed dev containers
+        if: steps.dev_container_changes.outputs.any_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.dev_container_changes.outputs.all_changed_files }}
+        run: |
+          set -euo pipefail
+
+          tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"; rm -rf packaging/docker/dev_env/alpine/common packaging/docker/dev_env/ubuntu/devel/common' EXIT
+
+          add_build() {
+            printf '%s\t%s\n' "$1" "$2" >> "$tmpdir/builds.tsv"
+          }
+
+          add_dir_dockerfiles() {
+            dir="$1"
+            for dockerfile in "$dir"/Dockerfile "$dir"/Dockerfile.arm; do
+              if [ -f "$dockerfile" ]; then
+                add_build "$dir" "$dockerfile"
+              fi
+            done
+          }
+
+          ensure_common_context() {
+            dir="$1"
+            case "$dir" in
+              packaging/docker/dev_env/alpine|packaging/docker/dev_env/ubuntu/devel)
+                rm -rf "$dir/common"
+                cp -r packaging/docker/dev_env/common "$dir/common"
+                ;;
+            esac
+          }
+
+          for changed in $CHANGED_FILES; do
+            case "$changed" in
+              devtools/ci/Dockerfile*)
+                add_build . "$changed"
+                ;;
+              packaging/docker/dev_env/common/*)
+                add_dir_dockerfiles packaging/docker/dev_env/alpine
+                add_dir_dockerfiles packaging/docker/dev_env/ubuntu/devel
+                ;;
+              packaging/docker/dev_env/*)
+                filename="$(basename "$changed")"
+                changed_dir="$(dirname "$changed")"
+                case "$filename" in
+                  Dockerfile|Dockerfile.arm)
+                    add_build "$changed_dir" "$changed"
+                    ;;
+                  setup-system.sh|build.sh)
+                    add_dir_dockerfiles "$changed_dir"
+                    ;;
+                  *)
+                    echo "Ignoring unmatched dev-container-related path: $changed"
+                    ;;
+                esac
+                ;;
+              .github/workflows/run_checks.yml)
+                echo "run_checks.yml changed; this job definition is validated by actionlint/zizmor and normal CI."
+                ;;
+              *)
+                echo "Ignoring unmatched dev-container-related path: $changed"
+                ;;
+            esac
+          done
+
+          if [ ! -s "$tmpdir/builds.tsv" ]; then
+            echo "No concrete dev-container Dockerfile build is required."
+            exit 0
+          fi
+
+          sort -u "$tmpdir/builds.tsv" > "$tmpdir/builds.unique.tsv"
+          while IFS="$(printf '\t')" read -r context dockerfile; do
+            ensure_common_context "$context"
+            tag_suffix="$(printf '%s' "$dockerfile" | tr '/:._' '----' | tr -cd '[:alnum:]-')"
+            tag="rsyslog-devcontainer-pr:${tag_suffix}"
+            echo "::group::docker build $dockerfile"
+            docker build --pull -f "$dockerfile" -t "$tag" "$context"
+            echo "::endgroup::"
+          done < "$tmpdir/builds.unique.tsv"
+
+      - name: Skip dev container build, no relevant changes
+        if: steps.dev_container_changes.outputs.any_changed != 'true'
+        run: echo "No dev container definition changes detected; required dev container build gate passes without building."
+
   arm_CI:
     needs: [compile, changes]
     if: ${{ needs.compile.result == 'success' && needs.changes.outputs.code == 'true' }}
@@ -1579,7 +1701,7 @@ jobs:
               export DEBIAN_FRONTEND=noninteractive
               apt-get update
               apt-get install -y --no-install-recommends \
-                build-essential autoconf automake libtool libtool-bin \
+                build-essential autoconf autoconf-archive automake libtool libtool-bin \
                 pkg-config flex bison python3-docutils curl openssl \
                 libestr-dev libfastjson-dev libgnutls28-dev \
                 zlib1g-dev libgcrypt20-dev librelp-dev uuid-dev \

--- a/.github/workflows/run_macos_weekly.yml
+++ b/.github/workflows/run_macos_weekly.yml
@@ -48,6 +48,7 @@ jobs:
             libfastjson \
             docutils \
             autoconf \
+            autoconf-archive \
             automake \
             libtool
 

--- a/configure.ac
+++ b/configure.ac
@@ -56,23 +56,14 @@ AC_CANONICAL_HOST
 
 if test "$GCC" = "yes"
 then
-	m4_ifdef([AX_IS_RELEASE], [
-		AX_IS_RELEASE([git-directory])
-		m4_ifdef([AX_COMPILER_FLAGS], [
-			AX_COMPILER_FLAGS(,,,,[-Wunused-parameter -Wmissing-field-initializers])
-			# unfortunately, AX_COMPILER_FLAGS does not provide a way to override
-			# the default -Wno-error=warning" flags. So we do this via sed below.
-			# Note: we *really* want to have this error out during CI testing!
-			# rgerhards, 2018-05-09
-			WARN_CFLAGS="$(echo "$WARN_CFLAGS" | sed s/-Wno-error=/-W/g)"
-		], [
-			CFLAGS="$CFLAGS -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -g"
-			AC_MSG_WARN([missing AX_COMPILER_FLAGS macro, not using it])
-		])
-	], [
-		CFLAGS="$CFLAGS -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -g"
-		AC_MSG_WARN([missing AX_IS_RELEASE macro, not using AX_COMPILER_FLAGS macro because of this])
-	])
+	m4_pattern_forbid([^AX_])
+	AX_IS_RELEASE([git-directory])
+	AX_COMPILER_FLAGS(,,,,[-Wunused-parameter -Wmissing-field-initializers])
+	# unfortunately, AX_COMPILER_FLAGS does not provide a way to override
+	# the default -Wno-error=warning" flags. So we do this via sed below.
+	# Note: we *really* want to have this error out during CI testing!
+	# rgerhards, 2018-05-09
+	WARN_CFLAGS="$(echo "$WARN_CFLAGS" | sed s/-Wno-error=/-W/g)"
 else
 	AC_MSG_WARN([compiler is not GCC or close compatible, not using ax_compiler_flags because of this (CC=$CC)])
 fi

--- a/devtools/ci/Dockerfile.arm
+++ b/devtools/ci/Dockerfile.arm
@@ -2,7 +2,7 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       build-essential autoconf automake libtool libtool-bin \
+       build-essential autoconf autoconf-archive automake libtool libtool-bin \
        pkg-config flex bison python3-docutils \
        libgnutls28-dev libestr-dev libfastjson-dev zlib1g-dev \
        libgcrypt20-dev librelp-dev uuid-dev libyaml-dev \

--- a/packaging/docker/dev_env/fedora/base/42/Dockerfile
+++ b/packaging/docker/dev_env/fedora/base/42/Dockerfile
@@ -299,7 +299,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-usertools \
 	--enable-valgrind \
 	\
-	--enable-compile-warning=error \
+	--enable-compile-warnings=error \
 	--enable-testbench
 
 # build errors at the moment: --enable-kmsg 

--- a/packaging/docker/dev_env/fedora/base/43/Dockerfile
+++ b/packaging/docker/dev_env/fedora/base/43/Dockerfile
@@ -302,7 +302,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-usertools \
 	--enable-valgrind \
 	\
-	--enable-compile-warning=error \
+	--enable-compile-warnings=error \
 	--enable-testbench
 
 # build errors at the moment: --enable-kmsg 

--- a/packaging/docker/dev_env/openeuler/base/24.03-lts/Dockerfile
+++ b/packaging/docker/dev_env/openeuler/base/24.03-lts/Dockerfile
@@ -113,7 +113,7 @@ RUN     pip3 install --no-cache-dir pysnmp
 RUN     mkdir /local_dep_cache
 
 ENV     RSYSLOG_CONFIGURE_OPTIONS=" \
-        --enable-compile-warning=error \
+        --enable-compile-warnings=error \
         --enable-elasticsearch \
         --disable-elasticsearch-tests \
         --disable-ffaup \

--- a/packaging/docker/dev_env/ubuntu/base/18.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/18.04/Dockerfile
@@ -306,7 +306,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-usertools \
 	--enable-valgrind \
 	\
-	--enable-compile-warning=error \
+	--enable-compile-warnings=error \
 	--enable-testbench
 
 # module needs fixes: --enable-kmsg

--- a/packaging/docker/dev_env/ubuntu/base/20.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/20.04/Dockerfile
@@ -297,7 +297,7 @@ ENV	SCAN_BUILD=scan-build-9 \
 RUN	chmod o+rx /var/run/mysqld && ls -ld /var/run/mysqld
 
 ENV RSYSLOG_CONFIGURE_OPTIONS \
-	--enable-compile-warning=error \
+	--enable-compile-warnings=error \
 	--enable-clickhouse \
 	--enable-clickhouse-tests=no \
 	--enable-elasticsearch \

--- a/packaging/docker/dev_env/ubuntu/base/22.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/22.04/Dockerfile
@@ -272,7 +272,7 @@ ENV	SCAN_BUILD=scan-build-9 \
 RUN	chmod o+rx /var/run/mysqld && ls -ld /var/run/mysqld
 
 ENV RSYSLOG_CONFIGURE_OPTIONS=" \
-	--enable-compile-warning=error \
+	--enable-compile-warnings=error \
 	--enable-clickhouse \
 	--enable-clickhouse-tests=no \
 	--enable-elasticsearch \

--- a/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
@@ -317,7 +317,7 @@ ENV	SCAN_BUILD=scan-build-9 \
 RUN	chmod o+rx /var/run/mysqld && ls -ld /var/run/mysqld
 
 ENV RSYSLOG_CONFIGURE_OPTIONS=" \
-	--enable-compile-warning=error \
+	--enable-compile-warnings=error \
 	--enable-clickhouse \
 	--enable-clickhouse-tests=no \
 	--enable-elasticsearch \

--- a/packaging/docker/dev_env/ubuntu/base/26.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/26.04/Dockerfile
@@ -318,7 +318,7 @@ ENV	SCAN_BUILD=scan-build \
 RUN	chmod o+rx /var/run/mysqld && ls -ld /var/run/mysqld
 
 ENV RSYSLOG_CONFIGURE_OPTIONS=" \
-	--enable-compile-warning=error \
+	--enable-compile-warnings=error \
 	--enable-clickhouse \
 	--enable-clickhouse-tests=no \
 	--enable-elasticsearch \

--- a/packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec
+++ b/packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec
@@ -32,6 +32,7 @@ Source6: qpid-proton-0.38.0.tar.gz
 BuildRequires: make
 BuildRequires: gcc
 BuildRequires: autoconf
+BuildRequires: autoconf-archive
 BuildRequires: automake
 BuildRequires: bison
 BuildRequires: dos2unix

--- a/packaging/ubuntu/jammy/v8-stable/debian/control
+++ b/packaging/ubuntu/jammy/v8-stable/debian/control
@@ -5,6 +5,7 @@ Maintainer: Andre Lorbach <alorbach@adiscon.com>
 XSBC-Original-Maintainer: Michael Biebl <biebl@debian.org>
 Build-Depends: debhelper-compat (= 12),
                dpkg-dev (>= 1.6.1),
+               autoconf-archive,
                autotools-dev (>= 20100122.1),
                libczmq-dev (>= 4.0.0),
                dh-autoreconf,
@@ -499,4 +500,3 @@ Description: HTTP input module for rsyslog
  receiving log messages via HTTP POST requests. It enables rsyslog to act
  as a lightweight HTTP server, accepting logs from applications or services
  that communicate over HTTP instead of traditional syslog protocols.
-

--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -44,7 +44,6 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <pthread.h>
-#include <semaphore.h>
 #if HAVE_FCNTL_H
     #include <fcntl.h>
 #endif
@@ -91,7 +90,7 @@ STATSCOUNTER_DEF(potentialArtificialDelayMs, mutPotentialArtificialDelayMs)
 STATSCOUNTER_DEF(actualArtificialDelayMs, mutActualArtificialDelayMs)
 STATSCOUNTER_DEF(delayInvocationCount, mutDelayInvocationCount)
 
-static sem_t statsReportingBlocker;
+static pthread_mutex_t statsReportingBlocker;
 static long long statsReportingBlockStartTimeMs = 0;
 static int allowOnlyOnce = 0;
 DEF_ATOMIC_HELPER_MUT(mutAllowOnlyOnce);
@@ -490,10 +489,12 @@ finalize_it:
 static void imdiag_statsReadCallback(statsobj_t __attribute__((unused)) *const ignore_stats,
                                      void __attribute__((unused)) *const ignore_ctx) {
     long long waitStartTimeMs = currentTimeMills();
-    sem_wait(&statsReportingBlocker);
+    if (pthread_mutex_lock(&statsReportingBlocker) != 0) {
+        return;
+    }
     long delta = currentTimeMills() - waitStartTimeMs;
     if ((int)ATOMIC_DEC_AND_FETCH(&allowOnlyOnce, &mutAllowOnlyOnce) < 0) {
-        sem_post(&statsReportingBlocker);
+        (void)pthread_mutex_unlock(&statsReportingBlocker);
     } else {
         LogError(0, RS_RET_OK,
                  "imdiag(stats-read-callback): current stats-reporting "
@@ -514,7 +515,7 @@ static void imdiag_statsReadCallback(statsobj_t __attribute__((unused)) *const i
 static rsRetVal blockStatsReporting(tcps_sess_t *pSess) {
     DEFiRet;
 
-    sem_wait(&statsReportingBlocker);
+    CHKiConcCtrl(pthread_mutex_lock(&statsReportingBlocker));
     CHKiConcCtrl(pthread_mutex_lock(&mutStatsReporterWatch));
     statsReported = 0;
     CHKiConcCtrl(pthread_mutex_unlock(&mutStatsReporterWatch));
@@ -548,7 +549,7 @@ static rsRetVal awaitStatsReport(uchar *pszCmd, tcps_sess_t *pSess) {
             statsReportingBlockStartTimeMs = 0;
             LogError(0, RS_RET_OK, "imdiag: un-blocking stats reporting");
         }
-        sem_post(&statsReportingBlocker);
+        CHKiConcCtrl(pthread_mutex_unlock(&statsReportingBlocker));
         LogError(0, RS_RET_OK, "imdiag: stats reporting unblocked");
         STATSCOUNTER_ADD(potentialArtificialDelayMs, mutPotentialArtificialDelayMs, delta);
         STATSCOUNTER_INC(delayInvocationCount, mutDelayInvocationCount);
@@ -1102,7 +1103,7 @@ BEGINmodExit
     free(pszStrmDrvrAuthMode);
 
     statsobj.Destruct(&diagStats);
-    sem_destroy(&statsReportingBlocker);
+    pthread_mutex_destroy(&statsReportingBlocker);
     DESTROY_ATOMIC_HELPER_MUT(mutAllowOnlyOnce);
     pthread_cond_destroy(&statsReporterWatch);
     pthread_mutex_destroy(&mutStatsReporterWatch);
@@ -1219,7 +1220,7 @@ BEGINmodInit()
     CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("resetconfigvariables"), 1, eCmdHdlrCustomHandler, resetConfigVariables,
                                NULL, STD_LOADABLE_MODULE_ID));
 
-    sem_init(&statsReportingBlocker, 0, 1);
+    CHKiConcCtrl(pthread_mutex_init(&statsReportingBlocker, NULL));
     INIT_ATOMIC_HELPER_MUT(mutAllowOnlyOnce);
     CHKiConcCtrl(pthread_mutex_init(&mutStatsReporterWatch, NULL));
     CHKiConcCtrl(pthread_cond_init(&statsReporterWatch, NULL));

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -71,10 +71,20 @@ static pthread_key_t keyThrdName;
 /* output the current thread ID to "relevant" places
  * (what "relevant" means is determinded by various ways)
  */
-void dbgOutputTID(char *name __attribute__((unused))) {
-#if defined(HAVE_SYSCALL) && defined(HAVE_SYS_gettid)
+void dbgOutputTID(char *name) {
+#if defined(__APPLE__)
+    uint64_t tid;
+    if (pthread_threadid_np(NULL, &tid) == 0) {
+        if (bOutputTidToStderr) fprintf(stderr, "thread tid %llu, name '%s'\n", (unsigned long long)tid, name);
+        DBGPRINTF("thread created, tid %llu, name '%s'\n", (unsigned long long)tid, name);
+    }
+#elif defined(HAVE_SYSCALL) && defined(HAVE_SYS_gettid)
     if (bOutputTidToStderr) fprintf(stderr, "thread tid %u, name '%s'\n", (unsigned)syscall(SYS_gettid), name);
     DBGPRINTF("thread created, tid %u, name '%s'\n", (unsigned)syscall(SYS_gettid), name);
+#else
+    const unsigned long tid = (unsigned long)pthread_self();
+    if (bOutputTidToStderr) fprintf(stderr, "thread pthread id %lu, name '%s'\n", tid, name);
+    DBGPRINTF("thread created, pthread id %lu, name '%s'\n", tid, name);
 #endif
 }
 

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -3090,7 +3090,7 @@ static rsRetVal ATTR_NONNULL(1, 4) jsonAddVal_escaped(uchar *const pSrc,
     uchar wrkbuf[100000];
     size_t dst_realloc_size;
     size_t dst_size;
-    uchar *dst_base;
+    uchar *dst_base = NULL;
     uchar *dst_w;
     uchar *newbuf;
     DEFiRet;
@@ -3219,7 +3219,7 @@ static rsRetVal ATTR_NONNULL(1, 4) jsonAddVal_escaped(uchar *const pSrc,
         es_addBuf(dst, (const char *)dst_base, dst_w - dst_base);
     }
 finalize_it:
-    if (dst_base != wrkbuf) {
+    if (dst_base != NULL && dst_base != wrkbuf) {
         free(dst_base);
     }
     RETiRet;

--- a/runtime/netns_socket.c
+++ b/runtime/netns_socket.c
@@ -114,19 +114,20 @@ rsRetVal ATTR_NONNULL() netns_save(int *fd) {
      * To avoid bugs, or possible descriptor leaks,
      * check that it is always -1 on entry.
      */
-#ifdef HAVE_SETNS
     if (*fd != -1) {
         LogError(0, RS_RET_CODE_ERR, "%s: called with uninitialized descriptor", __func__);
         ABORT_FINALIZE(RS_RET_CODE_ERR);
     }
+
+#ifdef HAVE_SETNS
     *fd = open("/proc/self/ns/net", O_RDONLY);
     if (*fd == -1) {
         LogError(errno, RS_RET_IO_ERROR, "%s: could not access startup namespace", __func__);
         ABORT_FINALIZE(RS_RET_IO_ERROR);
     }
     dbgprintf("%s: saved startup network namespace\n", __func__);
+#endif
 finalize_it:
-#endif  // def HAVE_SETNS
     RETiRet;
 }
 

--- a/runtime/netstrm.c
+++ b/runtime/netstrm.c
@@ -145,14 +145,15 @@ static rsRetVal ATTR_NONNULL(1, 3, 5) LstnInit(netstrms_t *pNS,
                                                const int iSessMax,
                                                const tcpLstnParams_t *const cnf_params) {
     DEFiRet;
-    const char *ns = cnf_params->pszNetworkNamespace;
-    int netns_fd = -1;
 
     ISOBJ_TYPE_assert(pNS, netstrms);
     assert(fAddLstn != NULL);
     assert(cnf_params->pszPort != NULL);
 
 #ifdef HAVE_SETNS
+    const char *ns = cnf_params->pszNetworkNamespace;
+    int netns_fd = -1;
+
     if (ns) {
         CHKiRet(net.netns_save(&netns_fd));
         CHKiRet(net.netns_switch(ns));

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -912,6 +912,9 @@ static void qqueueDestroyDiskStreams(qqueue_t *pThis) {
 }
 
 static void qqueueResetRecoveredQueueSize(qqueue_t *pThis, const sbool adjustOverallQueueSize) {
+#ifndef ENABLE_IMDIAG
+    (void)adjustOverallQueueSize;
+#endif
     if (pThis->iQueueSize > 0) {
 #ifdef ENABLE_IMDIAG
         if (adjustOverallQueueSize) {

--- a/runtime/rswatch.c
+++ b/runtime/rswatch.c
@@ -64,6 +64,7 @@ typedef struct rswatch_state_s {
 static rswatch_state_t g_rswatch = {PTHREAD_MUTEX_INITIALIZER, NULL, -1, 0};
 #endif
 
+#if defined(HAVE_INOTIFY_INIT) && defined(HAVE_SYS_INOTIFY_H)
 static char *rswatchDupDirname(const char *path) {
     const char *slash;
     size_t len;
@@ -101,6 +102,7 @@ static char *rswatchDupBasename(const char *path) {
     slash = strrchr(path, '/');
     return strdup((slash == NULL) ? path : slash + 1);
 }
+#endif
 
 static void rswatchFreeHandle(rswatch_handle_t *handle) {
     if (handle == NULL) {
@@ -265,8 +267,9 @@ static rswatch_handle_t *rswatchPopDueLocked(uint64_t now_ms) {
 
 rsRetVal rswatchRegister(const rswatch_desc_t *desc, rswatch_handle_t **out) {
     rswatch_handle_t *handle = NULL;
+#if defined(HAVE_INOTIFY_INIT) && defined(HAVE_SYS_INOTIFY_H)
     sbool bLocked = 0;
-    int wd;
+#endif
     DEFiRet;
 
     if (out != NULL) {
@@ -279,6 +282,8 @@ rsRetVal rswatchRegister(const rswatch_desc_t *desc, rswatch_handle_t **out) {
 #if !defined(HAVE_INOTIFY_INIT) || !defined(HAVE_SYS_INOTIFY_H)
     ABORT_FINALIZE(RS_RET_NOT_IMPLEMENTED);
 #else
+    int wd;
+
     CHKmalloc(handle = calloc(1, sizeof(*handle)));
     CHKmalloc(handle->id = strdup(desc->id));
     CHKmalloc(handle->path = strdup(desc->path));

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -1163,14 +1163,18 @@ static rsRetVal ATTR_NONNULL(1)
     doAccept(tcpsrv_io_descr_t *const pioDescr, tcpsrvWrkrData_t *const wrkrData ATTR_UNUSED) {
     DEFiRet;
     int bRun = 1;
+#if defined(ENABLE_IMTCP_EPOLL)
     int nAccept = 0;
+#endif
 
     while (bRun) {
         iRet = doSingleAccept(pioDescr);
         if (iRet != RS_RET_OK) {
             bRun = 0;
         }
+#if defined(ENABLE_IMTCP_EPOLL)
         ++nAccept;
+#endif
     }
 #if defined(ENABLE_IMTCP_EPOLL)
     if (pioDescr->pSrv->workQueue.numWrkr > 1) {

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -351,6 +351,7 @@ static void freeConfiguredPorts(instanceData *const pData) {
     pData->nPorts = 0;
 }
 
+#ifdef HAVE_RESOLV_NS_INITPARSE
 static int compareSrvPriority(const void *lhs, const void *rhs) {
     const srvRecord_t *const left = (const srvRecord_t *)lhs;
     const srvRecord_t *const right = (const srvRecord_t *)rhs;
@@ -421,10 +422,10 @@ static const char *resolverErrorString(const int err) {
             return "unrecoverable resolver failure";
         case NO_DATA:
             return "no data";
-#if defined(NO_ADDRESS) && (!defined(NO_DATA) || (NO_ADDRESS != NO_DATA))
+    #if defined(NO_ADDRESS) && (!defined(NO_DATA) || (NO_ADDRESS != NO_DATA))
         case NO_ADDRESS:
             return "no address";
-#endif
+    #endif
         default:
             return "unknown resolver error";
     }
@@ -433,19 +434,19 @@ static const char *resolverErrorString(const int err) {
 static rsRetVal initResolverState(res_state *const pres) {
     DEFiRet;
 
-#ifdef HAVE_RESOLV_RES_N_API
+    #ifdef HAVE_RESOLV_RES_N_API
     CHKmalloc(*pres = (res_state)calloc(1, sizeof(struct __res_state)));
     if (res_ninit(*pres) != 0) {
         LogError(0, RS_RET_INTERNAL_ERROR, "omfwd: failed to init resolver state: %s", strerror(errno));
         ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
     }
-#else
+    #else
     if (res_init() != 0) {
         LogError(0, RS_RET_INTERNAL_ERROR, "omfwd: failed to init resolver state: %s", strerror(errno));
         ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
     }
     *pres = &_res;
-#endif
+    #endif
 
 finalize_it:
     RETiRet;
@@ -455,25 +456,25 @@ static int queryResolverState(res_state const res,
                               const char *const srvName,
                               unsigned char *const answer,
                               const size_t answerSize) {
-#ifdef HAVE_RESOLV_RES_N_API
+    #ifdef HAVE_RESOLV_RES_N_API
     return res_nquery(res, srvName, ns_c_in, ns_t_srv, answer, answerSize);
-#else
+    #else
     (void)res;
     return res_query(srvName, ns_c_in, ns_t_srv, answer, answerSize);
-#endif
+    #endif
 }
 
 static void closeResolverState(res_state const res) {
     if (res == NULL) {
         return;
     }
-#ifdef HAVE_RESOLV_RES_N_API
+    #ifdef HAVE_RESOLV_RES_N_API
     res_nclose(res);
     free(res);
-#else
+    #else
     /* Old resolver APIs use global state; musl's implementation is stateless. */
     (void)res;
-#endif
+    #endif
 }
 
 static rsRetVal applyResolverOverrides(res_state res) {
@@ -534,6 +535,7 @@ static rsRetVal applyResolverOverrides(res_state res) {
 finalize_it:
     RETiRet;
 }
+#endif
 
 static rsRetVal resolveSrvTargets(instanceData *const pData) {
 #ifndef HAVE_RESOLV_NS_INITPARSE


### PR DESCRIPTION
## Summary
- make the compile-warning configure policy explicit and fail bootstrap if required AX macros are unavailable
- keep the existing Autoconf Archive option contract unchanged: `--enable-compile-warnings` is the supported macro option, while stale internal singular callers are corrected to the supported spelling
- install `autoconf-archive` in direct bootstrap paths that run `autoreconf` outside prebuilt dev images
- add a stable `dev container definition CI` check in `run_checks.yml` that builds only changed dev-container Dockerfiles and succeeds with an explicit skip when no container definitions changed
- fix the non-imdiag `runtime/queue.c` unused-parameter warning exposed by the restored warning-as-error path

## Why
This fixes a CI bug: some jobs requested warning-as-error behavior but either used a singular configure spelling that was never accepted by `configure`, or missed the Autoconf Archive macros needed by `AX_COMPILER_FLAGS`, allowing warning policy to weaken silently.

The singular spelling came from internal dev-container/CI call sites, with the earliest blame I found in a 2019 Ubuntu 18.04 dev-container update. It was masked because git-tree builds already default to warning level `error`; `--enable-compile-warning=error` therefore looked effective even though `configure` reported it as unrecognized.

This PR does not add, deprecate, or otherwise change the public configure option surface. It keeps the Autoconf Archive macro contract: the supported option is `--enable-compile-warnings`.

It also closes the validation gap for dev-container definition edits. The check remains branch-protection friendly because the job is always present, but it only spends Docker build time when relevant container inputs changed.

## Validation
- release-label regression probe on `v8.2504.0`: `--enable-compile-warnings=no` disables `-Werror`; `--enable-compile-warning=no` is reported as unrecognized and leaves default `-Werror`
- current-branch probe: `--enable-compile-warnings=error` enables `-Werror`; `--enable-compile-warning=no` remains unrecognized
- `autoreconf -fvi`
- `./configure --enable-compile-warnings=error --disable-libyaml --disable-default-tests --disable-generate-man-pages`
- local dev-container image build: `docker build --pull -t rsyslog/rsyslog_dev_base_ubuntu:26.04 packaging/docker/dev_env/ubuntu/base/26.04`
- local rebuilt-image validation: `docker run ... rsyslog/rsyslog_dev_base_ubuntu:26.04-pr7115-local bash -lc 'autoreconf -fvi; ./configure --enable-compile-warnings=error --disable-libyaml --disable-default-tests --disable-generate-man-pages; grep "^WARN_CFLAGS" Makefile; make -j"${RSYSLOG_LOCAL_BUILD_JOBS}"'`
- `actionlint .github/workflows/daily_focused_tests.yml .github/workflows/run_checks.yml .github/workflows/run_macos_weekly.yml .github/workflows/doc_build.yml .github/workflows/draft_release.yml`
- pinned `zizmor --strict-collection .github/workflows`
- `shellcheck .github/scripts/debian_package_build.sh`
- `bash devtools/format-code.sh --git-changed`
- `git diff --check`
- `cubic review --base origin/main`

## Notes
The follow-up policy question is whether every C helper in `tests/Makefile.am` should inherit strict warning flags. This PR fixes the configure/CI plumbing first and does not mix in the larger helper warning cleanup.

The new container-definition gate validates changed Dockerfiles in CI. It does not publish dev images; dev-container publishing remains manual pending the automation follow-up in https://github.com/rsyslog/rsyslog/issues/7116.