### PR TITLE
omclickhouse: document custom SQL template option

### DIFF
--- a/doc/source/reference/parameters/omclickhouse-template.rst
+++ b/doc/source/reference/parameters/omclickhouse-template.rst
@@ -28,7 +28,9 @@ Description
 -----------
 This is the message format that will be sent to ClickHouse. The resulting
 string needs to be a valid INSERT Query, otherwise ClickHouse will return an
-error. Defaults to:
+error. Custom INSERT templates must enable the template-level SQL escaping
+option, for example ``option.stdsql="on"`` in RainerScript. ``stdSQL`` is not
+an ``omclickhouse`` action parameter. Defaults to:
 
 .. note::
 
@@ -53,7 +55,9 @@ Input usage
 .. code-block:: rsyslog
 
    module(load="omclickhouse")
-   action(type="omclickhouse" template="StdClickHouseFmt")
+   template(name="CustomClickHouseFmt" type="string" option.stdsql="on"
+            string="INSERT INTO rsyslog.SystemEvents (severity, facility, timestamp, hostname, tag, message) VALUES (%syslogseverity%, %syslogfacility%, '%timereported:::date-unixtimestamp%', '%hostname%', '%syslogtag%', '%msg%')")
+   action(type="omclickhouse" template="CustomClickHouseFmt")
 
 See also
 --------

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -761,6 +761,7 @@ TESTS_MMANON = \
 	mmanon_truncated_dotted_suffix.sh
 
 TESTS_CLICKHOUSE = \
+	clickhouse-template-option-stdsql.sh \
 	clickhouse-start.sh \
 	clickhouse-basic.sh \
 	clickhouse-dflt-tpl.sh \

--- a/tests/clickhouse-template-option-stdsql.sh
+++ b/tests/clickhouse-template-option-stdsql.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Verify that omclickhouse accepts a custom INSERT template when the SQL
+# escaping requirement is expressed with the template-level option.stdsql
+# parameter. This covers the config-validation path from issue #6297 without
+# requiring a live ClickHouse service.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/omclickhouse/.libs/omclickhouse")
+
+template(name="CustomClickHouseFmt"
+         type="string"
+         option.stdsql="on"
+         string="INSERT INTO rsyslog.SystemEvents (severity, facility, timestamp, hostname, fromhost_ip, tag, message) VALUES (%syslogseverity%, %syslogfacility%, '\''%timereported:::date-unixtimestamp%'\'', '\''%hostname%'\'', '\''%fromhost-ip%'\'', '\''%syslogtag:1:32%'\'', '\''%msg%'\'')")
+
+action(type="omclickhouse"
+       server="127.0.0.1"
+       user="writer"
+       pwd="secret"
+       usehttps="off"
+       bulkmode="on"
+       template="CustomClickHouseFmt")
+'
+
+../tools/rsyslogd -C -N1 -f "${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" > "$RSYSLOG_DYNNAME.log" 2>&1
+content_check "End of config validation run" "$RSYSLOG_DYNNAME.log"
+check_not_present "Action disabled. To use this action" "$RSYSLOG_DYNNAME.log"
+
+exit_test


### PR DESCRIPTION
## Summary
- document that custom omclickhouse INSERT templates need template-level `option.stdsql="on"`
- clarify that `stdSQL` is not an omclickhouse action parameter
- add a config-validation-only regression test for the custom template path

Fixes https://github.com/rsyslog/rsyslog/issues/6297

## Validation
- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-clickhouse --enable-clickhouse-tests --disable-generate-man-pages`
- `make -j60 check TESTS=''`
- bad reproducer with action/template `stdSQL` spelling still fails cleanly; corrected `option.stdsql="on"` config passes `rsyslogd -N1`
- `shellcheck -S warning tests/clickhouse-template-option-stdsql.sh`
- `devtools/check-test-antipatterns.sh tests/clickhouse-template-option-stdsql.sh`
- `make -j60 check TESTS='clickhouse-template-option-stdsql.sh'`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 60`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j60`
- local Cubic: no issues found
- local container static analyzer: `rsyslog/rsyslog_dev_base_ubuntu:26.04`, image `sha256:cf0a5054550fefb22fadb4ec569b35110ebbc47191be8311abfd6b5afea02da4`, no bugs found
- local container Ubuntu 26.04 change-gated `run-ci.sh`: 1305 total, 1278 pass, 27 skip, 0 fail
- local container ClickHouse-targeted config test with ClickHouse tests enabled: 1 total, 1 pass, 0 fail

## Lane notes
The broad change-gated Ubuntu 26.04 run used PR-style service relevance and left ClickHouse service tests disabled in that run. Because this change touches the ClickHouse test family, I added a separate Ubuntu 26.04 container lane with ClickHouse tests enabled for the new config-validation test; it does not require a live ClickHouse service.