### PR TITLE
tests: add incremental doc sample coverage

### DIFF
--- a/doc/source/tutorials/database.rst
+++ b/doc/source/tutorials/database.rst
@@ -126,9 +126,10 @@ like this:
    template(
        name="sqlInsertMessage"
        type="list"
+       option.sql="on"
    ) {
        constant(value="insert into syslog(message) values ('")
-       property(name="msg" sql="on")
+       property(name="msg")
        constant(value="')")
    }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -35,7 +35,17 @@ TESTS_DOC_SAMPLES = \
 	doc-sample-default-config.sh \
 	doc-sample-first-config.sh \
 	doc-sample-forwarding-logs.sh \
+	doc-sample-message-app-name.sh \
 	doc-sample-message-pipeline.sh \
+	doc-sample-message-fromhost-ip.sh \
+	doc-sample-message-fromhost.sh \
+	doc-sample-message-hostname.sh \
+	doc-sample-message-inputname.sh \
+	doc-sample-message-msg.sh \
+	doc-sample-message-msgid.sh \
+	doc-sample-message-pri.sh \
+	doc-sample-message-programname.sh \
+	doc-sample-message-syslogtag.sh \
 	doc-sample-omfwd.sh \
 	doc-sample-order-matters.sh \
 	doc-sample-remote-server.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -32,9 +32,15 @@ TESTS_DOC_SAMPLES = \
 	doc-sample-basic-structure.sh \
 	doc-sample-config-examples.sh \
 	doc-sample-database.sh \
+	doc-sample-default-config.sh \
+	doc-sample-first-config.sh \
 	doc-sample-forwarding-logs.sh \
+	doc-sample-message-pipeline.sh \
 	doc-sample-omfwd.sh \
-	doc-sample-reliable-forwarding.sh
+	doc-sample-order-matters.sh \
+	doc-sample-remote-server.sh \
+	doc-sample-reliable-forwarding.sh \
+	doc-sample-understanding-default-config.sh
 EXTRA_DIST += $(TESTS_DOC_SAMPLES) doc-sample-lib.sh
 
 TESTS_IMPTCP_TABESCAPE = \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,6 +27,16 @@ TESTS_GSSAPI_LIBYAML = \
 	imgssapi-yaml-include-listen-port-file.sh
 EXTRA_DIST += $(TESTS_GSSAPI) $(TESTS_GSSAPI_LIBYAML) unit/gss_token_util_test.c
 
+TESTS_DOC_SAMPLES = \
+	doc-sample-basic-configuration.sh \
+	doc-sample-basic-structure.sh \
+	doc-sample-config-examples.sh \
+	doc-sample-database.sh \
+	doc-sample-forwarding-logs.sh \
+	doc-sample-omfwd.sh \
+	doc-sample-reliable-forwarding.sh
+EXTRA_DIST += $(TESTS_DOC_SAMPLES) doc-sample-lib.sh
+
 TESTS_IMPTCP_TABESCAPE = \
 	tabescape_dflt.sh \
 	tabescape_dflt-udp.sh \
@@ -80,6 +90,7 @@ TESTS_ELASTICSEARCH_VALGRIND = \
 	es-basic-ha-vg.sh
 
 TESTS_DEFAULT = \
+	$(TESTS_DOC_SAMPLES) \
 	backtick-cat-procfs.sh \
 	preservefqdn-localhostname-internal.sh \
 	immark.sh \

--- a/tests/doc-sample-basic-configuration.sh
+++ b/tests/doc-sample-basic-configuration.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Validate the runnable RainerScript example from
+# doc/source/getting_started/basic_configuration.rst.
+# The oracle is rsyslogd -C -N1 accepting the copied minimal local logging
+# config after the testbench rewrites module load paths for the build tree.
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+require_plugin imuxsock
+require_plugin imklog
+
+cat > "${RSYSLOG_DYNNAME}.basic-configuration.conf" <<CONF_EOF
+module(load="../plugins/imuxsock/.libs/imuxsock")
+module(load="../plugins/imklog/.libs/imklog")
+action(type="omfile" file="${RSYSLOG_OUT_LOG}")
+CONF_EOF
+
+doc_sample_expect_config_valid \
+	"basic-configuration" \
+	"${RSYSLOG_DYNNAME}.basic-configuration.conf"
+
+exit_test

--- a/tests/doc-sample-basic-structure.sh
+++ b/tests/doc-sample-basic-structure.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Validate the RainerScript configuration blocks from
+# doc/source/configuration/basic_structure.rst.
+# The oracle is rsyslogd -C -N1 accepting a config assembled from the page's
+# rule, input, action, and ruleset examples with only build-tree path fixes.
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+require_plugin imtcp
+
+cat > "${RSYSLOG_DYNNAME}.basic-structure.conf" <<CONF_EOF
+if \$syslogfacility-text == 'mail' and \$syslogseverity-text == 'err' then {
+    action(type="omfile" file="${RSYSLOG_OUT_LOG}.mail-errors")
+}
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0")
+
+action(type="omfile" file="${RSYSLOG_OUT_LOG}.messages")
+
+ruleset(name="fileLogging") {
+    if prifilt("*.info") then {
+        action(type="omfile" file="${RSYSLOG_OUT_LOG}.info")
+    }
+}
+CONF_EOF
+
+doc_sample_expect_config_valid \
+	"basic-structure" \
+	"${RSYSLOG_DYNNAME}.basic-structure.conf"
+
+exit_test

--- a/tests/doc-sample-config-examples.sh
+++ b/tests/doc-sample-config-examples.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Validate the larger template and rule examples from
+# doc/source/configuration/examples.rst.
+# The oracle is rsyslogd -C -N1 accepting the concatenated page examples so the
+# published template/action snippets keep matching current config syntax.
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+cat > "${RSYSLOG_DYNNAME}.config-examples.conf" <<CONF_EOF
+template(name="TraditionalFormat" type="list") {
+    property(name="timegenerated")
+    constant(value=" ")
+    property(name="hostname")
+    property(name="syslogtag")
+    property(name="msg" droplastlf="on")
+    constant(value="\n")
+}
+
+template(name="PreciseFormat" type="list") {
+    property(name="syslogpriority")
+    constant(value=",")
+    property(name="syslogfacility")
+    constant(value=",")
+    property(name="timegenerated")
+    constant(value=",")
+    property(name="hostname")
+    constant(value=",")
+    property(name="syslogtag")
+    constant(value=",")
+    property(name="msg")
+    constant(value="\n")
+}
+
+template(name="RFC3164fmt" type="list") {
+    constant(value="<")
+    property(name="pri")
+    constant(value=">")
+    property(name="timestamp")
+    constant(value=" ")
+    property(name="hostname")
+    constant(value=" ")
+    property(name="syslogtag")
+    property(name="msg")
+}
+
+template(name="MySQLInsert" type="list" option.sql="on") {
+    constant(value="insert iut, message, receivedat values ('")
+    property(name="iut")
+    constant(value="', '")
+    property(name="msg" caseconversion="upper")
+    constant(value="', '")
+    property(name="timegenerated" dateformat="mysql")
+    constant(value="') into systemevents\n")
+}
+
+if prifilt("*.crit") and not prifilt("kern.*") then {
+    action(type="omfile" file="${RSYSLOG_OUT_LOG}.critical")
+}
+
+if prifilt("kern.*") then {
+    action(type="omfile" file="${RSYSLOG_OUT_LOG}.kernel")
+}
+
+if prifilt("kern.crit") then {
+    action(
+        type="omfwd"
+        target="server.example.net"
+        protocol="tcp"
+        port="514"
+        template="RFC3164fmt"
+    )
+}
+
+if prifilt("*.emerg") then {
+    action(type="omusrmsg" users="*")
+}
+
+action(
+    type="omfwd"
+    target="server.example.net"
+    protocol="tcp"
+    port="514"
+)
+
+if (\$msg contains "error") then {
+    action(
+        type="omfwd"
+        target="server.example.net"
+        protocol="udp"
+    )
+}
+CONF_EOF
+
+doc_sample_expect_config_valid \
+	"config-examples" \
+	"${RSYSLOG_DYNNAME}.config-examples.conf"
+
+exit_test

--- a/tests/doc-sample-database.sh
+++ b/tests/doc-sample-database.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Validate the database tutorial examples from doc/source/tutorials/database.rst.
+# The oracle is rsyslogd -C -N1 accepting the published template/module/action
+# snippets with build-tree plugin paths, proving the tutorial still parses.
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+require_plugin ommysql
+doc_sample_require_loadable_module "../plugins/ommysql/.libs/ommysql.so" "doc-sample-database"
+
+cat > "${RSYSLOG_DYNNAME}.database.conf" <<CONF_EOF
+template(
+    name="sqlInsertMessage"
+    type="list"
+    option.sql="on"
+) {
+    constant(value="insert into syslog(message) values ('")
+    property(name="msg")
+    constant(value="')")
+}
+
+module(load="../plugins/ommysql/.libs/ommysql")
+
+action(
+    type="ommysql"
+    server="database-server"
+    db="database-name"
+    uid="database-userid"
+    pwd="database-password"
+)
+
+action(
+    type="ommysql"
+    server="127.0.0.1"
+    db="Syslog"
+    uid="syslogwriter"
+    pwd="topsecret"
+)
+
+if prifilt("mail.*") then {
+    action(
+        type="ommysql"
+        server="127.0.0.1"
+        db="Syslog"
+        uid="syslogwriter"
+        pwd="topsecret"
+    )
+}
+CONF_EOF
+
+doc_sample_expect_config_valid \
+	"database" \
+	"${RSYSLOG_DYNNAME}.database.conf"
+
+exit_test

--- a/tests/doc-sample-default-config.sh
+++ b/tests/doc-sample-default-config.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Validate the mixed-syntax extension example from
+# doc/source/getting_started/beginner_tutorials/03-default-config.rst.
+# The oracle is rsyslogd -C -N1 accepting the modern snippet additions.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+require_plugin imuxsock
+require_plugin imjournal
+
+cat > "${RSYSLOG_DYNNAME}.default-config.conf" <<'CONF_EOF'
+module(load="../plugins/imuxsock/.libs/imuxsock")
+module(load="../plugins/imjournal/.libs/imjournal")
+
+if ($syslogfacility-text == "local0") then {
+    action(type="omfile" file="/var/log/local0.log")
+}
+CONF_EOF
+
+doc_sample_expect_config_valid "default-config" "${RSYSLOG_DYNNAME}.default-config.conf"
+exit_test

--- a/tests/doc-sample-first-config.sh
+++ b/tests/doc-sample-first-config.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Validate the minimal config example from
+# doc/source/getting_started/beginner_tutorials/02-first-config.rst.
+# The oracle is rsyslogd -C -N1 accepting the page's first modern snippet.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+require_plugin imuxsock
+
+cat > "${RSYSLOG_DYNNAME}.first-config.conf" <<'CONF_EOF'
+module(load="../plugins/imuxsock/.libs/imuxsock")
+
+if ($msg contains "error") then {
+    action(type="omfile" file="/var/log/errors.log")
+}
+CONF_EOF
+
+doc_sample_expect_config_valid "first-config" "${RSYSLOG_DYNNAME}.first-config.conf"
+exit_test

--- a/tests/doc-sample-forwarding-logs.sh
+++ b/tests/doc-sample-forwarding-logs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Validate the minimal forwarding snippets from
+# doc/source/getting_started/forwarding_logs.rst.
+# The oracle is rsyslogd -C -N1 accepting the TCP and UDP forwarding examples
+# as published, confirming the getting-started guidance stays syntactically valid.
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+cat > "${RSYSLOG_DYNNAME}.forwarding-logs.conf" <<CONF_EOF
+action(
+    type="omfwd"
+    protocol="tcp"
+    target="logs.example.com"
+    port="514"
+    queue.type="linkedList"
+)
+
+action(
+    type="omfwd"
+    protocol="udp"
+    target="logs.example.com"
+    port="514"
+)
+CONF_EOF
+
+doc_sample_expect_config_valid \
+	"forwarding-logs" \
+	"${RSYSLOG_DYNNAME}.forwarding-logs.conf"
+
+exit_test

--- a/tests/doc-sample-lib.sh
+++ b/tests/doc-sample-lib.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Shared helper for documentation example tests. These tests copy user-facing
+# RainerScript snippets into generated configs and use rsyslogd -C -N1 as the
+# oracle so doc examples keep passing config validation.
+
+doc_sample_expect_config_valid() {
+	local label="$1"
+	local cfg="$2"
+	local log="${RSYSLOG_DYNNAME}.${label}.log"
+
+	../tools/rsyslogd -C -N1 -M"${RSYSLOG_MODDIR}" -f"${cfg}" >"${log}" 2>&1
+	local rc=$?
+	if [ $rc -ne 0 ]; then
+		echo "FAIL: expected documentation sample ${label} to validate"
+		echo "Generated config:"
+		cat -n "${cfg}"
+		echo "rsyslogd output:"
+		cat "${log}"
+		error_exit 1
+	fi
+}
+
+doc_sample_require_loadable_module() {
+	local module_path="$1"
+	local module_name="$2"
+
+	if ! command -v ldd >/dev/null 2>&1; then
+		return 0
+	fi
+
+	if ldd "${module_path}" 2>/dev/null | grep -q 'not found'; then
+		echo "${module_name}: unresolved shared-library dependency for ${module_path}, skipping"
+		exit 77
+	fi
+}

--- a/tests/doc-sample-message-app-name.sh
+++ b/tests/doc-sample-message-app-name.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Validate the property template example from
+# doc/source/reference/properties/message-app-name.rst.
+# The oracle is rsyslogd -C -N1 accepting the page's app-name template snippet.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+cat > "${RSYSLOG_DYNNAME}.message-app-name.conf" <<'CONF_EOF'
+template(name="example" type="list") {
+    property(name="app-name")
+}
+
+action(type="omfile" file="/dev/null" template="example")
+CONF_EOF
+
+doc_sample_expect_config_valid "message-app-name" "${RSYSLOG_DYNNAME}.message-app-name.conf"
+exit_test

--- a/tests/doc-sample-message-fromhost-ip.sh
+++ b/tests/doc-sample-message-fromhost-ip.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Validate the property template example from
+# doc/source/reference/properties/message-fromhost-ip.rst.
+# The oracle is rsyslogd -C -N1 accepting the page's fromhost-ip template snippet.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+cat > "${RSYSLOG_DYNNAME}.message-fromhost-ip.conf" <<'CONF_EOF'
+template(name="example" type="list") {
+    property(name="fromhost-ip")
+}
+
+action(type="omfile" file="/dev/null" template="example")
+CONF_EOF
+
+doc_sample_expect_config_valid "message-fromhost-ip" "${RSYSLOG_DYNNAME}.message-fromhost-ip.conf"
+exit_test

--- a/tests/doc-sample-message-fromhost.sh
+++ b/tests/doc-sample-message-fromhost.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Validate the property template example from
+# doc/source/reference/properties/message-fromhost.rst.
+# The oracle is rsyslogd -C -N1 accepting the page's fromhost template snippet.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+cat > "${RSYSLOG_DYNNAME}.message-fromhost.conf" <<'CONF_EOF'
+template(name="example" type="list") {
+    property(name="fromhost")
+}
+
+action(type="omfile" file="/dev/null" template="example")
+CONF_EOF
+
+doc_sample_expect_config_valid "message-fromhost" "${RSYSLOG_DYNNAME}.message-fromhost.conf"
+exit_test

--- a/tests/doc-sample-message-hostname.sh
+++ b/tests/doc-sample-message-hostname.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Validate the property template example from
+# doc/source/reference/properties/message-hostname.rst.
+# The oracle is rsyslogd -C -N1 accepting the page's hostname template snippet.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+cat > "${RSYSLOG_DYNNAME}.message-hostname.conf" <<'CONF_EOF'
+template(name="example" type="list") {
+    property(name="hostname")
+}
+
+action(type="omfile" file="/dev/null" template="example")
+CONF_EOF
+
+doc_sample_expect_config_valid "message-hostname" "${RSYSLOG_DYNNAME}.message-hostname.conf"
+exit_test

--- a/tests/doc-sample-message-inputname.sh
+++ b/tests/doc-sample-message-inputname.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Validate the property template example from
+# doc/source/reference/properties/message-inputname.rst.
+# The oracle is rsyslogd -C -N1 accepting the page's inputname template snippet.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+cat > "${RSYSLOG_DYNNAME}.message-inputname.conf" <<'CONF_EOF'
+template(name="example" type="list") {
+    property(name="inputname")
+}
+
+action(type="omfile" file="/dev/null" template="example")
+CONF_EOF
+
+doc_sample_expect_config_valid "message-inputname" "${RSYSLOG_DYNNAME}.message-inputname.conf"
+exit_test

--- a/tests/doc-sample-message-msg.sh
+++ b/tests/doc-sample-message-msg.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Validate the property template example from
+# doc/source/reference/properties/message-msg.rst.
+# The oracle is rsyslogd -C -N1 accepting the page's msg template snippet.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+cat > "${RSYSLOG_DYNNAME}.message-msg.conf" <<'CONF_EOF'
+template(name="example" type="list") {
+    property(name="msg")
+}
+
+action(type="omfile" file="/dev/null" template="example")
+CONF_EOF
+
+doc_sample_expect_config_valid "message-msg" "${RSYSLOG_DYNNAME}.message-msg.conf"
+exit_test

--- a/tests/doc-sample-message-msgid.sh
+++ b/tests/doc-sample-message-msgid.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Validate the property template example from
+# doc/source/reference/properties/message-msgid.rst.
+# The oracle is rsyslogd -C -N1 accepting the page's msgid template snippet.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+cat > "${RSYSLOG_DYNNAME}.message-msgid.conf" <<'CONF_EOF'
+template(name="example" type="list") {
+    property(name="msgid")
+}
+
+action(type="omfile" file="/dev/null" template="example")
+CONF_EOF
+
+doc_sample_expect_config_valid "message-msgid" "${RSYSLOG_DYNNAME}.message-msgid.conf"
+exit_test

--- a/tests/doc-sample-message-pipeline.sh
+++ b/tests/doc-sample-message-pipeline.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Validate the pipeline examples from
+# doc/source/getting_started/beginner_tutorials/04-message-pipeline.rst.
+# The oracle is rsyslogd -C -N1 accepting the filter and forwarding actions.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+require_plugin imuxsock
+
+cat > "${RSYSLOG_DYNNAME}.message-pipeline.conf" <<'CONF_EOF'
+module(load="../plugins/imuxsock/.libs/imuxsock")
+
+if ($msg contains "failed") then {
+    action(type="omfile" file="/var/log/failed.log")
+}
+
+if ($fromhost-ip == "10.0.0.5") then {
+    action(
+        type="omfwd"
+        target="192.0.2.10"
+        port="514"
+        protocol="udp"
+    )
+}
+CONF_EOF
+
+doc_sample_expect_config_valid "message-pipeline" "${RSYSLOG_DYNNAME}.message-pipeline.conf"
+exit_test

--- a/tests/doc-sample-message-pri.sh
+++ b/tests/doc-sample-message-pri.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Validate the property template example from
+# doc/source/reference/properties/message-pri.rst.
+# The oracle is rsyslogd -C -N1 accepting the page's pri template snippet.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+cat > "${RSYSLOG_DYNNAME}.message-pri.conf" <<'CONF_EOF'
+template(name="example" type="list") {
+    property(name="pri")
+}
+
+action(type="omfile" file="/dev/null" template="example")
+CONF_EOF
+
+doc_sample_expect_config_valid "message-pri" "${RSYSLOG_DYNNAME}.message-pri.conf"
+exit_test

--- a/tests/doc-sample-message-programname.sh
+++ b/tests/doc-sample-message-programname.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Validate the property examples from
+# doc/source/reference/properties/message-programname.rst.
+# The oracle is rsyslogd -C -N1 accepting both the global option and template snippets.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+cat > "${RSYSLOG_DYNNAME}.message-programname.conf" <<'CONF_EOF'
+global(parser.permitSlashInProgramName="on")
+
+template(name="example" type="list") {
+    property(name="programname")
+}
+
+action(type="omfile" file="/dev/null" template="example")
+CONF_EOF
+
+doc_sample_expect_config_valid "message-programname" "${RSYSLOG_DYNNAME}.message-programname.conf"
+exit_test

--- a/tests/doc-sample-message-syslogtag.sh
+++ b/tests/doc-sample-message-syslogtag.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Validate the property template example from
+# doc/source/reference/properties/message-syslogtag.rst.
+# The oracle is rsyslogd -C -N1 accepting the page's syslogtag template snippet.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+cat > "${RSYSLOG_DYNNAME}.message-syslogtag.conf" <<'CONF_EOF'
+template(name="example" type="list") {
+    property(name="syslogtag")
+}
+
+action(type="omfile" file="/dev/null" template="example")
+CONF_EOF
+
+doc_sample_expect_config_valid "message-syslogtag" "${RSYSLOG_DYNNAME}.message-syslogtag.conf"
+exit_test

--- a/tests/doc-sample-omfwd.sh
+++ b/tests/doc-sample-omfwd.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Validate the fuller omfwd examples from
+# doc/source/configuration/modules/omfwd.rst.
+# The oracle is rsyslogd -C -N1 accepting the page's modern forwarding
+# examples that can validate offline. The targetSrv example is left to the
+# dedicated SRV-discovery test family because config validation performs a real
+# DNS lookup and fails without an SRV-backed fixture.
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+cat > "${RSYSLOG_DYNNAME}.omfwd.conf" <<CONF_EOF
+action(
+    type="omfwd"
+    target="logs.example.com"
+    port="514"
+    protocol="tcp"
+    queue.type="linkedList"
+)
+
+action(
+    type="omfwd"
+    target="logs.example.com"
+    port="6514"
+    protocol="tcp"
+    StreamDriver="ossl"
+    StreamDriverMode="1"
+    StreamDriverAuthMode="x509/name"
+    StreamDriverPermittedPeers="logs.example.com"
+)
+
+action(
+    type="omfwd"
+    target="remote.example.com"
+    port="514"
+    protocol="tcp"
+    queue.type="linkedList"
+)
+
+action(
+    type="omfwd"
+    target="remote.example.com"
+    port="515"
+    protocol="udp"
+)
+CONF_EOF
+
+doc_sample_expect_config_valid \
+	"omfwd" \
+	"${RSYSLOG_DYNNAME}.omfwd.conf"
+
+exit_test

--- a/tests/doc-sample-order-matters.sh
+++ b/tests/doc-sample-order-matters.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Validate the stop-order examples from
+# doc/source/getting_started/beginner_tutorials/05-order-matters.rst.
+# The oracle is rsyslogd -C -N1 accepting both ordered rule variants.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+require_plugin imuxsock
+
+cat > "${RSYSLOG_DYNNAME}.order-matters.conf" <<'CONF_EOF'
+module(load="../plugins/imuxsock/.libs/imuxsock")
+
+if ($msg contains "error") then {
+    action(type="omfile" file="/var/log/errors.log")
+    stop
+}
+
+action(type="omfile" file="/var/log/all.log")
+
+if ($msg contains "error") then {
+    action(type="omfile" file="/var/log/errors.log")
+}
+
+action(type="omfile" file="/var/log/all.log")
+CONF_EOF
+
+doc_sample_expect_config_valid "order-matters" "${RSYSLOG_DYNNAME}.order-matters.conf"
+exit_test

--- a/tests/doc-sample-reliable-forwarding.sh
+++ b/tests/doc-sample-reliable-forwarding.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Validate the reliable forwarding tutorial examples from
+# doc/source/tutorials/reliable_forwarding.rst.
+# The oracle is rsyslogd -C -N1 accepting both disk-assisted forwarding
+# examples so the queueing tutorial remains aligned with current syntax. The
+# testbench rewrites the workDirectory to an absolute per-test spool dir so
+# validation does not depend on creating /rsyslog/work on the host.
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+require_plugin imuxsock
+
+mkdir -p "${RSYSLOG_DYNNAME}.spool"
+
+cat > "${RSYSLOG_DYNNAME}.reliable-forwarding.conf" <<CONF_EOF
+module(load="../plugins/imuxsock/.libs/imuxsock")
+global(workDirectory="${PWD}/${RSYSLOG_DYNNAME}.spool")
+
+action(
+    type="omfwd"
+    target="loghost.example.net"
+    port="10514"
+    protocol="tcp"
+    action.resumeRetryCount="-1"
+    queue.type="LinkedList"
+    queue.filename="srvrfwd"
+    queue.saveOnShutdown="on"
+)
+
+action(
+    type="omfwd"
+    target="west-loghost.example.net"
+    port="10514"
+    protocol="tcp"
+    action.resumeRetryCount="-1"
+    queue.type="LinkedList"
+    queue.filename="srvrfwd1"
+    queue.saveOnShutdown="on"
+)
+
+action(
+    type="omfwd"
+    target="east-loghost.example.net"
+    protocol="tcp"
+    action.resumeRetryCount="-1"
+    queue.type="LinkedList"
+    queue.filename="srvrfwd2"
+    queue.saveOnShutdown="on"
+)
+CONF_EOF
+
+doc_sample_expect_config_valid \
+	"reliable-forwarding" \
+	"${RSYSLOG_DYNNAME}.reliable-forwarding.conf"
+
+exit_test

--- a/tests/doc-sample-remote-server.sh
+++ b/tests/doc-sample-remote-server.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Validate the remote reception and forwarding examples from
+# doc/source/getting_started/beginner_tutorials/06-remote-server.rst.
+# The oracle is rsyslogd -C -N1 accepting both the UDP listener and forwarder.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+require_plugin imudp
+
+cat > "${RSYSLOG_DYNNAME}.remote-server.conf" <<'CONF_EOF'
+module(load="../plugins/imudp/.libs/imudp")
+
+input(type="imudp" port="514")
+
+action(
+    type="omfwd"
+    target="192.0.2.10"
+    port="514"
+    protocol="udp"
+)
+CONF_EOF
+
+doc_sample_expect_config_valid "remote-server" "${RSYSLOG_DYNNAME}.remote-server.conf"
+exit_test

--- a/tests/doc-sample-understanding-default-config.sh
+++ b/tests/doc-sample-understanding-default-config.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Validate the modern extension examples from
+# doc/source/getting_started/understanding_default_config.rst.
+# The oracle is rsyslogd -C -N1 accepting the mixed-syntax coexistence example.
+
+. ${srcdir:=.}/diag.sh init
+. $srcdir/doc-sample-lib.sh
+
+require_plugin imuxsock
+require_plugin imjournal
+
+cat > "${RSYSLOG_DYNNAME}.understanding-default-config.conf" <<'CONF_EOF'
+module(load="../plugins/imuxsock/.libs/imuxsock")
+module(load="../plugins/imjournal/.libs/imjournal")
+
+if ($syslogfacility-text == "local3") then {
+    action(type="omfile" file="/var/log/local3.log")
+}
+CONF_EOF
+
+doc_sample_expect_config_valid "understanding-default-config" "${RSYSLOG_DYNNAME}.understanding-default-config.conf"
+exit_test


### PR DESCRIPTION
## Summary
- add a first tranche of `doc-sample-*` tests for user-facing configuration examples
- fix the database tutorial sample that the new coverage exposed
- keep this branch open for incremental follow-up commits that extend coverage across more doc samples

## Validation
- rendered docs build passed locally
- local Cubic review passed locally
- focused first-tranche doc-sample runs are clean with the expected host-local result of 6 pass / 1 skip
- the skip is `doc-sample-database.sh` on hosts where `ommysql` exists in-tree but cannot load because a shared-library dependency such as `libmysqlclient.so.24` is missing
- `devtools/local-validation-plan.sh --run` is not yet fully green because it also hit unrelated existing failures in `imdtls-basic-vg` and `omprog-diskq-restart-save`

## Notes
This is intended as an incremental PR. I will keep extending coverage, including simpler documentation examples, in additional commits on the same branch.
