### PR TITLE
runtime: join final worker after shutdown wait

### DIFF
--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -294,6 +294,10 @@ PRAGMA_IGNORE_Wempty_body
             wtiWakeupThrd(pThis->pWrkr[i]);
         }
     }
+    /* The final worker can transition to WAIT_JOIN and decrement the active
+     * count to zero just before the loop exits. Join it now so destructors see
+     * the stable STOPPED state instead of a joinable terminated worker. */
+    wtpJoinTerminatedWrkr(pThis);
     pthread_cleanup_pop(1);
 
     if (bTimedOut) iRet = RS_RET_TIMED_OUT;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -949,6 +949,7 @@ TESTS_OMHTTP = \
 	omhttp-batch-newline.sh \
 	omhttp-retry.sh \
 	omhttp-retry-timeout.sh \
+	wti-shutdown-saveonshutdown-omhttp.sh \
 	omhttp-httpheaderkey.sh \
 	omhttp-multiplehttpheaders.sh \
 	omhttp-dynrestpath.sh \

--- a/tests/wti-shutdown-saveonshutdown-omhttp.sh
+++ b/tests/wti-shutdown-saveonshutdown-omhttp.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Regression coverage for issue #4803. A slow omhttp action with a
+# disk-assisted action queue is terminated while work is still in flight. The
+# oracle is process-level shutdown without an assertion/core; the test
+# intentionally unsets the testbench timeout-to-stderr knob because that knob
+# suppresses the debug-build worker-destruction assertion reported by the issue.
+
+. ${srcdir:=.}/diag.sh init
+
+unset RSYSLOG_DEBUG_TIMEOUTS_TO_STDERR
+export NUMMESSAGES=500
+export RS_REDIR=">$RSYSLOG_DYNNAME.rsyslog.log 2>&1"
+
+omhttp_start_server 0 --fail-every 2 --fail-with-delay-secs 10
+# omhttp_start_server assigns this helper variable after the listener binds.
+# shellcheck disable=SC2154
+port="$omhttp_server_lstnport"
+
+generate_conf
+add_conf '
+module(load="../contrib/omhttp/.libs/omhttp")
+
+global(workDirectory="'$RSYSLOG_DYNNAME'.spool")
+
+template(name="tpl" type="string" string="%msg%\n")
+
+if $msg contains "msgnum:" then {
+	action(
+		name="action_omhttp_shutdown"
+		type="omhttp"
+		server="localhost"
+		serverport="'$port'"
+		restpath="my/endpoint"
+		usehttps="off"
+		restpathtimeout="30000"
+		template="tpl"
+		batch="off"
+		action.resumeRetryCount="-1"
+		action.resumeInterval="1"
+		queue.type="LinkedList"
+		queue.filename="'$RSYSLOG_DYNNAME'.actq"
+		queue.saveonshutdown="on"
+		queue.timeoutshutdown="1"
+		queue.timeoutactioncompletion="1"
+	)
+}
+'
+
+startup
+injectmsg
+shutdown_immediate
+wait_shutdown "" 60
+check_not_present "Assertion" "$RSYSLOG_DYNNAME.rsyslog.log"
+check_not_present "worker not stopped during shutdown" "$RSYSLOG_DYNNAME.rsyslog.log"
+omhttp_stop_server
+exit_test


### PR DESCRIPTION
Summary:
- join the last worker that reaches WAIT_JOIN as shutdown drains the pool
- add an omhttp disk-assisted queue regression for issue #4803

Validation:
- ./tests/wti-shutdown-saveonshutdown-omhttp.sh
- make -j60 check TESTS="wti-shutdown-saveonshutdown-omhttp.sh"
- cubic review --print-logs --base upstream/main
- Ubuntu 26.04 static analyzer container, image rsyslog/rsyslog_dev_base_ubuntu:26.04 sha256:cf0a5054550fefb22fadb4ec569b35110ebbc47191be8311abfd6b5afea02da4
- Ubuntu 26.04 run-ci container, 1302 total / 1275 pass / 27 skip / 0 fail
- Ubuntu 26.04 TSAN container, 1047 total / 1014 pass / 33 skip / 0 fail

Closes https://github.com/rsyslog/rsyslog/issues/4803