### PR TITLE
ci: update Fedora coverage

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -445,7 +445,7 @@ jobs:
       matrix:
         config: [centos_7, debian_13,
                  ubuntu_26_imtcp_no_epoll,
-                 fedora_43,
+                 fedora_44,
                  ubuntu_20, ubuntu_24,
                  ubuntu_26_san, ubuntu_26_tsan, ubuntu_22_distcheck,
                  openeuler, wolfssl, elasticsearch]
@@ -543,8 +543,8 @@ jobs:
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
                      --disable-kafka-tests"
               ;;
-          'fedora_43')
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:43'
+          'fedora_44')
+              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:44'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
                      --disable-kafka-tests --enable-debug --enable-imdtls --enable-omdtls"
               ;;

--- a/.github/workflows/run_distro_daily.yml
+++ b/.github/workflows/run_distro_daily.yml
@@ -56,8 +56,8 @@ jobs:
               --disable-elasticsearch-tests --disable-kafka-tests
               --disable-snmp-tests --enable-imdtls --enable-omdtls
             valgrind_supp: ''
-          - lane: fedora_42
-            container: rsyslog/rsyslog_dev_base_fedora:42
+          - lane: fedora_43
+            container: rsyslog/rsyslog_dev_base_fedora:43
             configure_extra: >-
               --disable-elasticsearch-tests --disable-kafka-tests
               --enable-debug --enable-imdtls --enable-omdtls

--- a/packaging/docker/dev_env/fedora/base/42/tag-previous.sh
+++ b/packaging/docker/dev_env/fedora/base/42/tag-previous.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-docker tag rsyslog/rsyslog_dev_base_fedora:42 rsyslog/rsyslog_dev_base_fedora:42_previous
-docker push rsyslog/rsyslog_dev_base_fedora:42_previous

--- a/packaging/docker/dev_env/fedora/base/44/Dockerfile
+++ b/packaging/docker/dev_env/fedora/base/44/Dockerfile
@@ -2,9 +2,10 @@
 # creates the build environment
 # Note: this image currently uses in-container git checkouts to
 # build the "rsyslog libraries" - we do not have packages for them
-FROM	fedora:42
+FROM	fedora:44
 # search for packages that contain <file>: dnf whatprovides <file>
 RUN	dnf -y update
+# hadolint ignore=DL3041
 RUN	dnf -y install \
 	autoconf \
 	autoconf-archive \
@@ -23,11 +24,12 @@ RUN	dnf -y install \
 	gdb \
 	git \
 	gnutls-devel \
+	gnutls-utils \
 	hiredis \
 	hiredis-devel \
 	iproute \
-	java-21-openjdk \
-	java-21-openjdk-devel \
+	java-25-openjdk \
+	java-25-openjdk-devel \
 	apr-util-devel \
 	libcurl-devel \
 	libdbi-dbd-mysql \
@@ -74,7 +76,8 @@ RUN	dnf -y install \
 	tcl-devel \
 	valgrind \
 	wget \
-	zlib-devel
+	zlib-devel \
+	&& dnf clean all
 	# end of this RUN
 # unfortunately, tcl-devel does not properly setup required bits in the environment
 # so we now try to do that. In case this does no longer work with a version, search
@@ -176,7 +179,7 @@ RUN	cd helper-projects && \
 	git clone https://github.com/stricaud/faup.git && \
 	cd faup && \
 	cd build && \
-	cmake .. && make -j && \
+	cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 .. && make -j && \
 	make install && \
 	cd .. && \
 	cd .. && \

--- a/packaging/docker/dev_env/fedora/base/44/build.sh
+++ b/packaging/docker/dev_env/fedora/base/44/build.sh
@@ -15,8 +15,5 @@ autoreconf -fi && \
 ./configure \$RSYSLOG_CONFIGURE_OPTIONS --enable-compile-warnings=yes  && \
 make -j4
 "
-# shellcheck disable=SC2181
-if [ $? -eq 0 ]; then
-	printf "\nREADY TO PUSH!\n"
-	printf "\ndocker push rsyslog/rsyslog_dev_base_fedora:44\n"
-fi
+printf "\nREADY TO PUSH!\n"
+printf "\ndocker push rsyslog/rsyslog_dev_base_fedora:44\n"

--- a/packaging/docker/dev_env/fedora/base/44/build.sh
+++ b/packaging/docker/dev_env/fedora/base/44/build.sh
@@ -1,21 +1,22 @@
 #!/bin/sh
 set -e
-docker build $1 -t rsyslog/rsyslog_dev_base_fedora:42 .
+docker build "$@" -t rsyslog/rsyslog_dev_base_fedora:44 .
 printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:\n"
 DOCKER_TTY_FLAGS=""
 if [ -t 0 ] && [ -t 1 ]; then
 	DOCKER_TTY_FLAGS="-ti"
 fi
 
-docker run $DOCKER_TTY_FLAGS rsyslog/rsyslog_dev_base_fedora:42 bash -c  "
+docker run $DOCKER_TTY_FLAGS rsyslog/rsyslog_dev_base_fedora:44 bash -c  "
 set -e && \
 git clone https://github.com/rsyslog/rsyslog.git && \
 cd rsyslog && \
 autoreconf -fi && \
-./configure $RSYSLOG_CONFIGURE_OPTIONS --enable-compile-warnings=yes  && \
+./configure \$RSYSLOG_CONFIGURE_OPTIONS --enable-compile-warnings=yes  && \
 make -j4
 "
+# shellcheck disable=SC2181
 if [ $? -eq 0 ]; then
 	printf "\nREADY TO PUSH!\n"
-	printf "\ndocker push rsyslog/rsyslog_dev_base_fedora:42\n"
+	printf "\ndocker push rsyslog/rsyslog_dev_base_fedora:44\n"
 fi

--- a/packaging/docker/dev_env/fedora/base/44/tag-previous.sh
+++ b/packaging/docker/dev_env/fedora/base/44/tag-previous.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker tag rsyslog/rsyslog_dev_base_fedora:44 rsyslog/rsyslog_dev_base_fedora:44_previous
+docker push rsyslog/rsyslog_dev_base_fedora:44_previous


### PR DESCRIPTION
## Summary
- add the Fedora 44 dev-container definition
- move regular PR Fedora CI from Fedora 43 to Fedora 44
- keep Fedora 43 as the daily distro compatibility lane
- remove the obsolete Fedora 42 dev-container definition

## Rationale
Fedora 44 is the best PR-review signal now because it carries the newest stable Fedora compiler and dependency stack. Fedora 43 remains useful as the supported N-1 compatibility check, so it moves to daily coverage. Fedora 42 is no longer worth normal CI cost now that Fedora 44 is current.

## Validation
- Built `rsyslog/rsyslog_dev_base_fedora:44` locally.
- Ran the Fedora 44 container build-script smoke test successfully.
- Ran a full Fedora 44 all-module build with `make -j80` successfully.
- `actionlint .github/workflows/run_checks.yml .github/workflows/run_distro_daily.yml`
- `shellcheck packaging/docker/dev_env/fedora/base/44/build.sh packaging/docker/dev_env/fedora/base/44/tag-previous.sh`

Note: `hadolint` reports inherited `DL3003` warnings from the copied Fedora Dockerfile pattern.
