### PR TITLE
omrelp: add output ratelimit support

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1138,6 +1138,9 @@ EXTRA_DIST = \
     source/reference/parameters/omrelp-keepalive-time.rst \
     source/reference/parameters/omrelp-keepalive.rst \
     source/reference/parameters/omrelp-localclientip.rst \
+    source/reference/parameters/omrelp-ratelimit-burst.rst \
+    source/reference/parameters/omrelp-ratelimit-interval.rst \
+    source/reference/parameters/omrelp-ratelimit-name.rst \
     source/reference/parameters/omrelp-port.rst \
     source/reference/parameters/omrelp-rebindinterval.rst \
     source/reference/parameters/omrelp-target.rst \

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -19,6 +19,12 @@ omfwd:
   paths: ["plugins/omfwd/"]
   requires_serialization: false
 
+omrelp:
+  paths: ["plugins/omrelp/"]
+  requires_serialization: false
+  notes:
+    - Each worker owns its RELP client while the optional action-local ratelimiter is shared in pData and must stay thread-safe.
+
 omelasticsearch:
   paths: ["plugins/omelasticsearch/"]
   requires_serialization: false

--- a/doc/source/configuration/modules/omrelp.rst
+++ b/doc/source/configuration/modules/omrelp.rst
@@ -139,6 +139,18 @@ Action Parameters
      - .. include:: ../../reference/parameters/omrelp-localclientip.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-omrelp-ratelimit-interval`
+     - .. include:: ../../reference/parameters/omrelp-ratelimit-interval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-ratelimit-burst`
+     - .. include:: ../../reference/parameters/omrelp-ratelimit-burst.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-ratelimit-name`
+     - .. include:: ../../reference/parameters/omrelp-ratelimit-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 .. toctree::
    :hidden:
@@ -166,6 +178,9 @@ Action Parameters
    ../../reference/parameters/omrelp-tls-tlscfgcmd
    ../../reference/parameters/omrelp-tls-permanentfailuredisablesaction
    ../../reference/parameters/omrelp-localclientip
+   ../../reference/parameters/omrelp-ratelimit-interval
+   ../../reference/parameters/omrelp-ratelimit-burst
+   ../../reference/parameters/omrelp-ratelimit-name
 
 
 Examples
@@ -206,6 +221,18 @@ actual deployments. For details, see parameter descriptions.
 		tls.permittedpeer="rsyslog")
 
 
+Limiting omrelp forwarding rate
+-------------------------------
+
+The following example throttles one RELP destination to at most five messages
+per two-second interval.
+
+.. code-block:: none
+
+   action(type="omrelp" target="centralserv" port="2514"
+          ratelimit.interval="2" ratelimit.burst="5")
+
+
 |FmtObsoleteName| directives
 ============================
 
@@ -216,4 +243,3 @@ be specified. To send a message via RELP, use
 .. code-block:: none
 
    *.*  :omrelp:<server>:<port>;<template>
-

--- a/doc/source/reference/parameters/omrelp-ratelimit-burst.rst
+++ b/doc/source/reference/parameters/omrelp-ratelimit-burst.rst
@@ -4,6 +4,7 @@ RateLimit.Burst
 ^^^^^^^^^^^^^^^
 
 .. summary-start
+
 Sets how many messages one omrelp action may forward per rate-limit interval.
 .. summary-end
 

--- a/doc/source/reference/parameters/omrelp-ratelimit-burst.rst
+++ b/doc/source/reference/parameters/omrelp-ratelimit-burst.rst
@@ -1,0 +1,18 @@
+.. _param-omrelp-ratelimit-burst:
+
+RateLimit.Burst
+^^^^^^^^^^^^^^^
+
+.. summary-start
+Sets how many messages one omrelp action may forward per rate-limit interval.
+.. summary-end
+
+.. csv-table::
+   :header: "type", "default", "max", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "integer", "200", "(2^32)-1", "no", "none"
+
+Specifies the number of messages an omrelp action may forward during one
+rate-limit interval.

--- a/doc/source/reference/parameters/omrelp-ratelimit-interval.rst
+++ b/doc/source/reference/parameters/omrelp-ratelimit-interval.rst
@@ -1,0 +1,19 @@
+.. _param-omrelp-ratelimit-interval:
+
+RateLimit.Interval
+^^^^^^^^^^^^^^^^^^
+
+.. summary-start
+Sets the omrelp action-local rate-limit interval in seconds. ``0`` disables
+rate limiting.
+.. summary-end
+
+.. csv-table::
+   :header: "type", "default", "max", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "integer", "0", "", "no", "none"
+
+Specifies the rate-limiting interval in seconds for this omrelp action.
+The default value is ``0``, which disables rate limiting.

--- a/doc/source/reference/parameters/omrelp-ratelimit-interval.rst
+++ b/doc/source/reference/parameters/omrelp-ratelimit-interval.rst
@@ -4,6 +4,7 @@ RateLimit.Interval
 ^^^^^^^^^^^^^^^^^^
 
 .. summary-start
+
 Sets the omrelp action-local rate-limit interval in seconds. ``0`` disables
 rate limiting.
 .. summary-end

--- a/doc/source/reference/parameters/omrelp-ratelimit-name.rst
+++ b/doc/source/reference/parameters/omrelp-ratelimit-name.rst
@@ -4,6 +4,7 @@ RateLimit.Name
 ^^^^^^^^^^^^^^
 
 .. summary-start
+
 Binds the omrelp action to a named ``ratelimit()`` object.
 .. summary-end
 

--- a/doc/source/reference/parameters/omrelp-ratelimit-name.rst
+++ b/doc/source/reference/parameters/omrelp-ratelimit-name.rst
@@ -1,0 +1,20 @@
+.. _param-omrelp-ratelimit-name:
+
+RateLimit.Name
+^^^^^^^^^^^^^^
+
+.. summary-start
+Binds the omrelp action to a named ``ratelimit()`` object.
+.. summary-end
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "", "no", "none"
+
+Assigns a named :doc:`ratelimit object <../../rainerscript/configuration_objects/ratelimit>` to this
+omrelp action. ``ratelimit.name`` is mutually exclusive with
+``ratelimit.interval`` and ``ratelimit.burst``; if both forms are configured,
+the named ratelimit object takes precedence.

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -12,6 +12,8 @@
  *       definitely be optional and by default off due to the
  *       performance implications (and given the fact that message
  *       loss is pretty unlikely in usual cases).
+ * When output rate limiting is configured, the ratelimiter is shared
+ * across workers in pData and relies on the runtime ratelimit mutex.
  *
  *
  * File begun on 2008-03-13 by RGerhards
@@ -53,6 +55,7 @@
 #include "errmsg.h"
 #include "debug.h"
 #include "parserif.h"
+#include "ratelimit.h"
 #include "unicode-helper.h"
 #include "atomic.h"
 
@@ -97,6 +100,11 @@ typedef struct _instanceData {
 #endif
     uchar *tplName;
     uchar *localClientIP;
+    int ratelimitInterval;
+    int ratelimitBurst;
+    uchar *pszRatelimitName;
+    uchar *pszRatelimitKey;
+    ratelimit_t *ratelimiter;
     sbool bKeepAlive; /* support keep-alive packets */
     int iKeepAliveProbes;
     int iKeepAliveTime;
@@ -157,6 +165,9 @@ static struct cnfparamdescr actpdescr[] = {{"target", eCmdHdlrGetWord, 1},
                                            {"keepalive.time", eCmdHdlrInt, 0},
                                            {"keepalive.interval", eCmdHdlrInt, 0},
                                            {"localclientip", eCmdHdlrGetWord, 0},
+                                           {"ratelimit.interval", eCmdHdlrInt, 0},
+                                           {"ratelimit.burst", eCmdHdlrInt, 0},
+                                           {"ratelimit.name", eCmdHdlrString, 0},
                                            {"template", eCmdHdlrGetWord, 0}};
 static struct cnfparamblk actpblk = {CNFPARAMBLK_VERSION, sizeof(actpdescr) / sizeof(struct cnfparamdescr), actpdescr};
 
@@ -333,6 +344,11 @@ BEGINcreateInstance
     pData->pristring = NULL;
     pData->authmode = NULL;
     pData->localClientIP = NULL;
+    pData->ratelimitInterval = -1;
+    pData->ratelimitBurst = -1;
+    pData->pszRatelimitName = NULL;
+    pData->pszRatelimitKey = NULL;
+    pData->ratelimiter = NULL;
     pData->caCertFile = NULL;
     pData->myCertFile = NULL;
     pData->myPrivKeyFile = NULL;
@@ -365,6 +381,9 @@ BEGINfreeInstance
     free(pData->pristring);
     free(pData->authmode);
     free(pData->localClientIP);
+    free(pData->pszRatelimitName);
+    free(pData->pszRatelimitKey);
+    if (pData->ratelimiter != NULL) ratelimitDestruct(pData->ratelimiter);
     free(pData->caCertFile);
     free(pData->myCertFile);
     free(pData->myPrivKeyFile);
@@ -397,6 +416,11 @@ static void setInstParamDefaults(instanceData *pData) {
     pData->bTlsPermFailDisablesAction = DFLT_TLS_PERMFAIL_DISABLES_ACTION;
     pData->pristring = NULL;
     pData->authmode = NULL;
+    pData->ratelimitInterval = -1;
+    pData->ratelimitBurst = -1;
+    pData->pszRatelimitName = NULL;
+    pData->pszRatelimitKey = NULL;
+    pData->ratelimiter = NULL;
     if (glbl.GetSourceIPofLocalClient() == NULL)
         pData->localClientIP = NULL;
     else
@@ -490,7 +514,9 @@ BEGINnewActInst
     struct cnfparamvals *pvals;
     int i, j;
     FILE *fp;
+    const char *relpPt;
     relpClt_t *pRelpClt = NULL;
+    size_t ratelimitKeyLen;
     CODESTARTnewActInst;
     if ((pvals = nvlstGetParams(lst, &actpblk, NULL)) == NULL) {
         ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
@@ -509,6 +535,12 @@ BEGINnewActInst
             CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "localclientip")) {
             CHKmalloc(pData->localClientIP = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(actpblk.descr[i].name, "ratelimit.interval")) {
+            pData->ratelimitInterval = (int)pvals[i].val.d.n;
+        } else if (!strcmp(actpblk.descr[i].name, "ratelimit.burst")) {
+            pData->ratelimitBurst = (int)pvals[i].val.d.n;
+        } else if (!strcmp(actpblk.descr[i].name, "ratelimit.name")) {
+            CHKmalloc(pData->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "timeout")) {
             pData->timeout = (unsigned)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "conn.timeout")) {
@@ -585,6 +617,26 @@ BEGINnewActInst
         }
     }
 
+    if (pData->pszRatelimitName != NULL) {
+        if (pData->ratelimitInterval != -1 || pData->ratelimitBurst != -1) {
+            LogError(0, RS_RET_INVALID_PARAMS,
+                     "omrelp: ratelimit.name is mutually exclusive with "
+                     "ratelimit.interval and ratelimit.burst - using ratelimit.name");
+        }
+        pData->ratelimitInterval = 0;
+        pData->ratelimitBurst = 0;
+    } else {
+        if (pData->ratelimitInterval == -1) pData->ratelimitInterval = 0;
+        if (pData->ratelimitBurst == -1) pData->ratelimitBurst = 200;
+    }
+    if (pData->target == NULL) {
+        ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+    }
+    relpPt = (const char *)getRelpPt(pData);
+    ratelimitKeyLen = strlen((char *)pData->target) + strlen(relpPt) + 2;
+    CHKmalloc(pData->pszRatelimitKey = malloc(ratelimitKeyLen));
+    snprintf((char *)pData->pszRatelimitKey, ratelimitKeyLen, "%s:%s", pData->target, relpPt);
+
     CODE_STD_STRING_REQUESTnewActInst(1);
 
     CHKiRet(OMSRsetEntry(*ppOMSR, 0,
@@ -592,6 +644,19 @@ BEGINnewActInst
                          OMSR_NO_RQD_TPL_OPTS));
 
     warnIfPlainRelpActionConfigured(pData);
+
+    if (pData->pszRatelimitName != NULL) {
+        CHKiRet(ratelimitNewFromConfig(&pData->ratelimiter, loadModConf->pConf, (char *)pData->pszRatelimitName,
+                                       "omrelp", (char *)pData->pszRatelimitKey));
+        ratelimitSetNoTimeCache(pData->ratelimiter);
+    } else if (pData->ratelimitInterval > 0) {
+        CHKiRet(ratelimitNew(&pData->ratelimiter, "omrelp", (char *)pData->pszRatelimitKey));
+        ratelimitSetLinuxLike(pData->ratelimiter, (unsigned)pData->ratelimitInterval, (unsigned)pData->ratelimitBurst);
+        ratelimitSetNoTimeCache(pData->ratelimiter);
+    }
+    if (pData->ratelimiter != NULL) {
+        ratelimitSetThreadSafe(pData->ratelimiter);
+    }
 
     iRet = doCreateRelpClient(pData, &pRelpClt);
     if (pRelpClt != NULL) relpEngineCltDestruct(pRelpEngine, &pRelpClt);
@@ -728,6 +793,16 @@ BEGINdoAction
 
     /* we need to truncate oversize msgs - no way around that... */
     if ((int)lenMsg > glbl.GetMaxLine(runModConf->pConf)) lenMsg = glbl.GetMaxLine(runModConf->pConf);
+
+    if (pData->ratelimiter != NULL) {
+        iRet = ratelimitMsgCount(pData->ratelimiter, 0, (char *)pData->pszRatelimitKey);
+        if (iRet == RS_RET_DISCARDMSG) {
+            iRet = RS_RET_OK;
+            goto finalize_it;
+        } else if (iRet != RS_RET_OK) {
+            LogError(0, RS_RET_ERR, "omrelp: error during rate limit for target %s: %d", pData->pszRatelimitKey, iRet);
+        }
+    }
 
     /* forward */
     ret = relpCltSendSyslog(pWrkrData->pRelpClt, (uchar *)pMsg, lenMsg);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -615,6 +615,7 @@ TESTS_LIBYAML = \
 	ratelimit_hup.sh \
 	yaml-basic.sh \
 	yaml-basic-yamlonly.sh \
+	yaml-omrelp-ratelimit-name.sh \
 	yaml-omfile-dynafilecachesize-invalid.sh \
 	yaml-include.sh \
 	yaml-ruleset-script.sh \
@@ -1647,6 +1648,8 @@ TESTS_RELP = \
 	 imrelp-invld-tlslib.sh \
 	 imrelp-bigmessage.sh \
 	 imrelp_ratelimit_name.sh \
+	 omrelp_ratelimit.sh \
+	 omrelp_ratelimit_name.sh \
 	 omrelp-invld-tlslib.sh \
 	 sndrcv_relp_dflt_pt.sh \
 	 glbl-oversizeMsg-log.sh \

--- a/tests/omrelp_ratelimit.sh
+++ b/tests/omrelp_ratelimit.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Verify omrelp action-local ratelimit.interval/ratelimit.burst throttles RELP forwarding.
+# A sender instance injects 20 messages quickly into one omrelp action with burst 5 and
+# interval 2s. The receiver must get some, but not all, messages; that oracle proves the
+# limiter drops only excess output for this destination instead of blocking delivery entirely.
+. ${srcdir:=.}/diag.sh init
+skip_ARM "ratelimit timing flaky on ARM"
+export SENDMESSAGES=20
+
+########## receiver ##########
+generate_conf
+add_conf '
+module(load="../plugins/imrelp/.libs/imrelp")
+input(type="imrelp" address="127.0.0.1" port="0")
+
+$template outfmt,"%msg:F,58:2%\n"
+:msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+assign_single_tcp_listener_port PORT_RCVR
+
+########## sender ##########
+generate_conf 2
+add_conf '
+module(load="../plugins/omrelp/.libs/omrelp")
+
+action(type="omrelp" target="127.0.0.1" port="'$PORT_RCVR'"
+       ratelimit.interval="2" ratelimit.burst="5")
+' 2
+startup 2
+
+injectmsg2 0 $SENDMESSAGES
+
+shutdown_when_empty 2
+wait_shutdown 2
+shutdown_when_empty
+wait_shutdown
+
+if [ -f "$RSYSLOG_OUT_LOG" ]; then
+	content_count=$(wc -l < "$RSYSLOG_OUT_LOG")
+else
+	content_count=0
+fi
+
+if [ "$content_count" -eq "$SENDMESSAGES" ]; then
+	echo "FAIL: No rate limiting occurred (received all $content_count messages)"
+	error_exit 1
+fi
+
+if [ "$content_count" -eq 0 ]; then
+	echo "FAIL: All messages were lost (received 0)"
+	error_exit 1
+fi
+
+echo "SUCCESS: omrelp rate limiting occurred (received $content_count/$SENDMESSAGES)"
+exit_test

--- a/tests/omrelp_ratelimit_name.sh
+++ b/tests/omrelp_ratelimit_name.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Test named rate limits for omrelp (config-validation).
+# Verifies that omrelp accepts ratelimit.name without startup errors.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+ratelimit(name="omrelp_test_limit" interval="2" burst="5")
+
+module(load="../plugins/omrelp/.libs/omrelp")
+action(type="omrelp" target="127.0.0.1" port="2514"
+       ratelimit.name="omrelp_test_limit")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+exit_test

--- a/tests/yaml-omrelp-ratelimit-name.sh
+++ b/tests/yaml-omrelp-ratelimit-name.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Ensure YAML omrelp actions accept ratelimit.name.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" << 'YAMLEOF'
+ratelimits:
+  - name: yaml_omrelp_limit
+    interval: 2
+    burst: 5
+
+modules:
+  - load: "../plugins/omrelp/.libs/omrelp"
+
+rulesets:
+  - name: main
+    actions:
+      - type: omrelp
+        target: "127.0.0.1"
+        port: "2514"
+        ratelimit.name: yaml_omrelp_limit
+YAMLEOF
+
+startup
+shutdown_when_empty
+wait_shutdown
+exit_test


### PR DESCRIPTION
## Summary
- add omrelp action support for ratelimit.interval, ratelimit.burst, and ratelimit.name
- apply the limiter in the RELP send path with shared thread-safe action state
- document the new parameters and add RainerScript and YAML coverage

## Testing
- devtools/devcontainer.sh --rm tests/omrelp_ratelimit.sh
- devtools/devcontainer.sh --rm tests/omrelp_ratelimit_name.sh
- devtools/devcontainer.sh --rm tests/yaml-omrelp-ratelimit-name.sh
- ./doc/tools/build-doc-linux.sh --clean --format html --jobs 10
- devtools/local-validation-plan.sh --run

Partial for #4335.