### PR TITLE
action: avoid committing suspended retry batches

### DIFF
--- a/runtime/action.c
+++ b/runtime/action.c
@@ -1430,6 +1430,12 @@ static rsRetVal ATTR_NONNULL() actionTryCommit(action_t *__restrict__ const pThi
 
     DBGPRINTF("actionTryCommit[%s] enter\n", pThis->pszName);
     CHKiRet(actionPrepare(pThis, pWti));
+    if (getActionState(pWti, pThis) == ACT_STATE_RTRY || getActionState(pWti, pThis) == ACT_STATE_SUSP ||
+        getActionState(pWti, pThis) == ACT_STATE_DISABLED) {
+        DBGPRINTF("actionTryCommit[%s]: skip transaction while state is %s\n", pThis->pszName,
+                  getActStateName(pThis, pWti));
+        ABORT_FINALIZE(getReturnCode(pThis, pWti));
+    }
 
     CHKiRet(doTransaction(pThis, pWti, iparams, nparams));
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -145,6 +145,7 @@ TESTS_DEFAULT = \
 	omfwd-lb-2target-retry.sh \
 	omfwd-lb-2target-one_fail.sh \
 	omfwd-missing-target.sh \
+	omfwd-suspended-no-early-commit.sh \
 	omfwd-tls-invalid-permitExpiredCerts.sh \
 	omfwd-keepalive.sh \
 	omfwd-subtree-tpl.sh \

--- a/tests/omfwd-suspended-no-early-commit.sh
+++ b/tests/omfwd-suspended-no-early-commit.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Regression coverage for GitHub issue #5132. A transactional action that has
+# exhausted its immediate resume attempts must not call the module commit hook
+# again while its next retry timestamp is still in the future. The oracle is
+# the action/omfwd debug log: we wait until actionTryCommit reports that it
+# skipped transaction processing for the suspended action, then assert that no
+# commitTransaction call entered while the action state was still "susp".
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
+
+generate_conf
+add_conf '
+global(
+	debug.whitelist="on"
+	debug.files=["action.c", "../action.c", "../../runtime/action.c", "../../../runtime/action.c", "omfwd.c"]
+)
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+:msg, contains, "msgnum:" {
+	action(
+		name="forwarder"
+		type="omfwd"
+		target="127.0.0.1"
+		port="'$TCPFLOOD_PORT'"
+		protocol="tcp"
+		template="outfmt"
+		queue.type="LinkedList"
+		queue.dequeueBatchSize="1"
+		action.resumeInterval="1"
+		action.resumeIntervalMax="2"
+		action.resumeRetryCount="0"
+	)
+}
+'
+startup
+injectmsg 0 1
+
+wait_content "actionTryCommit\\[forwarder\\]: skip transaction while state is susp" "$RSYSLOG_DEBUGLOG"
+shutdown_immediate
+wait_shutdown
+
+check_not_present "entering actionCallCommitTransaction[forwarder], state: susp" "$RSYSLOG_DEBUGLOG"
+exit_test


### PR DESCRIPTION
## Summary
- avoid calling commitTransaction() when actionPrepare() leaves a transactional action suspended, retrying, or disabled
- preserve action.resumeInterval/action.resumeIntervalMax backoff instead of immediately reentering retry state
- add an omfwd regression test for GitHub issue #5132

Closes #5132

## Validation
- PASS: ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --disable-generate-man-pages
- PASS: make -j60 check TESTS='omfwd-suspended-no-early-commit.sh'
- PASS: shellcheck -S warning tests/omfwd-suspended-no-early-commit.sh
- PASS: devtools/check-test-antipatterns.sh tests/omfwd-suspended-no-early-commit.sh
- PASS: bash devtools/format-code.sh --git-changed --check --check-if-available
- PASS: git diff --check
- PASS: make -j60 check TESTS=''
- PASS: local Cubic review, no issues found
- PASS: Ubuntu 26.04 static analyzer container, rsyslog/rsyslog_dev_base_ubuntu:26.04, image sha256:cf0a5054550fefb22fadb4ec569b35110ebbc47191be8311abfd6b5afea02da4
- PASS: Ubuntu 26.04 change-gated container run-ci, 1306 total, 1279 pass, 27 skip, 0 fail
- PASS: TSAN container lane, 1051 total, 1018 pass, 33 skip, 0 fail; Valgrind disabled because TSAN and Valgrind are incompatible
- PASS: Ubuntu 22.04 MOCK-OK distcheck container, image sha256:441619c347e24f9604714b69244c699d001650020f6bf6d2ce8ccfe3cdb53271

## Lane notes
- action lifecycle/runtime change kept service-backed families enabled in the main Ubuntu 26.04 run.
- TSAN lane used the skill-provided sanitizer configuration and explicitly disabled Valgrind.
- Mock distcheck was run because this adds a new test and updates tests/Makefile.am.