### PR TITLE
ratelimit: centralize per-source enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,11 @@ _codeql_detected_source_root
 doc/.venv-docs/
 plugins/impstats/remote.pb-c.c
 plugins/impstats/remote.pb-c.h
+plugins/impstats/remote.pb-c.stamp
+tests/runtime_unit_gss_token_util
+tests/runtime_unit_linkedlist
+tests/runtime_unit_parser_pri
+tests/runtime_unit_stringbuf
 
 # Python cache artifacts
 __pycache__/

--- a/doc/source/rainerscript/configuration_objects/ratelimit.rst
+++ b/doc/source/rainerscript/configuration_objects/ratelimit.rst
@@ -84,7 +84,7 @@ policyWatch
 
 Enable automatic reload of configured external policy files when they change.
 When watch support is available, rsyslog monitors the configured ``policy`` and
-``perSourcePolicy`` files and reloads them after the debounce interval. When
+legacy ``perSourcePolicy`` files and reloads them after the debounce interval. When
 watch support is unavailable in the current build or runtime environment,
 rsyslog logs a warning and continues with HUP-only reload behavior.
 
@@ -116,6 +116,53 @@ perSource
 
 Enable per-source rate limiting using an external YAML policy.
 
+For new configurations, prefer defining the complete per-source policy inside
+the main ``policy`` YAML file. The inline ``perSource`` parameter remains
+available for split legacy configurations that use ``perSourcePolicy``.
+
+.. _ratelimit_policy:
+
+policy
+^^^^^^
+
+.. csv-table::
+   :header: "type", "required", "default"
+   :widths: 20, 10, 20
+
+   "string", "no", "none"
+
+Path to a YAML file that defines rate limit settings. The file can contain
+global settings and, for new configurations, a nested ``perSource`` section:
+
+.. code-block:: yaml
+
+   interval: 1
+   burst: 50
+   severity: info
+
+   perSource:
+     enabled: true
+     keyTemplate: "PerSourceIP"
+     maxStates: 10000
+     topN: 10
+     default:
+       max: 1000
+       window: 10s
+     overrides:
+       - key: "db01.corp.local"
+         max: 5000
+         window: 10s
+
+``perSource.keyTemplate`` is an rsyslog template name. On HUP or watched file
+reload, valid policy changes replace the previous global limits, per-source
+defaults and overrides, key template, ``maxStates``, and ``topN``. Invalid
+reloads keep the previous valid policy active.
+
+Do not mix a ``policy`` YAML file that contains ``perSource`` with legacy
+per-source parameters on the same ``ratelimit()`` object, such as
+``perSource``, ``perSourcePolicy``, ``perSourceKeyTpl``,
+``perSourceMaxStates``, or ``perSourceTopN``.
+
 .. _ratelimit_persourcepolicy:
 
 perSourcePolicy
@@ -127,7 +174,9 @@ perSourcePolicy
 
    "string", "no", "none"
 
-Path to the YAML file that defines per-source limits. Required when ``perSource`` is ``on``.
+Compatibility path to a YAML file that defines per-source limits separately
+from the main ``policy`` file. Required when the inline ``perSource`` parameter
+is ``on`` and the main ``policy`` file does not contain a ``perSource`` section.
 The YAML file must define a ``default`` block with ``max`` and ``window`` values
 and may optionally include ``overrides`` keyed by exact sender values.
 
@@ -152,8 +201,9 @@ perSourceKeyTpl
 
    "string", "no", "RSYSLOG_PerSourceKey"
 
-Template that computes the per-source key. The default template is equivalent to
-``%hostname%``.
+Template that computes the per-source key for split legacy configurations. The
+default template is equivalent to ``%hostname%``. In the canonical single-file
+``policy`` YAML, use ``perSource.keyTemplate`` instead.
 
 .. _ratelimit_persourcemaxstates:
 
@@ -203,10 +253,9 @@ Example
              policyWatchDebounce="500ms")
 
    # Define per-source policy for TCP inputs
+   template(name="PerSourceIP" type="string" string="%fromhost-ip%")
    ratelimit(name="per_source"
-             perSource="on"
-             perSourcePolicy="/etc/rsyslog/imtcp-ratelimits.yaml"
-             perSourceKeyTpl="PerSourceKey")
+             policy="/etc/rsyslog/imtcp-ratelimits.yaml")
 
    # Apply it to a TCP listener
    input(type="imtcp" port="10514" rateLimit.Name="strict")
@@ -223,20 +272,56 @@ Example
 Per-source key examples
 -----------------------
 
+The policy file selects the template through ``perSource.keyTemplate``; defining
+the template alone is not enough.
+
+.. code-block:: yaml
+
+   # /etc/rsyslog/imtcp-ratelimits-ip.yaml
+   interval: 1
+   burst: 100
+   perSource:
+     enabled: true
+     keyTemplate: "PerSourceIP"
+     default:
+       max: 10
+       window: 1s
+
 .. code-block:: rsyslog
 
    # Key by IP address
    template(name="PerSourceIP" type="string" string="%fromhost-ip%")
    ratelimit(name="per_source_ip"
-             perSource="on"
-             perSourcePolicy="/etc/rsyslog/imtcp-ratelimits.yaml"
-             perSourceKeyTpl="PerSourceIP")
+             policy="/etc/rsyslog/imtcp-ratelimits-ip.yaml")
    input(type="imtcp" port="514" rateLimit.Name="per_source_ip")
+
+.. code-block:: yaml
+
+   # /etc/rsyslog/imtcp-ratelimits-host.yaml
+   interval: 1
+   burst: 100
+   perSource:
+     enabled: true
+     keyTemplate: "PerSourceHost"
+     default:
+       max: 10
+       window: 1s
+
+.. code-block:: rsyslog
 
    # Key by hostname (default)
    template(name="PerSourceHost" type="string" string="%hostname%")
    ratelimit(name="per_source_host"
-             perSource="on"
-             perSourcePolicy="/etc/rsyslog/imtcp-ratelimits.yaml"
-             perSourceKeyTpl="PerSourceHost")
+             policy="/etc/rsyslog/imtcp-ratelimits-host.yaml")
    input(type="imtcp" port="514" rateLimit.Name="per_source_host")
+
+Input modules only reference the named ratelimit object with
+``rateLimit.Name``. Per-source key evaluation and enforcement are handled by the
+shared ratelimit object so modules inherit new ratelimit features without
+module-specific API calls.
+
+Per-source limit hits use the same discard semantics as global ratelimit hits:
+the message is consumed by the ratelimiter and is not counted as successfully
+submitted by the input module. Transport callbacks that must acknowledge a
+discarded message, such as RELP, handle that acknowledgement in the module after
+the ratelimiter has reported the discard.

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -241,7 +241,11 @@ static relpRetVal onSyslogRcv(void *pUsr, uchar *pHostname, uchar *pIP, uchar *m
     CHKiRet(MsgSetRcvFromIPStr(pMsg, pIP, ustrlen(pIP), &pProp));
     CHKiRet(prop.Destruct(&pProp));
     if (inst->data.ratelimiter != NULL) {
-        CHKiRet(ratelimitAddMsg(inst->data.ratelimiter, NULL, pMsg));
+        rsRetVal ratelimitRet = ratelimitAddMsg(inst->data.ratelimiter, NULL, pMsg);
+        if (ratelimitRet == RS_RET_DISCARDMSG) {
+            FINALIZE;
+        }
+        CHKiRet(ratelimitRet);
     } else {
         CHKiRet(submitMsg2(pMsg));
     }

--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -49,6 +49,7 @@
 #include "statsobj.h"
 #include "template.h"
 #include "hashtable_itr.h"
+#include "srUtils.h"
 #ifdef HAVE_LIBYAML
     #include <yaml.h>
 #endif
@@ -175,6 +176,25 @@ static enum ratelimit_ps_key_mode perSourceKeyModeFromTemplate(const struct temp
     return RL_PS_KEY_TPL;
 }
 
+static rsRetVal ratelimitLookupPerSourceTemplate(rsconf_t *conf,
+                                                 const char *tpl_name,
+                                                 struct template **tpl,
+                                                 sbool *is_default) {
+    const char *lookup_name;
+    DEFiRet;
+
+    if (conf == NULL || tpl == NULL || is_default == NULL) ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    lookup_name = (tpl_name == NULL) ? "RSYSLOG_PerSourceKey" : tpl_name;
+    *tpl = tplFind(conf, (char *)lookup_name, (int)strlen(lookup_name));
+    if (*tpl == NULL) {
+        ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+    }
+    *is_default = (tpl_name == NULL);
+
+finalize_it:
+    RETiRet;
+}
+
 static void ratelimitFreeShared(void *ptr) {
     ratelimit_shared_t *shared = (ratelimit_shared_t *)ptr;
     if (shared == NULL) return;
@@ -273,11 +293,29 @@ struct ratelimit_ps_policy_s {
 
 typedef struct ratelimit_ps_policy_s ratelimit_ps_policy_t;
 
+typedef struct ratelimit_policy_file_s {
+    sbool has_interval;
+    sbool has_burst;
+    sbool has_severity;
+    unsigned int interval;
+    unsigned int burst;
+    int severity;
+    sbool has_per_source;
+    sbool per_source_enabled;
+    char *per_source_key_tpl_name;
+    unsigned int per_source_max_states;
+    unsigned int per_source_topn;
+    ratelimit_ps_policy_t *per_source_policy;
+} ratelimit_policy_file_t;
+
 enum ratelimit_watch_kind { RATELIMIT_WATCH_GLOBAL = 0, RATELIMIT_WATCH_PERSOURCE };
 
 static rsRetVal parseDurationMillis(const char *value, unsigned int *out);
 #ifdef HAVE_LIBYAML
+static rsRetVal parseUnsignedInt(const char *value, unsigned int *out);
 static rsRetVal parseDurationSeconds(const char *value, unsigned int *out);
+static void ratelimitFreePerSourceOverrideValue(void *ptr);
+static void ratelimitFreePerSourceOverrideDirect(void *ptr);
 #endif
 static rsRetVal ratelimitReloadPolicyFile(ratelimit_shared_t *shared, const char *trigger);
 static rsRetVal ratelimitReloadPerSourcePolicyFile(ratelimit_shared_t *shared, const char *trigger);
@@ -398,7 +436,7 @@ static rsRetVal ratelimitRegisterWatchTargets(ratelimit_shared_t *shared) {
                    shared->name, ratelimitWatchKindName(RATELIMIT_WATCH_GLOBAL), shared->policy_file);
         }
     }
-    if (shared->per_source_policy_file != NULL) {
+    if (shared->per_source_policy_file != NULL && !shared->per_source_policy_from_policy_file) {
         memset(&desc, 0, sizeof(desc));
         desc.id = shared->name;
         desc.path = shared->per_source_policy_file;
@@ -419,22 +457,79 @@ finalize_it:
 }
 
 
-static rsRetVal parsePolicyFile(const char *policy_file
-#ifdef HAVE_LIBYAML
-                                ,
-                                unsigned int *interval,
-                                unsigned int *burst,
-                                int *severity
-#endif
-) {
+static void ratelimitPolicyFileDestruct(ratelimit_policy_file_t *policy) {
+    if (policy == NULL) return;
+    free(policy->per_source_key_tpl_name);
+    if (policy->per_source_policy != NULL) {
+        if (policy->per_source_policy->overrides != NULL) hashtable_destroy(policy->per_source_policy->overrides, 1);
+        free(policy->per_source_policy);
+    }
+    memset(policy, 0, sizeof(*policy));
+}
+
+static rsRetVal parseBoolValue(const char *value, sbool *out) {
+    DEFiRet;
+
+    if (value == NULL || out == NULL) ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    if (!strcasecmp(value, "on") || !strcasecmp(value, "yes") || !strcasecmp(value, "true") || !strcmp(value, "1")) {
+        *out = 1;
+    } else if (!strcasecmp(value, "off") || !strcasecmp(value, "no") || !strcasecmp(value, "false") ||
+               !strcmp(value, "0")) {
+        *out = 0;
+    } else {
+        ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal parseSeverityValue(const char *value, int *out) {
+    char *end = NULL;
+    long numeric;
+    int severity;
+    DEFiRet;
+
+    if (value == NULL || out == NULL) ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    while (isspace((unsigned char)*value)) value++;
+    if (*value == '-' || isdigit((unsigned char)*value)) {
+        errno = 0;
+        numeric = strtol(value, &end, 10);
+        if (errno != 0 || end == value || *end != '\0' || numeric < -1 || numeric > 127) {
+            ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+        }
+        severity = (int)numeric;
+    } else {
+        severity = decodeSyslogName((uchar *)value, syslogPriNames);
+        if (severity < 0 || severity > 127) {
+            ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+        }
+    }
+    *out = severity;
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal parsePolicyFile(const char *policy_file, ratelimit_policy_file_t *policy) {
     DEFiRet;
 #ifdef HAVE_LIBYAML
     FILE *fh = NULL;
     yaml_parser_t yamlParser;
     int bParserInitialized = 0;
-    yaml_token_t token;
-    int state = 0; /* 0: generic, 1: expect key, 2: expect value */
-    char *curr_key = NULL;
+    yaml_event_t event;
+    unsigned int depth = 0;
+    enum policy_ctx { CTX_TOP = 0, CTX_PERSOURCE, CTX_PS_DEFAULT, CTX_PS_OVERRIDE_ITEM } ctxStack[8];
+    int expectKey[8] = {0};
+    char *last_key = NULL;
+    sbool inOverridesSeq = 0;
+    sbool default_max_seen = 0;
+    sbool default_window_seen = 0;
+    unsigned int override_count = 0;
+    ratelimit_ps_override_t *current_override = NULL;
+
+    if (policy == NULL) ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    memset(policy, 0, sizeof(*policy));
 
     fh = fopen(policy_file, "r");
     if (fh == NULL) {
@@ -450,76 +545,226 @@ static rsRetVal parsePolicyFile(const char *policy_file
 
     yaml_parser_set_input_file(&yamlParser, fh);
 
-    int done = 0;
-    while (!done) {
-        if (!yaml_parser_scan(&yamlParser, &token)) {
+    while (1) {
+        if (!yaml_parser_parse(&yamlParser, &event)) {
             LogError(0, RS_RET_CONF_PARAM_INVLD, "ratelimit: yaml parser error in policy file %s: %s", policy_file,
                      yamlParser.problem ? yamlParser.problem : "unknown error");
             ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
         }
 
         PRAGMA_DIAGNOSTIC_PUSH
-        PRAGMA_IGNORE_Wswitch_enum switch (token.type) {
-            case YAML_KEY_TOKEN:
-                state = 1;
+        PRAGMA_IGNORE_Wswitch_enum switch (event.type) {
+            case YAML_NO_EVENT:
+            case YAML_STREAM_START_EVENT:
+            case YAML_DOCUMENT_START_EVENT:
+            case YAML_DOCUMENT_END_EVENT:
+            case YAML_ALIAS_EVENT:
                 break;
-            case YAML_VALUE_TOKEN:
-                state = 2;
+            case YAML_MAPPING_START_EVENT:
+                if (depth >= 8) {
+                    LogError(0, RS_RET_CONF_PARAM_INVLD, "ratelimit: yaml nesting too deep in %s", policy_file);
+                    ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+                }
+                if (depth == 0) {
+                    ctxStack[depth] = CTX_TOP;
+                } else if (inOverridesSeq) {
+                    if (override_count >= 10000U) {
+                        LogError(0, RS_RET_CONF_PARAM_INVLD, "ratelimit: too many per-source overrides in %s (max %u)",
+                                 policy_file, 10000U);
+                        ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+                    }
+                    ctxStack[depth] = CTX_PS_OVERRIDE_ITEM;
+                    CHKmalloc(current_override = calloc(1, sizeof(*current_override)));
+                    override_count++;
+                } else if (last_key != NULL && !strcmp(last_key, "perSource")) {
+                    ctxStack[depth] = CTX_PERSOURCE;
+                    policy->has_per_source = 1;
+                    policy->per_source_enabled = 1;
+                    CHKmalloc(policy->per_source_policy = calloc(1, sizeof(*policy->per_source_policy)));
+                    policy->per_source_policy->overrides =
+                        create_hashtable(32, hash_from_string, key_equals_string, ratelimitFreePerSourceOverrideValue);
+                    if (policy->per_source_policy->overrides == NULL) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+                } else if (depth > 0 && ctxStack[depth - 1] == CTX_PERSOURCE && last_key != NULL &&
+                           !strcmp(last_key, "default")) {
+                    ctxStack[depth] = CTX_PS_DEFAULT;
+                } else {
+                    ctxStack[depth] = CTX_TOP;
+                }
+                if (depth > 0 && last_key != NULL) {
+                    expectKey[depth - 1] = 1;
+                }
+                expectKey[depth] = 1;
+                depth++;
+                free(last_key);
+                last_key = NULL;
                 break;
-            case YAML_SCALAR_TOKEN:
-                if (state == 1) {
-                    if (curr_key) free(curr_key);
-                    curr_key = strdup((char *)token.data.scalar.value);
-                } else if (state == 2) {
-                    if (curr_key) {
-                        char *endptr;
-                        errno = 0;
-                        long val = 0;
-                        if (!strcmp(curr_key, "interval") || !strcmp(curr_key, "burst") ||
-                            !strcmp(curr_key, "severity")) {
-                            const int is_severity = !strcmp(curr_key, "severity");
-                            val = strtol((char *)token.data.scalar.value, &endptr, 10);
-                            const int out_of_range =
-                                is_severity ? (val < -1 || val > 127) : (val < 0 || (unsigned long)val > UINT_MAX);
-                            if ((errno == ERANGE && (val == LONG_MAX || val == LONG_MIN)) || (errno != 0 && val == 0) ||
-                                endptr == (char *)token.data.scalar.value || *endptr != '\0' || out_of_range) {
-                                LogError(0, RS_RET_CONF_PARAM_INVLD, "ratelimit: invalid integer value for '%s': %s",
-                                         curr_key, (char *)token.data.scalar.value);
-                                /* ignore invalid values, keep parsing */
-                            } else {
-                                if (!strcmp(curr_key, "interval")) {
-                                    *interval = (unsigned int)val;
-                                } else if (!strcmp(curr_key, "burst")) {
-                                    *burst = (unsigned int)val;
-                                } else if (!strcmp(curr_key, "severity")) {
-                                    if (val > 127) {
-                                        LogError(0, RS_RET_CONF_PARAM_INVLD,
-                                                 "ratelimit: severity value %ld out of range (max 127) in %s", val,
-                                                 policy_file);
-                                    } else {
-                                        *severity = (int)val;
-                                    }
-                                }
-                            }
+            case YAML_MAPPING_END_EVENT:
+                if (depth > 0) {
+                    depth--;
+                    if (ctxStack[depth] == CTX_PS_OVERRIDE_ITEM && current_override != NULL) {
+                        if (current_override->key == NULL) {
+                            LogError(0, RS_RET_CONF_PARAM_INVLD, "ratelimit: per-source override missing key in %s",
+                                     policy_file);
+                            ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
                         }
+                        if (hashtable_insert(policy->per_source_policy->overrides, current_override->key,
+                                             current_override) == 0) {
+                            LogError(0, RS_RET_OUT_OF_MEMORY, "ratelimit: error inserting per-source override '%s'",
+                                     current_override->key);
+                            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+                        }
+                        current_override = NULL;
                     }
                 }
+                free(last_key);
+                last_key = NULL;
                 break;
+            case YAML_SEQUENCE_START_EVENT:
+                if (depth > 0 && ctxStack[depth - 1] == CTX_PERSOURCE && last_key != NULL &&
+                    !strcmp(last_key, "overrides")) {
+                    inOverridesSeq = 1;
+                }
+                if (depth > 0 && last_key != NULL) {
+                    expectKey[depth - 1] = 1;
+                }
+                free(last_key);
+                last_key = NULL;
+                break;
+            case YAML_SEQUENCE_END_EVENT:
+                inOverridesSeq = 0;
+                free(last_key);
+                last_key = NULL;
+                break;
+            case YAML_SCALAR_EVENT:
+                if (depth == 0) break;
+                if (expectKey[depth - 1]) {
+                    free(last_key);
+                    CHKmalloc(last_key = strdup((char *)event.data.scalar.value));
+                    expectKey[depth - 1] = 0;
+                } else {
+                    const char *val = (const char *)event.data.scalar.value;
+                    unsigned int uintval = 0;
+                    int severity = 0;
+                    sbool boolval = 0;
+
+                    if (ctxStack[depth - 1] == CTX_TOP) {
+                        if (last_key != NULL && !strcmp(last_key, "interval")) {
+                            if (parseUnsignedInt(val, &uintval) != RS_RET_OK) {
+                                LogError(0, RS_RET_CONF_PARAM_INVLD, "ratelimit: invalid interval value '%s' in %s",
+                                         val, policy_file);
+                                ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+                            }
+                            policy->interval = uintval;
+                            policy->has_interval = 1;
+                        } else if (last_key != NULL && !strcmp(last_key, "burst")) {
+                            if (parseUnsignedInt(val, &uintval) != RS_RET_OK) {
+                                LogError(0, RS_RET_CONF_PARAM_INVLD, "ratelimit: invalid burst value '%s' in %s", val,
+                                         policy_file);
+                                ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+                            }
+                            policy->burst = uintval;
+                            policy->has_burst = 1;
+                        } else if (last_key != NULL && !strcmp(last_key, "severity")) {
+                            if (parseSeverityValue(val, &severity) != RS_RET_OK) {
+                                LogError(0, RS_RET_CONF_PARAM_INVLD, "ratelimit: invalid severity value '%s' in %s",
+                                         val, policy_file);
+                                ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+                            }
+                            policy->severity = severity;
+                            policy->has_severity = 1;
+                        }
+                    } else if (ctxStack[depth - 1] == CTX_PERSOURCE) {
+                        if (last_key != NULL && !strcmp(last_key, "enabled")) {
+                            if (parseBoolValue(val, &boolval) != RS_RET_OK) {
+                                LogError(0, RS_RET_CONF_PARAM_INVLD,
+                                         "ratelimit: invalid perSource.enabled value '%s' in %s", val, policy_file);
+                                ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+                            }
+                            policy->per_source_enabled = boolval;
+                        } else if (last_key != NULL && !strcmp(last_key, "keyTemplate")) {
+                            free(policy->per_source_key_tpl_name);
+                            CHKmalloc(policy->per_source_key_tpl_name = strdup(val));
+                        } else if (last_key != NULL && !strcmp(last_key, "maxStates")) {
+                            if (parseUnsignedInt(val, &policy->per_source_max_states) != RS_RET_OK) {
+                                LogError(0, RS_RET_CONF_PARAM_INVLD,
+                                         "ratelimit: invalid perSource.maxStates value '%s' in %s", val, policy_file);
+                                ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+                            }
+                        } else if (last_key != NULL && !strcmp(last_key, "topN")) {
+                            if (parseUnsignedInt(val, &policy->per_source_topn) != RS_RET_OK) {
+                                LogError(0, RS_RET_CONF_PARAM_INVLD,
+                                         "ratelimit: invalid perSource.topN value '%s' in %s", val, policy_file);
+                                ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+                            }
+                        }
+                    } else if (ctxStack[depth - 1] == CTX_PS_DEFAULT && policy->per_source_policy != NULL) {
+                        if (last_key != NULL && !strcmp(last_key, "max")) {
+                            if (parseUnsignedInt(val, &policy->per_source_policy->default_max) != RS_RET_OK) {
+                                LogError(0, RS_RET_CONF_PARAM_INVLD,
+                                         "ratelimit: invalid perSource.default.max value '%s' in %s", val, policy_file);
+                                ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+                            }
+                            default_max_seen = 1;
+                        } else if (last_key != NULL && !strcmp(last_key, "window")) {
+                            if (parseDurationSeconds(val, &policy->per_source_policy->default_window) != RS_RET_OK) {
+                                LogError(0, RS_RET_CONF_PARAM_INVLD,
+                                         "ratelimit: invalid perSource.default.window value '%s' in %s", val,
+                                         policy_file);
+                                ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+                            }
+                            default_window_seen = 1;
+                        }
+                    } else if (ctxStack[depth - 1] == CTX_PS_OVERRIDE_ITEM && current_override != NULL) {
+                        if (last_key != NULL && !strcmp(last_key, "key")) {
+                            free(current_override->key);
+                            CHKmalloc(current_override->key = strdup(val));
+                        } else if (last_key != NULL && !strcmp(last_key, "max")) {
+                            if (parseUnsignedInt(val, &current_override->max) != RS_RET_OK) {
+                                LogError(0, RS_RET_CONF_PARAM_INVLD,
+                                         "ratelimit: invalid perSource override.max value '%s' in %s", val,
+                                         policy_file);
+                                ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+                            }
+                            current_override->has_max = 1;
+                        } else if (last_key != NULL && !strcmp(last_key, "window")) {
+                            if (parseDurationSeconds(val, &current_override->window) != RS_RET_OK) {
+                                LogError(0, RS_RET_CONF_PARAM_INVLD,
+                                         "ratelimit: invalid perSource override.window value '%s' in %s", val,
+                                         policy_file);
+                                ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+                            }
+                            current_override->has_window = 1;
+                        }
+                    }
+                    expectKey[depth - 1] = 1;
+                }
+                break;
+            case YAML_STREAM_END_EVENT:
+                yaml_event_delete(&event);
+                goto finalize_it;
             default:
                 break;
         }
         PRAGMA_DIAGNOSTIC_POP
-
-        if (token.type == YAML_STREAM_END_TOKEN) done = 1;
-        yaml_token_delete(&token);
+        yaml_event_delete(&event);
     }
 
 finalize_it:
     if (bParserInitialized) {
         yaml_parser_delete(&yamlParser);
     }
-    if (curr_key) free(curr_key);
+    free(last_key);
+    if (current_override != NULL) ratelimitFreePerSourceOverrideDirect(current_override);
     if (fh) fclose(fh);
+    if (iRet == RS_RET_OK && policy->has_per_source && policy->per_source_enabled &&
+        (!default_max_seen || !default_window_seen)) {
+        LogError(0, RS_RET_CONF_PARAM_INVLD,
+                 "ratelimit: policy file %s perSource section missing default.max or default.window", policy_file);
+        iRet = RS_RET_CONF_PARAM_INVLD;
+    }
+    if (iRet != RS_RET_OK) {
+        ratelimitPolicyFileDestruct(policy);
+    }
 #else
     LogError(0, RS_RET_CONF_PARAM_INVLD,
              "ratelimit: policy file '%s' specified but rsyslog "
@@ -537,7 +782,13 @@ static void ratelimitFreePerSourceState(void *ptr) {
 }
 
 #ifdef HAVE_LIBYAML
-static void ratelimitFreePerSourceOverride(void *ptr) {
+static void ratelimitFreePerSourceOverrideValue(void *ptr) {
+    ratelimit_ps_override_t *ovr = (ratelimit_ps_override_t *)ptr;
+    if (ovr == NULL) return;
+    free(ovr);
+}
+
+static void ratelimitFreePerSourceOverrideDirect(void *ptr) {
     ratelimit_ps_override_t *ovr = (ratelimit_ps_override_t *)ptr;
     if (ovr == NULL) return;
     free(ovr->key);
@@ -582,7 +833,7 @@ static rsRetVal parsePerSourcePolicyFile(const char *policy_file, ratelimit_ps_p
     yaml_parser_t yamlParser;
     yaml_event_t event;
     int parserInitialized = 0;
-    int depth = 0;
+    unsigned int depth = 0;
     int expectKey[8] = {0};
     enum { CTX_TOP = 0, CTX_DEFAULT, CTX_OVERRIDE_ITEM } ctxStack[8];
     sbool inOverridesSeq = 0;
@@ -597,7 +848,7 @@ static rsRetVal parsePerSourcePolicyFile(const char *policy_file, ratelimit_ps_p
 
     CHKmalloc(policy = calloc(1, sizeof(*policy)));
     CHKmalloc(policy->overrides =
-                  create_hashtable(32, hash_from_string, key_equals_string, ratelimitFreePerSourceOverride));
+                  create_hashtable(32, hash_from_string, key_equals_string, ratelimitFreePerSourceOverrideValue));
 
     fh = fopen(policy_file, "r");
     if (fh == NULL) {
@@ -647,6 +898,9 @@ static rsRetVal parsePerSourcePolicyFile(const char *policy_file, ratelimit_ps_p
                 } else {
                     ctxStack[depth] = CTX_TOP;
                 }
+                if (depth > 0 && last_key != NULL) {
+                    expectKey[depth - 1] = 1;
+                }
                 expectKey[depth] = 1;
                 depth++;
                 free(last_key);
@@ -675,6 +929,9 @@ static rsRetVal parsePerSourcePolicyFile(const char *policy_file, ratelimit_ps_p
             case YAML_SEQUENCE_START_EVENT:
                 if (last_key != NULL && !strcmp(last_key, "overrides")) {
                     inOverridesSeq = 1;
+                }
+                if (depth > 0 && last_key != NULL) {
+                    expectKey[depth - 1] = 1;
                 }
                 free(last_key);
                 last_key = NULL;
@@ -753,7 +1010,7 @@ finalize_it:
     if (fh) fclose(fh);
     free(last_key);
     if (iRet != RS_RET_OK) {
-        if (current_override != NULL) ratelimitFreePerSourceOverride(current_override);
+        if (current_override != NULL) ratelimitFreePerSourceOverrideDirect(current_override);
         if (policy != NULL) {
             if (policy->overrides != NULL) hashtable_destroy(policy->overrides, 1);
             free(policy);
@@ -793,7 +1050,13 @@ static char *ratelimitSanitizeMetricName(const char *key) {
 }
 
 static void ratelimitPerSourceUpdateTopN(ratelimit_shared_t *shared) {
-    if (shared == NULL || shared->per_source_stats == NULL || shared->per_source_topn == 0) return;
+    if (shared == NULL || shared->per_source_stats == NULL) return;
+
+    pthread_mutex_lock(&shared->per_source_mut);
+    if (shared->per_source_topn == 0) {
+        pthread_mutex_unlock(&shared->per_source_mut);
+        return;
+    }
 
     unsigned int topn = shared->per_source_topn;
     uint64_t *values = calloc(topn, sizeof(uint64_t));
@@ -801,10 +1064,10 @@ static void ratelimitPerSourceUpdateTopN(ratelimit_shared_t *shared) {
     if (values == NULL || keys == NULL) {
         free(values);
         free(keys);
+        pthread_mutex_unlock(&shared->per_source_mut);
         return;
     }
 
-    pthread_mutex_lock(&shared->per_source_mut);
     if (shared->per_source_states != NULL && hashtable_count(shared->per_source_states) > 0) {
         struct hashtable_itr *itr = hashtable_iterator(shared->per_source_states);
         if (itr != NULL) {
@@ -831,7 +1094,6 @@ static void ratelimitPerSourceUpdateTopN(ratelimit_shared_t *shared) {
             keys[i] = strdup(keys[i]);
         }
     }
-    pthread_mutex_unlock(&shared->per_source_mut);
 
     if (shared->per_source_top_ctrs == NULL) {
         shared->per_source_top_ctrs = calloc(topn, sizeof(ctr_t *));
@@ -839,9 +1101,16 @@ static void ratelimitPerSourceUpdateTopN(ratelimit_shared_t *shared) {
         shared->per_source_top_keys = calloc(topn, sizeof(char *));
         if (shared->per_source_top_ctrs == NULL || shared->per_source_top_values == NULL ||
             shared->per_source_top_keys == NULL) {
+            free(shared->per_source_top_ctrs);
+            free(shared->per_source_top_values);
+            free(shared->per_source_top_keys);
+            shared->per_source_top_ctrs = NULL;
+            shared->per_source_top_values = NULL;
+            shared->per_source_top_keys = NULL;
             free(values);
             for (unsigned int i = 0; i < topn; ++i) free(keys[i]);
             free(keys);
+            pthread_mutex_unlock(&shared->per_source_mut);
             return;
         }
     }
@@ -886,6 +1155,7 @@ static void ratelimitPerSourceUpdateTopN(ratelimit_shared_t *shared) {
         }
     }
 
+    pthread_mutex_unlock(&shared->per_source_mut);
     free(values);
     for (unsigned int i = 0; i < topn; ++i) free(keys[i]);
     free(keys);
@@ -926,6 +1196,8 @@ static rsRetVal ratelimitInitPerSourceShared(ratelimit_shared_t *shared,
 
     STATSCOUNTER_INIT(shared->ctrPerSourceAllowed, shared->mutCtrPerSourceAllowed);
     STATSCOUNTER_INIT(shared->ctrPerSourceDropped, shared->mutCtrPerSourceDropped);
+    STATSCOUNTER_INIT(shared->ctrPerSourceKeyTplEvals, shared->mutCtrPerSourceKeyTplEvals);
+    STATSCOUNTER_INIT(shared->ctrPerSourceKeyParseEvals, shared->mutCtrPerSourceKeyParseEvals);
 
     CHKiRet(statsobj.Construct(&shared->per_source_stats));
     snprintf(statname, sizeof(statname), "ratelimit.%s.per_source", shared->name);
@@ -936,6 +1208,10 @@ static rsRetVal ratelimitInitPerSourceShared(ratelimit_shared_t *shared,
                                 CTR_FLAG_RESETTABLE, &shared->ctrPerSourceAllowed));
     CHKiRet(statsobj.AddCounter(shared->per_source_stats, UCHAR_CONSTANT("per_source_dropped"), ctrType_IntCtr,
                                 CTR_FLAG_RESETTABLE, &shared->ctrPerSourceDropped));
+    CHKiRet(statsobj.AddCounter(shared->per_source_stats, UCHAR_CONSTANT("per_source_key_tpl_evals"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &shared->ctrPerSourceKeyTplEvals));
+    CHKiRet(statsobj.AddCounter(shared->per_source_stats, UCHAR_CONSTANT("per_source_key_parse_evals"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &shared->ctrPerSourceKeyParseEvals));
     CHKiRet(statsobj.SetReadNotifier(shared->per_source_stats, ratelimitPerSourceStatsRead, shared));
     CHKiRet(statsobj.ConstructFinalize(shared->per_source_stats));
 
@@ -964,10 +1240,106 @@ static void ratelimitSwapPerSourcePolicy(ratelimit_shared_t *shared, ratelimit_p
     pthread_mutex_unlock(&shared->per_source_mut);
 }
 
+static void ratelimitResetPerSourceTopN(ratelimit_shared_t *shared) {
+    ctr_t **top_ctrs = NULL;
+    intctr_t *top_values = NULL;
+    char **top_keys = NULL;
+    unsigned int topn;
+
+    if (shared == NULL) return;
+
+    pthread_mutex_lock(&shared->per_source_mut);
+    if (shared->per_source_top_ctrs == NULL) {
+        pthread_mutex_unlock(&shared->per_source_mut);
+        return;
+    }
+    topn = shared->per_source_topn;
+    top_ctrs = shared->per_source_top_ctrs;
+    top_values = shared->per_source_top_values;
+    top_keys = shared->per_source_top_keys;
+    shared->per_source_top_ctrs = NULL;
+    shared->per_source_top_values = NULL;
+    shared->per_source_top_keys = NULL;
+    pthread_mutex_unlock(&shared->per_source_mut);
+
+    for (unsigned int i = 0; i < topn; ++i) {
+        if (top_ctrs[i] != NULL && shared->per_source_stats != NULL) {
+            statsobj.DestructCounter(shared->per_source_stats, top_ctrs[i]);
+        }
+        free(top_keys[i]);
+    }
+    free(top_ctrs);
+    free(top_values);
+    free(top_keys);
+}
+
+static rsRetVal ratelimitApplyPolicyPerSource(ratelimit_shared_t *shared,
+                                              ratelimit_policy_file_t *policy,
+                                              rsconf_t *conf,
+                                              const char *policy_file) {
+    struct template *key_tpl = NULL;
+    sbool key_tpl_default = 0;
+    char *key_tpl_name = NULL;
+    unsigned int effective_topn;
+    DEFiRet;
+
+    if (shared == NULL || policy == NULL || !policy->has_per_source) FINALIZE;
+
+    if (!policy->per_source_enabled) {
+        shared->per_source_enabled = 0;
+        shared->per_source_policy_from_policy_file = 1;
+        FINALIZE;
+    }
+
+    CHKiRet(ratelimitLookupPerSourceTemplate(conf, policy->per_source_key_tpl_name, &key_tpl, &key_tpl_default));
+    if (policy->per_source_key_tpl_name != NULL) {
+        CHKmalloc(key_tpl_name = strdup(policy->per_source_key_tpl_name));
+    }
+
+    if (shared->per_source_states == NULL) {
+        CHKiRet(ratelimitInitPerSourceShared(shared, policy->per_source_policy, policy_file,
+                                             policy->per_source_max_states, policy->per_source_topn));
+        policy->per_source_policy->overrides = NULL;
+    } else {
+        shared->per_source_enabled = 1;
+        ratelimitSwapPerSourcePolicy(shared, policy->per_source_policy);
+        policy->per_source_policy->overrides = NULL;
+    }
+
+    shared->per_source_policy_from_policy_file = 1;
+    if (shared->per_source_policy_file == NULL && policy_file != NULL) {
+        CHKmalloc(shared->per_source_policy_file = strdup(policy_file));
+    }
+    free(shared->per_source_key_tpl_name);
+    shared->per_source_key_tpl_name = key_tpl_name;
+    key_tpl_name = NULL;
+    shared->per_source_key_tpl = key_tpl;
+    shared->per_source_key_tpl_default = key_tpl_default;
+    shared->per_source_key_mode = perSourceKeyModeFromTemplate(shared->per_source_key_tpl);
+    shared->per_source_key_needs_parsing = (shared->per_source_key_mode == RL_PS_KEY_TPL);
+
+    pthread_mutex_lock(&shared->per_source_mut);
+    shared->per_source_max_states =
+        (policy->per_source_max_states == 0) ? RATELIMIT_PERSOURCE_DEFAULT_MAX_STATES : policy->per_source_max_states;
+    effective_topn = (policy->per_source_topn == 0) ? RATELIMIT_PERSOURCE_DEFAULT_TOPN : policy->per_source_topn;
+    if (shared->per_source_topn != effective_topn) {
+        pthread_mutex_unlock(&shared->per_source_mut);
+        ratelimitResetPerSourceTopN(shared);
+        pthread_mutex_lock(&shared->per_source_mut);
+        shared->per_source_topn = effective_topn;
+    }
+    pthread_mutex_unlock(&shared->per_source_mut);
+
+finalize_it:
+    free(key_tpl_name);
+    RETiRet;
+}
+
 static rsRetVal ratelimitReloadPolicyFile(ratelimit_shared_t *shared, const char *trigger) {
     unsigned int interval;
     unsigned int burst;
     int severity;
+    ratelimit_policy_file_t policy = {0};
     DEFiRet;
 
     if (shared == NULL || shared->policy_file == NULL) {
@@ -978,11 +1350,15 @@ static rsRetVal ratelimitReloadPolicyFile(ratelimit_shared_t *shared, const char
     burst = ratelimitSharedLoadUInt(&shared->burst, &shared->mut);
     severity = ratelimitSharedLoadSeverity(&shared->severity, &shared->mut);
 
-#ifdef HAVE_LIBYAML
-    CHKiRet(parsePolicyFile(shared->policy_file, &interval, &burst, &severity));
-#else
-    CHKiRet(parsePolicyFile(shared->policy_file));
-#endif
+    CHKiRet(parsePolicyFile(shared->policy_file, &policy));
+    if (policy.has_interval) interval = policy.interval;
+    if (policy.has_burst) burst = policy.burst;
+    if (policy.has_severity) severity = policy.severity;
+    if (policy.has_per_source) {
+        CHKiRet(ratelimitApplyPolicyPerSource(shared, &policy, runConf, shared->policy_file));
+    } else if (shared->per_source_policy_from_policy_file) {
+        shared->per_source_enabled = 0;
+    }
 
     ratelimitSharedStoreUInt(&shared->interval, &shared->mut, interval);
     ratelimitSharedStoreUInt(&shared->burst, &shared->mut, burst);
@@ -992,6 +1368,7 @@ static rsRetVal ratelimitReloadPolicyFile(ratelimit_shared_t *shared, const char
            shared->policy_file);
 
 finalize_it:
+    ratelimitPolicyFileDestruct(&policy);
     if (iRet != RS_RET_OK && shared != NULL && shared->policy_file != NULL) {
         LogError(0, iRet, "ratelimit: %s failed to reload policy '%s' from file '%s', keeping old values", trigger,
                  shared->name, shared->policy_file);
@@ -1155,7 +1532,9 @@ rsRetVal ratelimitAddConfig(rsconf_t *conf,
     ratelimit_shared_t *existing_shared = NULL;
     char *key = NULL;
     ratelimit_ps_policy_t *per_source_policy = NULL;
+    ratelimit_policy_file_t file_policy = {0};
     unsigned int debounce_ms = RATELIMIT_POLICY_WATCH_DEBOUNCE_DFLT_MS;
+    sbool per_source_from_policy_file = 0;
     sbool bLocked = 0;
 
 
@@ -1168,17 +1547,34 @@ rsRetVal ratelimitAddConfig(rsconf_t *conf,
     }
 
     if (policy_file != NULL) {
-#ifdef HAVE_LIBYAML
-        iRet = parsePolicyFile(policy_file, &interval, &burst, &severity);
-#else
-        iRet = parsePolicyFile(policy_file);
-#endif
-        if (iRet != RS_RET_OK) {
-            ABORT_FINALIZE(iRet);
+        CHKiRet(parsePolicyFile(policy_file, &file_policy));
+        if (file_policy.has_interval) interval = file_policy.interval;
+        if (file_policy.has_burst) burst = file_policy.burst;
+        if (file_policy.has_severity) severity = file_policy.severity;
+        if (file_policy.has_per_source) {
+            if (per_source_enabled || per_source_policy_file != NULL || per_source_key_tpl_name != NULL ||
+                per_source_max_states != 0 || per_source_topn != 0) {
+                LogError(0, RS_RET_CONFIG_ERROR,
+                         "ratelimit: policy file '%s' contains perSource for '%s'; do not mix it with legacy "
+                         "perSource/perSourcePolicy/perSourceKeyTpl/maxStates/topN parameters",
+                         policy_file, name);
+                ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+            }
+            per_source_from_policy_file = 1;
+            per_source_enabled = file_policy.per_source_enabled;
+            if (per_source_enabled) {
+                per_source_policy = file_policy.per_source_policy;
+                file_policy.per_source_policy = NULL;
+                per_source_policy_file = policy_file;
+                per_source_key_tpl_name = file_policy.per_source_key_tpl_name;
+                file_policy.per_source_key_tpl_name = NULL;
+                per_source_max_states = file_policy.per_source_max_states;
+                per_source_topn = file_policy.per_source_topn;
+            }
         }
     }
 
-    if (per_source_enabled) {
+    if (per_source_enabled && per_source_policy == NULL) {
         if (per_source_policy_file == NULL) {
             LogError(0, RS_RET_CONFIG_ERROR,
                      "ratelimit: per-source rate limiting enabled but perSourcePolicy is missing for '%s'", name);
@@ -1227,27 +1623,21 @@ rsRetVal ratelimitAddConfig(rsconf_t *conf,
         free(per_source_policy);
         per_source_policy = NULL;
         CHKiRet(iRet);
-        if (per_source_key_tpl_name != NULL) {
-            CHKmalloc(shared->per_source_key_tpl_name = strdup(per_source_key_tpl_name));
-            shared->per_source_key_tpl =
-                tplFind(conf, shared->per_source_key_tpl_name, (int)strlen(shared->per_source_key_tpl_name));
-            if (shared->per_source_key_tpl == NULL) {
+        shared->per_source_policy_from_policy_file = per_source_from_policy_file;
+        if (ratelimitLookupPerSourceTemplate(conf, per_source_key_tpl_name, &shared->per_source_key_tpl,
+                                             &shared->per_source_key_tpl_default) != RS_RET_OK) {
+            if (per_source_key_tpl_name != NULL) {
                 LogError(0, RS_RET_CONFIG_ERROR, "ratelimit: perSourceKeyTpl '%s' not found for '%s'",
                          per_source_key_tpl_name, name);
-                pthread_rwlock_unlock(&conf->ratelimit_cfgs.lock);
-                ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
-            }
-            shared->per_source_key_tpl_default = 0;
-        } else {
-            char default_tpl[] = "RSYSLOG_PerSourceKey";
-            shared->per_source_key_tpl = tplFind(conf, default_tpl, (int)sizeof(default_tpl) - 1);
-            if (shared->per_source_key_tpl == NULL) {
+            } else {
                 LogError(0, RS_RET_CONFIG_ERROR,
                          "ratelimit: default perSourceKeyTpl 'RSYSLOG_PerSourceKey' not found for '%s'", name);
-                pthread_rwlock_unlock(&conf->ratelimit_cfgs.lock);
-                ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
             }
-            shared->per_source_key_tpl_default = 1;
+            pthread_rwlock_unlock(&conf->ratelimit_cfgs.lock);
+            ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+        }
+        if (per_source_key_tpl_name != NULL) {
+            CHKmalloc(shared->per_source_key_tpl_name = strdup(per_source_key_tpl_name));
         }
         shared->per_source_key_mode = perSourceKeyModeFromTemplate(shared->per_source_key_tpl);
         shared->per_source_key_needs_parsing = (shared->per_source_key_mode == RL_PS_KEY_TPL);
@@ -1304,6 +1694,7 @@ finalize_it:
         if (per_source_policy->overrides != NULL) hashtable_destroy(per_source_policy->overrides, 1);
         free(per_source_policy);
     }
+    ratelimitPolicyFileDestruct(&file_policy);
 
     RETiRet;
 }
@@ -1577,35 +1968,144 @@ int ratelimitChecked(ratelimit_t *ratelimit) {
  * settings.
  * if pMultiSub == NULL, a single-message enqueue happens (under reconsideration)
  */
-rsRetVal ATTR_NONNULL(1, 3) ratelimitAddMsg(ratelimit_t *ratelimit, multi_submit_t *pMultiSub, smsg_t *pMsg) {
-    rsRetVal localRet;
-    smsg_t *repMsg;
+typedef struct per_source_key_ctx_s {
+    const char *key;
+    size_t key_len;
+    actWrkrIParams_t tpl_param;
+    char *combined;
+    uchar *free_host;
+    uchar *free_port;
+} per_source_key_ctx_t;
+
+static void ratelimitPerSourceKeyCtxFree(per_source_key_ctx_t *ctx) {
+    if (ctx == NULL) return;
+    free(ctx->tpl_param.param);
+    free(ctx->combined);
+    free(ctx->free_host);
+    free(ctx->free_port);
+    memset(ctx, 0, sizeof(*ctx));
+}
+
+static rsRetVal ratelimitGetMsgPropString(
+    smsg_t *pMsg, propid_t propid, const char **value, size_t *len, uchar **to_free) {
+    msgPropDescr_t prop;
+    rs_size_t prop_len = -1;
+    unsigned short must_be_freed = 0;
+    uchar *prop_value;
     DEFiRet;
 
-    assert(ratelimit != NULL);
-    assert(pMsg != NULL);
-    localRet = ratelimitMsg(ratelimit, pMsg, &repMsg);
+    if (pMsg == NULL || value == NULL || len == NULL || to_free == NULL) ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    prop.id = propid;
+    prop.name = NULL;
+    prop.nameLen = 0;
+    prop_value = MsgGetProp(pMsg, NULL, &prop, &prop_len, &must_be_freed, NULL);
+    if (prop_value == NULL) {
+        *value = "";
+        *len = 0;
+        FINALIZE;
+    }
+    *value = (const char *)prop_value;
+    *len = (prop_len < 0) ? strlen((const char *)prop_value) : (size_t)prop_len;
+    if (must_be_freed) {
+        *to_free = prop_value;
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal ratelimitComposePerSourceHostPort(
+    per_source_key_ctx_t *ctx, const char *host, size_t host_len, const char *port, size_t port_len) {
+    DEFiRet;
+
+    if (ctx == NULL) ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    CHKmalloc(ctx->combined = malloc(host_len + 1 + port_len + 1));
+    if (host_len > 0) memcpy(ctx->combined, host, host_len);
+    ctx->combined[host_len] = ':';
+    if (port_len > 0) memcpy(ctx->combined + host_len + 1, port, port_len);
+    ctx->combined[host_len + 1 + port_len] = '\0';
+    ctx->key = ctx->combined;
+    ctx->key_len = host_len + 1 + port_len;
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal ratelimitComputePerSourceKey(ratelimit_t *ratelimit, smsg_t *pMsg, per_source_key_ctx_t *ctx) {
+    ratelimit_shared_t *shared;
+    const char *host = "";
+    const char *port = "";
+    size_t host_len = 0;
+    size_t port_len = 0;
+    DEFiRet;
+
+    if (ratelimit == NULL || pMsg == NULL || ctx == NULL || ratelimit->pShared == NULL)
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    memset(ctx, 0, sizeof(*ctx));
+    shared = ratelimit->pShared;
+    if (!shared->per_source_enabled) FINALIZE;
+
+    switch (shared->per_source_key_mode) {
+        case RL_PS_KEY_FROMHOST_IP:
+            CHKiRet(ratelimitGetMsgPropString(pMsg, PROP_FROMHOST_IP, &ctx->key, &ctx->key_len, &ctx->free_host));
+            break;
+        case RL_PS_KEY_FROMHOST:
+            CHKiRet(ratelimitGetMsgPropString(pMsg, PROP_FROMHOST, &ctx->key, &ctx->key_len, &ctx->free_host));
+            break;
+        case RL_PS_KEY_FROMHOST_IP_PORT:
+            CHKiRet(ratelimitGetMsgPropString(pMsg, PROP_FROMHOST_IP, &host, &host_len, &ctx->free_host));
+            CHKiRet(ratelimitGetMsgPropString(pMsg, PROP_FROMHOST_PORT, &port, &port_len, &ctx->free_port));
+            CHKiRet(ratelimitComposePerSourceHostPort(ctx, host, host_len, port, port_len));
+            break;
+        case RL_PS_KEY_FROMHOST_PORT:
+            CHKiRet(ratelimitGetMsgPropString(pMsg, PROP_FROMHOST, &host, &host_len, &ctx->free_host));
+            CHKiRet(ratelimitGetMsgPropString(pMsg, PROP_FROMHOST_PORT, &port, &port_len, &ctx->free_port));
+            CHKiRet(ratelimitComposePerSourceHostPort(ctx, host, host_len, port, port_len));
+            break;
+        case RL_PS_KEY_TPL:
+        default:
+            if (shared->per_source_key_needs_parsing && (pMsg->msgFlags & NEEDS_PARSING) != 0) {
+                STATSCOUNTER_INC(shared->ctrPerSourceKeyParseEvals, shared->mutCtrPerSourceKeyParseEvals);
+                if (parser.ParseMsg(pMsg) != RS_RET_OK) {
+                    FINALIZE;
+                }
+            }
+            if (shared->per_source_key_tpl == NULL || shared->per_source_key_tpl_default) {
+                ctx->key = getHOSTNAME(pMsg);
+                ctx->key_len = getHOSTNAMELen(pMsg);
+                break;
+            }
+            STATSCOUNTER_INC(shared->ctrPerSourceKeyTplEvals, shared->mutCtrPerSourceKeyTplEvals);
+            if (tplToString(shared->per_source_key_tpl, pMsg, &ctx->tpl_param, NULL) == RS_RET_OK) {
+                ctx->key = (const char *)ctx->tpl_param.param;
+                ctx->key_len = ctx->tpl_param.lenStr;
+            }
+            break;
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal ratelimitSubmitCheckedMsg(multi_submit_t *pMultiSub, smsg_t **ppMsg) {
+    DEFiRet;
+
+    if (ppMsg == NULL || *ppMsg == NULL) FINALIZE;
+
     if (pMultiSub == NULL) {
-        if (repMsg != NULL) CHKiRet(submitMsg2(repMsg));
-        CHKiRet(localRet);
-        CHKiRet(submitMsg2(pMsg));
+        CHKiRet(submitMsg2(*ppMsg));
+        *ppMsg = NULL;
     } else {
-        if (repMsg != NULL) {
-            pMultiSub->ppMsgs[pMultiSub->nElem++] = repMsg;
-            if (pMultiSub->nElem == pMultiSub->maxElem) CHKiRet(multiSubmitMsg2(pMultiSub));
-        }
-        CHKiRet(localRet);
-        if (pMsg->iLenRawMsg > glblGetMaxLine(runConf)) {
-            /* oversize message needs special processing. We keep
-             * at least the previous batch as batch...
-             */
+        if ((*ppMsg)->iLenRawMsg > glblGetMaxLine(runConf)) {
             if (pMultiSub->nElem > 0) {
                 CHKiRet(multiSubmitMsg2(pMultiSub));
             }
-            CHKiRet(submitMsg2(pMsg));
+            CHKiRet(submitMsg2(*ppMsg));
+            *ppMsg = NULL;
             FINALIZE;
         }
-        pMultiSub->ppMsgs[pMultiSub->nElem++] = pMsg;
+        pMultiSub->ppMsgs[pMultiSub->nElem++] = *ppMsg;
+        *ppMsg = NULL;
         if (pMultiSub->nElem == pMultiSub->maxElem) CHKiRet(multiSubmitMsg2(pMultiSub));
     }
 
@@ -1613,62 +2113,59 @@ finalize_it:
     RETiRet;
 }
 
-rsRetVal ratelimitAddMsgPerSource(ratelimit_t *ratelimit,
-                                  multi_submit_t *pMultiSub,
-                                  smsg_t *pMsg,
-                                  const char *per_source_key,
-                                  size_t per_source_key_len,
-                                  time_t tt) {
-    rsRetVal localRet;
-    smsg_t *repMsg = NULL;
-    sbool per_source_dropped = 0;
+static rsRetVal ratelimitSubmitReportMsg(multi_submit_t *pMultiSub, smsg_t **ppRepMsg) {
     DEFiRet;
 
-    assert(ratelimit != NULL);
-    assert(pMsg != NULL);
-    assert(ratelimit->pShared != NULL);
+    if (ppRepMsg == NULL || *ppRepMsg == NULL) FINALIZE;
 
-    if (!ratelimit->pShared->per_source_enabled || per_source_key == NULL || per_source_key_len == 0) {
-        return ratelimitAddMsg(ratelimit, pMultiSub, pMsg);
-    }
-
-    localRet = ratelimitMsg(ratelimit, pMsg, &repMsg);
     if (pMultiSub == NULL) {
-        if (repMsg != NULL) CHKiRet(submitMsg2(repMsg));
-        CHKiRet(localRet);
-        if ((iRet = ratelimitPerSourceCheck(ratelimit, per_source_key, per_source_key_len, tt)) != RS_RET_OK) {
-            per_source_dropped = 1;
-            ABORT_FINALIZE(iRet);
-        }
-        CHKiRet(submitMsg2(pMsg));
+        CHKiRet(submitMsg2(*ppRepMsg));
+        *ppRepMsg = NULL;
     } else {
-        if (repMsg != NULL) {
-            pMultiSub->ppMsgs[pMultiSub->nElem++] = repMsg;
-            if (pMultiSub->nElem == pMultiSub->maxElem) CHKiRet(multiSubmitMsg2(pMultiSub));
-        }
-        CHKiRet(localRet);
-        if ((iRet = ratelimitPerSourceCheck(ratelimit, per_source_key, per_source_key_len, tt)) != RS_RET_OK) {
-            per_source_dropped = 1;
-            ABORT_FINALIZE(iRet);
-        }
-        if (pMsg->iLenRawMsg > glblGetMaxLine(runConf)) {
-            if (pMultiSub->nElem > 0) {
-                CHKiRet(multiSubmitMsg2(pMultiSub));
-            }
-            CHKiRet(submitMsg2(pMsg));
-            FINALIZE;
-        }
-        pMultiSub->ppMsgs[pMultiSub->nElem++] = pMsg;
+        pMultiSub->ppMsgs[pMultiSub->nElem++] = *ppRepMsg;
+        *ppRepMsg = NULL;
         if (pMultiSub->nElem == pMultiSub->maxElem) CHKiRet(multiSubmitMsg2(pMultiSub));
     }
 
 finalize_it:
-    if (per_source_dropped) {
+    RETiRet;
+}
+
+rsRetVal ATTR_NONNULL(1, 3) ratelimitAddMsg(ratelimit_t *ratelimit, multi_submit_t *pMultiSub, smsg_t *pMsg) {
+    rsRetVal localRet;
+    smsg_t *repMsg = NULL;
+    sbool msg_owned = 0;
+    sbool per_source_dropped = 0;
+    per_source_key_ctx_t per_source_key = {0};
+    DEFiRet;
+
+    assert(ratelimit != NULL);
+    assert(pMsg != NULL);
+
+    localRet = ratelimitMsg(ratelimit, pMsg, &repMsg);
+    CHKiRet(localRet);
+    msg_owned = 1;
+    CHKiRet(ratelimitSubmitReportMsg(pMultiSub, &repMsg));
+    CHKiRet(ratelimitComputePerSourceKey(ratelimit, pMsg, &per_source_key));
+    if (per_source_key.key != NULL && per_source_key.key_len > 0) {
+        if ((iRet = ratelimitPerSourceCheck(ratelimit, per_source_key.key, per_source_key.key_len, pMsg->ttGenTime)) !=
+            RS_RET_OK) {
+            per_source_dropped = 1;
+            ABORT_FINALIZE(iRet);
+        }
+    }
+    CHKiRet(ratelimitSubmitCheckedMsg(pMultiSub, &pMsg));
+
+finalize_it:
+    ratelimitPerSourceKeyCtxFree(&per_source_key);
+    if (repMsg != NULL) {
+        msgDestruct(&repMsg);
+    }
+    if (pMsg != NULL && (msg_owned || per_source_dropped)) {
         msgDestruct(&pMsg);
     }
     RETiRet;
 }
-
 
 /* modname must be a static name (usually expected to be the module
  * name and MUST be present. dynname may be NULL and can be used for
@@ -1807,7 +2304,7 @@ void ratelimitDoHUP(void) {
             if (shared && shared->policy_file) {
                 ratelimitReloadPolicyFile(shared, "HUP");
             }
-            if (shared && shared->per_source_policy_file) {
+            if (shared && shared->per_source_policy_file && !shared->per_source_policy_from_policy_file) {
                 ratelimitReloadPerSourcePolicyFile(shared, "HUP");
             }
         } while (hashtable_iterator_advance(itr));

--- a/runtime/ratelimit.h
+++ b/runtime/ratelimit.h
@@ -43,6 +43,7 @@ typedef struct ratelimit_shared_s {
     rswatch_handle_t *per_source_policy_watch_handle;
     pthread_mutex_t mut;
     sbool per_source_enabled;
+    sbool per_source_policy_from_policy_file;
     char *per_source_policy_file;
     unsigned int per_source_default_max;
     unsigned int per_source_default_window;
@@ -67,6 +68,8 @@ typedef struct ratelimit_shared_s {
     statsobj_t *per_source_stats;
     STATSCOUNTER_DEF(ctrPerSourceAllowed, mutCtrPerSourceAllowed);
     STATSCOUNTER_DEF(ctrPerSourceDropped, mutCtrPerSourceDropped);
+    STATSCOUNTER_DEF(ctrPerSourceKeyTplEvals, mutCtrPerSourceKeyTplEvals);
+    STATSCOUNTER_DEF(ctrPerSourceKeyParseEvals, mutCtrPerSourceKeyParseEvals);
     ctr_t **per_source_top_ctrs;
     intctr_t *per_source_top_values;
     char **per_source_top_keys;
@@ -121,12 +124,6 @@ void ratelimitSetSeverity(ratelimit_t *ratelimit, int severity);
 rsRetVal ratelimitMsgCount(ratelimit_t *ratelimit, time_t tt, const char *const appname);
 rsRetVal ATTR_NONNULL(1, 2, 3) ratelimitMsg(ratelimit_t *ratelimit, smsg_t *pMsg, smsg_t **ppRep);
 rsRetVal ATTR_NONNULL(1, 3) ratelimitAddMsg(ratelimit_t *ratelimit, multi_submit_t *pMultiSub, smsg_t *pMsg);
-rsRetVal ATTR_NONNULL(1, 3) ratelimitAddMsgPerSource(ratelimit_t *ratelimit,
-                                                     multi_submit_t *pMultiSub,
-                                                     smsg_t *pMsg,
-                                                     const char *per_source_key,
-                                                     size_t per_source_key_len,
-                                                     time_t tt);
 void ratelimitDestruct(ratelimit_t *pThis);
 int ratelimitChecked(ratelimit_t *ratelimit);
 rsRetVal ratelimitModInit(void);

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -45,34 +45,12 @@
 #include "obj.h"
 #include "errmsg.h"
 #include "netstrm.h"
-#include "template.h"
-#include "wti.h"
 #include "msg.h"
 #include "datetime.h"
 #include "prop.h"
-#include "parser.h"
 #include "ratelimit.h"
 #include "debug.h"
 #include "rsconf.h"
-
-static rsRetVal ensurePerSourceKeyBuf(actWrkrIParams_t *param, size_t need) {
-    uchar *pNewBuf;
-    size_t iNewSize;
-    DEFiRet;
-
-    if (param->lenBuf >= need + 1) {
-        RETiRet;
-    }
-
-    iNewSize = ((need + 1) / 128 + 1) * 128;
-    CHKmalloc(pNewBuf = (uchar *)realloc(param->param, iNewSize));
-    param->param = pNewBuf;
-    param->lenBuf = iNewSize;
-
-finalize_it:
-    RETiRet;
-}
-
 
 /* static data */
 DEFobjStaticHelpers;
@@ -81,11 +59,10 @@ DEFobjCurrIf(netstrm);
 DEFobjCurrIf(prop);
 DEFobjCurrIf(datetime);
 DEFobjCurrIf(regexp);
-DEFobjCurrIf(parser)
 
 
-    /* forward definitions */
-    static rsRetVal Close(tcps_sess_t *pThis);
+/* forward definitions */
+static rsRetVal Close(tcps_sess_t *pThis);
 
 
 /* Standard-Constructor */
@@ -106,7 +83,6 @@ BEGINobjConstruct(tcps_sess) /* be sure to specify the object type also in END m
     pThis->tlsProbeDone = 0;
     pThis->tlsMismatchWarned = 0;
     memset(pThis->tlsProbeBuf, 0, sizeof(pThis->tlsProbeBuf));
-    wtiInitIParam(&pThis->perSourceKeyParam);
     /* now allocate the message reception buffer */
     bufSize = (size_t)pThis->iMaxLine + 1;
     CHKmalloc(pThis->pMsg = (uchar *)malloc(bufSize));
@@ -159,7 +135,6 @@ BEGINobjDestruct(tcps_sess) /* be sure to specify the object type also in END an
     if (pThis->fromHost != NULL) CHKiRet(prop.Destruct(&pThis->fromHost));
     if (pThis->fromHostIP != NULL) CHKiRet(prop.Destruct(&pThis->fromHostIP));
     if (pThis->fromHostPort != NULL) CHKiRet(prop.Destruct(&pThis->fromHostPort));
-    free(pThis->perSourceKeyParam.param);
     free(pThis->pMsg);
     free(pThis->pMsg_save);
 ENDobjDestruct(tcps_sess)
@@ -363,89 +338,7 @@ static rsRetVal defaultDoSubmitMessage(tcps_sess_t *pThis,
         writeOversizeMessageLog(pMsg);
     }
 
-    if (pThis->pLstnInfo->ratelimiter->pShared != NULL && pThis->pLstnInfo->ratelimiter->pShared->per_source_enabled) {
-        const char *per_source_key = NULL;
-        size_t per_source_key_len = 0;
-        if (pThis->pLstnInfo->ratelimiter->pShared->per_source_key_needs_parsing &&
-            (pMsg->msgFlags & NEEDS_PARSING) != 0) {
-            parser.ParseMsg(pMsg);
-        }
-        if (pThis->pLstnInfo->ratelimiter->pShared->per_source_key_mode == RL_PS_KEY_TPL) {
-            if (pThis->pLstnInfo->ratelimiter->pShared->per_source_key_tpl == NULL ||
-                pThis->pLstnInfo->ratelimiter->pShared->per_source_key_tpl_default) {
-                per_source_key = getHOSTNAME(pMsg);
-                per_source_key_len = getHOSTNAMELen(pMsg);
-            } else {
-                if (tplToString(pThis->pLstnInfo->ratelimiter->pShared->per_source_key_tpl, pMsg,
-                                &pThis->perSourceKeyParam, NULL) == RS_RET_OK) {
-                    per_source_key = (const char *)pThis->perSourceKeyParam.param;
-                    per_source_key_len = pThis->perSourceKeyParam.lenStr;
-                }
-            }
-        } else {
-            uchar *pHost = NULL;
-            uchar *pPort = NULL;
-            int hostLen = 0;
-            int portLen = 0;
-
-            switch (pThis->pLstnInfo->ratelimiter->pShared->per_source_key_mode) {
-                case RL_PS_KEY_FROMHOST_IP:
-                    if (pThis->fromHostIP != NULL) {
-                        prop.GetString(pThis->fromHostIP, &pHost, &hostLen);
-                        per_source_key = (const char *)pHost;
-                        per_source_key_len = (size_t)hostLen;
-                    }
-                    break;
-                case RL_PS_KEY_FROMHOST:
-                    if (pThis->fromHost != NULL) {
-                        prop.GetString(pThis->fromHost, &pHost, &hostLen);
-                        per_source_key = (const char *)pHost;
-                        per_source_key_len = (size_t)hostLen;
-                    }
-                    break;
-                case RL_PS_KEY_FROMHOST_IP_PORT:
-                case RL_PS_KEY_FROMHOST_PORT:
-                    if (pThis->fromHostPort != NULL) {
-                        prop.GetString(pThis->fromHostPort, &pPort, &portLen);
-                    }
-                    if (pThis->pLstnInfo->ratelimiter->pShared->per_source_key_mode == RL_PS_KEY_FROMHOST_IP_PORT) {
-                        if (pThis->fromHostIP != NULL) {
-                            prop.GetString(pThis->fromHostIP, &pHost, &hostLen);
-                        }
-                    } else {
-                        if (pThis->fromHost != NULL) {
-                            prop.GetString(pThis->fromHost, &pHost, &hostLen);
-                        }
-                    }
-                    if (pHost == NULL) {
-                        pHost = (uchar *)"";
-                        hostLen = 0;
-                    }
-                    if (pPort == NULL) {
-                        pPort = (uchar *)"";
-                        portLen = 0;
-                    }
-                    if (ensurePerSourceKeyBuf(&pThis->perSourceKeyParam, (size_t)hostLen + 1 + (size_t)portLen) ==
-                        RS_RET_OK) {
-                        memcpy(pThis->perSourceKeyParam.param, pHost, (size_t)hostLen);
-                        pThis->perSourceKeyParam.param[hostLen] = ':';
-                        memcpy(pThis->perSourceKeyParam.param + hostLen + 1, pPort, (size_t)portLen);
-                        pThis->perSourceKeyParam.param[hostLen + 1 + portLen] = '\0';
-                        pThis->perSourceKeyParam.lenStr = (size_t)hostLen + 1 + (size_t)portLen;
-                        per_source_key = (const char *)pThis->perSourceKeyParam.param;
-                        per_source_key_len = pThis->perSourceKeyParam.lenStr;
-                    }
-                    break;
-                case RL_PS_KEY_TPL:
-                default:
-                    break;
-            }
-        }
-        localRet = ratelimitAddMsgPerSource(pThis->pLstnInfo->ratelimiter, pMultiSub, pMsg, per_source_key,
-                                            per_source_key_len, ttGenTime);
-    } else {
-        localRet = ratelimitAddMsg(pThis->pLstnInfo->ratelimiter, pMultiSub, pMsg);
-    }
+    localRet = ratelimitAddMsg(pThis->pLstnInfo->ratelimiter, pMultiSub, pMsg);
 
     if (localRet == RS_RET_OK) {
         STATSCOUNTER_INC(pThis->pLstnInfo->ctrSubmit, pThis->pLstnInfo->mutCtrSubmit);
@@ -891,7 +784,6 @@ BEGINObjClassExit(tcps_sess, OBJ_IS_LOADABLE_MODULE) /* CHANGE class also in END
     objRelease(netstrm, LM_NETSTRMS_FILENAME);
     objRelease(datetime, CORE_COMPONENT);
     objRelease(prop, CORE_COMPONENT);
-    objRelease(parser, CORE_COMPONENT);
 #ifdef FEATURE_REGEXP
     objRelease(regexp, LM_REGEXP_FILENAME);
 #endif
@@ -907,7 +799,6 @@ BEGINObjClassInit(tcps_sess, 1, OBJ_IS_CORE_MODULE) /* class, version - CHANGE c
     CHKiRet(objUse(netstrm, LM_NETSTRMS_FILENAME));
     CHKiRet(objUse(datetime, CORE_COMPONENT));
     CHKiRet(objUse(prop, CORE_COMPONENT));
-    CHKiRet(objUse(parser, CORE_COMPONENT));
 #ifdef FEATURE_REGEXP
     CHKiRet(objUse(regexp, LM_REGEXP_FILENAME));
 #endif

--- a/runtime/tcps_sess.h
+++ b/runtime/tcps_sess.h
@@ -55,7 +55,6 @@ struct tcps_sess_s {
         prop_t *fromHostPort;
         int iCurrLine; /* 2nd char of current line in regex framing mode */
         uchar *pMsg_save; /* message (fragment) save area in regex framing mode */
-        actWrkrIParams_t perSourceKeyParam; /**< reusable template buffer */
         void *pUsr; /* a user-pointer */
         rsRetVal (*DoSubmitMessage)(tcps_sess_t *, uchar *, int); /* submit message callback */
         int iMaxLine; /* fast lookup buffer for config property */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -694,7 +694,11 @@ TESTS_IMTCP = \
 	sndrcv_udp_nonstdpt.sh \
 	sndrcv_udp_nonstdpt_v6.sh
 TESTS_IMTCP_YAML = \
-	imtcp-persource-ratelimit.sh
+	imtcp-persource-ratelimit.sh \
+	ratelimit-legacy-persource-discard.sh \
+	ratelimit-persource-repeat-summary.sh \
+	ratelimit-policy-persource-topn-default-reload.sh \
+	ratelimit-policy-persource-mixed-invalid.sh
 
 TESTS_IMTCP_VALGRIND = \
 	imtcp-octet-framing-too-long-vg.sh \
@@ -708,6 +712,12 @@ TESTS_RATELIMIT = \
 	omelasticsearch_ratelimit_name.sh \
 	imklog_ratelimit_name.sh \
 	imuxsock_ratelimit_name.sh
+
+TESTS_RATELIMIT_YAML = \
+	imudp-persource-ratelimit-policy.sh
+
+TESTS_RATELIMIT_IMPTCP_YAML = \
+	imptcp-persource-ratelimit-policy.sh
 
 TESTS_IMTCP_IMPSTATS = \
 	imtcp-impstats.sh
@@ -1662,6 +1672,9 @@ TESTS_RELP = \
 	 glbl-oversizeMsg-truncate.sh \
 	 glbl-oversizeMsg-split.sh
 
+TESTS_RELP_YAML = \
+	imrelp-persource-ratelimit-policy.sh
+
 TESTS_RELP_OPENSSL = \
 	 omrelp-tls-ossl-authfail-no-cacert.sh \
 	 omrelp-tls-ossl-authfail-suspend.sh
@@ -1960,6 +1973,8 @@ EXTRA_DIST += $(TESTS_IMTCP_YAML)
 EXTRA_DIST += $(TESTS_IMTCP_VALGRIND)
 EXTRA_DIST += $(TESTS_IMTCP_IMPSTATS)
 EXTRA_DIST += $(TESTS_RATELIMIT)
+EXTRA_DIST += $(TESTS_RATELIMIT_YAML)
+EXTRA_DIST += $(TESTS_RATELIMIT_IMPTCP_YAML)
 EXTRA_DIST += $(TESTS_SNMP_MINIMAL)
 EXTRA_DIST += $(TESTS_SNMP_FULL)
 EXTRA_DIST += $(TESTS_MMUTF8FIX)
@@ -2073,6 +2088,7 @@ EXTRA_DIST += $(TESTS_GNUTLS_OPENSSL_INTEROP)
 EXTRA_DIST += $(TESTS_OMUXSOCK)
 EXTRA_DIST += $(TESTS_OMUXSOCK_VALGRIND)
 EXTRA_DIST += $(TESTS_RELP)
+EXTRA_DIST += $(TESTS_RELP_YAML)
 EXTRA_DIST += $(TESTS_RELP_OPENSSL)
 EXTRA_DIST += $(TESTS_RELP_GNUTLS)
 EXTRA_DIST += $(TESTS_RELP_GNUTLS_CFG)
@@ -2463,6 +2479,9 @@ endif # HAVE_LIBYAML
 if ENABLE_IMPTCP
 TESTS += $(TESTS_RATELIMIT)
 endif # ENABLE_IMPTCP
+if HAVE_LIBYAML
+TESTS += $(TESTS_RATELIMIT_YAML)
+endif # HAVE_LIBYAML
 
 if HAVE_VALGRIND
 TESTS += $(TESTS_IMTCP_VALGRIND)
@@ -2852,6 +2871,9 @@ if ENABLE_IMPTCP
 # need to be disabled if we do not have this module
 TESTS += $(TESTS_IMPTCP)
 TESTS += $(TESTS_IMPTCP_STREAM_ALWAYS)
+if HAVE_LIBYAML
+TESTS += $(TESTS_RATELIMIT_IMPTCP_YAML)
+endif # HAVE_LIBYAML
 if HAVE_VALGRIND
 TESTS += $(TESTS_IMPTCP_VALGRIND)
 if ENABLE_FMHASH
@@ -3057,6 +3079,9 @@ endif
 
 if ENABLE_RELP
 TESTS += $(TESTS_RELP)
+if HAVE_LIBYAML
+TESTS += $(TESTS_RELP_YAML)
+endif # HAVE_LIBYAML
 if ENABLE_OPENSSL
 TESTS += $(TESTS_RELP_OPENSSL)
 endif # ENABLE_OPENSSL

--- a/tests/imptcp-persource-ratelimit-policy.sh
+++ b/tests/imptcp-persource-ratelimit-policy.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+## Test that imptcp inherits per-source limiting through ratelimitAddMsg().
+## The policy key template is configured only in the ratelimit YAML file; the
+## module should not compute or pass a per-source key itself.
+## The impstats sleep gives the one-second stats interval time to publish the
+## key-evaluation counters that prove tplToString and parser use for this
+## custom hostname template. The submitted counter must match the delivered
+## message count, proving per-source drops return the same discard status as the
+## regular ratelimiter and are not counted as successfully submitted.
+
+. ${srcdir:=.}/diag.sh init
+require_plugin impstats
+skip_ARM "ratelimit timing flaky on ARM"
+export NUMMESSAGES=10
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+export STATSFILE="$RSYSLOG_DYNNAME.stats"
+
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+INPUT_FILE="$(pwd)/${RSYSLOG_DYNNAME}.input"
+export POLICY_FILE INPUT_FILE
+
+cat > "$POLICY_FILE" <<EOF
+perSource:
+  enabled: true
+  keyTemplate: "PerSourceKey"
+  default:
+    max: 5
+    window: 2s
+  overrides:
+    - key: "quiethost"
+      max: 50
+      window: 2s
+EOF
+
+generate_conf
+add_conf '
+template(name="PerSourceKey" type="string" string="%hostname%")
+ratelimit(name="per_source" policy="'$POLICY_FILE'")
+
+module(load="../plugins/imptcp/.libs/imptcp")
+module(load="../plugins/impstats/.libs/impstats" log.file="'$STATSFILE'" interval="1")
+input(type="imptcp"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.ptcp.port"
+      ratelimit.name="per_source")
+
+template(name="outfmt" type="string" string="host=%hostname% msg=%msg%\n")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+ptcp_port=$(cat "$RSYSLOG_DYNNAME.ptcp.port")
+
+: > "$INPUT_FILE"
+for i in $(seq 1 20); do
+    echo "<13>Jan 1 00:00:00 noisyhost app: msgnum:$i" >> "$INPUT_FILE"
+done
+for i in $(seq 1 5); do
+    echo "<13>Jan 1 00:00:00 quiethost app: msgnum:$i" >> "$INPUT_FILE"
+done
+
+./tcpflood -p"$ptcp_port" -I "$INPUT_FILE"
+
+sleep 2
+shutdown_when_empty
+wait_shutdown
+
+noisy_count=$(grep -c "host=noisyhost" "$RSYSLOG_OUT_LOG")
+quiet_count=$(grep -c "host=quiethost" "$RSYSLOG_OUT_LOG")
+content_count=$((noisy_count + quiet_count))
+submitted_count=$(grep "origin=imptcp" "$STATSFILE" | grep -o "submitted=[0-9]*" | sed 's/.*=//' | sort -n | tail -1)
+tpl_evals=$(grep "ratelimit.per_source.per_source" "$STATSFILE" | grep -o "per_source_key_tpl_evals=[0-9]*" | tail -1 | sed 's/.*=//')
+parse_evals=$(grep "ratelimit.per_source.per_source" "$STATSFILE" | grep -o "per_source_key_parse_evals=[0-9]*" | tail -1 | sed 's/.*=//')
+
+echo "noisy_count: $noisy_count"
+echo "quiet_count: $quiet_count"
+echo "submitted_count: $submitted_count"
+echo "tpl_evals: $tpl_evals"
+echo "parse_evals: $parse_evals"
+
+if [ "$quiet_count" -ne 5 ]; then
+    echo "FAIL: expected 5 quiethost messages, got $quiet_count"
+    error_exit 1
+fi
+
+if [ "$noisy_count" -ge 20 ]; then
+    echo "FAIL: per-source ratelimit did not drop noisyhost messages"
+    error_exit 1
+fi
+
+if [ "$noisy_count" -le 0 ]; then
+    echo "FAIL: per-source ratelimit dropped all noisyhost messages"
+    error_exit 1
+fi
+
+if [ "${submitted_count:-0}" -ne "$content_count" ]; then
+    echo "FAIL: imptcp submitted counter counted per-source-dropped messages"
+    echo "stats content:"
+    cat "$STATSFILE"
+    error_exit 1
+fi
+
+if [ "${tpl_evals:-0}" -le 0 ]; then
+    echo "FAIL: expected custom per-source template to use tplToString"
+    error_exit 1
+fi
+
+if [ "${parse_evals:-0}" -le 0 ]; then
+    echo "FAIL: expected custom hostname template to parse messages before evaluation"
+    error_exit 1
+fi
+
+exit_test

--- a/tests/imrelp-persource-ratelimit-policy.sh
+++ b/tests/imrelp-persource-ratelimit-policy.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+## Test that imrelp inherits per-source limiting through ratelimitAddMsg().
+## The oracle also covers discard handling: rate-limited RELP messages must not
+## make librelp treat the receive callback as a session-level failure.
+## The submitted counter must match the delivered message count, proving RELP
+## maps per-source discard to callback success only after preserving regular
+## ratelimiter discard semantics for module accounting.
+## The impstats sleep gives the one-second stats interval time to publish that
+## submitted counter before shutdown.
+
+. ${srcdir:=.}/diag.sh init
+require_plugin impstats
+skip_ARM "ratelimit timing flaky on ARM"
+export SENDMESSAGES=20
+export NUMMESSAGES=5
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+export STATSFILE="$RSYSLOG_DYNNAME.stats"
+
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+export POLICY_FILE
+
+cat > "$POLICY_FILE" <<EOF
+perSource:
+  enabled: true
+  keyTemplate: "PerSourceIP"
+  default:
+    max: 5
+    window: 2s
+EOF
+
+generate_conf
+add_conf '
+template(name="PerSourceIP" type="string" string="%fromhost-ip%")
+ratelimit(name="per_source" policy="'$POLICY_FILE'")
+
+module(load="../plugins/imrelp/.libs/imrelp")
+module(load="../plugins/impstats/.libs/impstats" log.file="'$STATSFILE'" interval="1")
+input(type="imrelp" port="'$TCPFLOOD_PORT'" ratelimit.name="per_source")
+
+template(name="outfmt" type="string" string="%msg%\n")
+if $msg contains "msgnum:" then
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+tcpflood -Trelp-plain -p"$TCPFLOOD_PORT" -m "$SENDMESSAGES"
+
+sleep 2
+shutdown_when_empty
+wait_shutdown
+
+content_count=$(grep -c "msgnum:" "$RSYSLOG_OUT_LOG")
+submitted_count=$(grep "origin=imrelp" "$STATSFILE" | grep -o "submitted=[0-9]*" | sed 's/.*=//' | sort -n | tail -1)
+echo "content_count: $content_count"
+echo "submitted_count: $submitted_count"
+
+if [ "$content_count" -eq "$SENDMESSAGES" ]; then
+    echo "FAIL: per-source ratelimit did not drop RELP messages"
+    error_exit 1
+fi
+
+if [ "$content_count" -eq 0 ]; then
+    echo "FAIL: all RELP messages were lost or dropped"
+    error_exit 1
+fi
+
+if [ "${submitted_count:-0}" -ne "$content_count" ]; then
+    echo "FAIL: imrelp submitted counter counted per-source-dropped messages"
+    echo "stats content:"
+    cat "$STATSFILE"
+    error_exit 1
+fi
+
+exit_test

--- a/tests/imtcp-persource-ratelimit.sh
+++ b/tests/imtcp-persource-ratelimit.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-## Test per-source ratelimiting for imtcp using a YAML policy.
+## Test per-source ratelimiting for imtcp using the canonical ratelimit
+## policy YAML. The oracle is that the shared ratelimit API drops the noisy
+## sender while allowing the override sender through; imtcp itself does not
+## compute or pass a per-source key.
 
 . ${srcdir:=.}/diag.sh init
 
@@ -9,20 +12,23 @@ INPUT_FILE="$(pwd)/${RSYSLOG_DYNNAME}.input"
 export INPUT_FILE
 
 cat > "$POLICY_FILE" <<EOF
-default:
-  max: 5
-  window: 2s
-overrides:
-  - key: "quiethost"
-    max: 50
+perSource:
+  enabled: true
+  keyTemplate: "PerSourceKey"
+  default:
+    max: 5
     window: 2s
+  overrides:
+    - key: "quiethost"
+      max: 50
+      window: 2s
 EOF
 
 generate_conf
 add_conf '
 template(name="PerSourceKey" type="string" string="%hostname%")
 
-ratelimit(name="per_source" perSource="on" perSourcePolicy="'$POLICY_FILE'" perSourceKeyTpl="PerSourceKey")
+ratelimit(name="per_source" policy="'$POLICY_FILE'")
 
 module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp"

--- a/tests/imudp-persource-ratelimit-policy.sh
+++ b/tests/imudp-persource-ratelimit-policy.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+## Test that imudp inherits per-source limiting through ratelimitAddMsg().
+## The key template is `%fromhost-ip%`, an optimized mode that must not need
+## generic template evaluation; the observable oracle is that one UDP source is
+## capped by the shared ratelimiter policy.
+## The impstats sleep gives the one-second stats interval time to publish the
+## zero-valued key-evaluation counters that prove the fast path avoided
+## tplToString and parser calls. The submitted counter must match the delivered
+## message count, proving per-source drops keep the same discard semantics as
+## the regular ratelimiter instead of returning success to the module.
+
+. ${srcdir:=.}/diag.sh init
+require_plugin impstats
+skip_ARM "ratelimit timing flaky on ARM"
+export SENDMESSAGES=20
+export NUMMESSAGES=5
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
+export STATSFILE="$RSYSLOG_DYNNAME.stats"
+
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+export POLICY_FILE
+
+cat > "$POLICY_FILE" <<EOF
+perSource:
+  enabled: true
+  keyTemplate: "PerSourceIP"
+  default:
+    max: 5
+    window: 2s
+EOF
+
+generate_conf
+add_conf '
+template(name="PerSourceIP" type="string" string="%fromhost-ip%")
+ratelimit(name="per_source" policy="'$POLICY_FILE'")
+
+module(load="../plugins/imudp/.libs/imudp")
+module(load="../plugins/impstats/.libs/impstats" log.file="'$STATSFILE'" interval="1")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'"
+      ratelimit.name="per_source")
+
+template(name="outfmt" type="string" string="%msg%\n")
+if $msg contains "msgnum:" then
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
+
+./tcpflood -Tudp -p"$PORT_RCVR" -m "$SENDMESSAGES"
+
+sleep 2
+shutdown_when_empty
+wait_shutdown
+
+content_count=$(grep -c "msgnum:" "$RSYSLOG_OUT_LOG")
+submitted_count=$(grep "origin=imudp" "$STATSFILE" | grep -o "submitted=[0-9]*" | sed 's/.*=//' | sort -n | tail -1)
+tpl_evals=$(grep "ratelimit.per_source.per_source" "$STATSFILE" | grep -o "per_source_key_tpl_evals=[0-9]*" | tail -1 | sed 's/.*=//')
+parse_evals=$(grep "ratelimit.per_source.per_source" "$STATSFILE" | grep -o "per_source_key_parse_evals=[0-9]*" | tail -1 | sed 's/.*=//')
+echo "content_count: $content_count"
+echo "submitted_count: $submitted_count"
+echo "tpl_evals: $tpl_evals"
+echo "parse_evals: $parse_evals"
+
+if [ "$content_count" -eq "$SENDMESSAGES" ]; then
+    echo "FAIL: per-source ratelimit did not drop UDP messages"
+    error_exit 1
+fi
+
+if [ "$content_count" -eq 0 ]; then
+    echo "FAIL: all UDP messages were lost or dropped"
+    error_exit 1
+fi
+
+if [ "${submitted_count:-0}" -ne "$content_count" ]; then
+    echo "FAIL: imudp submitted counter counted per-source-dropped messages"
+    echo "stats content:"
+    cat "$STATSFILE"
+    error_exit 1
+fi
+
+if [ "${tpl_evals:-0}" -ne 0 ]; then
+    echo "FAIL: optimized fromhost-ip per-source key used tplToString"
+    error_exit 1
+fi
+
+if [ "${parse_evals:-0}" -ne 0 ]; then
+    echo "FAIL: optimized fromhost-ip per-source key parsed messages"
+    error_exit 1
+fi
+
+exit_test

--- a/tests/ratelimit-legacy-persource-discard.sh
+++ b/tests/ratelimit-legacy-persource-discard.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+## Regression test for legacy split per-source ratelimit configuration.
+## `perSource=on` plus `perSourcePolicy` and `perSourceKeyTpl` must still be
+## enforced through the unified ratelimitAddMsg() path. The oracle checks both
+## delivered output and imtcp's submitted counter so per-source drops keep the
+## same discard semantics as the regular ratelimiter.
+## The impstats sleep gives the one-second stats interval time to publish that
+## submitted counter before shutdown.
+
+. ${srcdir:=.}/diag.sh init
+require_plugin impstats
+
+export STATSFILE="$RSYSLOG_DYNNAME.stats"
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.legacy-persource.yaml"
+INPUT_FILE="$(pwd)/${RSYSLOG_DYNNAME}.input"
+export POLICY_FILE INPUT_FILE
+
+cat > "$POLICY_FILE" <<EOF
+default:
+  max: 5
+  window: 2s
+overrides:
+  - key: "quiethost"
+    max: 50
+    window: 2s
+EOF
+
+generate_conf
+add_conf '
+template(name="PerSourceKey" type="string" string="%hostname%")
+ratelimit(name="legacy_per_source"
+          perSource="on"
+          perSourcePolicy="'$POLICY_FILE'"
+          perSourceKeyTpl="PerSourceKey")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/impstats/.libs/impstats" log.file="'$STATSFILE'" interval="1")
+input(type="imtcp"
+      name="legacy-persource"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.tcp.port"
+      ratelimit.name="legacy_per_source")
+
+template(name="outfmt" type="string" string="host=%hostname% msg=%msg%\n")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+tcp_port=$(cat "$RSYSLOG_DYNNAME.tcp.port")
+
+: > "$INPUT_FILE"
+for i in $(seq 1 20); do
+    echo "<13>Jan 1 00:00:00 noisyhost app: msgnum:$i" >> "$INPUT_FILE"
+done
+for i in $(seq 1 5); do
+    echo "<13>Jan 1 00:00:00 quiethost app: msgnum:$i" >> "$INPUT_FILE"
+done
+
+./tcpflood -p"$tcp_port" -I "$INPUT_FILE"
+
+sleep 2
+shutdown_when_empty
+wait_shutdown
+
+noisy_count=$(grep -c "host=noisyhost" "$RSYSLOG_OUT_LOG")
+quiet_count=$(grep -c "host=quiethost" "$RSYSLOG_OUT_LOG")
+content_count=$((noisy_count + quiet_count))
+submitted_count=$(grep "origin=imtcp" "$STATSFILE" | grep -o "submitted=[0-9]*" | sed 's/.*=//' | sort -n | tail -1)
+
+echo "noisy_count: $noisy_count"
+echo "quiet_count: $quiet_count"
+echo "submitted_count: $submitted_count"
+
+if [ "$quiet_count" -ne 5 ]; then
+    echo "FAIL: expected 5 quiethost messages, got $quiet_count"
+    error_exit 1
+fi
+
+if [ "$noisy_count" -ge 20 ]; then
+    echo "FAIL: legacy per-source ratelimit did not drop noisyhost messages"
+    error_exit 1
+fi
+
+if [ "$noisy_count" -le 0 ]; then
+    echo "FAIL: legacy per-source ratelimit dropped all noisyhost messages"
+    error_exit 1
+fi
+
+if [ "${submitted_count:-0}" -ne "$content_count" ]; then
+    echo "FAIL: imtcp submitted counter counted legacy per-source-dropped messages"
+    echo "stats content:"
+    cat "$STATSFILE"
+    error_exit 1
+fi
+
+exit_test

--- a/tests/ratelimit-persource-repeat-summary.sh
+++ b/tests/ratelimit-persource-repeat-summary.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+## Repeated-message reduction can emit a summary for already accepted messages
+## when the next distinct message arrives. If that distinct message is then
+## dropped by per-source rate limiting, the summary must still be submitted.
+## The oracle checks that only the first original message and the repeat
+## summary are written; the distinct over-limit message must not appear.
+
+. ${srcdir:=.}/diag.sh init
+
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.persource-repeat.yaml"
+export POLICY_FILE
+INPUT_FILE="$(pwd)/${RSYSLOG_DYNNAME}.input"
+export INPUT_FILE
+
+cat > "$POLICY_FILE" <<EOF
+perSource:
+  enabled: true
+  keyTemplate: "PerSourceKey"
+  default:
+    max: 1
+    window: 60s
+EOF
+
+generate_conf
+add_conf '
+$RepeatedMsgReduction on
+
+template(name="PerSourceKey" type="string" string="%hostname%")
+
+ratelimit(name="per_source" policy="'$POLICY_FILE'")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.tcp.port"
+      ratelimit.name="per_source")
+
+template(name="outfmt" type="string" string="%msg%\n")
+if $msg contains "repeated payload" or $msg contains "distinct over limit" then {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+startup
+
+tcp_port=$(cat "$RSYSLOG_DYNNAME.tcp.port")
+
+: > "$INPUT_FILE"
+for _ in $(seq 1 4); do
+    echo "<13>Jan 1 00:00:00 noisyhost app: repeated payload" >> "$INPUT_FILE"
+done
+echo "<13>Jan 1 00:00:00 noisyhost app: distinct over limit" >> "$INPUT_FILE"
+
+./tcpflood -p"$tcp_port" -I "$INPUT_FILE"
+
+shutdown_when_empty
+wait_shutdown
+
+line_count=$(wc -l < "$RSYSLOG_OUT_LOG")
+echo "line_count: $line_count"
+
+if [ "$line_count" -ne 2 ]; then
+    echo "FAIL: expected original message plus repeat summary only"
+    cat "$RSYSLOG_OUT_LOG"
+    error_exit 1
+fi
+
+if ! grep -q "repeated payload" "$RSYSLOG_OUT_LOG"; then
+    echo "FAIL: original repeated payload missing"
+    cat "$RSYSLOG_OUT_LOG"
+    error_exit 1
+fi
+
+if ! grep -q "message repeated 3 times" "$RSYSLOG_OUT_LOG"; then
+    echo "FAIL: repeat summary missing"
+    cat "$RSYSLOG_OUT_LOG"
+    error_exit 1
+fi
+
+if grep -q "distinct over limit" "$RSYSLOG_OUT_LOG"; then
+    echo "FAIL: over-limit distinct message was submitted"
+    cat "$RSYSLOG_OUT_LOG"
+    error_exit 1
+fi
+
+exit_test

--- a/tests/ratelimit-policy-persource-mixed-invalid.sh
+++ b/tests/ratelimit-policy-persource-mixed-invalid.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+## Regression test for ambiguous per-source ratelimit configuration.
+## A policy YAML file that contains a perSource section is the canonical
+## source of per-source settings; mixing it with legacy perSourcePolicy or
+## perSourceKeyTpl on the same ratelimit object must fail at config load.
+
+. ${srcdir:=.}/diag.sh init
+if [ -z "$RSYSLOGD" ]; then
+    export RSYSLOGD=../tools/rsyslogd
+fi
+
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+STDERR_FILE="${RSYSLOG_DYNNAME}.stderr.log"
+export POLICY_FILE
+
+cat > "$POLICY_FILE" <<EOF
+perSource:
+  enabled: true
+  keyTemplate: "PerSourceKey"
+  default:
+    max: 5
+    window: 2s
+EOF
+
+generate_conf
+add_conf '
+template(name="PerSourceKey" type="string" string="%hostname%")
+ratelimit(name="bad"
+          policy="'$POLICY_FILE'"
+          perSourcePolicy="'$POLICY_FILE'")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" ratelimit.name="bad")
+'
+export CONF_FILE="${TESTCONF_NM}.conf"
+"$RSYSLOGD" -N1 -M"$RSYSLOG_MODDIR" -f "$CONF_FILE" > /dev/null 2> "$STDERR_FILE"
+
+if grep -q "do not mix it with legacy perSource/perSourcePolicy/perSourceKeyTpl/maxStates/topN parameters" "$STDERR_FILE"; then
+    exit_test
+fi
+
+echo "FAIL: mixed canonical and legacy per-source ratelimit config was not rejected as expected"
+cat "$STDERR_FILE"
+error_exit 1

--- a/tests/ratelimit-policy-persource-topn-default-reload.sh
+++ b/tests/ratelimit-policy-persource-topn-default-reload.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+## HUP reloads of canonical ratelimit policy YAML must treat an omitted
+## perSource.topN as the documented default, not as "keep the previous value".
+## The oracle uses impstats top-drop counters: after reloading from topN=1 to
+## omitted topN, a second per-source top counter must be created.
+
+. ${srcdir:=.}/diag.sh init
+require_plugin impstats
+
+export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.tcp_port"
+export STATSFILE="${RSYSLOG_DYNNAME}.stats"
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+export POLICY_FILE
+INPUT_FILE="$(pwd)/${RSYSLOG_DYNNAME}.input"
+export INPUT_FILE
+
+write_policy() {
+    local topn_line="$1"
+    cat > "$POLICY_FILE" <<EOF
+perSource:
+  enabled: true
+  keyTemplate: "PerSourceKey"
+$topn_line
+  default:
+    max: 1
+    window: 30s
+EOF
+}
+
+send_host_messages() {
+    local host="$1"
+    local count="$2"
+    : > "$INPUT_FILE"
+    for i in $(seq 1 "$count"); do
+        echo "<13>Jan 1 00:00:00 $host app: msgnum:$host:$i" >> "$INPUT_FILE"
+    done
+    ./tcpflood -p"$PORT_RCVR" -I "$INPUT_FILE"
+}
+
+wait_stats_contains() {
+    local pattern="$1"
+    local retries=0
+    while [ "$retries" -lt 20 ]; do
+        if [ -f "$STATSFILE" ] && grep -q "$pattern" "$STATSFILE"; then
+            return 0
+        fi
+        retries=$((retries + 1))
+        ./msleep 250
+    done
+    return 1
+}
+
+write_policy "  topN: 1"
+
+generate_conf
+add_conf '
+template(name="PerSourceKey" type="string" string="%hostname%")
+ratelimit(name="topn_reload" policy="'$POLICY_FILE'")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/impstats/.libs/impstats" log.file="'$STATSFILE'" interval="1")
+input(type="imtcp" port="0" listenPortFileName="'$PORT_RCVR_FILE'"
+      ratelimit.name="topn_reload")
+
+template(name="outfmt" type="string" string="%msg%\n")
+if $msg contains "msgnum:" then
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
+
+send_host_messages alpha 4
+send_host_messages beta 3
+
+if ! wait_stats_contains "per_source_drop_1_alpha"; then
+    echo "FAIL: expected first topN counter before reload"
+    cat "$STATSFILE"
+    error_exit 1
+fi
+
+if grep -q "per_source_drop_2_beta" "$STATSFILE"; then
+    echo "FAIL: topN=1 exposed a second topN counter before reload"
+    error_exit 1
+fi
+
+write_policy ""
+issue_HUP
+./msleep 1000
+
+send_host_messages alpha 2
+send_host_messages beta 2
+wait_queueempty
+
+if ! wait_stats_contains "per_source_drop_2_beta"; then
+    echo "FAIL: omitted topN on reload did not restore the default topN depth"
+    echo "impstats content:"
+    cat "$STATSFILE"
+    error_exit 1
+fi
+
+shutdown_when_empty
+wait_shutdown
+exit_test


### PR DESCRIPTION
## Summary
- keep modules on the single ratelimitAddMsg() submit API
- move per-source key computation and enforcement into runtime/ratelimit.c
- preserve the regular ratelimiter contract for per-source hits: the message is consumed and RS_RET_DISCARDMSG is returned
- add canonical policy= YAML perSource support, including keyTemplate, defaults, overrides, maxStates, and topN
- keep legacy split perSourcePolicy config when policy YAML has no perSource, but reject ambiguous mixed config
- document per-source discard semantics and add module inheritance/accounting tests

## Backward compatibility
- existing ratelimit.name users continue to call the same module-facing API
- legacy inline perSource/perSourcePolicy/perSourceKeyTpl remains supported
- split policy= plus perSourcePolicy= remains supported if policy= has no perSource section
- policy= YAML with perSource mixed with legacy per-source fields is rejected clearly
- canonical reloads that remove perSource disable the previously canonical per-source policy

## Obsoletes
This PR obsoletes #7045 and #7082.

- #7045 is covered because imrelp now uses the same centralized ratelimitAddMsg() enforcement, including configured per-source keys. RELP still maps a discarded frame to callback success locally, after preserving the regular RS_RET_DISCARDMSG accounting path.
- #7082 is covered because imudp and imptcp inherit the same central per-source enforcement without module-local key/parser duplication.

## Validation
- tests/ratelimit-legacy-persource-discard.sh
- tests/imudp-persource-ratelimit-policy.sh
- tests/imptcp-persource-ratelimit-policy.sh
- tests/imrelp-persource-ratelimit-policy.sh
- devtools/format-code.sh --git-changed --check --check-if-available
- shellcheck -S warning on changed shell tests
- devtools/check-test-antipatterns.sh on changed shell tests: only documented impstats publication sleeps reported
- ./doc/tools/build-doc-linux.sh --clean --format html --jobs 28
- make distcheck TEST_RUN_TYPE=MOCK-OK -j28
- Ubuntu 26.04 dev-container devtools/run-ci.sh: rsyslog/rsyslog_dev_base_ubuntu:26.04 (sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d), 1305 total, 1278 pass, 27 skip, 0 fail/error
- Ubuntu 26.04 dev-container devtools/run-static-analyzer.sh: scan-build reported no bugs

The command devtools/local-validation-plan.sh --run was also invoked. Its C format check passed, but the helper stopped at Cubic findings in sanitizer workflow files that are not in this PR diff; the static analyzer and container CI lanes above were then run directly.
