### PR TITLE
testbench cleanup: remove AI Agent guidance - did not work out

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2510,15 +2510,6 @@ error_exit() {
 	printf '%s FAIL: Test %s (took %s seconds)\n' "$(tb_timestamp)" "$0" "$(( $(date +%s) - TB_STARTTEST ))"
 	if [ $exitval -ne 77 ] && [ "$TESTBENCH_SUPPRESS_FAIL_MARKER" != "YES" ]; then
 		echo $0 > testbench_test_failed_rsyslog
-		# --- AI AGENT GUIDANCE ---
-		echo " "
-		echo " AI AGENT NOTICE:"
-		echo "   If this output is sparse or you ran 'make check', you are doing it wrong."
-		echo "   1. READ AGENTS.md NOW."
-		echo "   2. Run this test directly: ./tests/$(basename $0)"
-		echo "   3. Do NOT use specific make targets like 'check-TESTS'."
-		echo " "
-		# -------------------------
 	fi
 	exit $exitval
 }


### PR DESCRIPTION
This was introduced for less capable agents, but it did never really work out and introduced only noise. Time to get rid of it.
