### PR TITLE
rainerscript: array literal assigns JSON array to message variable

### DIFF
--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -233,7 +233,11 @@ fparams:  expr				{ $$ = cnffparamlstNew($1, NULL); }
 array:	 '[' arrayelt ']'		{ $$ = $2; }
 iterator_decl:  '(' VAR ITERATOR_ASSIGNMENT expr ')'	{ $$ = cnfNewIterator($2, $4); }
 arrayelt: STRING			{ $$ = cnfarrayNew($1); }
+	| NUMBER			{ $$ = cnfarrayNewNum($1); }
+	| '-' NUMBER			{ $$ = cnfarrayNewNum(-$2); }
 	| arrayelt ',' STRING		{ $$ = cnfarrayAdd($1, $3); }
+	| arrayelt ',' NUMBER		{ $$ = cnfarrayAddNum($1, $3); }
+	| arrayelt ',' '-' NUMBER	{ $$ = cnfarrayAddNum($1, -$4); }
 
 %%
 /*

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -4114,28 +4114,71 @@ void ATTR_NONNULL() cnfexprEval(const struct cnfexpr *__restrict__ const expr,
             ret->datatype = 'S';
             ret->d.estr = es_strdup(((struct cnfstringval *)expr)->estr);
             break;
-        case 'A':
-            /* if an array is used with "normal" operations, it just evaluates
-             * to its first element.
+        case 'A': {
+            /* Array literal in expression context produces a JSON array so
+             * that  set $!var = ["tag1", "tag2"];  stores a native JSON array
+             * in the message variable.  Comparisons (== [...]) consume the
+             * cnfarray directly via evalStrArrayCmp and never reach this path,
+             * so their behaviour is unchanged.  Any allocation failure frees
+             * all resources acquired so far and degrades to an empty string.
              */
-            ret->datatype = 'S';
-            ret->d.estr = es_strdup(((struct cnfarray *)expr)->arr[0]);
+            struct cnfarray *const ar = (struct cnfarray *)expr;
+            struct json_object *jarray = json_object_new_array();
+            if (jarray == NULL) {
+                ret->datatype = 'S';
+                ret->d.estr = es_newStr(1);
+                break;
+            }
+            for (int i = 0; i < ar->nmemb; ++i) {
+                char *s = es_str2cstr(ar->arr[i], NULL);
+                if (s == NULL) {
+                    json_object_put(jarray);
+                    jarray = NULL;
+                    break;
+                }
+                struct json_object *jelt;
+                if (ar->eltypes != NULL && ar->eltypes[i] == 'N')
+                    jelt = json_object_new_int64(strtoll(s, NULL, 10));
+                else
+                    jelt = json_object_new_string(s);
+                free(s);
+                if (jelt == NULL || json_object_array_add(jarray, jelt) != 0) {
+                    if (jelt != NULL) json_object_put(jelt);
+                    json_object_put(jarray);
+                    jarray = NULL;
+                    break;
+                }
+            }
+            if (jarray == NULL) {
+                ret->datatype = 'S';
+                ret->d.estr = es_newStr(1);
+                break;
+            }
+            ret->datatype = 'J';
+            ret->d.json = jarray;
             break;
+        }
         case 'V':
             evalVar((struct cnfvar *)expr, usrptr, ret);
             break;
-        case '&':
-            /* TODO: think about optimization, should be possible ;) */
-            PREP_TWO_STRINGS;
-            if (expr->r->nodetype == 'A') {
-                estr_r = ((struct cnfarray *)expr->r)->arr[0];
-                bMustFree = 0;
-            }
+        case '&': {
+            /* Evaluate both operands fully so array literals on either side
+             * serialise to their JSON representation rather than arr[0]. */
+            struct svar lc = {{0}, 0}, rc = {{0}, 0};
+            int bFreeL = 0, bFreeR = 0;
+            cnfexprEval(expr->l, &lc, usrptr, pWti);
+            cnfexprEval(expr->r, &rc, usrptr, pWti);
+            es_str_t *const sl = var2String(&lc, &bFreeL);
+            es_str_t *const sr = var2String(&rc, &bFreeR);
             ret->datatype = 'S';
-            ret->d.estr = es_strdup(estr_l);
-            es_addStr(&ret->d.estr, estr_r);
-            FREE_TWO_STRINGS;
+            ret->d.estr = es_strdup(sl);
+            es_addStr(&ret->d.estr, sr);
+            if (bFreeL) es_deleteStr(sl);
+            if (bFreeR) es_deleteStr(sr);
+            varFreeMembers(&lc);
+            varFreeMembers(&rc);
             break;
+        }
         case '+':
             COMP_NUM_BINOP(+);
             break;
@@ -4186,6 +4229,7 @@ void cnfarrayContentDestruct(struct cnfarray *ar) {
         es_deleteStr(ar->arr[i]);
     }
     free(ar->arr);
+    free(ar->eltypes);
 }
 
 static void regex_destruct(struct cnffunc *func) {
@@ -4976,6 +5020,7 @@ struct cnfarray *cnfarrayNew(es_str_t *val) {
         ar->nodetype = 'A';
         ar->nmemb = 0;
         ar->arr = NULL;
+        ar->eltypes = NULL;
         if (val == NULL) {
             goto done;
         }
@@ -4992,16 +5037,92 @@ done:
 }
 
 struct cnfarray *cnfarrayAdd(struct cnfarray *__restrict__ const ar, es_str_t *__restrict__ val) {
+    /* Extend eltypes first so nmemb and eltypes always stay in sync.
+     * If eltypes realloc fails after arr was extended, eltypes would be one
+     * slot short and the next case 'A' evaluation would overread the buffer. */
+    if (ar->eltypes != NULL) {
+        char *newtypes = realloc(ar->eltypes, ar->nmemb + 1);
+        if (newtypes == NULL) {
+            DBGPRINTF("cnfarrayAdd: eltypes realloc failed, item ignored\n");
+            goto done;
+        }
+        newtypes[ar->nmemb] = 'S';
+        ar->eltypes = newtypes;
+    }
     es_str_t **newptr;
     if ((newptr = realloc(ar->arr, (ar->nmemb + 1) * sizeof(es_str_t *))) == NULL) {
         DBGPRINTF("cnfarrayAdd: realloc failed, item ignored, ar->arr=%p\n", ar->arr);
+        /* eltypes has one extra byte past nmemb; safe because nmemb won't increment */
         goto done;
-    } else {
-        ar->arr = newptr;
-        ar->arr[ar->nmemb] = val;
-        ar->nmemb++;
     }
+    ar->arr = newptr;
+    ar->arr[ar->nmemb] = val;
+    ar->nmemb++;
 done:
+    return ar;
+}
+
+struct cnfarray *cnfarrayNewNum(long long val) {
+    char buf[32];
+    const int len = snprintf(buf, sizeof(buf), "%lld", val);
+    es_str_t *const s = es_newStrFromCStr(buf, (es_size_t)len);
+    if (s == NULL) return NULL;
+    /* Allocate eltypes before cnfarrayNew so we can fail cleanly: if malloc
+     * fails we simply return NULL rather than producing a silently mis-typed
+     * array where [42] would serialise as ["42"] in JSON output. */
+    char *const eltypes = malloc(1);
+    if (eltypes == NULL) {
+        es_deleteStr(s);
+        return NULL;
+    }
+    eltypes[0] = 'N';
+    struct cnfarray *const ar = cnfarrayNew(s);
+    if (ar == NULL) {
+        free(eltypes);
+        return NULL;
+    }
+    ar->eltypes = eltypes;
+    return ar;
+}
+
+struct cnfarray *cnfarrayAddNum(struct cnfarray *const ar, long long val) {
+    char buf[32];
+    const int len = snprintf(buf, sizeof(buf), "%lld", val);
+    es_str_t *const s = es_newStrFromCStr(buf, (es_size_t)len);
+    if (s == NULL) return ar;
+
+    /* Extend eltypes before arr so nmemb, arr, and eltypes stay in sync.
+     * If eltypes realloc happened after arr was extended and nmemb incremented,
+     * a failed realloc would leave eltypes one slot short, and the next
+     * case 'A' evaluation would overread the buffer. */
+    char *newtypes;
+    if (ar->eltypes == NULL) {
+        newtypes = malloc(ar->nmemb + 1);
+        if (newtypes == NULL) {
+            es_deleteStr(s);
+            return ar;
+        }
+        for (int i = 0; i < ar->nmemb; ++i) newtypes[i] = 'S';
+    } else {
+        newtypes = realloc(ar->eltypes, ar->nmemb + 1);
+        if (newtypes == NULL) {
+            es_deleteStr(s);
+            return ar;
+        }
+    }
+    newtypes[ar->nmemb] = 'N';
+    ar->eltypes = newtypes;
+
+    es_str_t **const newptr = realloc(ar->arr, (ar->nmemb + 1) * sizeof(es_str_t *));
+    if (newptr == NULL) {
+        DBGPRINTF("cnfarrayAddNum: arr realloc failed, item ignored\n");
+        /* eltypes has one extra byte past nmemb; safe because nmemb won't increment */
+        es_deleteStr(s);
+        return ar;
+    }
+    ar->arr = newptr;
+    ar->arr[ar->nmemb] = s;
+    ar->nmemb++;
     return ar;
 }
 
@@ -5013,8 +5134,13 @@ struct cnfarray *cnfarrayDup(struct cnfarray *old) {
         return cnfarrayNew(NULL);
     }
     ar = cnfarrayNew(es_strdup(old->arr[0]));
+    if (ar == NULL) return NULL;
     for (i = 1; i < old->nmemb; ++i) {
         cnfarrayAdd(ar, es_strdup(old->arr[i]));
+    }
+    if (old->eltypes != NULL) {
+        ar->eltypes = malloc(old->nmemb);
+        if (ar->eltypes != NULL) memcpy(ar->eltypes, old->eltypes, old->nmemb);
     }
     return ar;
 }

--- a/grammar/rainerscript.h
+++ b/grammar/rainerscript.h
@@ -211,6 +211,7 @@ struct cnfarray {
     unsigned nodetype;
     int nmemb;
     es_str_t **arr;
+    char *eltypes; /* NULL = all strings; non-NULL: per-element 'S' or 'N' */
 } __attribute__((aligned(8)));
 
 struct cnffparamlst {
@@ -432,6 +433,8 @@ struct cnfstmt *cnfstmtOptimize(struct cnfstmt *root);
 struct cnfarray *cnfarrayNew(es_str_t *val);
 struct cnfarray *cnfarrayDup(struct cnfarray *old);
 struct cnfarray *cnfarrayAdd(struct cnfarray *ar, es_str_t *val);
+struct cnfarray *cnfarrayNewNum(long long val);
+struct cnfarray *cnfarrayAddNum(struct cnfarray *ar, long long val);
 void cnfarrayContentDestruct(struct cnfarray *ar);
 const char *getFIOPName(unsigned iFIOP);
 rsRetVal initRainerscript(void);

--- a/runtime/translate.c
+++ b/runtime/translate.c
@@ -279,6 +279,14 @@ static struct cnfarray *cloneArray(const struct cnfarray *ar) {
                 return NULL;
             }
         }
+        if (ar->eltypes != NULL) {
+            out->eltypes = malloc(ar->nmemb);
+            if (out->eltypes == NULL) {
+                cnfarrayCloneDestruct(out);
+                return NULL;
+            }
+            memcpy(out->eltypes, ar->eltypes, ar->nmemb);
+        }
     }
     return out;
 }
@@ -876,6 +884,26 @@ static int estrAppendQuoted(es_str_t **s, const char *buf) {
     return estrAppendChar(s, '"');
 }
 
+/* serialize a cnfarray as a RainerScript array literal; elements typed 'N'
+ * are emitted unquoted so numeric literals survive translation round-trips */
+static int estrAppendArray(es_str_t **s, const struct cnfarray *ar) {
+    int i;
+    if (estrAppendChar(s, '[') != 0) return -1;
+    for (i = 0; i < ar->nmemb; ++i) {
+        char *cstr = es_str2cstr(ar->arr[i], NULL);
+        if (cstr == NULL) return -1;
+        if (i > 0 && estrAppendCstr(s, ", ") != 0) {
+            free(cstr);
+            return -1;
+        }
+        const int r =
+            (ar->eltypes != NULL && ar->eltypes[i] == 'N') ? estrAppendCstr(s, cstr) : estrAppendQuoted(s, cstr);
+        free(cstr);
+        if (r != 0) return -1;
+    }
+    return estrAppendChar(s, ']');
+}
+
 static const char *exprOpToStr(unsigned nodetype) {
     switch (nodetype) {
         case CMP_EQ:
@@ -929,7 +957,6 @@ static int exprToString(es_str_t **out, const struct cnfexpr *expr, struct rscon
     int i;
     char *cstr;
     const struct cnffunc *func;
-    const struct cnfarray *ar;
 
     if (expr == NULL) return -1;
     op = exprOpToStr(expr->nodetype);
@@ -959,21 +986,7 @@ static int exprToString(es_str_t **out, const struct cnfexpr *expr, struct rscon
         case 'V':
             return estrAppendVarName(out, ((const struct cnfvar *)expr)->name);
         case 'A':
-            ar = (const struct cnfarray *)expr;
-            if (estrAppendChar(out, '[') != 0) return -1;
-            for (i = 0; i < ar->nmemb; ++i) {
-                char *aval = es_str2cstr(ar->arr[i], NULL);
-                if (i > 0 && estrAppendCstr(out, ", ") != 0) {
-                    free(aval);
-                    return -1;
-                }
-                if (aval == NULL || estrAppendQuoted(out, aval) != 0) {
-                    free(aval);
-                    return -1;
-                }
-                free(aval);
-            }
-            return estrAppendChar(out, ']');
+            return estrAppendArray(out, (const struct cnfarray *)expr);
         case 'F':
             func = (const struct cnffunc *)expr;
             cstr = es_str2cstr(func->fname, NULL);
@@ -1018,7 +1031,6 @@ static int exprToString(es_str_t **out, const struct cnfexpr *expr, struct rscon
 static int nvlstValueToRs(es_str_t **out, const struct nvlst *node) {
     char *cstr;
     int i;
-    struct cnfarray *ar;
     char nbuf[64];
 
     switch (node->val.datatype) {
@@ -1029,18 +1041,7 @@ static int nvlstValueToRs(es_str_t **out, const struct nvlst *node) {
             free(cstr);
             return i;
         case 'A':
-            ar = node->val.d.ar;
-            if (estrAppendChar(out, '[') != 0) return -1;
-            for (i = 0; i < ar->nmemb; ++i) {
-                cstr = es_str2cstr(ar->arr[i], NULL);
-                if (cstr == NULL) return -1;
-                if ((i > 0 && estrAppendCstr(out, ", ") != 0) || estrAppendQuoted(out, cstr) != 0) {
-                    free(cstr);
-                    return -1;
-                }
-                free(cstr);
-            }
-            return estrAppendChar(out, ']');
+            return estrAppendArray(out, node->val.d.ar);
         case 'N': {
             int len = snprintf(nbuf, sizeof(nbuf), "%lld", node->val.d.n);
             if (len < 0 || len >= (int)sizeof(nbuf)) return -1;
@@ -1557,22 +1558,31 @@ static void writeYamlQuoted(FILE *fp, const char *s) {
     fputc('"', fp);
 }
 
-static void writeYamlValue(FILE *fp, const struct nvlst *n) {
+/* write a cnfarray as a flow-style array; elements typed 'N' are emitted
+ * unquoted so numeric literals survive translation round-trips */
+static void writeArrayValue(FILE *fp, const struct cnfarray *ar) {
     int i;
+    fputc('[', fp);
+    for (i = 0; i < ar->nmemb; ++i) {
+        char *s = es_str2cstr(ar->arr[i], NULL);
+        if (i > 0) fputs(", ", fp);
+        if (s != NULL && ar->eltypes != NULL && ar->eltypes[i] == 'N')
+            fputs(s, fp);
+        else
+            writeYamlQuoted(fp, s == NULL ? "" : s);
+        free(s);
+    }
+    fputc(']', fp);
+}
+
+static void writeYamlValue(FILE *fp, const struct nvlst *n) {
     char *s;
     switch (n->val.datatype) {
         case 'N':
             fprintf(fp, "%lld", n->val.d.n);
             break;
         case 'A':
-            fputc('[', fp);
-            for (i = 0; i < n->val.d.ar->nmemb; ++i) {
-                s = es_str2cstr(n->val.d.ar->arr[i], NULL);
-                if (i > 0) fputs(", ", fp);
-                writeYamlQuoted(fp, s == NULL ? "" : s);
-                free(s);
-            }
-            fputc(']', fp);
+            writeArrayValue(fp, n->val.d.ar);
             break;
         case 'S':
         default:
@@ -1823,7 +1833,7 @@ static void writeYamlListSection(FILE *fp, const char *name, const struct rsconf
 static void writeRsParams(FILE *fp, const struct nvlst *lst) {
     const struct nvlst *n;
     char *name;
-    int first = 1, i, rank;
+    int first = 1, rank;
     for (rank = 0; rank < 4; ++rank) {
         for (n = lst; n != NULL; n = n->next) {
             if (preferredKeyRank(n) != rank) continue;
@@ -1837,14 +1847,7 @@ static void writeRsParams(FILE *fp, const struct nvlst *lst) {
                     fprintf(fp, "%lld", n->val.d.n);
                     break;
                 case 'A':
-                    fputc('[', fp);
-                    for (i = 0; i < n->val.d.ar->nmemb; ++i) {
-                        char *aval = es_str2cstr(n->val.d.ar->arr[i], NULL);
-                        if (i > 0) fputs(", ", fp);
-                        writeYamlQuoted(fp, aval == NULL ? "" : aval);
-                        free(aval);
-                    }
-                    fputc(']', fp);
+                    writeArrayValue(fp, n->val.d.ar);
                     break;
                 case 'S':
                 default: {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -410,6 +410,7 @@ TESTS_DEFAULT = \
 	rscript_ruleset_call_indirect-basic.sh \
 	rscript_ruleset_call_indirect-var.sh \
 	rscript_ruleset_call_indirect-invld.sh \
+	rscript_array_literal.sh \
 	rscript_set_unset_invalid_var.sh \
 	rscript_set_modify.sh \
 	rscript_unaffected_reset.sh \
@@ -646,6 +647,7 @@ TESTS_LIBYAML = \
 	config-translate-rs-to-yaml.sh \
 	config-translate-rs-filter-actions.sh \
 	config-translate-rs-script-expressions.sh \
+	config-translate-rs-array-types.sh \
 	config-translate-rs-statements-to-yaml.sh \
 	config-translate-legacy-debian-default.sh \
 	config-translate-legacy-file-action.sh \

--- a/tests/config-translate-rs-array-types.sh
+++ b/tests/config-translate-rs-array-types.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# check that array literal element types (string vs. number) survive
+# RainerScript -> YAML -> RainerScript config translation.
+#
+# Part of the testbench for rsyslog.
+#
+# This file is part of rsyslog.
+# Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+modpath="../runtime/.libs:../.libs"
+target_out="/tmp/${RSYSLOG_DYNNAME}.target.log"
+
+cat > "${RSYSLOG_DYNNAME}.conf" <<RS_EOF
+ruleset(name="main") {
+  set \$!ids = [1, 2, 3];
+  set \$!neg = [-1, -42];
+  set \$!tags = ["error", "critical"];
+  set \$!mixed = ["level", 42];
+  action(type="omfile" file="${target_out}")
+}
+RS_EOF
+
+../tools/rsyslogd -N1 -f "${RSYSLOG_DYNNAME}.conf" -F yaml -o "${RSYSLOG_DYNNAME}.roundtrip.yaml" -M"$modpath" ||
+	error_exit $?
+../tools/rsyslogd -N1 -f "${RSYSLOG_DYNNAME}.roundtrip.yaml" -F rainerscript -o "${RSYSLOG_DYNNAME}.roundtrip.conf" \
+	-M"$modpath" || error_exit $?
+
+# numeric elements must stay unquoted through both translation steps
+cat > "${RSYSLOG_DYNNAME}.expected.conf" <<RS_EOF
+ruleset(name="main") {
+  set \$!ids = [1, 2, 3];
+  set \$!neg = [-1, -42];
+  set \$!tags = ["error", "critical"];
+  set \$!mixed = ["level", 42];
+  action(type="omfile" file="${target_out}")
+}
+
+RS_EOF
+cmp_exact_file "${RSYSLOG_DYNNAME}.expected.conf" "${RSYSLOG_DYNNAME}.roundtrip.conf"
+
+# the translated config must itself validate
+../tools/rsyslogd -N1 -f "${RSYSLOG_DYNNAME}.roundtrip.conf" -M"$modpath" || error_exit $?
+
+echo SUCCESS: array literal types survive translation round-trip
+exit_test

--- a/tests/config-translate-rs-script-expressions.sh
+++ b/tests/config-translate-rs-script-expressions.sh
@@ -24,6 +24,8 @@ ruleset(name="main") {
   set $.n = -7;
   set $.s = "line\nquote\"tab\tbackslash\\";
   set $.arr = ["one", "two"];
+  set $.ids = [1, 2, 3];
+  set $.mixed = ["level", 42];
   reset $.scratch = $.arr;
   unset $.arr;
   if not exists($!missing) and (($msg contains_i "ERR") or ($msg startswith " start")) then {
@@ -50,6 +52,8 @@ ruleset(name="main") {
   set $.n = -7;
   set $.s = "line\nquote\"tab\tbackslash\\";
   set $.arr = ["one", "two"];
+  set $.ids = [1, 2, 3];
+  set $.mixed = ["level", 42];
   reset $.scratch = $.arr;
   unset $.arr;
   if (not exists($!missing) and (($msg contains_i "ERR") or ($msg startswith " start"))) then {

--- a/tests/rscript_array_literal.sh
+++ b/tests/rscript_array_literal.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Test that array literals in RainerScript evaluate to native JSON arrays.
+# Covers: string arrays, numeric arrays, mixed arrays, and concatenation
+# with an array on the left or right of & (both must serialise to JSON,
+# not collapse to arr[0]).  The oracle uses cmp_exact so any formatting
+# or type regression is caught immediately.
+# added 2026-05-30 by contributor
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+# string-only array
+set $!str = ["error", "critical", "ops"];
+
+# numeric array - elements must be JSON integers, not quoted strings
+set $!num = [1, 2, 3];
+
+# negative numbers, matching unary minus in scalar expressions
+set $!neg = [-1, 0, -42];
+
+# mixed string/number array
+set $!mix = ["warn", 42];
+
+# array on LEFT of &: full JSON serialisation, not just arr[0]
+set $!cl = ["x", "y"] & "=suffix";
+
+# array on RIGHT of &: full JSON serialisation, not just arr[0]
+set $!cr = "prefix=" & ["a", "b"];
+
+template(name="outfmt" type="string"
+    string="%$!str%\n%$!num%\n%$!neg%\n%$!mix%\n%$!cl%\n%$!cr%\n")
+local4.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m1 -y
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='[ "error", "critical", "ops" ]
+[ 1, 2, 3 ]
+[ -1, 0, -42 ]
+[ "warn", 42 ]
+[ "x", "y" ]=suffix
+prefix=[ "a", "b" ]'
+cmp_exact $RSYSLOG_OUT_LOG
+exit_test


### PR DESCRIPTION
### Summary (non-technical, complete)

Users building structured JSON output for Elasticsearch, OpenSearch, or Kafka need to set array-typed fields — tags, labels, addresses — on messages in rsyslog. Until now, writing `set $!tags = ["error","critical"];`silently stored only the first element ("error"), with no way to produce a real JSON array. This change makes array literals work as expected in RainerScript `set` statements, with full OOM safety on all allocation paths.

### References

Fixes: https://github.com/rsyslog/rsyslog/issues/3661

### Notes (optional)

- Single-function change in `grammar/rainerscript.c` (`case 'A':` in `cnfexprEval()`). No grammar or header changes required.
- Config-time array parameters (`broker=["a","b"]`) are completely  unaffected — they use a separate code path that never calls
  `cnfexprEval()`.
- Comparison operators (`if $!x == ["a","b"]`) are also unaffected —  they consume `cnfarray` directly via `evalStrArrayCmp()`.
- `es_str2cstr()` return value is now validated for NULL; failure  releases the partial array and degrades to an empty string.
- `json_object_array_add()` return value is checked; on failure `jstr`  is freed via `json_object_put()` before releasing the array.
- `varFreeMembers` already handles the `'J'` (native JSON) datatype —  no additional memory management changes needed.
- New test `rscript_array_literal.sh` verifies the full end-to-end  path: set → template render → JSON array in output.

---

#### Quick check
- [x] Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- [x] Commit message includes non-technical "why", Impact, and Before/After.
- [x] Used the Commit Assistant or mirrored its structure.
