### PR TITLE
ci: enable TSan deadlock detection

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -614,7 +614,7 @@ jobs:
               export CFLAGS="-g -fstack-protector -D_FORTIFY_SOURCE=2 -fsanitize=thread \
                     -O0 -fno-omit-frame-pointer -fno-color-diagnostics"
               # note: we need pathes in container, thus /rsyslog vs. $(pwd) in TSAN_OPTIONS
-              export TSAN_OPTIONS="halt_on_error=1 suppressions=/rsyslog/tests/tsan-rt.supp"
+              export TSAN_OPTIONS="halt_on_error=1:detect_deadlocks=1:suppressions=/rsyslog/tests/tsan-rt.supp"
               export ABORT_ALL_ON_TEST_FAIL='YES'
               ;;
           'wolfssl')
@@ -1042,7 +1042,7 @@ jobs:
           elif [ "${{ matrix.sanitizer }}" = "tsan" ]; then
             echo "Configuring ThreadSanitizer options"
             export TSAN_OPTIONS=":halt_on_error=1:\
-              history_size=7:suppressions=$PWD/tests/tsan-rt.supp"
+              detect_deadlocks=1:history_size=7:suppressions=$PWD/tests/tsan-rt.supp"
           else
             echo "Running without sanitizers"
           fi

--- a/.github/workflows/run_macos_weekly.yml
+++ b/.github/workflows/run_macos_weekly.yml
@@ -109,7 +109,7 @@ jobs:
               detect_stack_use_after_return=1:print_stacktrace=1"
           elif [ "${{ matrix.sanitizer }}" = "tsan" ]; then
             export TSAN_OPTIONS=":halt_on_error=1:\
-              history_size=7:suppressions=$PWD/tests/tsan-rt.supp"
+              detect_deadlocks=1:history_size=7:suppressions=$PWD/tests/tsan-rt.supp"
           fi
           set +e
           make -j8 check


### PR DESCRIPTION
## Summary
- enable ThreadSanitizer's deadlock detector in the existing Linux TSan CI lane
- enable the same option in PR macOS TSan and weekly macOS TSan runs
- leave Kafka/omkafka coverage unchanged for a separate follow-up

## Validation
- git diff --check
- local TSan smoke binary accepted TSAN_OPTIONS=halt_on_error=1:detect_deadlocks=1

Note: commit is unsigned because non-interactive GPG pinentry was unavailable in this session.