### PR TITLE
tests: synchronize mmexternal too-long recovery

### DIFF
--- a/tests/mmexternal-response-too-long.sh
+++ b/tests/mmexternal-response-too-long.sh
@@ -1,11 +1,37 @@
 #!/bin/bash
 # Regression coverage for bounded mmexternal replies: a helper that emits an
 # oversized unterminated JSON line must be restarted before responseTimeout is
-# reached, and the queue must continue to the following action. The oracle
-# waits a short time for both downstream messages and checks that a second
+# reached, and the queue must continue to the following action. The oracle uses
+# the helper side file to observe the oversized-reply and recovery milestones,
+# then checks that both messages reached the downstream action and that a second
 # helper instance handled the recovery message.
 
 . ${srcdir:=.}/diag.sh init
+
+wait_side_content() {
+	local needle="$1"
+	local timeout="${2:-${TB_TEST_TIMEOUT:-60}}"
+	local deadline=$(( $(date +%s) + timeout ))
+	local sidefile="$RSYSLOG_DYNNAME.side"
+
+	while true; do
+		if [ -f "$sidefile" ] && grep -Fq -- "$needle" "$sidefile"; then
+			printf 'side-file milestone reached: %s\n' "$needle"
+			return
+		fi
+		if [ "$(date +%s)" -ge "$deadline" ]; then
+			printf 'FAIL: side-file milestone not reached before timeout: %s\n' "$needle"
+			if [ -f "$sidefile" ]; then
+				printf 'side-file content:\n'
+				cat -n "$sidefile"
+			else
+				printf 'side-file %s does not exist\n' "$sidefile"
+			fi
+			error_exit 1
+		fi
+		$TESTTOOL_DIR/msleep 200
+	done
+}
 
 generate_conf
 add_conf '
@@ -25,8 +51,10 @@ if $msg contains "too-long-message" then {
 
 startup
 injectmsg literal "<13>Mar 10 01:00:00 host tag:too-long-message-1"
+wait_side_content "Oversized too-long-message-1"
 injectmsg literal "<13>Mar 10 01:00:00 host tag:too-long-message-2"
-wait_file_lines "$RSYSLOG_OUT_LOG" 2 5
+wait_side_content "Recovered too-long-message-2"
+wait_file_lines "$RSYSLOG_OUT_LOG" 2
 shutdown_when_empty
 wait_shutdown
 


### PR DESCRIPTION
## Summary
- replace the short fixed output wait in `mmexternal-response-too-long.sh` with helper side-file milestones
- inject the recovery message only after the oversized first reply is observed
- keep the original oracle: helper restart, both messages reach omfile, exactly one recovery for message 2

## Why
Buildbot Solaris showed a slow-runner race where the test saw only one downstream line before the five-second output wait expired:
https://build.rsyslog.com/#/builders/77/builds/7132

This is test synchronization hardening, not a product-code semantic change. The helper already emits side-file events for the relevant phases, so the test can synchronize on those events instead of guessing with a short wall-clock wait.

## Validation
- `shellcheck -S warning tests/mmexternal-response-too-long.sh`
- `./devtools/local-validation-plan.sh --run`
  - focused Ubuntu 26.04 container test: `mmexternal-response-too-long.sh` passed
- broad Ubuntu 26.04 change-gated container run
  - image: `rsyslog/rsyslog_dev_base_ubuntu:26.04`
  - result: `# TOTAL: 1293`, `# PASS: 1266`, `# SKIP: 27`, `# FAIL: 0`
  - runtime: `312.83s`
  
  closes: https://github.com/rsyslog/rsyslog/issues/7111 (via fixing the flake - no real problem existed)
