### PR TITLE
imkafka: support multiple topics in one input() instance

### DIFF
--- a/doc/source/configuration/modules/imkafka.rst
+++ b/doc/source/configuration/modules/imkafka.rst
@@ -137,7 +137,10 @@ Definition list (Global Stats)
 
 Definition list (Local Stats)
 -----------------------------
-- **name** Identifier for the action-level statistics object. It includes the module name and the topic_consumer group pair in brackets. (eg: "name": "imkafka[topic_consumergroup]")
+- **name** Identifier for the action-level statistics object. It includes the
+  module name and the topic or comma-separated topic list plus consumer group
+  in brackets, for example ``"name": "imkafka[topic_consumergroup]"`` or
+  ``"name": "imkafka[topic1,topic2_consumergroup]"``.
 - **origin** The module that registered the counters; for these metrics it is always `"imkafka"`.
 - **received** Number of Kafka records fetched for this specific topic and consumer group since rsyslog start (or last reset).
 - **submitted** Number of messages successfully submitted into rsyslog’s processing pipeline for this topic and consumer group.
@@ -170,6 +173,24 @@ In this sample a consumer for the topic static is created and will forward the m
    module(load="imkafka")
    input(type="imkafka" topic="static" broker="localhost:9092"
                         consumergroup="default" ruleset="pRuleset")
+
+   ruleset(name="pRuleset") {
+        action(type="omfile" file="path/to/file")
+   }
+
+Example 2
+---------
+
+In this sample a consumer for multiple topics is created and will forward the messages to the omfile action.
+
+.. code-block:: none
+
+   module(load="imkafka")
+   input(type="imkafka"
+         topic=["topic1", "topic2", "topic3"]
+         broker="localhost:9092"
+         consumergroup="default"
+         ruleset="pRuleset")
 
    ruleset(name="pRuleset") {
    	action(type="omfile" file="path/to/file")

--- a/doc/source/reference/parameters/imkafka-topic.rst
+++ b/doc/source/reference/parameters/imkafka-topic.rst
@@ -10,7 +10,7 @@ topic
 
 .. summary-start
 
-Identifies the Kafka topic from which imkafka consumes messages.
+Identifies one or more Kafka topics from which imkafka consumes messages.
 
 .. summary-end
 
@@ -18,23 +18,39 @@ This parameter applies to :doc:`../../configuration/modules/imkafka`.
 
 :Name: topic
 :Scope: input
-:Type: string
+:Type: array
 :Required?: yes
 :Introduced: 8.27.0
 
 Description
 -----------
-Specifies the name of the Kafka topic from which messages will be consumed.
-This is a mandatory parameter for the imkafka input.
+Specifies the Kafka topic or topics to consume from. A single topic name may
+be given as a string. Multiple topics may be given as an array, allowing one
+``input()`` to consume from several topics at once.
 
 Input usage
 -----------
 .. _imkafka.parameter.input.topic-usage:
 
+Single topic:
+
 .. code-block:: rsyslog
 
    module(load="imkafka")
-   input(type="imkafka" topic="static")
+   input(type="imkafka"
+         topic="mytopic"
+         broker="localhost:9092"
+         consumergroup="default")
+
+Multiple topics:
+
+.. code-block:: rsyslog
+
+   module(load="imkafka")
+   input(type="imkafka"
+         topic=["topic1", "topic2", "topic3"]
+         broker="localhost:9092"
+         consumergroup="default")
 
 See also
 --------

--- a/plugins/imkafka/MODULE_METADATA.yaml
+++ b/plugins/imkafka/MODULE_METADATA.yaml
@@ -1,7 +1,7 @@
 support_status: contributor-supported
 maturity_level: mature
 primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
-last_reviewed: 2025-09-26
+last_reviewed: 2026-05-29
 build_dependencies:
   - librdkafka development headers (`./devtools/codex-setup.sh`)
 runtime_dependencies:

--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -58,11 +58,7 @@
 #include "dirty.h"
 #include "datetime.h"
 
-/* If your build already injects the header, you may omit this include.
-   Otherwise, prefer the canonical libfastjson path: */
-// #include <json.h>
-#include <libfastjson/json.h>
-#include <libfastjson/json_tokener.h>
+#include <json.h>
 
 MODULE_TYPE_INPUT;
 MODULE_TYPE_NOKEEP;
@@ -133,7 +129,8 @@ struct kafka_params {
 
 /* Module static data */
 static struct configSettings_s {
-    uchar *topic;
+    uchar **topics;
+    int nTopics;
     uchar *consumergroup;
     char *brokers;
     uchar *pszBindRuleset;
@@ -142,7 +139,8 @@ static struct configSettings_s {
 } cs;
 
 typedef struct instanceConf_s {
-    uchar *topic;
+    uchar **topics; /* Array of topic names to consume from */
+    int nTopics; /* Number of topics in the topics array */
     uchar *consumergroup;
     char *brokers;
     int64_t offset;
@@ -176,7 +174,8 @@ typedef struct instanceConf_s {
 
 typedef struct modConfData_s {
     rsconf_t *pConf; /* our overall config object */
-    uchar *topic;
+    uchar **topics; /* Array of topic names (module default) */
+    int nTopics; /* Number of default topics */
     uchar *consumergroup;
     char *brokers;
     instanceConf_t *root, *tail;
@@ -209,8 +208,8 @@ static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / si
 
 /* input instance parameters */
 static struct cnfparamdescr inppdescr[] = {
-    {"topic", eCmdHdlrString, CNFPARAM_REQUIRED}, {"broker", eCmdHdlrArray, 0},   {"confparam", eCmdHdlrArray, 0},
-    {"consumergroup", eCmdHdlrString, 0},         {"ruleset", eCmdHdlrString, 0}, {"parsehostname", eCmdHdlrBinary, 0},
+    {"topic", eCmdHdlrArray, CNFPARAM_REQUIRED}, {"broker", eCmdHdlrArray, 0},   {"confparam", eCmdHdlrArray, 0},
+    {"consumergroup", eCmdHdlrString, 0},        {"ruleset", eCmdHdlrString, 0}, {"parsehostname", eCmdHdlrBinary, 0},
     {"split.json.records", eCmdHdlrBinary, 0},
 };
 static struct cnfparamblk inppblk = {CNFPARAMBLK_VERSION, sizeof(inppdescr) / sizeof(struct cnfparamdescr), inppdescr};
@@ -607,7 +606,7 @@ static void msgConsume(instanceConf_t *inst) {
     do { /* Consume messages */
         rkmessage = rd_kafka_consumer_poll(inst->rk, 1000); /* Block for 1000 ms max */
         if (rkmessage == NULL) {
-            DBGPRINTF("imkafka: msgConsume EMPTY Loop on %s/%s/%s\n", inst->topic, inst->consumergroup, inst->brokers);
+            DBGPRINTF("imkafka: msgConsume EMPTY Loop on group %s/%s\n", inst->consumergroup, inst->brokers);
             /* poll returned nothing */
             STATSCOUNTER_INC(ctrPollEmpty, mutCtrPollEmpty);
             INST_STATSCOUNTER_INC(inst, inst->ctrPollEmpty, inst->mutCtrPollEmpty);
@@ -640,8 +639,8 @@ static void msgConsume(instanceConf_t *inst) {
         }
 
         DBGPRINTF("imkafka: msgConsume Loop on %s/%s/%s: [%" PRId32 "], offset %" PRId64 ", %zd bytes):\n",
-                  rd_kafka_topic_name(rkmessage->rkt) /*inst->topic*/, inst->consumergroup, inst->brokers,
-                  rkmessage->partition, rkmessage->offset, rkmessage->len);
+                  rd_kafka_topic_name(rkmessage->rkt), inst->consumergroup, inst->brokers, rkmessage->partition,
+                  rkmessage->offset, rkmessage->len);
 
         /* message received */
         STATSCOUNTER_INC(ctrReceived, mutCtrReceived);
@@ -690,7 +689,8 @@ static rsRetVal createInstance(instanceConf_t **pinst) {
     CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
     inst->next = NULL;
     inst->brokers = NULL;
-    inst->topic = NULL;
+    inst->topics = NULL;
+    inst->nTopics = 0;
     inst->consumergroup = NULL;
     inst->pszBindRuleset = NULL;
     inst->nConfParams = 0;
@@ -857,18 +857,29 @@ static inline void std_checkRuleset_genErrMsg(__attribute__((unused)) modConfDat
 static rsRetVal ATTR_NONNULL(2) addConsumer(modConfData_t __attribute__((unused)) * modConf, instanceConf_t *inst) {
     DEFiRet;
     rd_kafka_resp_err_t err;
+    int i;
     assert(inst != NULL);
+    assert(inst->nTopics > 0);
 
     rd_kafka_topic_partition_list_t *topics = NULL;
 
-    DBGPRINTF("imkafka: creating kafka consumer on %s/%s/%s\n", inst->topic, inst->consumergroup, inst->brokers);
+    if (inst->nTopics == 1) {
+        DBGPRINTF("imkafka: creating kafka consumer on %s/%s/%s\n", inst->topics[0], inst->consumergroup,
+                  inst->brokers);
+    } else {
+        DBGPRINTF("imkafka: creating kafka consumer for %d topics on %s/%s\n", inst->nTopics, inst->consumergroup,
+                  inst->brokers);
+    }
 
     /* Redirect rd_kafka_poll() to consumer_poll() */
     rd_kafka_poll_set_consumer(inst->rk);
 
-    topics = rd_kafka_topic_partition_list_new(1);
-    rd_kafka_topic_partition_list_add(topics, (const char *)inst->topic, inst->partition);
-    DBGPRINTF("imkafka: Created topics(%d) for %s)\n", topics->cnt, inst->topic);
+    topics = rd_kafka_topic_partition_list_new(inst->nTopics);
+    for (i = 0; i < inst->nTopics; i++) {
+        rd_kafka_topic_partition_list_add(topics, (const char *)inst->topics[i], inst->partition);
+        DBGPRINTF("imkafka: Added topic %d: %s\n", i, inst->topics[i]);
+    }
+    DBGPRINTF("imkafka: Created topics list with %d entries\n", topics->cnt);
 
     if ((err = rd_kafka_subscribe(inst->rk, topics))) {
         /* Subscription failed */
@@ -876,7 +887,13 @@ static rsRetVal ATTR_NONNULL(2) addConsumer(modConfData_t __attribute__((unused)
         LogError(0, RS_RET_KAFKA_ERROR, "imkafka: Failed to start consuming topics: %s\n", rd_kafka_err2str(err));
         ABORT_FINALIZE(RS_RET_KAFKA_ERROR);
     } else {
-        DBGPRINTF("imkafka: Successfully subscribed to %s/%s/%s\n", inst->topic, inst->consumergroup, inst->brokers);
+        if (inst->nTopics == 1) {
+            DBGPRINTF("imkafka: Successfully subscribed to %s/%s/%s\n", inst->topics[0], inst->consumergroup,
+                      inst->brokers);
+        } else {
+            DBGPRINTF("imkafka: Successfully subscribed to %d topics in consumer group %s on %s\n", inst->nTopics,
+                      inst->consumergroup, inst->brokers);
+        }
         /* Subscription is working */
         inst->bIsSubscribed = 1;
     }
@@ -884,6 +901,39 @@ static rsRetVal ATTR_NONNULL(2) addConsumer(modConfData_t __attribute__((unused)
 finalize_it:
     if (topics != NULL) rd_kafka_topic_partition_list_destroy(topics);
     RETiRet;
+}
+
+static void buildStatsName(const instanceConf_t *const inst, char *const namebuf, const size_t namebufLen) {
+    size_t off;
+    int ret;
+
+    if (namebufLen == 0) {
+        return;
+    }
+
+    ret = snprintf(namebuf, namebufLen, "imkafka[");
+    if (ret < 0 || (size_t)ret >= namebufLen) {
+        strncpy(namebuf, "imkafka", namebufLen);
+        namebuf[namebufLen - 1] = '\0';
+        return;
+    }
+    off = (size_t)ret;
+
+    for (int i = 0; i < inst->nTopics; i++) {
+        ret = snprintf(namebuf + off, namebufLen - off, "%s%s", i == 0 ? "" : ",",
+                       inst->topics[i] ? (char *)inst->topics[i] : "topic?");
+        if (ret < 0 || (size_t)ret >= namebufLen - off) {
+            namebuf[namebufLen - 1] = '\0';
+            return;
+        }
+        off += (size_t)ret;
+    }
+
+    ret =
+        snprintf(namebuf + off, namebufLen - off, "_%s]", inst->consumergroup ? (char *)inst->consumergroup : "group?");
+    if (ret < 0 || (size_t)ret >= namebufLen - off) {
+        namebuf[namebufLen - 1] = '\0';
+    }
 }
 
 static rsRetVal ATTR_NONNULL()
@@ -947,7 +997,16 @@ BEGINnewInpInst
                 free(cstr);
             }
         } else if (!strcmp(inppblk.descr[i].name, "topic")) {
-            CHKmalloc(inst->topic = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+            inst->nTopics = pvals[i].val.d.ar->nmemb;
+            if (inst->nTopics <= 0) {
+                LogError(0, RS_RET_MISSING_CNFPARAMS, "imkafka: no topics specified");
+                ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+            }
+            CHKmalloc(inst->topics = calloc(inst->nTopics, sizeof(uchar *)));
+            for (int j = 0; j < inst->nTopics; j++) {
+                CHKmalloc(inst->topics[j] = (uchar *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL));
+                DBGPRINTF("imkafka: parsed topic %d: %s\n", j, inst->topics[j]);
+            }
         } else if (!strcmp(inppblk.descr[i].name, "consumergroup")) {
             CHKmalloc(inst->consumergroup = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
@@ -970,7 +1029,11 @@ BEGINnewInpInst
                "imkafka: \"broker\" parameter not specified using default of localhost:9092 -- this may not be what "
                "you want!");
     }
-    DBGPRINTF("imkafka: newInpIns brokers=%s, topic=%s, consumergroup=%s\n", inst->brokers, inst->topic,
+    if (inst->nTopics == 0) {
+        LogError(0, RS_RET_MISSING_CNFPARAMS, "imkafka: no topics specified");
+        ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+    }
+    DBGPRINTF("imkafka: newInpIns brokers=%s, topics=%d, consumergroup=%s\n", inst->brokers, inst->nTopics,
               inst->consumergroup);
 finalize_it:
     CODE_STD_FINALIZERnewInpInst cnfparamvalsDestruct(pvals, &inppblk);
@@ -1048,8 +1111,7 @@ BEGINactivateCnf
         if (iRet == RS_RET_OK && inst->stats == NULL) {
             char namebuf[256];
             (void)statsobj.Construct(&inst->stats);
-            snprintf(namebuf, sizeof(namebuf), "imkafka[%s_%s]", inst->topic ? (char *)inst->topic : "topic?",
-                     inst->consumergroup ? (char *)inst->consumergroup : "group?");
+            buildStatsName(inst, namebuf, sizeof(namebuf));
             (void)statsobj.SetName(inst->stats, (uchar *)namebuf);
             (void)statsobj.SetOrigin(inst->stats, (uchar *)"imkafka");
             /* init and register per-instance counters */
@@ -1081,7 +1143,12 @@ BEGINfreeCnf
         if (inst->stats) {
             statsobj.Destruct(&inst->stats);
         }
-        free(inst->topic);
+        if (inst->topics != NULL) {
+            for (int i = 0; i < inst->nTopics; i++) {
+                free(inst->topics[i]);
+            }
+            free(inst->topics);
+        }
         free(inst->consumergroup);
         free(inst->brokers);
         free(inst->pszBindRuleset);
@@ -1115,13 +1182,22 @@ static void shutdownKafkaWorkers(void) {
         if (inst->rk == NULL) {
             continue;
         }
-        DBGPRINTF("imkafka: stop consuming %s/%s/%s\n", inst->topic, inst->consumergroup, inst->brokers);
+        if (inst->nTopics == 1) {
+            DBGPRINTF("imkafka: stop consuming %s/%s/%s\n", inst->topics[0], inst->consumergroup, inst->brokers);
+        } else {
+            DBGPRINTF("imkafka: stop consuming %d topics/%s/%s\n", inst->nTopics, inst->consumergroup, inst->brokers);
+        }
         rd_kafka_consumer_close(inst->rk); /* Close the consumer, committing final offsets, etc. */
         rd_kafka_destroy(inst->rk); /* Destroy handle object */
         inst->rk = NULL;
         inst->bIsConnected = 0;
         inst->bIsSubscribed = 0;
-        DBGPRINTF("imkafka: stopped consuming %s/%s/%s\n", inst->topic, inst->consumergroup, inst->brokers);
+        if (inst->nTopics == 1) {
+            DBGPRINTF("imkafka: stopped consuming %s/%s/%s\n", inst->topics[0], inst->consumergroup, inst->brokers);
+        } else {
+            DBGPRINTF("imkafka: stopped consuming %d topics/%s/%s\n", inst->nTopics, inst->consumergroup,
+                      inst->brokers);
+        }
 #if RD_KAFKA_VERSION < 0x00090001
         /* Wait for kafka being destroyed in old API */
         if (rd_kafka_wait_destroyed(10000) < 0) {
@@ -1308,8 +1384,8 @@ ENDmodInit
  */
 static void *imkafkawrkr(void *myself) {
     struct kafkaWrkrInfo_s *me = (struct kafkaWrkrInfo_s *)myself;
-    DBGPRINTF("imkafka: started kafka consumer workerthread on %s/%s/%s\n", me->inst->topic, me->inst->consumergroup,
-              me->inst->brokers);
+    DBGPRINTF("imkafka: started kafka consumer workerthread on group %s/%s with %d topics\n", me->inst->consumergroup,
+              me->inst->brokers, me->inst->nTopics);
     do {
         if (glbl.GetGlobalInputTermState() == 1) break; /* terminate input! */
         if (me->inst->rk == NULL) {
@@ -1329,7 +1405,7 @@ static void *imkafkawrkr(void *myself) {
          */
         if (glbl.GetGlobalInputTermState() == 0) srSleep(0, 100000);
     } while (glbl.GetGlobalInputTermState() == 0);
-    DBGPRINTF("imkafka: stopped kafka consumer workerthread on %s/%s/%s\n", me->inst->topic, me->inst->consumergroup,
-              me->inst->brokers);
+    DBGPRINTF("imkafka: stopped kafka consumer workerthread on group %s/%s with %d topics\n", me->inst->consumergroup,
+              me->inst->brokers, me->inst->nTopics);
     return NULL;
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1015,6 +1015,7 @@ TESTS_KAFKA = \
 	imkafka-hang-other-action-on-no-kafka.sh \
 	imkafka_multi_single.sh \
 	imkafka_multi_group.sh \
+	imkafka_multi_topic.sh \
 	sndrcv_kafka.sh \
 	sndrcv_kafka_multi_topics.sh
 
@@ -2737,7 +2738,8 @@ imkafka-hang-other-action-on-no-kafka.log: imkafka-hang-on-no-kafka.log
 imkafka_multi_single.log: imkafka-hang-other-action-on-no-kafka.log
 sndrcv_kafka.log: imkafka_multi_single.log
 imkafka_multi_group.log: sndrcv_kafka.log
-sndrcv_kafka_multi_topics.log: imkafka_multi_group.log
+imkafka_multi_topic.log: imkafka_multi_group.log
+sndrcv_kafka_multi_topics.log: imkafka_multi_topic.log
 omkafkadynakey.log: sndrcv_kafka_multi_topics.log
 omkafka-headers.log: omkafkadynakey.log
 

--- a/tests/imkafka_multi_topic.sh
+++ b/tests/imkafka_multi_topic.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Test that a single imkafka input() can consume from multiple topics
+# specified as an array: topic=["topic1", "topic2"]
+# added 2026-05-29 by contributor
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+check_command_available kcat
+export KEEP_KAFKA_RUNNING="YES"
+
+export TESTMESSAGES=1000
+export TESTMESSAGESFULL=$TESTMESSAGES
+export EXTRA_EXITCHECK=dumpkafkalogs
+export EXTRA_EXIT=kafka
+
+RANDTOPIC1="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC2="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC1 RANDTOPIC2
+
+download_kafka
+stop_zookeeper
+stop_kafka
+
+start_zookeeper
+start_kafka
+wait_for_kafka_startup
+create_kafka_topic $RANDTOPIC1 '.dep_wrk' '22181'
+create_kafka_topic $RANDTOPIC2 '.dep_wrk' '22181'
+
+generate_conf
+add_conf '
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
+
+module(load="../plugins/imkafka/.libs/imkafka")
+input(	type="imkafka"
+	topic=["'$RANDTOPIC1'", "'$RANDTOPIC2'"]
+	broker="127.0.0.1:29092"
+	consumergroup="default"
+	confParam=[ "compression.codec=none",
+		"session.timeout.ms=10000",
+		"socket.timeout.ms=5000",
+		"socket.keepalive.enable=true",
+		"reconnect.backoff.jitter.ms=1000",
+		"enable.partition.eof=false" ]
+	)
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if ($msg contains "msgnum:") then {
+	action( type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt" )
+}
+'
+startup
+
+HALF=$((TESTMESSAGES / 2))
+
+# Inject first half of messages into topic 1
+i=1
+while (( i <= HALF )); do
+	printf ' msgnum:%8.8d\n' $i
+	i=$((i + 1))
+done | kcat -P -b 127.0.0.1:29092 -t $RANDTOPIC1
+
+# Inject second half of messages into topic 2
+i=$((HALF + 1))
+while (( i <= TESTMESSAGES )); do
+	printf ' msgnum:%8.8d\n' $i
+	i=$((i + 1))
+done | kcat -P -b 127.0.0.1:29092 -t $RANDTOPIC2
+
+wait_file_lines $RSYSLOG_OUT_LOG $TESTMESSAGES ${RETRIES:-200}
+shutdown_when_empty
+wait_shutdown
+
+delete_kafka_topic $RANDTOPIC1 '.dep_wrk' '22181'
+delete_kafka_topic $RANDTOPIC2 '.dep_wrk' '22181'
+
+seq_check 1 $TESTMESSAGESFULL -d
+
+exit_test


### PR DESCRIPTION
Users consuming many Kafka topics previously needed one input()block per topic, which was verbose and hard to maintain at scale.This change lets operators list all topics in a single input(),reducing config size and worker-thread overhead.

Before: each topic required a separate input() definition.After: topic=["t1","t2","t3"] subscribes to all in one input().

## Technical overview:

- instanceConf_t.topic (single uchar*) replaced by topics (uchar** array) + nTopics (int count).
- inppdescr declares "topic" as eCmdHdlrArray so the config framework accepts both a bare string and a bracket list.
- newInpInst builds the topics[] array from parsed values.
- addConsumer() iterates topics[] and adds each to a single
  rd_kafka_topic_partition_list_t before calling
  rd_kafka_subscribe(), matching librdkafka's native API.
- BEGINfreeCnf frees every element of the array on teardown.
- imkafka-topic.rst and imkafka.rst updated with array syntax
  examples; include corrected to canonical <json.h> path used
  across all rsyslog modules.
- New test imkafka_multi_topic.sh injects half the messages
  to each of two topics and verifies all arrive via seq_check.

Impact: existing single-topic configs are unchanged; the
eCmdHdlrArray type accepts a bare string as a one-element array.

Refs: https://github.com/rsyslog/rsyslog/issues/3520

AI-Agent: Claude Sonnet 4.6 2026-05

### Summary (non-technical, complete)

Users consuming many Kafka topics previously needed one input() block per topic — verbose and hard to maintain at scale. This change lets operators list all topics in a single input() using an array, reducing config size and eliminating redundant worker threads.

### References

Refs: https://github.com/rsyslog/rsyslog/issues/3520

### Notes (optional)

- New test `imkafka_multi_topic.sh`: injects 500 messages to each oftwo topics via one `input()`, verifies all 1000 arrive with `seq_check`.
- Existing single-topic configs are unchanged — `eCmdHdlrArray` accepts a bare string as a one-element array, no migration needed.
- Docs updated: `imkafka.rst` (Example 2) and `imkafka-topic.rst`  (single and multi-topic usage examples).
- Include corrected from non-standard `libfastjson/json.h` to the canonical `<json.h>` path used across all rsyslog modules.

---

#### Quick check
- [x] Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- [x] Commit message includes non-technical "why", Impact, and Before/After.
- [x] Used the Commit Assistant or mirrored its structure.