### PR TITLE
parser: fix NetAddr cleanup on mask parse errors

### DIFF
--- a/runtime/parse.c
+++ b/runtime/parse.c
@@ -46,6 +46,15 @@
  * public members                                                    *
  * ################################################################# */
 
+static void freeNetAddrContent(struct NetAddr *const pIP) {
+    if (pIP == NULL) return;
+
+    if (F_ISSET(pIP->flags, ADDR_NAME))
+        free(pIP->addr.HostWildcard);
+    else
+        free(pIP->addr.NetAddr);
+}
+
 
 /**
  * Destruct a rsPars object and its associated string.
@@ -419,9 +428,9 @@ rsRetVal parsAddrWithBits(rsParsObj *pThis, struct NetAddr **pIP, int *pBits) {
             /* mask bits follow, let's parse them! */
             ++pThis->iCurrPos; /* eat slash */
             if ((iRet = parsInt(pThis, pBits)) != RS_RET_OK) {
-                free((*pIP)->addr.NetAddr);
-                free((*pIP)->addr.HostWildcard);
+                freeNetAddrContent(*pIP);
                 free(*pIP);
+                *pIP = NULL;
                 FINALIZE;
             }
             /* we need to refresh pointer (changed by parsInt()) */
@@ -455,9 +464,9 @@ rsRetVal parsAddrWithBits(rsParsObj *pThis, struct NetAddr **pIP, int *pBits) {
             /* mask bits follow, let's parse them! */
             ++pThis->iCurrPos; /* eat slash */
             if ((iRet = parsInt(pThis, pBits)) != RS_RET_OK) {
-                free((*pIP)->addr.NetAddr);
-                free((*pIP)->addr.HostWildcard);
+                freeNetAddrContent(*pIP);
                 free(*pIP);
+                *pIP = NULL;
                 FINALIZE;
             }
             /* we need to refresh pointer (changed by parsInt()) */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -239,6 +239,7 @@ TESTS_DEFAULT = \
 	allowed-sender-tcp-fail.sh \
 	allowed-sender-tcp-hostname-ok.sh \
 	allowed-sender-tcp-hostname-fail.sh \
+	allowed-sender-wildcard-invalid-bits.sh \
 	imtcp-discard-truncated-msg.sh \
 	da-queue-persist.sh \
 	daqueue-persist.sh \
@@ -653,6 +654,7 @@ TESTS_IMTCP = \
 	allowed-sender-tcp-fail.sh \
 	allowed-sender-tcp-hostname-ok.sh \
 	allowed-sender-tcp-hostname-fail.sh \
+	allowed-sender-wildcard-invalid-bits.sh \
 	imtcp-discard-truncated-msg.sh \
 	imtcp-basic.sh \
 	imtcp_framing_regex.sh \

--- a/tests/allowed-sender-wildcard-invalid-bits.sh
+++ b/tests/allowed-sender-wildcard-invalid-bits.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Regression test for malformed $AllowedSender wildcard masks.
+#
+# A hostname wildcard is stored in the same NetAddr union as a numeric socket
+# address. When parsing the following invalid /bits value fails, cleanup must
+# release only the active union member. The oracle is a clean config-check
+# failure with the normal parser diagnostic, not a double-free abort.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+$AllowedSender TCP,*.example.invalid/not-a-number
+'
+
+rsyslogd_config_check >"${RSYSLOG_DYNNAME}.config-check.log" 2>&1
+status=$?
+
+if [ "$status" -eq 0 ]; then
+    echo "Expected configuration failure for invalid AllowedSender mask"
+    error_exit 1
+fi
+if [ "$status" -gt 128 ]; then
+    echo "rsyslogd config check exited like it received a signal: $status"
+    cat "${RSYSLOG_DYNNAME}.config-check.log"
+    error_exit 1
+fi
+
+custom_content_check "Error -3005 parsing address in allowed senderlist" "${RSYSLOG_DYNNAME}.config-check.log"
+if grep -Ei "double free|corruption|aborted|sigabrt" "${RSYSLOG_DYNNAME}.config-check.log"; then
+    echo "Unexpected allocator or abort diagnostic in config-check output"
+    error_exit 1
+fi
+exit_test


### PR DESCRIPTION
## Summary
- free only the active NetAddr union member when AllowedSender /bits parsing fails
- clear the caller pointer after freeing the partially parsed NetAddr
- add a regression for wildcard AllowedSender masks with malformed /bits values

Closes #5551

## Local validation
- devtools/format-code.sh --git-changed --check --check-if-available: PASS
- shellcheck -S warning tests/allowed-sender-wildcard-invalid-bits.sh: PASS
- ./autogen.sh; ./configure --enable-testbench --disable-generate-man-pages; make -j60 check TESTS="": PASS
- ./tests/allowed-sender-wildcard-invalid-bits.sh: PASS
- make -j60 check TESTS="allowed-sender-wildcard-invalid-bits.sh": PASS
- local Cubic review: PASS after addressing its test-oracle finding
- clang static analyzer container: PASS, scan-build found no bugs
- Ubuntu 26.04 change-gated run-ci container: PASS, 1301 total / 1274 pass / 27 skip / 0 fail
- Ubuntu 26.04 ASAN/UBSAN run-ci container: PASS, 1105 total / 1078 pass / 27 skip / 0 fail

Container image: rsyslog/rsyslog_dev_base_ubuntu:26.04, sha256:cf0a5054550fefb22fadb4ec569b35110ebbc47191be8311abfd6b5afea02da4

## Lane notes
- Kafka and Elasticsearch service tests were relaxed by the standard PR relevance/configure path where unrelated to this parser/test change.
- Valgrind was disabled in the sanitizer lane per the workflow; TSAN was not run because the change is ownership/parser cleanup, not threading.