### PR TITLE
tests: narrow service relevance for test files

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2626,13 +2626,12 @@ _service_relevance_is_broad_change() {
 	local changed_file="$1"
 
 	# Broad relevance is the conservative fallback for service families that do
-	# not yet have focused dependency rules. It keeps the pre-gating behavior for
-	# those modules while allowing expensive Kafka, imfile, and Elasticsearch
-	# tests to use narrower rules below.
+	# not yet have focused dependency rules. Generic testbench files are not
+	# service-family signals here; higher-level local and CI validation decide
+	# how much core testbench coverage they need.
 	case "$changed_file" in
 		configure.ac|Makefile.am|m4/*|\
 		.github/workflows/*|devtools/run-ci.sh|devtools/run-configure.sh|\
-		tests/Makefile.am|tests/diag.sh|tests/*.sh|tests/testsuites/*|\
 		grammar/lexer.l|grammar/grammar.y|grammar/Makefile.am|\
 		runtime/Makefile.am|compat/Makefile.am|tools/Makefile.am)
 			return 0
@@ -2674,13 +2673,12 @@ _service_relevance_is_broad_change() {
 _service_relevance_is_selective_common_change() {
 	local changed_file="$1"
 
-	# Changes to build, CI, parser grammar, or testbench plumbing can alter the
-	# way the heavy service tests are configured or executed. Keep these changes
-	# relevant even for the focused Kafka/imfile/Elasticsearch gates.
+	# Changes to build, CI, or parser grammar can alter how heavy service tests
+	# are configured or executed. Generic testbench files are handled by the
+	# higher-level validation plan, not by per-service relevance.
 	case "$changed_file" in
 		configure.ac|Makefile.am|m4/*|\
 		.github/workflows/*|devtools/run-ci.sh|devtools/run-configure.sh|\
-		tests/Makefile.am|tests/diag.sh|tests/*.sh|tests/testsuites/*|\
 		grammar/lexer.l|grammar/grammar.y|grammar/Makefile.am|\
 		runtime/Makefile.am|compat/Makefile.am|tools/Makefile.am)
 			return 0


### PR DESCRIPTION
## Summary
- stop treating generic testbench files as service-family relevance signals
- keep code/plugin/runtime matches and explicit service test names as service relevance signals
- preserve higher-level local/CI validation for generic testbench plumbing while avoiding all-external-service fanout

## Validation
- bash -n tests/diag.sh
- git diff --check
- module-needs-testing checks:
  - tests/Makefile.am no longer enables kafka
  - tests/diag.sh no longer enables kafka
  - unrelated tests/plain-regression.sh no longer enables mysql
  - plugins/omkafka/omkafka.c still enables kafka
  - runtime/msg.c still enables kafka
  - tests/omkafka-basic.sh still enables kafka
  - plugins/ommysql/ommysql.c still enables mysql
  - tests/mysql-basic.sh still enables mysql

## Monitoring note
This intentionally trades less local/runtime fanout for reliance on targeted service relevance and hosted CI. Future flake-campaign artifact reviews should watch for missed service regressions that would justify adding narrower patterns back.