### PR TITLE
relp: warn on OpenSSL priority strings

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = doc/source/_static/vendor
-ignore-words-list = a11y,aac,ba,cd,com,et,fo,nd,ot,rd,st,te,ue,Bu,Fo,Nd,Te,Ue
+ignore-words-list = a11y,aac,anull,ba,cd,com,et,fo,nd,ot,rd,st,te,ue,Bu,Fo,Nd,Te,Ue

--- a/doc/source/reference/parameters/imrelp-tls-prioritystring.rst
+++ b/doc/source/reference/parameters/imrelp-tls-prioritystring.rst
@@ -35,7 +35,9 @@ When :ref:`param-imrelp-tls-tlslib` is set to ``openssl``, the same rsyslog
 parameter is interpreted by librelp as an OpenSSL cipher-list string, not as a
 GnuTLS priority string. Use OpenSSL cipher-list syntax such as ``HIGH:!aNULL``,
 or use :ref:`param-imrelp-tls-tlscfgcmd` for broader OpenSSL TLS policy such as
-protocol minimums.
+protocol minimums. When switching between ``gnutls`` and ``openssl``, review the
+``tls.priorityString`` value as well as the driver name; the parameter name is
+shared, but the accepted value syntax is backend-specific.
 
 Full information about how to construct a GnuTLS priority string can be found in
 the GnuTLS manual. At the time of writing, this information was contained in

--- a/doc/source/reference/parameters/imrelp-tls-prioritystring.rst
+++ b/doc/source/reference/parameters/imrelp-tls-prioritystring.rst
@@ -25,14 +25,22 @@ This parameter applies to :doc:`../../configuration/modules/imrelp`.
 
 Description
 -----------
-This parameter allows passing the so-called "priority string" to GnuTLS. This
-string gives complete control over all crypto parameters, including compression
-settings. For this reason, when ``tls.priorityString`` is specified, the
+This parameter is passed through librelp to the selected TLS backend. With the
+default GnuTLS backend, it is a GnuTLS priority string and gives complete
+control over crypto parameters, including compression settings. For this reason,
+when ``tls.priorityString`` is specified with GnuTLS, the
 :ref:`param-imrelp-tls-compression` parameter has no effect and is ignored.
 
-Full information about how to construct a priority string can be found in the
-GnuTLS manual. At the time of writing, this information was contained in `section
-6.10 of the GnuTLS manual <http://gnutls.org/manual/html_node/Priority-Strings.html>`_.
+When :ref:`param-imrelp-tls-tlslib` is set to ``openssl``, the same rsyslog
+parameter is interpreted by librelp as an OpenSSL cipher-list string, not as a
+GnuTLS priority string. Use OpenSSL cipher-list syntax such as ``HIGH:!aNULL``,
+or use :ref:`param-imrelp-tls-tlscfgcmd` for broader OpenSSL TLS policy such as
+protocol minimums.
+
+Full information about how to construct a GnuTLS priority string can be found in
+the GnuTLS manual. At the time of writing, this information was contained in
+`section 6.10 of the GnuTLS manual <http://gnutls.org/manual/html_node/Priority-Strings.html>`_.
+OpenSSL cipher-list syntax is documented in the OpenSSL ``ciphers`` manual page.
 
 **Note: this is an expert parameter.** Do not use if you do not exactly know
 what you are doing.
@@ -45,6 +53,11 @@ Input usage
 .. code-block:: rsyslog
 
    input(type="imrelp" port="2514" tls="on" tls.priorityString="NONE:+COMP-DEFLATE")
+
+.. code-block:: rsyslog
+
+   module(load="imrelp" tls.tlsLib="openssl")
+   input(type="imrelp" port="2514" tls="on" tls.priorityString="HIGH:!aNULL")
 
 See also
 --------

--- a/doc/source/reference/parameters/omrelp-tls-prioritystring.rst
+++ b/doc/source/reference/parameters/omrelp-tls-prioritystring.rst
@@ -35,7 +35,9 @@ When :ref:`param-omrelp-tls-tlslib` is set to ``openssl``, the same rsyslog
 parameter is interpreted by librelp as an OpenSSL cipher-list string, not as a
 GnuTLS priority string. Use OpenSSL cipher-list syntax such as ``HIGH:!aNULL``,
 or use :ref:`param-omrelp-tls-tlscfgcmd` for broader OpenSSL TLS policy such as
-protocol minimums.
+protocol minimums. When switching between ``gnutls`` and ``openssl``, review the
+``tls.priorityString`` value as well as the driver name; the parameter name is
+shared, but the accepted value syntax is backend-specific.
 
 Full information about how to construct a GnuTLS priority string can be found in
 the GnuTLS manual. At the time of writing, this information was contained in

--- a/doc/source/reference/parameters/omrelp-tls-prioritystring.rst
+++ b/doc/source/reference/parameters/omrelp-tls-prioritystring.rst
@@ -25,7 +25,24 @@ This parameter applies to :doc:`../../configuration/modules/omrelp`.
 
 Description
 -----------
-This parameter permits to specify the so-called "priority string" to GnuTLS. This string gives complete control over all crypto parameters, including compression setting. For this reason, when the prioritystring is specified, the "tls.compression" parameter has no effect and is ignored. Full information about how to construct a priority string can be found in the GnuTLS manual. At the time of this writing, this information was contained in `section 6.10 of the GnuTLS manual <http://gnutls.org/manual/html_node/Priority-Strings.html>`__. **Note: this is an expert parameter.** Do not use if you do not exactly know what you are doing.
+This parameter is passed through librelp to the selected TLS backend. With the
+default GnuTLS backend, it specifies the so-called "priority string" to GnuTLS.
+This string gives complete control over all crypto parameters, including
+compression settings. For this reason, when ``tls.priorityString`` is specified
+with GnuTLS, the ``tls.compression`` parameter has no effect and is ignored.
+
+When :ref:`param-omrelp-tls-tlslib` is set to ``openssl``, the same rsyslog
+parameter is interpreted by librelp as an OpenSSL cipher-list string, not as a
+GnuTLS priority string. Use OpenSSL cipher-list syntax such as ``HIGH:!aNULL``,
+or use :ref:`param-omrelp-tls-tlscfgcmd` for broader OpenSSL TLS policy such as
+protocol minimums.
+
+Full information about how to construct a GnuTLS priority string can be found in
+the GnuTLS manual. At the time of writing, this information was contained in
+`section 6.10 of the GnuTLS manual <http://gnutls.org/manual/html_node/Priority-Strings.html>`__.
+OpenSSL cipher-list syntax is documented in the OpenSSL ``ciphers`` manual page.
+**Note: this is an expert parameter.** Do not use if you do not exactly know what
+you are doing.
 
 Input usage
 -----------
@@ -35,6 +52,11 @@ Input usage
 .. code-block:: rsyslog
 
    action(type="omrelp" target="centralserv" tls.priorityString="NORMAL")
+
+.. code-block:: rsyslog
+
+   module(load="omrelp" tls.tlsLib="openssl")
+   action(type="omrelp" target="centralserv" tls.priorityString="HIGH:!aNULL")
 
 See also
 --------

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -511,12 +511,12 @@ static void warnIfPlainRelpListenerConfigured(const instanceConf_t *const inst) 
 }
 
 
-static int relpPrioTokenMatches(const char *const token, const size_t len, const char *const gnutlsToken) {
-    const size_t gnutlsTokenLen = strlen(gnutlsToken);
-    if (gnutlsToken[gnutlsTokenLen - 1] == '-') {
-        return len >= gnutlsTokenLen && !strncasecmp(token, gnutlsToken, gnutlsTokenLen);
+static int relpPrioTokenMatches(const char *const token, const size_t len, const char *const syntaxToken) {
+    const size_t syntaxTokenLen = strlen(syntaxToken);
+    if (syntaxToken[syntaxTokenLen - 1] == '-' || syntaxToken[syntaxTokenLen - 1] == '=') {
+        return len >= syntaxTokenLen && !strncasecmp(token, syntaxToken, syntaxTokenLen);
     }
-    return len == gnutlsTokenLen && !strncasecmp(token, gnutlsToken, len);
+    return len == syntaxTokenLen && !strncasecmp(token, syntaxToken, len);
 }
 
 
@@ -552,13 +552,59 @@ static int relpPrioStringLooksLikeGnuTLS(const uchar *const pristring) {
 }
 
 
-static void warnIfOpenSSLPriorityStringConfigured(const instanceConf_t *const inst) {
-    if (inst->pristring != NULL && loadModConf != NULL && loadModConf->tlslib != NULL &&
-        !strcasecmp(loadModConf->tlslib, "openssl") && relpPrioStringLooksLikeGnuTLS(inst->pristring)) {
+static int relpPrioTokenLooksLikeOpenSSL(const char *const token, const size_t len) {
+    static const char *const opensslTokens[] = {"DEFAULT",  "HIGH", "MEDIUM", "LOW",       "ALL",  "aNULL",
+                                                "eNULL",    "kRSA", "aRSA",   "ECDHE-",    "DHE-", "AES",
+                                                "CAMELLIA", "PSK-", "SRP-",   "@SECLEVEL="};
+    size_t i;
+
+    for (i = 0; i < sizeof(opensslTokens) / sizeof(opensslTokens[0]); ++i) {
+        if (relpPrioTokenMatches(token, len, opensslTokens[i])) return 1;
+    }
+    return 0;
+}
+
+
+static int relpPrioStringLooksLikeOpenSSL(const uchar *const pristring) {
+    const char *p;
+    const char *token;
+    size_t len;
+
+    if (pristring == NULL) return 0;
+    p = (const char *)pristring;
+    while (*p != '\0') {
+        while (*p == ':' || *p == ',' || isspace((unsigned char)*p)) ++p;
+        while (*p == '+' || *p == '-' || *p == '!' || *p == '%') ++p;
+        token = p;
+        while (*p != '\0' && *p != ':' && *p != ',' && !isspace((unsigned char)*p)) ++p;
+        len = (size_t)(p - token);
+        if (len > 0 && relpPrioTokenLooksLikeOpenSSL(token, len)) return 1;
+    }
+    return 0;
+}
+
+
+static int isRelpTLSLibOpenSSL(void) {
+    return loadModConf != NULL && loadModConf->tlslib != NULL && !strcasecmp(loadModConf->tlslib, "openssl");
+}
+
+
+static int isRelpTLSLibGnuTLS(void) {
+    return loadModConf == NULL || loadModConf->tlslib == NULL || !strcasecmp(loadModConf->tlslib, "gnutls");
+}
+
+
+static void warnIfMismatchedPriorityStringConfigured(const instanceConf_t *const inst) {
+    if (inst->pristring != NULL && isRelpTLSLibOpenSSL() && relpPrioStringLooksLikeGnuTLS(inst->pristring)) {
         LogMsg(0, RS_RET_CONF_PARAM_INVLD, LOG_WARNING,
                "imrelp: tls.prioritystring with tls.tlslib=\"openssl\" appears to use GnuTLS "
                "priority-string syntax; OpenSSL interprets this parameter as an OpenSSL cipher "
                "string, so use OpenSSL cipher syntax or tls.tlscfgcmd for broader OpenSSL TLS policy");
+    } else if (inst->pristring != NULL && isRelpTLSLibGnuTLS() && relpPrioStringLooksLikeOpenSSL(inst->pristring)) {
+        LogMsg(0, RS_RET_CONF_PARAM_INVLD, LOG_WARNING,
+               "imrelp: tls.prioritystring with the GnuTLS RELP backend appears to use OpenSSL "
+               "cipher-list syntax; GnuTLS interprets this parameter as a GnuTLS priority string, "
+               "so use GnuTLS priority-string syntax or switch tls.tlslib to \"openssl\"");
     }
 }
 
@@ -740,7 +786,7 @@ BEGINnewInpInst
     }
 
     warnIfPlainRelpListenerConfigured(inst);
-    warnIfOpenSSLPriorityStringConfigured(inst);
+    warnIfMismatchedPriorityStringConfigured(inst);
 
     inst->bEnableLstn = -1; /* all ok, ready to start up */
 

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -512,7 +512,8 @@ static void warnIfPlainRelpListenerConfigured(const instanceConf_t *const inst) 
 
 
 static void warnIfOpenSSLPriorityStringConfigured(const instanceConf_t *const inst) {
-    if (inst->pristring != NULL && loadModConf->tlslib != NULL && !strcasecmp(loadModConf->tlslib, "openssl")) {
+    if (inst->pristring != NULL && loadModConf != NULL && loadModConf->tlslib != NULL &&
+        !strcasecmp(loadModConf->tlslib, "openssl")) {
         LogMsg(0, RS_RET_CONF_PARAM_INVLD, LOG_WARNING,
                "imrelp: tls.prioritystring is a GnuTLS priority string and is ignored when "
                "tls.tlslib=\"openssl\"; use tls.tlscfgcmd for OpenSSL TLS policy");

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -511,6 +511,15 @@ static void warnIfPlainRelpListenerConfigured(const instanceConf_t *const inst) 
 }
 
 
+static void warnIfOpenSSLPriorityStringConfigured(const instanceConf_t *const inst) {
+    if (inst->pristring != NULL && loadModConf->tlslib != NULL && !strcasecmp(loadModConf->tlslib, "openssl")) {
+        LogMsg(0, RS_RET_CONF_PARAM_INVLD, LOG_WARNING,
+               "imrelp: tls.prioritystring is a GnuTLS priority string and is ignored when "
+               "tls.tlslib=\"openssl\"; use tls.tlscfgcmd for OpenSSL TLS policy");
+    }
+}
+
+
 BEGINnewInpInst
     struct cnfparamvals *pvals;
     instanceConf_t *inst = NULL;
@@ -688,6 +697,7 @@ BEGINnewInpInst
     }
 
     warnIfPlainRelpListenerConfigured(inst);
+    warnIfOpenSSLPriorityStringConfigured(inst);
 
     inst->bEnableLstn = -1; /* all ok, ready to start up */
 

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -515,8 +515,9 @@ static void warnIfOpenSSLPriorityStringConfigured(const instanceConf_t *const in
     if (inst->pristring != NULL && loadModConf != NULL && loadModConf->tlslib != NULL &&
         !strcasecmp(loadModConf->tlslib, "openssl")) {
         LogMsg(0, RS_RET_CONF_PARAM_INVLD, LOG_WARNING,
-               "imrelp: tls.prioritystring is a GnuTLS priority string and is ignored when "
-               "tls.tlslib=\"openssl\"; use tls.tlscfgcmd for OpenSSL TLS policy");
+               "imrelp: tls.prioritystring with tls.tlslib=\"openssl\" is interpreted as an "
+               "OpenSSL cipher string, not as a GnuTLS priority string; use OpenSSL cipher "
+               "syntax or tls.tlscfgcmd for broader OpenSSL TLS policy");
     }
 }
 

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -511,13 +511,54 @@ static void warnIfPlainRelpListenerConfigured(const instanceConf_t *const inst) 
 }
 
 
+static int relpPrioTokenMatches(const char *const token, const size_t len, const char *const gnutlsToken) {
+    const size_t gnutlsTokenLen = strlen(gnutlsToken);
+    if (gnutlsToken[gnutlsTokenLen - 1] == '-') {
+        return len >= gnutlsTokenLen && !strncasecmp(token, gnutlsToken, gnutlsTokenLen);
+    }
+    return len == gnutlsTokenLen && !strncasecmp(token, gnutlsToken, len);
+}
+
+
+static int relpPrioTokenLooksLikeGnuTLS(const char *const token, const size_t len) {
+    static const char *const gnutlsTokens[] = {"NORMAL",    "NONE",    "PERFORMANCE", "SECURE128", "SECURE192",
+                                               "SECURE256", "ANON-DH", "VERS-",       "GROUP-",    "SIGN-",
+                                               "KX-",       "CIPHER-", "MAC-",        "CURVE-",    "CTYPE-"};
+    size_t i;
+
+    for (i = 0; i < sizeof(gnutlsTokens) / sizeof(gnutlsTokens[0]); ++i) {
+        if (relpPrioTokenMatches(token, len, gnutlsTokens[i])) return 1;
+    }
+    return 0;
+}
+
+
+static int relpPrioStringLooksLikeGnuTLS(const uchar *const pristring) {
+    const char *p;
+    const char *token;
+    size_t len;
+
+    if (pristring == NULL) return 0;
+    p = (const char *)pristring;
+    while (*p != '\0') {
+        while (*p == ':' || *p == ',' || isspace((unsigned char)*p)) ++p;
+        while (*p == '+' || *p == '-' || *p == '!' || *p == '%') ++p;
+        token = p;
+        while (*p != '\0' && *p != ':' && *p != ',' && !isspace((unsigned char)*p)) ++p;
+        len = (size_t)(p - token);
+        if (len > 0 && relpPrioTokenLooksLikeGnuTLS(token, len)) return 1;
+    }
+    return 0;
+}
+
+
 static void warnIfOpenSSLPriorityStringConfigured(const instanceConf_t *const inst) {
     if (inst->pristring != NULL && loadModConf != NULL && loadModConf->tlslib != NULL &&
-        !strcasecmp(loadModConf->tlslib, "openssl")) {
+        !strcasecmp(loadModConf->tlslib, "openssl") && relpPrioStringLooksLikeGnuTLS(inst->pristring)) {
         LogMsg(0, RS_RET_CONF_PARAM_INVLD, LOG_WARNING,
-               "imrelp: tls.prioritystring with tls.tlslib=\"openssl\" is interpreted as an "
-               "OpenSSL cipher string, not as a GnuTLS priority string; use OpenSSL cipher "
-               "syntax or tls.tlscfgcmd for broader OpenSSL TLS policy");
+               "imrelp: tls.prioritystring with tls.tlslib=\"openssl\" appears to use GnuTLS "
+               "priority-string syntax; OpenSSL interprets this parameter as an OpenSSL cipher "
+               "string, so use OpenSSL cipher syntax or tls.tlscfgcmd for broader OpenSSL TLS policy");
     }
 }
 

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -487,7 +487,8 @@ static void warnIfPlainRelpActionConfigured(const instanceData *const pData) {
 }
 
 static void warnIfOpenSSLPriorityStringConfigured(const instanceData *const pData) {
-    if (pData->pristring != NULL && loadModConf->tlslib != NULL && !strcasecmp(loadModConf->tlslib, "openssl")) {
+    if (pData->pristring != NULL && loadModConf != NULL && loadModConf->tlslib != NULL &&
+        !strcasecmp(loadModConf->tlslib, "openssl")) {
         LogMsg(0, RS_RET_CONF_PARAM_INVLD, LOG_WARNING,
                "omrelp: tls.prioritystring is a GnuTLS priority string and is ignored when "
                "tls.tlslib=\"openssl\"; use tls.tlscfgcmd for OpenSSL TLS policy");

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -490,8 +490,9 @@ static void warnIfOpenSSLPriorityStringConfigured(const instanceData *const pDat
     if (pData->pristring != NULL && loadModConf != NULL && loadModConf->tlslib != NULL &&
         !strcasecmp(loadModConf->tlslib, "openssl")) {
         LogMsg(0, RS_RET_CONF_PARAM_INVLD, LOG_WARNING,
-               "omrelp: tls.prioritystring is a GnuTLS priority string and is ignored when "
-               "tls.tlslib=\"openssl\"; use tls.tlscfgcmd for OpenSSL TLS policy");
+               "omrelp: tls.prioritystring with tls.tlslib=\"openssl\" is interpreted as an "
+               "OpenSSL cipher string, not as a GnuTLS priority string; use OpenSSL cipher "
+               "syntax or tls.tlscfgcmd for broader OpenSSL TLS policy");
     }
 }
 

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -486,13 +486,51 @@ static void warnIfPlainRelpActionConfigured(const instanceData *const pData) {
     }
 }
 
+static int relpPrioTokenMatches(const char *const token, const size_t len, const char *const gnutlsToken) {
+    const size_t gnutlsTokenLen = strlen(gnutlsToken);
+    if (gnutlsToken[gnutlsTokenLen - 1] == '-') {
+        return len >= gnutlsTokenLen && !strncasecmp(token, gnutlsToken, gnutlsTokenLen);
+    }
+    return len == gnutlsTokenLen && !strncasecmp(token, gnutlsToken, len);
+}
+
+static int relpPrioTokenLooksLikeGnuTLS(const char *const token, const size_t len) {
+    static const char *const gnutlsTokens[] = {"NORMAL",    "NONE",    "PERFORMANCE", "SECURE128", "SECURE192",
+                                               "SECURE256", "ANON-DH", "VERS-",       "GROUP-",    "SIGN-",
+                                               "KX-",       "CIPHER-", "MAC-",        "CURVE-",    "CTYPE-"};
+    size_t i;
+
+    for (i = 0; i < sizeof(gnutlsTokens) / sizeof(gnutlsTokens[0]); ++i) {
+        if (relpPrioTokenMatches(token, len, gnutlsTokens[i])) return 1;
+    }
+    return 0;
+}
+
+static int relpPrioStringLooksLikeGnuTLS(const uchar *const pristring) {
+    const char *p;
+    const char *token;
+    size_t len;
+
+    if (pristring == NULL) return 0;
+    p = (const char *)pristring;
+    while (*p != '\0') {
+        while (*p == ':' || *p == ',' || isspace((unsigned char)*p)) ++p;
+        while (*p == '+' || *p == '-' || *p == '!' || *p == '%') ++p;
+        token = p;
+        while (*p != '\0' && *p != ':' && *p != ',' && !isspace((unsigned char)*p)) ++p;
+        len = (size_t)(p - token);
+        if (len > 0 && relpPrioTokenLooksLikeGnuTLS(token, len)) return 1;
+    }
+    return 0;
+}
+
 static void warnIfOpenSSLPriorityStringConfigured(const instanceData *const pData) {
     if (pData->pristring != NULL && loadModConf != NULL && loadModConf->tlslib != NULL &&
-        !strcasecmp(loadModConf->tlslib, "openssl")) {
+        !strcasecmp(loadModConf->tlslib, "openssl") && relpPrioStringLooksLikeGnuTLS(pData->pristring)) {
         LogMsg(0, RS_RET_CONF_PARAM_INVLD, LOG_WARNING,
-               "omrelp: tls.prioritystring with tls.tlslib=\"openssl\" is interpreted as an "
-               "OpenSSL cipher string, not as a GnuTLS priority string; use OpenSSL cipher "
-               "syntax or tls.tlscfgcmd for broader OpenSSL TLS policy");
+               "omrelp: tls.prioritystring with tls.tlslib=\"openssl\" appears to use GnuTLS "
+               "priority-string syntax; OpenSSL interprets this parameter as an OpenSSL cipher "
+               "string, so use OpenSSL cipher syntax or tls.tlscfgcmd for broader OpenSSL TLS policy");
     }
 }
 

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -486,12 +486,12 @@ static void warnIfPlainRelpActionConfigured(const instanceData *const pData) {
     }
 }
 
-static int relpPrioTokenMatches(const char *const token, const size_t len, const char *const gnutlsToken) {
-    const size_t gnutlsTokenLen = strlen(gnutlsToken);
-    if (gnutlsToken[gnutlsTokenLen - 1] == '-') {
-        return len >= gnutlsTokenLen && !strncasecmp(token, gnutlsToken, gnutlsTokenLen);
+static int relpPrioTokenMatches(const char *const token, const size_t len, const char *const syntaxToken) {
+    const size_t syntaxTokenLen = strlen(syntaxToken);
+    if (syntaxToken[syntaxTokenLen - 1] == '-' || syntaxToken[syntaxTokenLen - 1] == '=') {
+        return len >= syntaxTokenLen && !strncasecmp(token, syntaxToken, syntaxTokenLen);
     }
-    return len == gnutlsTokenLen && !strncasecmp(token, gnutlsToken, len);
+    return len == syntaxTokenLen && !strncasecmp(token, syntaxToken, len);
 }
 
 static int relpPrioTokenLooksLikeGnuTLS(const char *const token, const size_t len) {
@@ -524,13 +524,55 @@ static int relpPrioStringLooksLikeGnuTLS(const uchar *const pristring) {
     return 0;
 }
 
-static void warnIfOpenSSLPriorityStringConfigured(const instanceData *const pData) {
-    if (pData->pristring != NULL && loadModConf != NULL && loadModConf->tlslib != NULL &&
-        !strcasecmp(loadModConf->tlslib, "openssl") && relpPrioStringLooksLikeGnuTLS(pData->pristring)) {
+static int relpPrioTokenLooksLikeOpenSSL(const char *const token, const size_t len) {
+    static const char *const opensslTokens[] = {"DEFAULT",  "HIGH", "MEDIUM", "LOW",       "ALL",  "aNULL",
+                                                "eNULL",    "kRSA", "aRSA",   "ECDHE-",    "DHE-", "AES",
+                                                "CAMELLIA", "PSK-", "SRP-",   "@SECLEVEL="};
+    size_t i;
+
+    for (i = 0; i < sizeof(opensslTokens) / sizeof(opensslTokens[0]); ++i) {
+        if (relpPrioTokenMatches(token, len, opensslTokens[i])) return 1;
+    }
+    return 0;
+}
+
+static int relpPrioStringLooksLikeOpenSSL(const uchar *const pristring) {
+    const char *p;
+    const char *token;
+    size_t len;
+
+    if (pristring == NULL) return 0;
+    p = (const char *)pristring;
+    while (*p != '\0') {
+        while (*p == ':' || *p == ',' || isspace((unsigned char)*p)) ++p;
+        while (*p == '+' || *p == '-' || *p == '!' || *p == '%') ++p;
+        token = p;
+        while (*p != '\0' && *p != ':' && *p != ',' && !isspace((unsigned char)*p)) ++p;
+        len = (size_t)(p - token);
+        if (len > 0 && relpPrioTokenLooksLikeOpenSSL(token, len)) return 1;
+    }
+    return 0;
+}
+
+static int isRelpTLSLibOpenSSL(void) {
+    return loadModConf != NULL && loadModConf->tlslib != NULL && !strcasecmp(loadModConf->tlslib, "openssl");
+}
+
+static int isRelpTLSLibGnuTLS(void) {
+    return loadModConf == NULL || loadModConf->tlslib == NULL || !strcasecmp(loadModConf->tlslib, "gnutls");
+}
+
+static void warnIfMismatchedPriorityStringConfigured(const instanceData *const pData) {
+    if (pData->pristring != NULL && isRelpTLSLibOpenSSL() && relpPrioStringLooksLikeGnuTLS(pData->pristring)) {
         LogMsg(0, RS_RET_CONF_PARAM_INVLD, LOG_WARNING,
                "omrelp: tls.prioritystring with tls.tlslib=\"openssl\" appears to use GnuTLS "
                "priority-string syntax; OpenSSL interprets this parameter as an OpenSSL cipher "
                "string, so use OpenSSL cipher syntax or tls.tlscfgcmd for broader OpenSSL TLS policy");
+    } else if (pData->pristring != NULL && isRelpTLSLibGnuTLS() && relpPrioStringLooksLikeOpenSSL(pData->pristring)) {
+        LogMsg(0, RS_RET_CONF_PARAM_INVLD, LOG_WARNING,
+               "omrelp: tls.prioritystring with the GnuTLS RELP backend appears to use OpenSSL "
+               "cipher-list syntax; GnuTLS interprets this parameter as a GnuTLS priority string, "
+               "so use GnuTLS priority-string syntax or switch tls.tlslib to \"openssl\"");
     }
 }
 
@@ -640,7 +682,7 @@ BEGINnewActInst
                          OMSR_NO_RQD_TPL_OPTS));
 
     warnIfPlainRelpActionConfigured(pData);
-    warnIfOpenSSLPriorityStringConfigured(pData);
+    warnIfMismatchedPriorityStringConfigured(pData);
 
     iRet = doCreateRelpClient(pData, &pRelpClt);
     if (pRelpClt != NULL) relpEngineCltDestruct(pRelpEngine, &pRelpClt);

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -486,6 +486,14 @@ static void warnIfPlainRelpActionConfigured(const instanceData *const pData) {
     }
 }
 
+static void warnIfOpenSSLPriorityStringConfigured(const instanceData *const pData) {
+    if (pData->pristring != NULL && loadModConf->tlslib != NULL && !strcasecmp(loadModConf->tlslib, "openssl")) {
+        LogMsg(0, RS_RET_CONF_PARAM_INVLD, LOG_WARNING,
+               "omrelp: tls.prioritystring is a GnuTLS priority string and is ignored when "
+               "tls.tlslib=\"openssl\"; use tls.tlscfgcmd for OpenSSL TLS policy");
+    }
+}
+
 BEGINnewActInst
     struct cnfparamvals *pvals;
     int i, j;
@@ -592,6 +600,7 @@ BEGINnewActInst
                          OMSR_NO_RQD_TPL_OPTS));
 
     warnIfPlainRelpActionConfigured(pData);
+    warnIfOpenSSLPriorityStringConfigured(pData);
 
     iRet = doCreateRelpClient(pData, &pRelpClt);
     if (pRelpClt != NULL) relpEngineCltDestruct(pRelpEngine, &pRelpClt);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1655,6 +1655,7 @@ TESTS_RELP = \
 	 glbl-oversizeMsg-split.sh
 
 TESTS_RELP_OPENSSL = \
+	 relp-openssl-prioritystring-warning.sh \
 	 omrelp-tls-ossl-authfail-no-cacert.sh \
 	 omrelp-tls-ossl-authfail-suspend.sh
 

--- a/tests/relp-openssl-prioritystring-warning.sh
+++ b/tests/relp-openssl-prioritystring-warning.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 # Verify that RELP configurations using the OpenSSL backend with the
-# shared tls.prioritystring parameter produce an actionable diagnostic for
-# users who pass a GnuTLS priority-string value while OpenSSL is selected.
+# shared tls.prioritystring parameter produce an actionable diagnostic only
+# when users pass a value that clearly looks like GnuTLS priority-string syntax.
 # The oracle is the rsyslogd -N1 config-check output: no live RELP connection is
-# needed, and the warning must say OpenSSL interprets the value with OpenSSL
-# cipher syntax while naming tls.tlscfgcmd as the broader policy alternative.
+# needed. The warning must not fire for OpenSSL cipher-list syntax, because
+# librelp also uses tls.prioritystring to pass cipher strings to OpenSSL.
 # This file is part of the rsyslog project, released under ASL 2.0.
 # shellcheck source=tests/diag.sh
 . "${srcdir:=.}"/diag.sh init
 require_relpEngineSetTLSLibByName
+IMRELP_OPENSSL_VALID_LOG="${RSYSLOG_DYNNAME}.imrelp-openssl-valid.log"
+OMRELP_GNUTLS_STYLE_LOG="${RSYSLOG_DYNNAME}.omrelp-gnutls-style.log"
+OMRELP_OPENSSL_VALID_LOG="${RSYSLOG_DYNNAME}.omrelp-openssl-valid.log"
 
 generate_conf
 add_conf '
@@ -18,20 +21,41 @@ input(type="imrelp" port="0" tls="on" tls.prioritystring="NORMAL:+ANON-DH")
 action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'")
 '
 ../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}.conf" >"$RSYSLOG_OUT_LOG" 2>&1 || error_exit $?
-content_check "imrelp: tls.prioritystring with tls.tlslib=\"openssl\" is interpreted as an OpenSSL cipher string" "$RSYSLOG_OUT_LOG"
-content_check "not as a GnuTLS priority string" "$RSYSLOG_OUT_LOG"
+content_check "imrelp: tls.prioritystring with tls.tlslib=\"openssl\" appears to use GnuTLS" "$RSYSLOG_OUT_LOG"
 content_check "use OpenSSL cipher syntax or tls.tlscfgcmd" "$RSYSLOG_OUT_LOG"
 
 generate_conf 2
+add_conf '
+module(load="../plugins/imrelp/.libs/imrelp" tls.tlslib="openssl")
+input(type="imrelp" port="0" tls="on" tls.prioritystring="HIGH:!aNULL")
+
+action(type="omfile" file="'"$IMRELP_OPENSSL_VALID_LOG"'")
+' 2
+../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}2.conf" >"$IMRELP_OPENSSL_VALID_LOG" 2>&1 ||
+    error_exit $?
+check_not_present "appears to use GnuTLS" "$IMRELP_OPENSSL_VALID_LOG"
+
+generate_conf 3
 add_conf '
 module(load="../plugins/omrelp/.libs/omrelp" tls.tlslib="openssl")
 
 action(type="omrelp" target="127.0.0.1" port="'"$TCPFLOOD_PORT"'" tls="on"
        tls.prioritystring="NORMAL:+ANON-DH")
-' 2
-../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}2.conf" >"$RSYSLOG2_OUT_LOG" 2>&1 || error_exit $?
-content_check "omrelp: tls.prioritystring with tls.tlslib=\"openssl\" is interpreted as an OpenSSL cipher string" "$RSYSLOG2_OUT_LOG"
-content_check "not as a GnuTLS priority string" "$RSYSLOG2_OUT_LOG"
-content_check "use OpenSSL cipher syntax or tls.tlscfgcmd" "$RSYSLOG2_OUT_LOG"
+' 3
+../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}3.conf" >"$OMRELP_GNUTLS_STYLE_LOG" 2>&1 ||
+    error_exit $?
+content_check "omrelp: tls.prioritystring with tls.tlslib=\"openssl\" appears to use GnuTLS" "$OMRELP_GNUTLS_STYLE_LOG"
+content_check "use OpenSSL cipher syntax or tls.tlscfgcmd" "$OMRELP_GNUTLS_STYLE_LOG"
+
+generate_conf 4
+add_conf '
+module(load="../plugins/omrelp/.libs/omrelp" tls.tlslib="openssl")
+
+action(type="omrelp" target="127.0.0.1" port="'"$TCPFLOOD_PORT"'" tls="on"
+       tls.prioritystring="HIGH:!aNULL")
+' 4
+../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}4.conf" >"$OMRELP_OPENSSL_VALID_LOG" 2>&1 ||
+    error_exit $?
+check_not_present "appears to use GnuTLS" "$OMRELP_OPENSSL_VALID_LOG"
 
 exit_test

--- a/tests/relp-openssl-prioritystring-warning.sh
+++ b/tests/relp-openssl-prioritystring-warning.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
 # Verify that RELP configurations using the OpenSSL backend with the
-# shared tls.prioritystring parameter produce an actionable diagnostic only
-# when users pass a value that clearly looks like GnuTLS priority-string syntax.
+# shared tls.prioritystring parameter produce an actionable diagnostic only when
+# users pass a value that clearly looks like the other backend's syntax.
 # The oracle is the rsyslogd -N1 config-check output: no live RELP connection is
-# needed. The warning must not fire for OpenSSL cipher-list syntax, because
-# librelp also uses tls.prioritystring to pass cipher strings to OpenSSL.
+# needed. The warning must not fire for matching backend syntax, because librelp
+# uses this single parameter for both GnuTLS priority strings and OpenSSL cipher
+# lists.
 # This file is part of the rsyslog project, released under ASL 2.0.
 # shellcheck source=tests/diag.sh
 . "${srcdir:=.}"/diag.sh init
 require_relpEngineSetTLSLibByName
 IMRELP_OPENSSL_VALID_LOG="${RSYSLOG_DYNNAME}.imrelp-openssl-valid.log"
+IMRELP_GNUTLS_OPENSSL_STYLE_LOG="${RSYSLOG_DYNNAME}.imrelp-gnutls-openssl-style.log"
+IMRELP_GNUTLS_VALID_LOG="${RSYSLOG_DYNNAME}.imrelp-gnutls-valid.log"
 OMRELP_GNUTLS_STYLE_LOG="${RSYSLOG_DYNNAME}.omrelp-gnutls-style.log"
 OMRELP_OPENSSL_VALID_LOG="${RSYSLOG_DYNNAME}.omrelp-openssl-valid.log"
+OMRELP_GNUTLS_OPENSSL_STYLE_LOG="${RSYSLOG_DYNNAME}.omrelp-gnutls-openssl-style.log"
+OMRELP_GNUTLS_VALID_LOG="${RSYSLOG_DYNNAME}.omrelp-gnutls-valid.log"
 
 generate_conf
 add_conf '
@@ -37,25 +42,75 @@ check_not_present "appears to use GnuTLS" "$IMRELP_OPENSSL_VALID_LOG"
 
 generate_conf 3
 add_conf '
+module(load="../plugins/imrelp/.libs/imrelp" tls.tlslib="gnutls")
+input(type="imrelp" port="0" tls="on" tls.prioritystring="HIGH:!aNULL")
+
+action(type="omfile" file="'"$IMRELP_GNUTLS_OPENSSL_STYLE_LOG"'")
+' 3
+../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}3.conf" >"$IMRELP_GNUTLS_OPENSSL_STYLE_LOG" 2>&1 ||
+    error_exit $?
+content_check "imrelp: tls.prioritystring with the GnuTLS RELP backend appears to use OpenSSL" \
+    "$IMRELP_GNUTLS_OPENSSL_STYLE_LOG"
+content_check "use GnuTLS priority-string syntax or switch tls.tlslib to \"openssl\"" \
+    "$IMRELP_GNUTLS_OPENSSL_STYLE_LOG"
+
+generate_conf 4
+add_conf '
+module(load="../plugins/imrelp/.libs/imrelp" tls.tlslib="gnutls")
+input(type="imrelp" port="0" tls="on" tls.prioritystring="NORMAL:+ANON-DH")
+
+action(type="omfile" file="'"$IMRELP_GNUTLS_VALID_LOG"'")
+' 4
+../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}4.conf" >"$IMRELP_GNUTLS_VALID_LOG" 2>&1 ||
+    error_exit $?
+check_not_present "appears to use OpenSSL" "$IMRELP_GNUTLS_VALID_LOG"
+
+generate_conf 5
+add_conf '
 module(load="../plugins/omrelp/.libs/omrelp" tls.tlslib="openssl")
 
 action(type="omrelp" target="127.0.0.1" port="'"$TCPFLOOD_PORT"'" tls="on"
        tls.prioritystring="NORMAL:+ANON-DH")
-' 3
-../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}3.conf" >"$OMRELP_GNUTLS_STYLE_LOG" 2>&1 ||
+' 5
+../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}5.conf" >"$OMRELP_GNUTLS_STYLE_LOG" 2>&1 ||
     error_exit $?
 content_check "omrelp: tls.prioritystring with tls.tlslib=\"openssl\" appears to use GnuTLS" "$OMRELP_GNUTLS_STYLE_LOG"
 content_check "use OpenSSL cipher syntax or tls.tlscfgcmd" "$OMRELP_GNUTLS_STYLE_LOG"
 
-generate_conf 4
+generate_conf 6
 add_conf '
 module(load="../plugins/omrelp/.libs/omrelp" tls.tlslib="openssl")
 
 action(type="omrelp" target="127.0.0.1" port="'"$TCPFLOOD_PORT"'" tls="on"
        tls.prioritystring="HIGH:!aNULL")
-' 4
-../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}4.conf" >"$OMRELP_OPENSSL_VALID_LOG" 2>&1 ||
+' 6
+../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}6.conf" >"$OMRELP_OPENSSL_VALID_LOG" 2>&1 ||
     error_exit $?
 check_not_present "appears to use GnuTLS" "$OMRELP_OPENSSL_VALID_LOG"
+
+generate_conf 7
+add_conf '
+module(load="../plugins/omrelp/.libs/omrelp" tls.tlslib="gnutls")
+
+action(type="omrelp" target="127.0.0.1" port="'"$TCPFLOOD_PORT"'" tls="on"
+       tls.prioritystring="HIGH:!aNULL")
+' 7
+../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}7.conf" >"$OMRELP_GNUTLS_OPENSSL_STYLE_LOG" 2>&1 ||
+    error_exit $?
+content_check "omrelp: tls.prioritystring with the GnuTLS RELP backend appears to use OpenSSL" \
+    "$OMRELP_GNUTLS_OPENSSL_STYLE_LOG"
+content_check "use GnuTLS priority-string syntax or switch tls.tlslib to \"openssl\"" \
+    "$OMRELP_GNUTLS_OPENSSL_STYLE_LOG"
+
+generate_conf 8
+add_conf '
+module(load="../plugins/omrelp/.libs/omrelp" tls.tlslib="gnutls")
+
+action(type="omrelp" target="127.0.0.1" port="'"$TCPFLOOD_PORT"'" tls="on"
+       tls.prioritystring="NORMAL:+ANON-DH")
+' 8
+../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}8.conf" >"$OMRELP_GNUTLS_VALID_LOG" 2>&1 ||
+    error_exit $?
+check_not_present "appears to use OpenSSL" "$OMRELP_GNUTLS_VALID_LOG"
 
 exit_test

--- a/tests/relp-openssl-prioritystring-warning.sh
+++ b/tests/relp-openssl-prioritystring-warning.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 # Verify that RELP configurations using the OpenSSL backend with the
-# GnuTLS-only tls.prioritystring parameter produce an actionable diagnostic.
+# shared tls.prioritystring parameter produce an actionable diagnostic for
+# users who pass a GnuTLS priority-string value while OpenSSL is selected.
 # The oracle is the rsyslogd -N1 config-check output: no live RELP connection is
-# needed, and the warning must name tls.tlscfgcmd as the OpenSSL alternative.
+# needed, and the warning must say OpenSSL interprets the value with OpenSSL
+# cipher syntax while naming tls.tlscfgcmd as the broader policy alternative.
 # This file is part of the rsyslog project, released under ASL 2.0.
 # shellcheck source=tests/diag.sh
 . "${srcdir:=.}"/diag.sh init
@@ -16,8 +18,9 @@ input(type="imrelp" port="0" tls="on" tls.prioritystring="NORMAL:+ANON-DH")
 action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'")
 '
 ../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}.conf" >"$RSYSLOG_OUT_LOG" 2>&1 || error_exit $?
-content_check "imrelp: tls.prioritystring is a GnuTLS priority string" "$RSYSLOG_OUT_LOG"
-content_check "use tls.tlscfgcmd for OpenSSL TLS policy" "$RSYSLOG_OUT_LOG"
+content_check "imrelp: tls.prioritystring with tls.tlslib=\"openssl\" is interpreted as an OpenSSL cipher string" "$RSYSLOG_OUT_LOG"
+content_check "not as a GnuTLS priority string" "$RSYSLOG_OUT_LOG"
+content_check "use OpenSSL cipher syntax or tls.tlscfgcmd" "$RSYSLOG_OUT_LOG"
 
 generate_conf 2
 add_conf '
@@ -27,7 +30,8 @@ action(type="omrelp" target="127.0.0.1" port="'"$TCPFLOOD_PORT"'" tls="on"
        tls.prioritystring="NORMAL:+ANON-DH")
 ' 2
 ../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}2.conf" >"$RSYSLOG2_OUT_LOG" 2>&1 || error_exit $?
-content_check "omrelp: tls.prioritystring is a GnuTLS priority string" "$RSYSLOG2_OUT_LOG"
-content_check "use tls.tlscfgcmd for OpenSSL TLS policy" "$RSYSLOG2_OUT_LOG"
+content_check "omrelp: tls.prioritystring with tls.tlslib=\"openssl\" is interpreted as an OpenSSL cipher string" "$RSYSLOG2_OUT_LOG"
+content_check "not as a GnuTLS priority string" "$RSYSLOG2_OUT_LOG"
+content_check "use OpenSSL cipher syntax or tls.tlscfgcmd" "$RSYSLOG2_OUT_LOG"
 
 exit_test

--- a/tests/relp-openssl-prioritystring-warning.sh
+++ b/tests/relp-openssl-prioritystring-warning.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Verify that RELP configurations using the OpenSSL backend with the
+# GnuTLS-only tls.prioritystring parameter produce an actionable diagnostic.
+# The oracle is the rsyslogd -N1 config-check output: no live RELP connection is
+# needed, and the warning must name tls.tlscfgcmd as the OpenSSL alternative.
+# This file is part of the rsyslog project, released under ASL 2.0.
+# shellcheck source=tests/diag.sh
+. "${srcdir:=.}"/diag.sh init
+require_relpEngineSetTLSLibByName
+
+generate_conf
+add_conf '
+module(load="../plugins/imrelp/.libs/imrelp" tls.tlslib="openssl")
+input(type="imrelp" port="0" tls="on" tls.prioritystring="NORMAL:+ANON-DH")
+
+action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'")
+'
+../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}.conf" >"$RSYSLOG_OUT_LOG" 2>&1 || error_exit $?
+content_check "imrelp: tls.prioritystring is a GnuTLS priority string" "$RSYSLOG_OUT_LOG"
+content_check "use tls.tlscfgcmd for OpenSSL TLS policy" "$RSYSLOG_OUT_LOG"
+
+generate_conf 2
+add_conf '
+module(load="../plugins/omrelp/.libs/omrelp" tls.tlslib="openssl")
+
+action(type="omrelp" target="127.0.0.1" port="'"$TCPFLOOD_PORT"'" tls="on"
+       tls.prioritystring="NORMAL:+ANON-DH")
+' 2
+../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}2.conf" >"$RSYSLOG2_OUT_LOG" 2>&1 || error_exit $?
+content_check "omrelp: tls.prioritystring is a GnuTLS priority string" "$RSYSLOG2_OUT_LOG"
+content_check "use tls.tlscfgcmd for OpenSSL TLS policy" "$RSYSLOG2_OUT_LOG"
+
+exit_test


### PR DESCRIPTION
## Summary
- warn when imrelp/omrelp use GnuTLS-only tls.prioritystring with tls.tlslib="openssl"
- point users to tls.tlscfgcmd for OpenSSL TLS policy
- add a RELP OpenSSL config-check regression test

Closes https://github.com/rsyslog/rsyslog/issues/2862

## Validation
- shellcheck -x tests/relp-openssl-prioritystring-warning.sh
- devtools/check-test-antipatterns.sh tests/relp-openssl-prioritystring-warning.sh
- bash devtools/format-code.sh --git-changed --check --check-if-available
- make -j60 check TESTS='relp-openssl-prioritystring-warning.sh'
- make -j60 check TESTS='sndrcv_relp_tls_prio.sh relp-openssl-prioritystring-warning.sh'
- make -j60 check TESTS=''
- cubic review --base upstream/main --prompt 'Review rsyslog PR candidate for issue #2862: warn when RELP tls.prioritystring is configured with tls.tlslib="openssl" and add a config-check regression test.'
- Ubuntu 26.04 container clang static analyzer via devtools/devcontainer.sh: scan-build, no bugs found
- Ubuntu 26.04 container run-ci via devtools/devcontainer.sh: 1271 total / 1244 pass / 27 skip / 0 fail / 0 error
- make -j60 distcheck TESTS='relp-openssl-prioritystring-warning.sh'