### PR TITLE
rainerscript: add tocef() and cef_ext_escape() for CEF output

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -448,6 +448,7 @@ EXTRA_DIST = \
     source/rainerscript/functions/mo-http_request.rst \
     source/rainerscript/functions/mo-unflatten.rst \
     source/rainerscript/functions/rs-append_json.rst \
+    source/rainerscript/functions/rs-cef_ext_escape.rst \
     source/rainerscript/functions/rs-cnum.rst \
     source/rainerscript/functions/rs-cstr.rst \
     source/rainerscript/functions/rs-dyn_inc.rst \
@@ -477,6 +478,7 @@ EXTRA_DIST = \
     source/rainerscript/functions/rs-split.rst \
     source/rainerscript/functions/rs-strlen.rst \
     source/rainerscript/functions/rs-substring.rst \
+    source/rainerscript/functions/rs-tocef.rst \
     source/rainerscript/functions/rs-tolower.rst \
     source/rainerscript/functions/rs-toupper.rst \
     source/rainerscript/functions/rs-trim.rst \

--- a/doc/source/rainerscript/functions/rs-cef_ext_escape.rst
+++ b/doc/source/rainerscript/functions/rs-cef_ext_escape.rst
@@ -1,0 +1,60 @@
+cef_ext_escape()
+================
+
+Purpose
+-------
+
+Escapes a string for safe use as a CEF extension field value.
+
+Syntax
+------
+
+.. code-block:: none
+
+   cef_ext_escape(value)
+
+Parameters
+----------
+
+value
+   The string to escape.
+
+Return Value
+------------
+
+Returns the escaped string with the following substitutions applied per
+the CEF spec:
+
+- Backslash ``\`` becomes ``\\``
+- Equals sign ``=`` becomes ``\=``
+- Newline becomes ``\n``
+- Carriage return becomes ``\r``
+
+Use this function when embedding dynamic rsyslog property values inside
+the extensions argument of :doc:`tocef() <rs-tocef>`. The extensions
+argument itself is appended verbatim by ``tocef()``, so any ``=`` or
+``\`` in a value must be escaped before concatenation.
+
+Examples
+--------
+
+.. code-block:: none
+
+   # Escape a file path containing backslashes
+   set $!ext = cef_ext_escape("C:\\dir\\file.txt");
+   # Result: C:\\dir\\file.txt
+
+   # Escape a value containing an equals sign
+   set $!ext = cef_ext_escape("status=ok");
+   # Result: status\=ok
+
+   # Use inside tocef()
+   set $!cef = tocef("0", "MyVendor", "rsyslog", "1.0",
+                     $syslogtag, $msg, "5",
+                     "filePath=" & cef_ext_escape($!path) &
+                     " msg="     & cef_ext_escape($msg));
+
+See Also
+--------
+
+- :doc:`tocef() <rs-tocef>` - Build a complete CEF header string

--- a/doc/source/rainerscript/functions/rs-tocef.rst
+++ b/doc/source/rainerscript/functions/rs-tocef.rst
@@ -1,0 +1,76 @@
+tocef()
+*******
+
+Purpose
+-------
+
+Builds a CEF (Common Event Format) header string from the seven mandatory
+pipe-delimited header fields and an extensions string.
+
+Syntax
+------
+
+.. code-block:: none
+
+   tocef(version, vendor, product, devversion, eventclassid, name, severity, extensions)
+
+Parameters
+----------
+
+version
+   CEF version number. Use ``"0"`` for CEF 0.x or ``"1"`` for CEF 1.x.
+
+vendor
+   Device vendor string.
+
+product
+   Device product string.
+
+devversion
+   Device version string.
+
+eventclassid
+   Unique identifier for the event type. This field is escaped like the
+   other header fields, and additionally escapes ``=``, ``%``, and ``#`` as
+   ``\=``, ``\%``, and ``\#``.
+
+name
+   Human-readable description of the event.
+
+severity
+   Event severity. Valid string values: ``Unknown``, ``Low``, ``Medium``,
+   ``High``, ``Very-High``. Valid integer values: ``0``-``10``.
+
+extensions
+   Pre-formed key=value extension pairs separated by spaces. Appended
+   verbatim. Use :doc:`cef_ext_escape() <rs-cef_ext_escape>` to escape
+   dynamic property values before embedding them here.
+
+Return Value
+------------
+
+Returns a string containing the complete CEF line:
+``CEF:version|vendor|product|devversion|eventclassid|name|severity|extensions``
+
+The seven header fields are automatically escaped per the CEF spec:
+backslash becomes ``\\`` and pipe becomes ``\|``.
+
+Examples
+--------
+
+.. code-block:: none
+
+   set $!cef = tocef("0", "MyVendor", "rsyslog", "1.0",
+                     $syslogtag, $msg, "5",
+                     "src=" & $fromhost-ip & " spt=514");
+
+   # With extension value escaping for dynamic fields
+   set $!cef = tocef("0", "MyVendor", "rsyslog", "1.0",
+                     $syslogtag, $msg, "5",
+                     "src=" & $fromhost-ip &
+                     " msg=" & cef_ext_escape($msg));
+
+See Also
+--------
+
+- :doc:`cef_ext_escape() <rs-cef_ext_escape>` - Escape a CEF extension field value

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -2633,7 +2633,7 @@ static void ATTR_NONNULL() doFunct_FormatTime(struct cnffunc *__restrict__ const
     char *str;
     int retval;
     long long unixtime;
-    const int resMax = 64;
+    enum { resMax = 64 };
     char result[resMax];
     char *formatstr = NULL;
 
@@ -3151,6 +3151,156 @@ done:
     if (bMustFree2) free(separator);
     varFreeMembers(&srcVal[0]);
     varFreeMembers(&srcVal[1]);
+}
+
+/* Append s to *pOut with CEF header escaping:
+ *   backslash  ->  \\
+ *   pipe       ->  \|
+ * Used for all seven pipe-delimited header fields. */
+static void cef_escape_header(es_str_t **pOut, const char *s) {
+    if (s == NULL) return;
+    while (*s != '\0') {
+        if (*s == '\\' || *s == '|') es_addChar(pOut, '\\');
+        es_addChar(pOut, (unsigned char)*s);
+        ++s;
+    }
+}
+
+/* Append s to *pOut with CEF deviceEventClassId escaping.
+ * The spec requires additional escaping beyond normal header fields:
+ *   backslash  ->  \\
+ *   pipe       ->  \|
+ *   equals     ->  \=
+ *   percent    ->  \%
+ *   hash       ->  \#
+ */
+static void cef_escape_eventclassid(es_str_t **pOut, const char *s) {
+    if (s == NULL) return;
+    while (*s != '\0') {
+        if (*s == '\\' || *s == '|' || *s == '=' || *s == '%' || *s == '#') es_addChar(pOut, '\\');
+        es_addChar(pOut, (unsigned char)*s);
+        ++s;
+    }
+}
+
+/**
+ * tocef(version, vendor, product, devversion, eventclassid, name, severity, extensions)
+ *
+ * Builds a CEF (Common Event Format) header string from eight positional
+ * arguments and returns it as a RainerScript string variable.  The seven
+ * header fields are automatically escaped per the CEF spec (backslash and
+ * pipe are escaped with a leading backslash).  The extensions argument is
+ * appended verbatim; callers are responsible for escaping extension values
+ * (backslash -> \\, equals -> \=, newline -> \n, CR -> \r).
+ *
+ * Example:
+ *   set $!cef = tocef("0", "MyVendor", "rsyslog", "1.0",
+ *                     $syslogtag, $msg, "5",
+ *                     "src=" & $fromhost-ip & " spt=" & $fromhost);
+ *
+ * Produces:
+ *   CEF:0|MyVendor|rsyslog|1.0|<tag>|<msg>|5|src=... spt=...
+ */
+static void ATTR_NONNULL() doFunct_tocef(struct cnffunc *__restrict__ const func,
+                                         struct svar *__restrict__ const ret,
+                                         void *const usrptr,
+                                         wti_t *const pWti) {
+    struct svar srcVal[8];
+    int bMustFree[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    char *params[8] = {NULL};
+    es_str_t *out = NULL;
+
+    for (int i = 0; i < 8; ++i) {
+        cnfexprEval(func->expr[i], &srcVal[i], usrptr, pWti);
+        params[i] = (char *)var2CString(&srcVal[i], &bMustFree[i]);
+    }
+
+    out = es_newStr(256);
+    if (out == NULL) goto done;
+
+    es_addBufConstcstr(&out, "CEF:");
+    cef_escape_header(&out, params[0] ? params[0] : "0"); /* version */
+    es_addChar(&out, '|');
+    cef_escape_header(&out, params[1] ? params[1] : ""); /* vendor */
+    es_addChar(&out, '|');
+    cef_escape_header(&out, params[2] ? params[2] : ""); /* product */
+    es_addChar(&out, '|');
+    cef_escape_header(&out, params[3] ? params[3] : ""); /* devversion */
+    es_addChar(&out, '|');
+    cef_escape_eventclassid(&out, params[4] ? params[4] : ""); /* eventclassid */
+    es_addChar(&out, '|');
+    cef_escape_header(&out, params[5] ? params[5] : ""); /* name */
+    es_addChar(&out, '|');
+    cef_escape_header(&out, params[6] ? params[6] : ""); /* severity */
+    es_addChar(&out, '|');
+    if (params[7] != NULL) /* extensions - verbatim */
+        es_addBuf(&out, params[7], strlen(params[7]));
+
+done:
+    ret->datatype = 'S';
+    ret->d.estr = (out != NULL) ? out : es_newStrFromCStr("", 0);
+
+    for (int i = 0; i < 8; ++i) {
+        if (bMustFree[i]) free(params[i]);
+        varFreeMembers(&srcVal[i]);
+    }
+}
+
+/**
+ * cef_ext_escape(value) -> string
+ *
+ * Escapes a single CEF extension field VALUE per the CEF spec:
+ *   backslash  ->  \\
+ *   equals     ->  \=
+ *   newline    ->  \n  (literal two characters)
+ *   CR         ->  \r  (literal two characters)
+ *
+ * Use this to safely embed dynamic rsyslog property values inside a
+ * pre-formed extension string passed to tocef():
+ *
+ *   set $!cef = tocef("0","V","P","1.0",$syslogtag,$msg,"5",
+ *                     "src=" & $fromhost-ip &
+ *                     " msg=" & cef_ext_escape($msg));
+ */
+static void ATTR_NONNULL() doFunct_cef_ext_escape(struct cnffunc *__restrict__ const func,
+                                                  struct svar *__restrict__ const ret,
+                                                  void *const usrptr,
+                                                  wti_t *const pWti) {
+    struct svar srcVal;
+    int bMustFree = 0;
+    es_str_t *out = NULL;
+
+    cnfexprEval(func->expr[0], &srcVal, usrptr, pWti);
+    char *const orig = (char *)var2CString(&srcVal, &bMustFree);
+    const char *s = orig;
+
+    out = es_newStr(64);
+    if (out == NULL || s == NULL) goto done;
+
+    while (*s != '\0') {
+        if (*s == '\\') {
+            es_addChar(&out, '\\');
+            es_addChar(&out, '\\');
+        } else if (*s == '=') {
+            es_addChar(&out, '\\');
+            es_addChar(&out, '=');
+        } else if (*s == '\n') {
+            es_addChar(&out, '\\');
+            es_addChar(&out, 'n');
+        } else if (*s == '\r') {
+            es_addChar(&out, '\\');
+            es_addChar(&out, 'r');
+        } else {
+            es_addChar(&out, (unsigned char)*s);
+        }
+        ++s;
+    }
+
+done:
+    ret->datatype = 'S';
+    ret->d.estr = (out != NULL) ? out : es_newStrFromCStr("", 0);
+    if (bMustFree) free(orig);
+    varFreeMembers(&srcVal);
 }
 
 /**
@@ -4186,6 +4336,8 @@ static struct scriptFunct functions[] = {
     {"split", 2, 2, doFunct_split, NULL, NULL},
     {"is_in_subnet", 2, 2, doFunct_is_in_subnet, NULL, NULL},
     {"append_json", 2, 3, doFunct_append_json, NULL, NULL},
+    {"tocef", 8, 8, doFunct_tocef, NULL, NULL},
+    {"cef_ext_escape", 1, 1, doFunct_cef_ext_escape, NULL, NULL},
     {NULL, 0, 0, NULL, NULL, NULL}  // last element to check end of array
 };
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -368,6 +368,7 @@ TESTS_DEFAULT = \
 	rcvr_fail_restore.sh \
 	snd-array-cmp-json.sh \
 	rscript_b64_decode.sh \
+	rscript_tocef.sh \
 	rscript_contains.sh \
 	rscript_bare_var_root.sh \
 	rscript_bare_var_root-empty.sh \

--- a/tests/rscript_tocef.sh
+++ b/tests/rscript_tocef.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Test for tocef() and cef_ext_escape() RainerScript functions.
+# Verifies CEF header construction, header escaping, and extension
+# value escaping per the CEF spec (Character Encoding section). The
+# oracle compares the complete rendered output exactly so formatting,
+# ordering, and escaping regressions cannot hide behind fragment matches.
+# added 2026-05-30 by contributor
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+# tocef: basic output
+set $!cef1 = tocef("0", "MyVendor", "rsyslog", "1.0", "100", "test event", "5", "src=10.0.0.1");
+
+# tocef: pipe in vendor header field must be escaped as \|
+set $!cef2 = tocef("0", "Vendor|X", "prod", "1.0", "100", "name", "3", "");
+
+# tocef: backslash in product header field must be escaped by doubling it.
+set $!cef3 = tocef("0", "V", "prod\\name", "1.0", "100", "name", "3", "");
+
+# tocef: extensions appended verbatim
+set $!cef4 = tocef("1", "V", "P", "2.0", "99", "n", "7", "src=1.2.3.4 dst=5.6.7.8 spt=514");
+
+# tocef: eventclassid with =, %, # must be escaped (spec sec. "Header Field Definitions")
+set $!cef6 = tocef("0", "V", "P", "1.0", "CVE=2021%1234#x", "vuln", "8", "");
+
+# cef_ext_escape: backslash in a value must be escaped by doubling it.
+set $!ext1 = cef_ext_escape("C:\\Windows\\file.txt");
+
+# cef_ext_escape: equals sign in a value must become \=
+set $!ext2 = cef_ext_escape("user=admin");
+
+# cef_ext_escape: newline and CR must become literal \n and \r
+set $!ext3 = cef_ext_escape("line1\nline2");
+set $!ext4 = cef_ext_escape("line1\rline2");
+
+# tocef combined with cef_ext_escape for a dynamic extension value
+set $!cef5 = tocef("0", "V", "P", "1.0", "200", "file copy", "3",
+                   "filePath=" & cef_ext_escape("C:\\dir\\file.txt") &
+                   " msg=" & cef_ext_escape("status=ok"));
+
+template(name="outfmt" type="string"
+    string="%!cef1%\n%!cef2%\n%!cef3%\n%!cef4%\n%!ext1%\n%!ext2%\n%!ext3%\n%!ext4%\n%!cef5%\n%!cef6%\n")
+local4.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m1 -y
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='CEF:0|MyVendor|rsyslog|1.0|100|test event|5|src=10.0.0.1
+CEF:0|Vendor\|X|prod|1.0|100|name|3|
+CEF:0|V|prod\\name|1.0|100|name|3|
+CEF:1|V|P|2.0|99|n|7|src=1.2.3.4 dst=5.6.7.8 spt=514
+C:\\Windows\\file.txt
+user\=admin
+line1\nline2
+line1\rline2
+CEF:0|V|P|1.0|200|file copy|3|filePath=C:\\dir\\file.txt msg=status\=ok
+CEF:0|V|P|1.0|CVE\=2021\%1234\#x|vuln|8|'
+cmp_exact $RSYSLOG_OUT_LOG
+exit_test


### PR DESCRIPTION
### Summary (non-technical, complete)

Security teams forwarding rsyslog events to ArcSight, Splunk, or any other SIEM that requires CEF (Common Event Format) had no native way to produce correctly escaped CEF output. The workarounds — manually
building CEF strings in templates or using an external Python script — were fragile and easy to get wrong, particularly when log messages contained pipe characters, backslashes, or equals signs that CEF treats as delimiters.

This change adds two built-in RainerScript functions that handle all CEF escaping automatically, making spec compliant CEF output possible in a single config line without any external tooling.

### References

Fixes: https://github.com/rsyslog/rsyslog/issues/3880

### Notes (optional)

- `tocef(version, vendor, product, devversion, eventclassid, name, severity, extensions)` builds the complete CEF header string.  All seven header fields are auto-escaped per the ArcSight CEF spec v26 (backslash → `\\`, pipe → `\|`). The `eventclassid` field  receives the additional escaping the spec requires for vulnerability  strings (equals → `\=`, percent → `\%`, hash → `\#`).
- `cef_ext_escape(value)` escapes a single extension field value (backslash → `\\`, equals → `\=`, newline → `\n`, CR → `\r`) for  safe embedding in the extensions argument of `tocef()`.
- Both functions follow the established `scriptFunct` table pattern used by `split()`, `append_json()`, and other built-in functions. No grammar changes required.
- Docs added: `rs-tocef.rst` and `rs-cef_ext_escape.rst` following
  the same structure as other built-in function reference pages.
- Test `rscript_tocef.sh` covers: basic output, pipe escaping,  backslash escaping, eventclassid special-char escaping (`=/%/#`),  verbatim extension passthrough, and `cef_ext_escape()` for equals  and backslash values.
- Spec reference used: ArcSight CEF Implementation Standard v26 (OpenText SmartConnectors 8.4.3), Character Encoding section and  Header Field Definitions section for `deviceEventClassId`.
- Discussion context: @davidelang noted in #3880 that the "nasty"  part of CEF output is the escaping rules. These functions address that directly while leaving extension field selection and ordering  to the caller via normal RainerScript string concatenation.

---

#### Quick check
- [x] Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- [x] Commit message includes non-technical "why", Impact, and Before/After.
- [x] Used the Commit Assistant or mirrored its structure.
