### PR TITLE
mmsnareparse: preserve regex end-anchor semantics

### DIFF
--- a/plugins/mmsnareparse/mmsnareparse.c
+++ b/plugins/mmsnareparse/mmsnareparse.c
@@ -5187,7 +5187,8 @@ static char *detect_and_truncate_trailing_extradata(instanceData *pData, char *m
             searchStart[pData->searchLimit] = '\0';
         }
 
-        const int isMatch = !regexec(&pData->ignoreTrailingPattern_preg, searchStart, 0, NULL, 0);
+        const int regexecFlags = tokenWasTruncated ? REG_NOTEOL : 0;
+        const int isMatch = !regexec(&pData->ignoreTrailingPattern_preg, searchStart, 0, NULL, regexecFlags);
         if (tokenWasTruncated) {
             searchStart[pData->searchLimit] = savedChar;
         }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -498,7 +498,8 @@ TESTS_MMSNAREPARSE_MINIMAL = \
 	mmsnareparse-custom.sh \
 	mmsnareparse-realworld-4624-4634-5140.sh \
 	mmsnareparse-trailing-extradata.sh \
-	mmsnareparse-trailing-extradata-regex.sh
+	mmsnareparse-trailing-extradata-regex.sh \
+	mmsnareparse-trailing-extradata-regex-anchor.sh
 
 TESTS_MMSNAREPARSE_VALGRIND = \
 	mmsnareparse-comprehensive-vg.sh

--- a/tests/mmsnareparse-trailing-extradata-regex-anchor.sh
+++ b/tests/mmsnareparse-trailing-extradata-regex-anchor.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Validate that mmsnareparse regex trailing extra-data detection does not let
+# the search-window boundary act as the end of the trailing token. The oracle is
+# that an end-anchored pattern must not match only the bounded prefix of a longer
+# non-matching token, so the final token remains parsed data and no
+# extradata_section is emitted for it.
+unset RSYSLOG_DYNNAME
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/mmsnareparse/.libs/mmsnareparse")
+
+template(name="outfmt" type="list") {
+    property(name="$!win!Event!EventID")
+    constant(value=",")
+    property(name="$!win!Event!Channel")
+    constant(value=",")
+    property(name="$!win!EventData!User")
+    constant(value=",")
+    property(name="$!extradata_section")
+    constant(value="\n")
+}
+
+action(type="mmsnareparse"
+       definition.file="../plugins/mmsnareparse/sysmon_definitions.json"
+       ignoreTrailingPattern.regex="^[0-9]+$"
+       ignoreTrailingPattern.searchWindow="3")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+startup
+
+cat <<'MSG' > ${RSYSLOG_DYNNAME}.input
+<14>Mar 22 08:47:23 testhost MSWinEventLog	1	Microsoft-Windows-Sysmon/Operational	20977	Mon Mar 22 08:47:23 2025	13	Windows	SYSTEM	User	SetValue	testhost	Registry value set (rule: RegistryEvent)		Registry value set:  RuleName: Default RegistryEvent  EventType: SetValue  UtcTime: 2025-03-22 08:47:23.284  ProcessGuid: {fd4d0da6-d589-6916-eb03-000000000000}  ProcessId: 4  Image: System  TargetObject: HKLM\System\CurrentControlSet\Services\TestService\ImagePath  Details: "C:\Program Files\TestAgent\TestService.exe"  User: NT AUTHORITY\SYSTEM	123abc
+MSG
+
+injectmsg_file ${RSYSLOG_DYNNAME}.input
+
+shutdown_when_empty
+wait_shutdown
+
+content_check '13,Microsoft-Windows-Sysmon/Operational,NT AUTHORITY\SYSTEM 123abc,' "$RSYSLOG_OUT_LOG"
+
+exit_test

--- a/tests/mmsnareparse-trailing-extradata-regex-anchor.sh
+++ b/tests/mmsnareparse-trailing-extradata-regex-anchor.sh
@@ -40,6 +40,6 @@ injectmsg_file ${RSYSLOG_DYNNAME}.input
 shutdown_when_empty
 wait_shutdown
 
-content_check '13,Microsoft-Windows-Sysmon/Operational,NT AUTHORITY\SYSTEM 123abc,' "$RSYSLOG_OUT_LOG"
+content_check --regex '^13,Microsoft-Windows-Sysmon/Operational,NT AUTHORITY\\SYSTEM 123abc,$' "$RSYSLOG_OUT_LOG"
 
 exit_test


### PR DESCRIPTION
### Motivation
- Prevent a correctness regression where temporarily NUL-terminating the trailing-token to bound regex input made `$` match the artificial window boundary and led to false-positive truncation of the last token.
- Keep the bounded-regex optimization (to limit work on untrusted input) while restoring correct end-anchored (`$`) semantics so only a true token end can match.

### Description
- When the final token is truncated for the regex search window, pass `REG_NOTEOL` into `regexec()` so `$` cannot match the artificial NUL boundary and the full token is re-checked if needed. (change in `plugins/mmsnareparse/mmsnareparse.c`).
- Add a focused regression test `tests/mmsnareparse-trailing-extradata-regex-anchor.sh` that configures `ignoreTrailingPattern.regex="^[0-9]+$"` with a small `searchWindow` and verifies a longer non-matching final token remains parsed data instead of becoming `extradata_section`.
- Register the new test in `tests/Makefile.am` under the mmsnareparse minimal test set.

### Testing
- Ran `./autogen.sh --enable-mmsnareparse --enable-testbench --disable-impstats-push CFLAGS='-O0 -g'` successfully. 
- Ran `make -j"${RSYSLOG_LOCAL_BUILD_JOBS:-10}" check TESTS=""` and the build completed without errors. 
- Executed `./tests/mmsnareparse-trailing-extradata-regex-anchor.sh` and the existing `./tests/mmsnareparse-trailing-extradata-regex.sh`, both of which passed. 
- Ran automated checks: `devtools/format-code.sh --git-changed`, `shellcheck -S warning` on the new test, and `devtools/check-test-antipatterns.sh` on the new test, all of which completed cleanly. 
- Attempted `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)` but it failed in this environment due to a missing system dependency (`libsnappy-dev` / `snappy` header), so full distcheck was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19464bea2c833287e72a10d84dba6b)