### PR TITLE
runtime/tests: fix $!all-json capture handling

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -3754,13 +3754,14 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg,
             break;
         case PROP_CEE_ALL_JSON:
         case PROP_CEE_ALL_JSON_PLAIN:
+            MsgLock(pMsg);
             if (pMsg->json == NULL) {
+                MsgUnlock(pMsg);
                 pRes = (uchar *)"{}";
                 bufLen = 2;
                 *pbMustBeFreed = 0;
             } else {
                 const char *jstr;
-                MsgLock(pMsg);
                 int jflag = 0;
                 if (pProp->id == PROP_CEE_ALL_JSON) {
                     jflag = JSON_C_TO_STRING_SPACED;
@@ -3768,11 +3769,12 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg,
                     jflag = JSON_C_TO_STRING_PLAIN;
                 }
                 jstr = json_object_to_json_string_ext(pMsg->json, jflag);
-                MsgUnlock(pMsg);
                 if (jstr == NULL) {
+                    MsgUnlock(pMsg);
                     RET_OUT_OF_MEMORY;
                 }
                 pRes = (uchar *)strdup(jstr);
+                MsgUnlock(pMsg);
                 if (pRes == NULL) {
                     RET_OUT_OF_MEMORY;
                 }


### PR DESCRIPTION
Follow-up to #6480.

## Summary
- recognize `!all-json` aliases in runtime property lookup used by RainerScript variable evaluation
- copy the serialized `$!all-json` string while the message lock is still held
- re-enable `prop-all-json-concurrency.sh` with an oracle that validates the captured string after `unset`

## Testing
- `RSYSLOG_DEV_CONTAINER="rsyslog/rsyslog_dev_base_ubuntu:26.04" CI_MAKE_CHECK_TESTS="prop-all-json-concurrency.sh" devtools/devcontainer.sh --rm devtools/run-ci.sh`
- `devtools/local-validation-plan.sh --run`
