### PR TITLE
omkafka: fix NULL topic in onDestroy log for dynatopic

### DIFF
--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -1327,6 +1327,10 @@ static void do_rd_kafka_destroy(instanceData *const __restrict__ pData) {
         DBGPRINTF("omkafka: onDestroy can't close, handle wasn't open\n");
         goto done;
     }
+    const char *const actName = pData->statsName ? (const char *)pData->statsName : rd_kafka_name(pData->rk);
+    const char *const topicName =
+        pData->dynaTopic ? (const char *)pData->topic
+                         : (pData->pTopic ? rd_kafka_topic_name(pData->pTopic) : (const char *)pData->topic);
     int queuedCount = rd_kafka_outq_len(pData->rk);
     DBGPRINTF("omkafka: onDestroy closing - items left in outqueue: %d\n", queuedCount);
 
@@ -1340,9 +1344,9 @@ static void do_rd_kafka_destroy(instanceData *const __restrict__ pData) {
             const int flushStatus = rd_kafka_flush(pData->rk, pData->closeTimeout);
             if (flushStatus == RD_KAFKA_RESP_ERR_NO_ERROR) {
                 DBGPRINTF(
-                    "omkafka: onDestroyflushed remaining '%d' messages "
+                    "omkafka: onDestroy flushed remaining '%d' messages "
                     "to kafka topic '%s'\n",
-                    queuedCount, (pData->pTopic == NULL ? "NULL" : rd_kafka_topic_name(pData->pTopic)));
+                    queuedCount, topicName);
 
                 /* Trigger callbacks a last time before shutdown */
                 const int callbacksCalled = rd_kafka_poll(pData->rk, 0); /* call callbacks */
@@ -1353,11 +1357,10 @@ static void do_rd_kafka_destroy(instanceData *const __restrict__ pData) {
             } else /* TODO: Handle unsend messages here! */ {
                 /* timeout = RD_KAFKA_RESP_ERR__TIMED_OUT */
                 LogError(0, RS_RET_KAFKA_ERROR,
-                         "omkafka: onDestroy "
-                         "Failed to send remaining '%d' messages to "
-                         "topic '%s' on shutdown with error: '%s'",
-                         queuedCount, (pData->pTopic == NULL ? "NULL" : rd_kafka_topic_name(pData->pTopic)),
-                         rd_kafka_err2str(flushStatus));
+                         "omkafka[%s]: onDestroy "
+                         "failed to flush remaining '%d' messages to "
+                         "topic '%s' on shutdown: %s",
+                         actName, queuedCount, topicName, rd_kafka_err2str(flushStatus));
 #if RD_KAFKA_VERSION >= 0x010001ff
                 rd_kafka_purge(pData->rk, RD_KAFKA_PURGE_F_QUEUE | RD_KAFKA_PURGE_F_INFLIGHT);
                 /* Trigger callbacks a last time before shutdown */
@@ -1374,9 +1377,9 @@ static void do_rd_kafka_destroy(instanceData *const __restrict__ pData) {
     }
     if (queuedCount > 0) {
         LogMsg(0, RS_RET_ERR, LOG_WARNING,
-               "omkafka: queue-drain for close timed-out took too long, "
+               "omkafka[%s]: queue-drain on shutdown timed out for topic '%s', "
                "items left in outqueue: %d -- this may indicate data loss",
-               rd_kafka_outq_len(pData->rk));
+               actName, topicName, rd_kafka_outq_len(pData->rk));
     }
     if (pData->dynaTopic) {
         dynaTopicFreeCacheEntries(pData);


### PR DESCRIPTION
### Summary (non-technical, complete)

When using `dynatopic="on"` and Kafka brokers are unreachable at shutdown, the rsyslog error log printed "NULL" as the topic name instead of the configured topic. This made it impossible to identify which action failed to flush its outbound queue from the log alone.

### References

Fixes: https://github.com/rsyslog/rsyslog/issues/4909

### Notes (optional)

- Two-line fix in `do_rd_kafka_destroy()` in `plugins/omkafka/omkafka.c`.
- Root cause: `pData->pTopic` is always NULL for dynamic topics —  resolved topic handles live per-message in `pData->dynCache`. The  existing `pData->pTopic == NULL ? "NULL" : ...` check therefore  always printed the literal string `"NULL"`.
- Fix follows the pattern already used in `deliveryCallback` (line 1131) which falls back to `pData->topic` when the per-message topic handle is unavailable.
- Log output change only — no flush or error-handling logic is affected.

---

#### Quick check
- [x] Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- [x] Commit message includes non-technical "why", Impact, and Before/After.
- [x] Used the Commit Assistant or mirrored its structure.