### PR TITLE
doc: clarify queue crash durability limits

### DIFF
--- a/doc/source/concepts/queues.rst
+++ b/doc/source/concepts/queues.rst
@@ -183,6 +183,12 @@ disk for best performance and/or isolation by setting a dedicated
 ``queue.spoolDirectory`` on that queue definition. To create a disk
 queue, set ``queue.type="Disk"``.
 
+Disk queue durability is a configuration tradeoff, not an unconditional
+guarantee. A larger ``queue.checkpointInterval`` improves throughput but
+can require replay or recovery work after an ungraceful stop. Enabling
+``queue.syncqueuefiles`` and a very small checkpoint interval improves
+crash and power-loss resilience at a significant performance cost.
+
 If you happen to lose or otherwise need the housekeeping structures and
 have all your queue chunks you can use the ``recover_qi.pl`` script
 included in rsyslog to regenerate them::
@@ -258,10 +264,11 @@ parameters can be set. From the user's point of view, think of a DA
 queue like a "super-queue" which does all within a single queue.
 
 DA queues are typically used to de-couple potentially long-running and
-unreliable actions (to make them reliable). For example, it is
+unreliable actions and make them more resilient to destination outages.
+For example, it is
 recommended to use a disk-assisted linked list in-memory queue in front
-of each database and "send via tcp" action. Doing so makes these actions
-reliable and de-couples their potential low execution speed from the
+of each database and "send via tcp" action. Doing so de-couples their
+potential low execution speed from the
 rest of your rules (e.g. the local file writes). There is a howto on
 :doc:`massive database inserts </tutorials/high_database_rate>` which
 nicely describes this use case. It may even be a good read if you do not
@@ -279,6 +286,14 @@ eventually written to disk, but only if the high water mark is ever
 reached again. If it isn't, these items never touch the disk. So even
 when a queue runs disk-assisted, there is in-memory data present (this
 is a big difference to pure disk queues!).
+
+This also means that disk-assisted queues should not be treated like
+pure disk queues for crash durability. ``queue.saveOnShutdown="on"``
+persists the in-memory portion during an orderly rsyslog shutdown, but
+it cannot run after an immediate process kill, kernel OOM kill, system
+crash, or power loss. For scenarios where every accepted message must
+survive those events, use a pure disk queue and tune checkpointing and
+file synchronization for the required durability level.
 
 This algorithm prevents unnecessary disk writes but also leaves some
 additional buffer space for message bursts. Remember that creating disk

--- a/doc/source/rainerscript/queue_parameters.rst
+++ b/doc/source/rainerscript/queue_parameters.rst
@@ -542,7 +542,17 @@ queue.saveOnShutdown
 
    "binary", "off", "no", "``$ActionQueueSaveOnShutdown``"
 
-This parameter specifies if data should be saved at shutdown.
+This parameter specifies if queued data should be saved during an
+orderly rsyslog shutdown. It applies to disk-assisted queues, letting
+rsyslog persist messages that are still in the memory portion of the
+queue before the process exits.
+
+The setting does not protect messages that are still in memory when the
+process is killed without graceful shutdown handling, for example by
+``SIGKILL``, the kernel OOM killer, a system crash, or power loss. Use a
+pure disk queue plus appropriate ``queue.checkpointInterval`` and
+``queue.syncqueuefiles`` settings when crash durability is more important
+than throughput.
 
 
 queue.dequeueSlowDown

--- a/doc/source/tutorials/reliable_forwarding.rst
+++ b/doc/source/tutorials/reliable_forwarding.rst
@@ -92,6 +92,13 @@ files. So that name should not be at the file size name length limit
 :doc:`../rainerscript/queue_parameters` for the full list of queue
 options.
 
+``queue.saveOnShutdown="on"`` applies to orderly rsyslog shutdowns. It
+does not make a disk-assisted queue equivalent to a pure disk queue
+after an immediate process kill, kernel OOM kill, system crash, or power
+loss. Use RELP plus a pure disk queue with durability-oriented queue
+checkpointing and synchronization settings when the deployment requires
+crash-resistant end-to-end delivery.
+
 Please note that actual spool files are only created if the remote
 server is down **and** there is no more space in the in-memory queue. By
 default, a short failure of the remote server will never result in the
@@ -199,4 +206,3 @@ Revision History
 
 -  2008-06-27 \* `Rainer Gerhards <https://rainer.gerhards.net/>`_ \*
    Initial Version created
-


### PR DESCRIPTION
## Summary
- clarify that disk-assisted queues plus queue.saveOnShutdown protect orderly shutdowns, not SIGKILL/OOM/crash/power loss
- point crash-durability use cases at pure disk queues with checkpoint/sync tuning
- update the reliable forwarding tutorial to avoid over-promising disk-assisted durability

Refs https://github.com/rsyslog/rsyslog/issues/2965

## Validation
- devtools/local-validation-plan.sh classified this as rendered-docs
- git diff --check
- ./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"