### PR TITLE
dev_env: include lcov in Ubuntu coverage images

### DIFF
--- a/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
@@ -61,6 +61,7 @@ RUN 	apt-get update && \
 	libwolfssl-dev \
 	libyaml-dev \
 	libzstd-dev \
+	lcov \
 	logrotate \
 	lsof \
 	make \

--- a/packaging/docker/dev_env/ubuntu/base/26.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/26.04/Dockerfile
@@ -62,6 +62,7 @@ RUN 	apt-get update && \
 	libwolfssl-dev \
 	libyaml-dev \
 	libzstd-dev \
+	lcov \
 	logrotate \
 	lsof \
 	make \


### PR DESCRIPTION
## Summary

- add `lcov` to the Ubuntu 24.04 and 26.04 dev base image package lists
- keeps `genhtml` available with the lcov package for local and CI-style coverage reporting

## Validation

- `devtools/local-validation-plan.sh`
- `hadolint packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile packaging/docker/dev_env/ubuntu/base/26.04/Dockerfile` (existing baseline warnings only)
- `trivy config --severity HIGH,CRITICAL packaging/docker/dev_env/ubuntu/base` (existing baseline DS-0029 findings only)
- `cubic review --base origin/main ...` -> no issues found
- `docker build -t rsyslog-dev-base-ubuntu-26.04-lcov-local packaging/docker/dev_env/ubuntu/base/26.04 --progress=plain`
- `docker run --rm -u 1000:1000 rsyslog-dev-base-ubuntu-26.04-lcov-local ...` verified `lcov`, `genhtml`, and passwordless sudo
- `docker build -t rsyslog-dev-base-ubuntu-24.04-lcov-local packaging/docker/dev_env/ubuntu/base/24.04 --progress=plain`
- `docker run --rm -u 1000:1000 rsyslog-dev-base-ubuntu-24.04-lcov-local ...` verified `lcov`, `genhtml`, and passwordless sudo
