### PR TITLE
Keep transactional action queue messages on shutdown

### DIFF
--- a/runtime/action.c
+++ b/runtime/action.c
@@ -1771,6 +1771,14 @@ static void markBatchCommittedFrom(batch_t *const pBatch, const int firstElem) {
     }
 }
 
+static void markBatchReadyFrom(batch_t *const pBatch, const int firstElem) {
+    for (int i = firstElem; i < batchNumMsgs(pBatch); ++i) {
+        if (batchIsValidElem(pBatch, i)) {
+            batchSetElemState(pBatch, i, BATCH_STATE_RDY);
+        }
+    }
+}
+
 /**
  * @brief Worker callback for action queues.
  *
@@ -1823,6 +1831,12 @@ static rsRetVal ATTR_NONNULL() processBatchMain(void *__restrict__ const pVoid,
         STATSCOUNTER_INC(pAction->ctrBatchesProcessed, pAction->mutCtrBatchesProcessed);
     }
     iRet = actionCommit(pAction, pWti);
+    /* Transactional messages are tentatively marked committed when queued for
+     * the commit call. If shutdown interrupts retry handling, keep them on the
+     * queue so disk queues can persist and retry them after restart. */
+    if (iRet == RS_RET_FORCE_TERM && pAction->isTransactional) {
+        markBatchReadyFrom(pBatch, 0);
+    }
 
 finalize_it:
     RETiRet;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -917,6 +917,7 @@ TESTS_OMPROG = \
 	omprog-close-unresponsive-noterm.sh \
 	omprog-restart-terminated.sh \
 	omprog-restart-terminated-outfile.sh \
+	omprog-diskq-restart-save.sh \
 	omprog-single-instance.sh \
 	omprog-single-instance-outfile.sh \
 	omprog-invalid-args.sh \
@@ -3391,6 +3392,7 @@ EXTRA_DIST += \
 	testsuites/omprog-feedback-mt-bin.sh \
 	testsuites/omprog-feedback-timeout-bin.sh \
 	testsuites/omprog-close-unresponsive-bin.sh \
+	testsuites/omprog-diskq-restart-save-bin.sh \
 	testsuites/omprog-invalid-args-bin.sh \
 	testsuites/omprog-restart-terminated-bin.sh \
 	testsuites/omprog-single-instance-bin.sh \

--- a/tests/omprog-diskq-restart-save.sh
+++ b/tests/omprog-diskq-restart-save.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Regression coverage for GitHub issue #5364. An omprog action with a pure disk
+# action queue receives a negative acknowledgement, then rsyslog is restarted
+# before the action can drain. The oracle is that the message is still retried
+# after restart and is acknowledged once the helper switches to success mode.
+
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=1
+export RSYSLOG_OMPROG_RESTART_OK="$PWD/$RSYSLOG_DYNNAME.allow-ok"
+export RSYSLOG_OMPROG_RESTART_OUT="$PWD/$RSYSLOG_OUT_LOG"
+
+cp -f "$srcdir/testsuites/omprog-diskq-restart-save-bin.sh" \
+	"$RSYSLOG_DYNNAME.omprog-diskq-restart-save-bin.sh"
+chmod +x "$RSYSLOG_DYNNAME.omprog-diskq-restart-save-bin.sh"
+
+generate_conf
+add_conf '
+global(workDirectory="'$RSYSLOG_DYNNAME'.spool")
+module(load="../plugins/omprog/.libs/omprog")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+if $msg contains "msgnum:" then {
+	action(
+		type="omprog"
+		binary="'$RSYSLOG_DYNNAME'.omprog-diskq-restart-save-bin.sh"
+		template="outfmt"
+		name="omprog_action"
+		confirmMessages="on"
+		confirmTimeout="1000"
+		reportFailures="on"
+		action.resumeRetryCount="-1"
+		action.resumeInterval="1"
+		queue.type="Disk"
+		queue.filename="'$RSYSLOG_DYNNAME'.actq"
+		queue.syncqueuefiles="on"
+		queue.checkpointInterval="1"
+		queue.workerThreads="1"
+		queue.timeoutShutdown="1000"
+		queue.timeoutActionCompletion="1000"
+		queue.saveOnShutdown="on"
+	)
+}
+'
+
+startup
+injectmsg
+for _ in {1..30}; do
+	if content_check --check-only "<= ERROR"; then
+		break
+	fi
+	$TESTTOOL_DIR/msleep 1000
+done
+content_check "<= ERROR"
+
+shutdown_immediate
+wait_shutdown
+
+touch "$RSYSLOG_OMPROG_RESTART_OK"
+startup
+for _ in {1..90}; do
+	ok_count=0
+	if [ -f "$RSYSLOG_OMPROG_RESTART_OUT" ]; then
+		ok_count=$(grep -c -F -- "<= OK" "$RSYSLOG_OMPROG_RESTART_OUT")
+	fi
+	if [ "$ok_count" -ge 3 ]; then
+		break
+	fi
+	$TESTTOOL_DIR/msleep 1000
+done
+shutdown_when_empty
+wait_shutdown
+
+content_check "=>  msgnum:00000000:"
+content_check "<= ERROR"
+content_count_check "<= OK" 3
+
+exit_test

--- a/tests/testsuites/omprog-diskq-restart-save-bin.sh
+++ b/tests/testsuites/omprog-diskq-restart-save-bin.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+printf '<= OK\n' >> "$RSYSLOG_OMPROG_RESTART_OUT"
+printf 'OK\n'
+
+while IFS= read -r line; do
+	printf '=> %s\n' "$line" >> "$RSYSLOG_OMPROG_RESTART_OUT"
+	if [ -e "$RSYSLOG_OMPROG_RESTART_OK" ]; then
+		printf '<= OK\n' >> "$RSYSLOG_OMPROG_RESTART_OUT"
+		printf 'OK\n'
+	else
+		printf '<= ERROR\n' >> "$RSYSLOG_OMPROG_RESTART_OUT"
+		printf 'ERROR\n'
+	fi
+done


### PR DESCRIPTION
## Summary
- keep transactional action queue batches retryable when shutdown interrupts actionCommit() with RS_RET_FORCE_TERM
- add an omprog pure disk queue restart regression for issue #5364

Fixes #5364.

## Validation
- ./tests/omprog-diskq-restart-save.sh: reproduced failure before fix, PASS after fix
- make -j60 check TESTS='omprog-diskq-restart-save.sh': PASS
- shellcheck -S warning tests/omprog-diskq-restart-save.sh tests/testsuites/omprog-diskq-restart-save-bin.sh: PASS
- bash devtools/format-code.sh --git-changed --check --check-if-available: PASS
- cubic review --print-logs --base HEAD: PASS, no issues found
- static analyzer container: PASS, scan-build no bugs found
- Ubuntu 26.04 run-ci container: PASS, 1305 total / 1278 pass / 27 skip / 0 fail
- Ubuntu 26.04 TSAN container: PASS, 1050 total / 1017 pass / 33 skip / 0 fail

Container image: rsyslog/rsyslog_dev_base_ubuntu:26.04, sha256:cf0a5054550fefb22fadb4ec569b35110ebbc47191be8311abfd6b5afea02da4.