### PR TITLE
omkafka: fix suspension not triggered on host resolution failure

### DIFF
--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -1419,7 +1419,7 @@ static void errorCallback(rd_kafka_t __attribute__((unused)) * rk,
     /* count kafka transport errors that cause action suspension */
     if (err == RD_KAFKA_RESP_ERR__MSG_TIMED_OUT) {
         STATSCOUNTER_INC(ctrKafkaRespTimedOut, mutCtrKafkaRespTimedOut);
-    } else if (err == RD_KAFKA_RESP_ERR__TRANSPORT) {
+    } else if (err == RD_KAFKA_RESP_ERR__TRANSPORT || err == RD_KAFKA_RESP_ERR__RESOLVE) {
         STATSCOUNTER_INC(ctrKafkaRespTransport, mutCtrKafkaRespTransport);
     } else if (err == RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN) {
         STATSCOUNTER_INC(ctrKafkaRespBrokerDown, mutCtrKafkaRespBrokerDown);
@@ -1431,13 +1431,17 @@ static void errorCallback(rd_kafka_t __attribute__((unused)) * rk,
         STATSCOUNTER_INC(ctrKafkaRespOther, mutCtrKafkaRespOther);
     }
 
-    /* Handle common transport error codes*/
+    /* Suspend action on any error that means brokers are unreachable.
+     * RD_KAFKA_RESP_ERR__RESOLVE (-193) was missing from this list, causing
+     * host-resolution failures to bypass suspension and silence
+     * action.reportSuspension/reportSuspensionContinuation messages. */
     if (err == RD_KAFKA_RESP_ERR__MSG_TIMED_OUT || err == RD_KAFKA_RESP_ERR__TRANSPORT ||
-        err == RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN || err == RD_KAFKA_RESP_ERR__AUTHENTICATION ||
-        err == RD_KAFKA_RESP_ERR__SSL) {
-        /* Broker transport error, we need to disable the action for now!*/
-        pData->bIsSuspended = 1;
-        LogMsg(0, RS_RET_KAFKA_ERROR, LOG_WARNING, "omkafka: action will suspended due to kafka error %d: %s", err,
+        err == RD_KAFKA_RESP_ERR__RESOLVE || err == RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN ||
+        err == RD_KAFKA_RESP_ERR__AUTHENTICATION || err == RD_KAFKA_RESP_ERR__SSL) {
+        if (pData != NULL) {
+            pData->bIsSuspended = 1;
+        }
+        LogMsg(0, RS_RET_KAFKA_ERROR, LOG_WARNING, "omkafka: action suspended due to kafka error %d: %s", err,
                rd_kafka_err2str(err));
     } else {
         LogError(0, RS_RET_KAFKA_ERROR, "omkafka: kafka error message: %d,'%s','%s'", err, rd_kafka_err2str(err),


### PR DESCRIPTION
### Summary (non-technical, complete)

When a Kafka broker is unreachable due to a DNS failure, rsyslog's`action.reportSuspension` and `reportSuspensionContinuation` messageswere silently suppressed. Operators saw the librdkafka error in the
system log but received no suspension or retry notifications, making itimpossible to detect broker outages or trigger failover actions reliably.

### References

Fixes: https://github.com/rsyslog/rsyslog/issues/4374

### Notes (optional)

- Root cause: `errorCallback` had a hard-coded list of five error codes  that set `bIsSuspended = 1`. `RD_KAFKA_RESP_ERR__RESOLVE` (-193,  "Local: Host resolution failure") was absent, so it fell into the `else` branch — logged a generic error but never suspended the action.  `doAction` saw `bIsSuspended = 0` and returned `RS_RET_OK`, so the  rsyslog core never called `actionSuspend` and never emitted suspension  messages.
- Fix: `RD_KAFKA_RESP_ERR__RESOLVE` is now treated the same as
  `RD_KAFKA_RESP_ERR__TRANSPORT` (both mean the broker is unreachable
  at the network layer). It is counted in the existing
  `ctrKafkaRespTransport` stats counter and included in the suspension-trigger condition.
- Also fixed a grammar typo in the existing log message:
  `"action will suspended"` → `"action suspended"`.
- No tests added: this requires a live Kafka cluster with DNS manipulation to reproduce; build-only validation is acceptable per  `plugins/imkafka/AGENTS.md`.

---

#### Quick check
- [x] Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- [x] Commit message includes non-technical "why", Impact, and Before/After.
- [x] Used the Commit Assistant or mirrored its structure.