### PR TITLE
Fix msg replacement and JSON set handling

### DIFF
--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -36,6 +36,7 @@ librsyslog_la_SOURCES = \
 	strgen.c \
 	msg.c \
 	msg.h \
+	msg_replace_helper.h \
 	linkedlist.c \
 	linkedlist.h \
 	objomsr.c \

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -64,6 +64,7 @@
 #include "unicode-helper.h"
 #include "ruleset.h"
 #include "prop.h"
+#include "msg_replace_helper.h"
 #include "net.h"
 #include "var.h"
 #include "rsconf.h"
@@ -2668,8 +2669,6 @@ void MsgSetMSGoffs(smsg_t *const pMsg, int offs) {
  * rgerhards, 2009-06-23
  */
 rsRetVal MsgReplaceMSG(smsg_t *pThis, const uchar *pszMSG, int lenMSG) {
-    int lenNew;
-    uchar *bufNew;
     DEFiRet;
     ISOBJ_TYPE_assert(pThis, msg);
     assert(pszMSG != NULL);
@@ -2685,19 +2684,8 @@ rsRetVal MsgReplaceMSG(smsg_t *pThis, const uchar *pszMSG, int lenMSG) {
     } else if (pThis->iLenMSG < 0 || pThis->iLenMSG > pThis->iLenRawMsg - pThis->offMSG) {
         pThis->iLenMSG = pThis->iLenRawMsg - pThis->offMSG;
     }
-
-    lenNew = pThis->iLenRawMsg + lenMSG - pThis->iLenMSG;
-    if (lenMSG > pThis->iLenMSG && lenNew >= CONF_RAWMSG_BUFSIZE) {
-        /*  we have lost our "bet" and need to alloc a new buffer ;) */
-        CHKmalloc(bufNew = malloc(lenNew + 1));
-        memcpy(bufNew, pThis->pszRawMsg, pThis->offMSG);
-        if (pThis->pszRawMsg != pThis->szRawMsg) free(pThis->pszRawMsg);
-        pThis->pszRawMsg = bufNew;
-    }
-
-    if (lenMSG > 0) memcpy(pThis->pszRawMsg + pThis->offMSG, pszMSG, lenMSG);
-    pThis->pszRawMsg[lenNew] = '\0'; /* this also works with truncation! */
-    pThis->iLenRawMsg = lenNew;
+    CHKiRet(msgReplaceRawMsgSegment(&pThis->pszRawMsg, pThis->szRawMsg, CONF_RAWMSG_BUFSIZE, pThis->offMSG,
+                                    pThis->iLenMSG, &pThis->iLenRawMsg, pszMSG, lenMSG));
     pThis->iLenMSG = lenMSG;
 
 finalize_it:
@@ -4713,10 +4701,14 @@ static rsRetVal jsonPathFindNext(
     DEFiRet;
 
     if (*p == '!' || (*name == namestart && (*p == '.' || *p == '/'))) ++p;
-    for (i = 0;
-         *p && !(p == namestart && (*p == '.' || *p == '/')) && *p != '!' && p != leaf && i < sizeof(namebuf) - 1;
-         ++i, ++p)
+    for (i = 0; *p && !(p == namestart && (*p == '.' || *p == '/')) && *p != '!' && p != leaf; ++i, ++p) {
+        if (i >= sizeof(namebuf) - 1) {
+            LogError(0, RS_RET_INVLD_SETOP, "json path component too long in '%s' - refusing truncated lookup",
+                     namestart);
+            ABORT_FINALIZE(RS_RET_INVLD_SETOP);
+        }
         namebuf[i] = *p;
+    }
     if (i > 0) {
         namebuf[i] = '\0';
         if (jsonVarExtract(root, (char *)namebuf, &json) == FALSE) {
@@ -4882,7 +4874,11 @@ rsRetVal msgAddJSON(smsg_t *const pM, uchar *name, struct json_object *json, int
             json_object_object_add(parent, (char *)leaf, json);
         } else {
             if (json_object_get_type(json) == json_type_object) {
-                CHKiRet(jsonMerge(*jroot, json));
+                if (json_object_get_type(leafnode) == json_type_object) {
+                    CHKiRet(jsonMerge(leafnode, json));
+                } else {
+                    json_object_object_add(parent, (char *)leaf, json);
+                }
             } else {
                 /* TODO: improve the code below, however, the current
                  *       state is not really bad */

--- a/runtime/msg_replace_helper.h
+++ b/runtime/msg_replace_helper.h
@@ -7,14 +7,14 @@
 
 #include "rsyslog.h"
 
-static inline rsRetVal msgReplaceRawMsgSegment(uchar **ppRawMsg,
-                                               uchar *stackBuf,
-                                               int stackBufSize,
-                                               int offMSG,
-                                               int lenOldMSG,
-                                               int *pLenRawMsg,
-                                               const uchar *pszMSG,
-                                               int lenMSG) {
+static rsRetVal msgReplaceRawMsgSegment(uchar **ppRawMsg,
+                                        uchar *stackBuf,
+                                        int stackBufSize,
+                                        int offMSG,
+                                        int lenOldMSG,
+                                        int *pLenRawMsg,
+                                        const uchar *pszMSG,
+                                        int lenMSG) {
     int lenNew;
     int lenSuffix;
     uchar *bufNew;

--- a/runtime/msg_replace_helper.h
+++ b/runtime/msg_replace_helper.h
@@ -1,0 +1,68 @@
+#ifndef INCLUDED_MSG_REPLACE_HELPER_H
+#define INCLUDED_MSG_REPLACE_HELPER_H
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rsyslog.h"
+
+static inline rsRetVal
+msgReplaceRawMsgSegment(uchar **ppRawMsg,
+	uchar *stackBuf,
+	int stackBufSize,
+	int offMSG,
+	int lenOldMSG,
+	int *pLenRawMsg,
+	const uchar *pszMSG,
+	int lenMSG)
+{
+	int lenNew;
+	int lenSuffix;
+	uchar *bufNew;
+
+	assert(ppRawMsg != NULL);
+	assert(*ppRawMsg != NULL);
+	assert(stackBuf != NULL);
+	assert(pLenRawMsg != NULL);
+	assert(pszMSG != NULL);
+	assert(offMSG >= 0);
+	assert(lenOldMSG >= 0);
+	assert(*pLenRawMsg >= offMSG + lenOldMSG);
+
+	lenNew = *pLenRawMsg + lenMSG - lenOldMSG;
+	lenSuffix = *pLenRawMsg - offMSG - lenOldMSG;
+	bufNew = *ppRawMsg;
+
+	if (lenMSG > lenOldMSG && lenNew >= stackBufSize) {
+		if (bufNew == stackBuf) {
+			bufNew = malloc(lenNew + 1);
+			if (bufNew == NULL) {
+				return RS_RET_OUT_OF_MEMORY;
+			}
+			memcpy(bufNew, *ppRawMsg, offMSG);
+			if (lenSuffix > 0) {
+				memcpy(bufNew + offMSG + lenMSG, *ppRawMsg + offMSG + lenOldMSG, lenSuffix);
+			}
+		} else {
+			uchar *tmp = realloc(bufNew, lenNew + 1);
+
+			if (tmp == NULL) {
+				return RS_RET_OUT_OF_MEMORY;
+			}
+			bufNew = tmp;
+		}
+	} else if (lenSuffix > 0 && lenMSG != lenOldMSG) {
+		memmove(bufNew + offMSG + lenMSG, bufNew + offMSG + lenOldMSG, lenSuffix);
+	}
+
+	if (lenMSG > 0) {
+		memcpy(bufNew + offMSG, pszMSG, lenMSG);
+	}
+	bufNew[lenNew] = '\0';
+	*ppRawMsg = bufNew;
+	*pLenRawMsg = lenNew;
+	return RS_RET_OK;
+}
+
+#endif

--- a/runtime/msg_replace_helper.h
+++ b/runtime/msg_replace_helper.h
@@ -1,3 +1,21 @@
+/* msg_replace_helper.h
+ *
+ * Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef INCLUDED_MSG_REPLACE_HELPER_H
 #define INCLUDED_MSG_REPLACE_HELPER_H
 
@@ -32,7 +50,8 @@ static rsRetVal msgReplaceRawMsgSegment(uchar **ppRawMsg,
     lenSuffix = *pLenRawMsg - offMSG - lenOldMSG;
     bufNew = *ppRawMsg;
 
-    if (lenMSG > lenOldMSG && lenNew >= stackBufSize) {
+    if (lenMSG > lenOldMSG &&
+        ((bufNew == stackBuf && lenNew >= stackBufSize) || (bufNew != stackBuf && lenNew > *pLenRawMsg))) {
         if (bufNew == stackBuf) {
             bufNew = malloc(lenNew + 1);
             if (bufNew == NULL) {

--- a/runtime/msg_replace_helper.h
+++ b/runtime/msg_replace_helper.h
@@ -49,6 +49,9 @@ static inline rsRetVal msgReplaceRawMsgSegment(uchar **ppRawMsg,
                 return RS_RET_OUT_OF_MEMORY;
             }
             bufNew = tmp;
+            if (lenSuffix > 0) {
+                memmove(bufNew + offMSG + lenMSG, bufNew + offMSG + lenOldMSG, lenSuffix);
+            }
         }
     } else if (lenSuffix > 0 && lenMSG != lenOldMSG) {
         memmove(bufNew + offMSG + lenMSG, bufNew + offMSG + lenOldMSG, lenSuffix);

--- a/runtime/msg_replace_helper.h
+++ b/runtime/msg_replace_helper.h
@@ -7,62 +7,60 @@
 
 #include "rsyslog.h"
 
-static inline rsRetVal
-msgReplaceRawMsgSegment(uchar **ppRawMsg,
-	uchar *stackBuf,
-	int stackBufSize,
-	int offMSG,
-	int lenOldMSG,
-	int *pLenRawMsg,
-	const uchar *pszMSG,
-	int lenMSG)
-{
-	int lenNew;
-	int lenSuffix;
-	uchar *bufNew;
+static inline rsRetVal msgReplaceRawMsgSegment(uchar **ppRawMsg,
+                                               uchar *stackBuf,
+                                               int stackBufSize,
+                                               int offMSG,
+                                               int lenOldMSG,
+                                               int *pLenRawMsg,
+                                               const uchar *pszMSG,
+                                               int lenMSG) {
+    int lenNew;
+    int lenSuffix;
+    uchar *bufNew;
 
-	assert(ppRawMsg != NULL);
-	assert(*ppRawMsg != NULL);
-	assert(stackBuf != NULL);
-	assert(pLenRawMsg != NULL);
-	assert(pszMSG != NULL);
-	assert(offMSG >= 0);
-	assert(lenOldMSG >= 0);
-	assert(*pLenRawMsg >= offMSG + lenOldMSG);
+    assert(ppRawMsg != NULL);
+    assert(*ppRawMsg != NULL);
+    assert(stackBuf != NULL);
+    assert(pLenRawMsg != NULL);
+    assert(pszMSG != NULL);
+    assert(offMSG >= 0);
+    assert(lenOldMSG >= 0);
+    assert(*pLenRawMsg >= offMSG + lenOldMSG);
 
-	lenNew = *pLenRawMsg + lenMSG - lenOldMSG;
-	lenSuffix = *pLenRawMsg - offMSG - lenOldMSG;
-	bufNew = *ppRawMsg;
+    lenNew = *pLenRawMsg + lenMSG - lenOldMSG;
+    lenSuffix = *pLenRawMsg - offMSG - lenOldMSG;
+    bufNew = *ppRawMsg;
 
-	if (lenMSG > lenOldMSG && lenNew >= stackBufSize) {
-		if (bufNew == stackBuf) {
-			bufNew = malloc(lenNew + 1);
-			if (bufNew == NULL) {
-				return RS_RET_OUT_OF_MEMORY;
-			}
-			memcpy(bufNew, *ppRawMsg, offMSG);
-			if (lenSuffix > 0) {
-				memcpy(bufNew + offMSG + lenMSG, *ppRawMsg + offMSG + lenOldMSG, lenSuffix);
-			}
-		} else {
-			uchar *tmp = realloc(bufNew, lenNew + 1);
+    if (lenMSG > lenOldMSG && lenNew >= stackBufSize) {
+        if (bufNew == stackBuf) {
+            bufNew = malloc(lenNew + 1);
+            if (bufNew == NULL) {
+                return RS_RET_OUT_OF_MEMORY;
+            }
+            memcpy(bufNew, *ppRawMsg, offMSG);
+            if (lenSuffix > 0) {
+                memcpy(bufNew + offMSG + lenMSG, *ppRawMsg + offMSG + lenOldMSG, lenSuffix);
+            }
+        } else {
+            uchar *tmp = realloc(bufNew, lenNew + 1);
 
-			if (tmp == NULL) {
-				return RS_RET_OUT_OF_MEMORY;
-			}
-			bufNew = tmp;
-		}
-	} else if (lenSuffix > 0 && lenMSG != lenOldMSG) {
-		memmove(bufNew + offMSG + lenMSG, bufNew + offMSG + lenOldMSG, lenSuffix);
-	}
+            if (tmp == NULL) {
+                return RS_RET_OUT_OF_MEMORY;
+            }
+            bufNew = tmp;
+        }
+    } else if (lenSuffix > 0 && lenMSG != lenOldMSG) {
+        memmove(bufNew + offMSG + lenMSG, bufNew + offMSG + lenOldMSG, lenSuffix);
+    }
 
-	if (lenMSG > 0) {
-		memcpy(bufNew + offMSG, pszMSG, lenMSG);
-	}
-	bufNew[lenNew] = '\0';
-	*ppRawMsg = bufNew;
-	*pLenRawMsg = lenNew;
-	return RS_RET_OK;
+    if (lenMSG > 0) {
+        memcpy(bufNew + offMSG, pszMSG, lenMSG);
+    }
+    bufNew[lenNew] = '\0';
+    *ppRawMsg = bufNew;
+    *pLenRawMsg = lenNew;
+    return RS_RET_OK;
 }
 
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -426,6 +426,7 @@ TESTS_DEFAULT = \
 	rscript_get_property.sh \
 	rscript_split.sh \
 	rscript_append_json.sh \
+	msg_json_set_regression.sh \
 	config_output-o-option.sh \
 	rs-cnum.sh \
 	rs-substring.sh \
@@ -2122,8 +2123,8 @@ liboverride_getaddrinfo_la_CFLAGS =
 liboverride_getaddrinfo_la_LDFLAGS = -avoid-version -shared
 
 # TODO: reenable TESTRUNS = rt_init rscript
-check_PROGRAMS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri
-TESTS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri
+check_PROGRAMS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace
+TESTS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace
 
 runtime_unit_linkedlist_SOURCES = \
 	unit/linkedlist_test.c
@@ -2133,6 +2134,9 @@ runtime_unit_stringbuf_SOURCES = \
 
 runtime_unit_parser_pri_SOURCES = \
 	unit/parser_pri_test.c
+
+runtime_unit_msg_replace_SOURCES = \
+	unit/msg_replace_test.c
 
 if ENABLE_GSSAPI
 check_PROGRAMS += runtime_unit_gss_token_util
@@ -2165,15 +2169,19 @@ runtime_unit_stringbuf_CPPFLAGS = \
 	$(runtime_unit_linkedlist_CPPFLAGS)
 runtime_unit_parser_pri_CPPFLAGS = \
 	$(runtime_unit_linkedlist_CPPFLAGS)
+runtime_unit_msg_replace_CPPFLAGS = \
+	$(runtime_unit_linkedlist_CPPFLAGS)
 
 runtime_unit_linkedlist_LDADD = $(RSRT_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
 runtime_unit_stringbuf_LDADD = $(LIBESTR_LIBS) $(LIBFASTJSON_LIBS) $(LIBSYSTEMD_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
 runtime_unit_parser_pri_LDADD = $(LIBESTR_LIBS) $(LIBFASTJSON_LIBS) $(LIBSYSTEMD_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
+runtime_unit_msg_replace_LDADD = $(runtime_unit_linkedlist_LDADD)
 
 if ENABLE_LIBLOGGING_STDLOG
 runtime_unit_linkedlist_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
 runtime_unit_stringbuf_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
 runtime_unit_parser_pri_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+runtime_unit_msg_replace_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
 endif
 
 if ENABLE_TESTBENCH

--- a/tests/msg_json_set_regression.sh
+++ b/tests/msg_json_set_regression.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# added 2026-05-29 by Copilot
+#
+# This regression covers two runtime/msg.c behaviors:
+# - nested `set $!...` updates must merge into the existing leaf object rather
+#   than the root object
+# - overlong JSON path components must be rejected instead of silently creating
+#   truncated keys
+#
+# Oracle:
+# - the nested node retains "keep" and gains "escape"
+# - the emitted JSON tree is otherwise unchanged, so no root-level escape field
+#   or truncated overlong key appears
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+
+LONG_PATH_COMPONENT="toolong_$(printf 'x%.0s' $(seq 1 1200))"
+
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+template(name="outfmt" type="string" string="%$!%\n")
+
+local4.* {
+	set $.ret = parse_json("{\"keep\":\"orig\"}", "\$.target");
+	set $.ret = parse_json("{\"escape\":\"merged\"}", "\$.merge");
+	set $!target!node = $.target;
+	set $!target!node = $.merge;
+	unset $.target;
+	unset $.merge;
+	set $!'"$LONG_PATH_COMPONENT"'!child = "blocked";
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+
+startup
+tcpflood -m1
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='{ "target": { "node": { "keep": "orig", "escape": "merged" } } }'
+cmp_exact $RSYSLOG_OUT_LOG
+
+exit_test

--- a/tests/unit/msg_replace_test.c
+++ b/tests/unit/msg_replace_test.c
@@ -15,7 +15,7 @@
         }                                                                            \
     } while (0)
 
-int main(void) {
+static int test_stack_to_heap_growth(void) {
     static const uchar initialRawMsg[] = "prefix old suffix";
     static const uchar replacement[] = "much longer replacement";
     static const uchar expectedRawMsg[] = "prefix much longer replacement suffix";
@@ -37,4 +37,38 @@ int main(void) {
     }
 
     return 0;
+}
+
+static int test_heap_realloc_growth(void) {
+    static const uchar initialRawMsg[] = "prefix old suffix";
+    static const uchar replacement[] = "much longer replacement";
+    static const uchar expectedRawMsg[] = "prefix much longer replacement suffix";
+    uchar stackBuf[8];
+    uchar *rawMsg = malloc(sizeof(initialRawMsg));
+    int lenRawMsg = sizeof(initialRawMsg) - 1;
+    rsRetVal ret;
+
+    CHECK(rawMsg != NULL);
+    memcpy(rawMsg, initialRawMsg, sizeof(initialRawMsg) - 1);
+    ret = msgReplaceRawMsgSegment(&rawMsg, stackBuf, sizeof(stackBuf), sizeof("prefix ") - 1, sizeof("old") - 1,
+                                  &lenRawMsg, replacement, sizeof(replacement) - 1);
+    CHECK(ret == RS_RET_OK);
+    CHECK(lenRawMsg == (int)sizeof(expectedRawMsg) - 1);
+    CHECK(memcmp(rawMsg, expectedRawMsg, sizeof(expectedRawMsg) - 1) == 0);
+    CHECK(memcmp(rawMsg + sizeof("prefix ") - 1 + sizeof(replacement) - 1, " suffix", sizeof(" suffix") - 1) == 0);
+
+    free(rawMsg);
+
+    return 0;
+}
+
+int main(void) {
+    int ret;
+
+    ret = test_stack_to_heap_growth();
+    if (ret != 0) {
+        return ret;
+    }
+
+    return test_heap_realloc_growth();
 }

--- a/tests/unit/msg_replace_test.c
+++ b/tests/unit/msg_replace_test.c
@@ -8,36 +8,33 @@
 #include "msg_replace_helper.h"
 
 #define CHECK(cond)                                                                  \
-	do {                                                                             \
-		if (!(cond)) {                                                               \
-			fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__, #cond); \
-			return 1;                                                                \
-		}                                                                            \
-	} while (0)
+    do {                                                                             \
+        if (!(cond)) {                                                               \
+            fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__, #cond); \
+            return 1;                                                                \
+        }                                                                            \
+    } while (0)
 
-int
-main(void)
-{
-	static const uchar initialRawMsg[] = "prefix old suffix";
-	static const uchar replacement[] = "much longer replacement";
-	static const uchar expectedRawMsg[] = "prefix much longer replacement suffix";
-	uchar stackBuf[CONF_RAWMSG_BUFSIZE];
-	uchar *rawMsg = stackBuf;
-	int lenRawMsg = sizeof(initialRawMsg) - 1;
-	rsRetVal ret;
+int main(void) {
+    static const uchar initialRawMsg[] = "prefix old suffix";
+    static const uchar replacement[] = "much longer replacement";
+    static const uchar expectedRawMsg[] = "prefix much longer replacement suffix";
+    uchar stackBuf[CONF_RAWMSG_BUFSIZE];
+    uchar *rawMsg = stackBuf;
+    int lenRawMsg = sizeof(initialRawMsg) - 1;
+    rsRetVal ret;
 
-	memcpy(stackBuf, initialRawMsg, sizeof(initialRawMsg) - 1);
-	ret = msgReplaceRawMsgSegment(&rawMsg, stackBuf, sizeof(stackBuf), sizeof("prefix ") - 1,
-		sizeof("old") - 1, &lenRawMsg, replacement, sizeof(replacement) - 1);
-	CHECK(ret == RS_RET_OK);
-	CHECK(lenRawMsg == (int)sizeof(expectedRawMsg) - 1);
-	CHECK(memcmp(rawMsg, expectedRawMsg, sizeof(expectedRawMsg) - 1) == 0);
-	CHECK(memcmp(rawMsg + sizeof("prefix ") - 1 + sizeof(replacement) - 1,
-		" suffix", sizeof(" suffix") - 1) == 0);
+    memcpy(stackBuf, initialRawMsg, sizeof(initialRawMsg) - 1);
+    ret = msgReplaceRawMsgSegment(&rawMsg, stackBuf, sizeof(stackBuf), sizeof("prefix ") - 1, sizeof("old") - 1,
+                                  &lenRawMsg, replacement, sizeof(replacement) - 1);
+    CHECK(ret == RS_RET_OK);
+    CHECK(lenRawMsg == (int)sizeof(expectedRawMsg) - 1);
+    CHECK(memcmp(rawMsg, expectedRawMsg, sizeof(expectedRawMsg) - 1) == 0);
+    CHECK(memcmp(rawMsg + sizeof("prefix ") - 1 + sizeof(replacement) - 1, " suffix", sizeof(" suffix") - 1) == 0);
 
-	if (rawMsg != stackBuf) {
-		free(rawMsg);
-	}
+    if (rawMsg != stackBuf) {
+        free(rawMsg);
+    }
 
-	return 0;
+    return 0;
 }

--- a/tests/unit/msg_replace_test.c
+++ b/tests/unit/msg_replace_test.c
@@ -1,0 +1,43 @@
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rsyslog.h"
+#include "msg_replace_helper.h"
+
+#define CHECK(cond)                                                                  \
+	do {                                                                             \
+		if (!(cond)) {                                                               \
+			fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__, #cond); \
+			return 1;                                                                \
+		}                                                                            \
+	} while (0)
+
+int
+main(void)
+{
+	static const uchar initialRawMsg[] = "prefix old suffix";
+	static const uchar replacement[] = "much longer replacement";
+	static const uchar expectedRawMsg[] = "prefix much longer replacement suffix";
+	uchar stackBuf[CONF_RAWMSG_BUFSIZE];
+	uchar *rawMsg = stackBuf;
+	int lenRawMsg = sizeof(initialRawMsg) - 1;
+	rsRetVal ret;
+
+	memcpy(stackBuf, initialRawMsg, sizeof(initialRawMsg) - 1);
+	ret = msgReplaceRawMsgSegment(&rawMsg, stackBuf, sizeof(stackBuf), sizeof("prefix ") - 1,
+		sizeof("old") - 1, &lenRawMsg, replacement, sizeof(replacement) - 1);
+	CHECK(ret == RS_RET_OK);
+	CHECK(lenRawMsg == (int)sizeof(expectedRawMsg) - 1);
+	CHECK(memcmp(rawMsg, expectedRawMsg, sizeof(expectedRawMsg) - 1) == 0);
+	CHECK(memcmp(rawMsg + sizeof("prefix ") - 1 + sizeof(replacement) - 1,
+		" suffix", sizeof(" suffix") - 1) == 0);
+
+	if (rawMsg != stackBuf) {
+		free(rawMsg);
+	}
+
+	return 0;
+}

--- a/tests/unit/msg_replace_test.c
+++ b/tests/unit/msg_replace_test.c
@@ -16,6 +16,10 @@
     } while (0)
 
 static int test_stack_to_heap_growth(void) {
+    /* Replacing a stack-backed MSG with a longer value must preserve the suffix
+     * after moving storage to the heap. The exact raw message content is the
+     * oracle.
+     */
     static const uchar initialRawMsg[] = "prefix old suffix";
     static const uchar replacement[] = "much longer replacement";
     static const uchar expectedRawMsg[] = "prefix much longer replacement suffix";
@@ -40,10 +44,15 @@ static int test_stack_to_heap_growth(void) {
 }
 
 static int test_heap_realloc_growth(void) {
+    /* Replacing a heap-backed MSG with a longer value must realloc when the new
+     * length exceeds the current heap allocation even if it still fits inside
+     * CONF_RAWMSG_BUFSIZE. The preserved suffix and final full raw message are
+     * the oracle.
+     */
     static const uchar initialRawMsg[] = "prefix old suffix";
     static const uchar replacement[] = "much longer replacement";
     static const uchar expectedRawMsg[] = "prefix much longer replacement suffix";
-    uchar stackBuf[8];
+    uchar stackBuf[CONF_RAWMSG_BUFSIZE];
     uchar *rawMsg = malloc(sizeof(initialRawMsg));
     int lenRawMsg = sizeof(initialRawMsg) - 1;
     rsRetVal ret;


### PR DESCRIPTION
## Summary
- fix raw message replacement so MSG-length changes preserve trailing raw-message bytes
- reject overlong JSON path components instead of silently truncating them
- fix nested JSON set updates to merge into the existing object leaf while safely replacing scalar leaves

## Testing
- compiled and ran `tests/unit/msg_replace_test.c` as a focused helper-based regression
- ran `tests/msg_json_set_regression.sh`
- attempted `./devtools/local-validation-plan.sh --run`

## Validation notes
- focused regressions passed
- `./devtools/local-validation-plan.sh --run` previously surfaced one real nested-merge issue, which this branch fixes
- PR-ready container validation is not claimed here: the helper did not produce a usable completion in this TTY, and a later full local rebuild after build-system refresh hit missing optional local headers (`mbedtls/debug.h`, `ksi/ksi.h`) in this environment