### PR TITLE
translate: cover script serialization

### DIFF
--- a/runtime/translate.c
+++ b/runtime/translate.c
@@ -843,7 +843,7 @@ static int estrAppendChar(es_str_t **s, char c) {
 }
 
 static int estrAppendVarName(es_str_t **s, const char *name) {
-    if (name == NULL) return -1;
+    if (name == NULL || name[0] == '\0') return -1;
     if (name[0] != '$' && estrAppendChar(s, '$') != 0) return -1;
     return estrAppendCstr(s, name);
 }

--- a/runtime/translate.c
+++ b/runtime/translate.c
@@ -842,6 +842,12 @@ static int estrAppendChar(es_str_t **s, char c) {
     return es_addChar(s, (unsigned char)c);
 }
 
+static int estrAppendVarName(es_str_t **s, const char *name) {
+    if (name == NULL) return -1;
+    if (name[0] != '$' && estrAppendChar(s, '$') != 0) return -1;
+    return estrAppendCstr(s, name);
+}
+
 static int estrAppendQuoted(es_str_t **s, const char *buf) {
     size_t i;
     if (estrAppendChar(s, '"') != 0) return -1;
@@ -949,7 +955,7 @@ static int exprToString(es_str_t **out, const struct cnfexpr *expr, struct rscon
             free(cstr);
             return i;
         case 'V':
-            return estrAppendCstr(out, ((const struct cnfvar *)expr)->name);
+            return estrAppendVarName(out, ((const struct cnfvar *)expr)->name);
         case 'A':
             ar = (const struct cnfarray *)expr;
             if (estrAppendChar(out, '[') != 0) return -1;
@@ -981,7 +987,7 @@ static int exprToString(es_str_t **out, const struct cnfexpr *expr, struct rscon
             return 0;
         case S_FUNC_EXISTS:
             if (estrAppendCstr(out, "exists(") != 0) return -1;
-            if (estrAppendCstr(out, ((const struct cnffuncexists *)expr)->varname) != 0) return -1;
+            if (estrAppendVarName(out, ((const struct cnffuncexists *)expr)->varname) != 0) return -1;
             return estrAppendChar(out, ')');
         case '&':
         case '+':
@@ -1146,13 +1152,13 @@ static int stmtListToString(es_str_t **out,
             case S_SET:
                 if (appendIndent(out, indent) != 0) return -1;
                 if (estrAppendCstr(out, stmt->d.s_set.force_reset ? "reset " : "set ") != 0 ||
-                    estrAppendCstr(out, (char *)stmt->d.s_set.varname) != 0 || estrAppendCstr(out, " = ") != 0 ||
+                    estrAppendVarName(out, (char *)stmt->d.s_set.varname) != 0 || estrAppendCstr(out, " = ") != 0 ||
                     exprToString(out, stmt->d.s_set.expr, warnings) != 0 || estrAppendCstr(out, ";\n") != 0)
                     return -1;
                 break;
             case S_UNSET:
                 if (appendIndent(out, indent) != 0 || estrAppendCstr(out, "unset ") != 0 ||
-                    estrAppendCstr(out, (char *)stmt->d.s_unset.varname) != 0 || estrAppendCstr(out, ";\n") != 0)
+                    estrAppendVarName(out, (char *)stmt->d.s_unset.varname) != 0 || estrAppendCstr(out, ";\n") != 0)
                     return -1;
                 break;
             case S_IF:
@@ -1172,7 +1178,7 @@ static int stmtListToString(es_str_t **out,
                 break;
             case S_FOREACH:
                 if (appendIndent(out, indent) != 0 || estrAppendCstr(out, "foreach (") != 0 ||
-                    estrAppendCstr(out, stmt->d.s_foreach.iter->var) != 0 || estrAppendCstr(out, " in ") != 0 ||
+                    estrAppendVarName(out, stmt->d.s_foreach.iter->var) != 0 || estrAppendCstr(out, " in ") != 0 ||
                     exprToString(out, stmt->d.s_foreach.iter->collection, warnings) != 0 ||
                     estrAppendCstr(out, ") do {\n") != 0 ||
                     stmtListToString(out, stmt->d.s_foreach.body, indent + 1, warnings) != 0 ||

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -608,6 +608,8 @@ TESTS_LIBGCRYPT_VALGRIND = \
 TESTS_LIBYAML = \
 	config-translate-rs-to-yaml.sh \
 	config-translate-rs-filter-actions.sh \
+	config-translate-rs-script-expressions.sh \
+	config-translate-rs-statements-to-yaml.sh \
 	config-translate-legacy-debian-default.sh \
 	config-translate-legacy-file-action.sh \
 	config-translate-yaml-to-rs.sh \

--- a/tests/config-translate-rs-script-expressions.sh
+++ b/tests/config-translate-rs-script-expressions.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Check canonical RainerScript emission for complex script statements.
+#
+# This is a cheap -N1 translation test for runtime/translate.c's script
+# serializer. It covers escaped strings, arrays, unary minus, set/reset/unset,
+# boolean/comparison expressions, exists(), foreach, call, call_indirect, and
+# if/else block formatting. The translated RainerScript is validated again so
+# the exact-output oracle proves the emitted config remains parseable.
+#
+# Part of the testbench for rsyslog.
+#
+# This file is part of rsyslog.
+# Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+modpath="../runtime/.libs:../.libs"
+target_out="/tmp/${RSYSLOG_DYNNAME}.target.log"
+
+cat > "${RSYSLOG_DYNNAME}.conf" <<'RS_EOF'
+ruleset(name="target") {
+  action(type="omfile" file="@TARGET_OUT@")
+}
+
+ruleset(name="main") {
+  set $.n = -7;
+  set $.s = "line\nquote\"tab\tbackslash\\";
+  set $.arr = ["one", "two"];
+  reset $.scratch = $.arr;
+  unset $.arr;
+  if not exists($!missing) and (($msg contains_i "ERR") or ($msg startswith " start")) then {
+    foreach ($.item in $!items) do {
+      call target
+    }
+  } else {
+    call_indirect "tar" & "get";
+  }
+}
+RS_EOF
+sed -i "s|@TARGET_OUT@|${target_out}|g" "${RSYSLOG_DYNNAME}.conf"
+
+../tools/rsyslogd -N1 -f "${RSYSLOG_DYNNAME}.conf" -F rainerscript -o "${RSYSLOG_DYNNAME}.out.conf" -M"$modpath" ||
+	error_exit $?
+
+cat > "${RSYSLOG_DYNNAME}.expected.conf" <<'RS_EOF'
+ruleset(name="target") {
+  action(type="omfile" file="@TARGET_OUT@")
+}
+
+ruleset(name="main") {
+  set $.n = -7;
+  set $.s = "line\nquote\"tab\tbackslash\\";
+  set $.arr = ["one", "two"];
+  reset $.scratch = $.arr;
+  unset $.arr;
+  if (not exists($!missing) and (($msg contains_i "ERR") or ($msg startswith " start"))) then {
+    foreach ($.item in $!items) do {
+      call target
+    }
+  } else {
+    call_indirect ("tar" & "get");
+  }
+}
+
+RS_EOF
+sed -i "s|@TARGET_OUT@|${target_out}|g" "${RSYSLOG_DYNNAME}.expected.conf"
+cmp_exact_file "${RSYSLOG_DYNNAME}.expected.conf" "${RSYSLOG_DYNNAME}.out.conf"
+
+../tools/rsyslogd -N1 -f "${RSYSLOG_DYNNAME}.out.conf" -M"$modpath" || error_exit $?
+
+echo SUCCESS: RainerScript script expression translation
+exit_test

--- a/tests/config-translate-rs-script-expressions.sh
+++ b/tests/config-translate-rs-script-expressions.sh
@@ -35,7 +35,8 @@ ruleset(name="main") {
   }
 }
 RS_EOF
-sed -i "s|@TARGET_OUT@|${target_out}|g" "${RSYSLOG_DYNNAME}.conf"
+sed "s|@TARGET_OUT@|${target_out}|g" "${RSYSLOG_DYNNAME}.conf" >"${RSYSLOG_DYNNAME}.conf.tmp" &&
+	mv "${RSYSLOG_DYNNAME}.conf.tmp" "${RSYSLOG_DYNNAME}.conf"
 
 ../tools/rsyslogd -N1 -f "${RSYSLOG_DYNNAME}.conf" -F rainerscript -o "${RSYSLOG_DYNNAME}.out.conf" -M"$modpath" ||
 	error_exit $?
@@ -61,7 +62,8 @@ ruleset(name="main") {
 }
 
 RS_EOF
-sed -i "s|@TARGET_OUT@|${target_out}|g" "${RSYSLOG_DYNNAME}.expected.conf"
+sed "s|@TARGET_OUT@|${target_out}|g" "${RSYSLOG_DYNNAME}.expected.conf" >"${RSYSLOG_DYNNAME}.expected.conf.tmp" &&
+	mv "${RSYSLOG_DYNNAME}.expected.conf.tmp" "${RSYSLOG_DYNNAME}.expected.conf"
 cmp_exact_file "${RSYSLOG_DYNNAME}.expected.conf" "${RSYSLOG_DYNNAME}.out.conf"
 
 ../tools/rsyslogd -N1 -f "${RSYSLOG_DYNNAME}.out.conf" -M"$modpath" || error_exit $?

--- a/tests/config-translate-rs-statements-to-yaml.sh
+++ b/tests/config-translate-rs-statements-to-yaml.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Check RainerScript selector bodies translated into canonical YAML statements.
+#
+# This keeps coverage focused on runtime/translate.c without starting a daemon:
+# multiple legacy selector statements must become a YAML statements: list, a
+# selector with two structured actions must use then:, and a single-action
+# selector must use the compact action: form. The generated YAML is validated
+# with -N1 so the exact-output oracle also proves the translation is parseable.
+#
+# Part of the testbench for rsyslog.
+#
+# This file is part of rsyslog.
+# Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+modpath="../runtime/.libs:../.libs"
+out_a="/tmp/${RSYSLOG_DYNNAME}.a.log"
+out_a2="/tmp/${RSYSLOG_DYNNAME}.a2.log"
+out_b="/tmp/${RSYSLOG_DYNNAME}.b.log"
+
+cat > "${RSYSLOG_DYNNAME}.conf" <<RS_EOF
+ruleset(name="main") {
+  mail.info action(type="omfile" file="${out_a}")
+  & action(type="omfile" file="${out_a2}")
+  authpriv.* action(type="omfile" file="${out_b}")
+}
+RS_EOF
+
+../tools/rsyslogd -N1 -f "${RSYSLOG_DYNNAME}.conf" -F yaml -o "${RSYSLOG_DYNNAME}.yaml" -M"$modpath" ||
+	error_exit $?
+
+cat > "${RSYSLOG_DYNNAME}.expected.yaml" <<YAML_EOF
+version: 2
+
+rulesets:
+  - name: "main"
+    statements:
+      - if: "prifilt('mail.info')"
+        then:
+          - type: "omfile"
+            file: "${out_a}"
+          - type: "omfile"
+            file: "${out_a2}"
+      - if: "prifilt('authpriv.*')"
+        action:
+          type: "omfile"
+          file: "${out_b}"
+YAML_EOF
+cmp_exact_file "${RSYSLOG_DYNNAME}.expected.yaml" "${RSYSLOG_DYNNAME}.yaml"
+
+../tools/rsyslogd -N1 -f "${RSYSLOG_DYNNAME}.yaml" -M"$modpath" || error_exit $?
+
+echo SUCCESS: RainerScript selector statements to YAML translation
+exit_test


### PR DESCRIPTION
## Summary
- add focused -N1 translation tests for canonical RainerScript script serialization
- add focused selector-to-YAML statements translation coverage
- preserve leading dollar signs when serializing variables in translated RainerScript output

## Root cause
The RainerScript serializer was emitting internal variable names directly in several paths. Those names can be stored without the leading dollar sign, which produced invalid translated output such as set .n = -7.

## Validation
- bash syntax checks for both new tests
- devtools/format-code.sh --git-changed --check --check-if-available
- git diff --check
- targeted Ubuntu 26.04 dev_env run of both new tests
- devtools/local-validation-plan.sh --run including Cubic, static analyzer, and change-gated Ubuntu 26.04 run-ci.sh check
