### PR TITLE
core/imfile: synchronize sd_notify READY=1 with module startup

### DIFF
--- a/doc/source/rainerscript/global.rst
+++ b/doc/source/rainerscript/global.rst
@@ -127,7 +127,18 @@ The following parameters can be set:
   Note that earlier versions of rsyslog worked the opposite way. More
   information about the change can be found in `rsyslog-error-reporting-improved <http://www.rsyslog.com/rsyslog-error-reporting-improved>`_.
 
+- **systemd.notifyReadyDelay** binary (on/off), default "off"
 
+  When set to "on", rsyslog delays the systemd ``READY=1`` notification until
+  input modules that explicitly participate in startup readiness have completed
+  their initialisation, or until the readiness wait times out. This can help
+  deployments where services ordered after rsyslog must not begin until inputs
+  such as imfile have loaded their startup state.
+
+  The default is "off" to preserve the historical startup behavior: rsyslog
+  sends ``READY=1`` as soon as the daemon reaches the normal post-startup
+  notification point. Modules that do not participate in the readiness scheme
+  are unaffected.
 
 - **stdlog.channelspec**
 

--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -2909,7 +2909,10 @@ static rsRetVal do_inotify(void) {
 
 finalize_it:
     if (!bSignaledReady) rsconfSignalReady();
-    close(ino_fd);
+    if (ino_fd >= 0) {
+        close(ino_fd);
+        ino_fd = -1;
+    }
     RETiRet;
 }
 

--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -57,6 +57,7 @@
     #include <sys/port.h>
 #endif
 #include "rsyslog.h" /* error codes etc... */
+#include "rsconf.h"
 #include "dirty.h"
 #include "cfsysline.h" /* access to config file objects */
 #include "module-template.h" /* generic module interface code - very important, read it! */
@@ -2608,6 +2609,7 @@ static void do_initial_poll_run(void) {
     for (instanceConf_t *inst = runModConf->root; inst != NULL; inst = inst->next) {
         inst->freshStartTail = 0;
     }
+    rsconfSignalReady();
 }
 
 
@@ -2769,6 +2771,7 @@ static rsRetVal do_inotify(void) {
     time_t last_fallback = 0;
     time_t last_delete_check = 0;
     struct pollfd pollfd;
+    int bSignaledReady = 0;
     DEFiRet;
 
     CHKiRet(wdmapInit());
@@ -2777,11 +2780,12 @@ static rsRetVal do_inotify(void) {
         LogError(errno, RS_RET_INOTIFY_INIT_FAILED,
                  "imfile: Init inotify "
                  "instance failed ");
-        return RS_RET_INOTIFY_INIT_FAILED;
+        ABORT_FINALIZE(RS_RET_INOTIFY_INIT_FAILED);
     }
     DBGPRINTF("inotify fd %d\n", ino_fd);
 
     do_initial_poll_run();
+    bSignaledReady = 1;
 
     while (glbl.GetGlobalInputTermState() == 0) {
         int r;
@@ -2904,6 +2908,7 @@ static rsRetVal do_inotify(void) {
     }
 
 finalize_it:
+    if (!bSignaledReady) rsconfSignalReady();
     close(ino_fd);
     RETiRet;
 }
@@ -2963,6 +2968,7 @@ static rsRetVal do_fen(void) {
     /* create port instance */
     if ((glport = port_create()) == -1) {
         LogError(errno, RS_RET_FEN_INIT_FAILED, "do_fen INIT Port failed ");
+        rsconfSignalReady();
         return RS_RET_FEN_INIT_FAILED;
     }
 
@@ -3063,6 +3069,7 @@ BEGINwillRun
     CHKiRet(prop.Construct(&pInputName));
     CHKiRet(prop.SetString(pInputName, UCHAR_CONSTANT("imfile"), sizeof("imfile") - 1));
     CHKiRet(prop.ConstructFinalize(pInputName));
+    rsconfRegisterReadiness();
 finalize_it:
 ENDwillRun
 

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -173,6 +173,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
     {"compatibility.configformat.syslogd", eCmdHdlrGetWord, 0},
     {"compatibility.configformat.property", eCmdHdlrGetWord, 0},
     {"compatibility.defaults.secure", eCmdHdlrGetWord, 0},
+    {"systemd.notifyreadydelay", eCmdHdlrBinary, 0},
     {"abortonuncleanconfig", eCmdHdlrBinary, 0},
     {"abortonfailedqueuestartup", eCmdHdlrBinary, 0},
     {"variables.casesensitive", eCmdHdlrBinary, 0},
@@ -1175,6 +1176,7 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) * pp, void __
     free((void *)loadConf->globals.operatingStateFile);
     loadConf->globals.operatingStateFile = NULL;
     loadConf->globals.bDropMalPTRMsgs = 0;
+    loadConf->globals.systemdNotifyReadyDelay = 0;
     bPreserveFQDN = 0;
     loadConf->globals.iMaxLine = 8192;
     loadConf->globals.reportOversizeMsg = 1;
@@ -1553,6 +1555,8 @@ rsRetVal glblDoneLoadCnf(void) {
             SetOptionDisallowWarning(!((int)cnfparamvals[i].val.d.n));
         } else if (!strncmp(paramblk.descr[i].name, "compatibility.", 14)) {
             /* processed immediately by glblProcessCnf(), as later syntax depends on it */
+        } else if (!strcmp(paramblk.descr[i].name, "systemd.notifyreadydelay")) {
+            loadConf->globals.systemdNotifyReadyDelay = (int)cnfparamvals[i].val.d.n;
         } else if (!strcmp(paramblk.descr[i].name, "abortonuncleanconfig")) {
             loadConf->globals.bAbortOnUncleanConfig = cnfparamvals[i].val.d.n;
         } else if (!strcmp(paramblk.descr[i].name, "abortonfailedqueuestartup")) {

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -90,22 +90,64 @@ rsconf_t *loadConf = NULL; /* the config currently being loaded (no concurrent c
 
 #ifdef HAVE_LIBSYSTEMD
 /* module readiness barrier: modules that need startup time call rsconfRegisterReadiness(),
- * then rsconfSignalReady() once initialised. rsconfWaitForModulesReady() blocks until all
- * registered modules have signalled, then sd_notify(READY=1) can fire safely.
- * The whole barrier is compiled only when systemd support is present; on non-systemd
- * builds, rsconf.h provides inline no-ops for Register/Signal so opt-in modules
- * (imfile, etc.) need no #ifdef guards of their own. */
+ * then rsconfSignalReady() once initialised. When global(systemd.notifyReadyDelay="on")
+ * is configured, rsconfWaitForModulesReady() blocks until all registered modules have
+ * signalled, then sd_notify(READY=1) can fire safely. The whole barrier is compiled only
+ * when systemd support is present; on non-systemd builds, rsconf.h provides inline no-ops
+ * for Register/Signal so opt-in modules need no #ifdef guards of their own. */
 static pthread_mutex_t mutModulesReady = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t condModulesReady = PTHREAD_COND_INITIALIZER;
+static pthread_cond_t condModulesReady;
+static pthread_once_t onceModulesReadyCond = PTHREAD_ONCE_INIT;
+static clockid_t clockModulesReady = CLOCK_REALTIME;
 static int nModulesPendingReady = 0;
+static int bModulesReadyWaitStarted = 0;
+static int bModulesReadyWaitActive = 0;
+static int bModulesReadyNotifySent = 0;
+
+static void initModulesReadyCond(void) {
+    pthread_condattr_t attr;
+
+    if (pthread_condattr_init(&attr) != 0) {
+        pthread_cond_init(&condModulesReady, NULL);
+        return;
+    }
+    if (pthread_condattr_setclock(&attr, CLOCK_MONOTONIC) == 0) {
+        clockModulesReady = CLOCK_MONOTONIC;
+    }
+    if (pthread_cond_init(&condModulesReady, &attr) != 0) {
+        pthread_cond_init(&condModulesReady, NULL);
+        clockModulesReady = CLOCK_REALTIME;
+    }
+    pthread_condattr_destroy(&attr);
+}
+
+int rsconfShouldDelayReadyNotify(rsconf_t *cnf) {
+    return cnf != NULL && cnf->globals.systemdNotifyReadyDelay;
+}
 
 void rsconfRegisterReadiness(void) {
+    pthread_once(&onceModulesReadyCond, initModulesReadyCond);
+    if (!rsconfShouldDelayReadyNotify(runConf)) return;
+
     pthread_mutex_lock(&mutModulesReady);
-    ++nModulesPendingReady;
+    if (bModulesReadyNotifySent) {
+        /* Reload-time module setup happens after the one-shot systemd READY=1. */
+    } else if (bModulesReadyWaitActive) {
+        LogError(0, RS_RET_SYS_ERR,
+                 "rsyslogd: module registered readiness after systemd READY wait "
+                 "started - ignoring late registration");
+    } else if (bModulesReadyWaitStarted) {
+        /* The initial barrier already closed; do not corrupt the pending count. */
+    } else {
+        ++nModulesPendingReady;
+    }
     pthread_mutex_unlock(&mutModulesReady);
 }
 
 void rsconfSignalReady(void) {
+    pthread_once(&onceModulesReadyCond, initModulesReadyCond);
+    if (!rsconfShouldDelayReadyNotify(runConf)) return;
+
     pthread_mutex_lock(&mutModulesReady);
     if (nModulesPendingReady > 0 && --nModulesPendingReady == 0) pthread_cond_broadcast(&condModulesReady);
     pthread_mutex_unlock(&mutModulesReady);
@@ -114,7 +156,20 @@ void rsconfSignalReady(void) {
 /* Wait up to 60 s for all registered modules to signal readiness. */
 void rsconfWaitForModulesReady(void) {
     struct timespec ts;
-    timeoutComp(&ts, 60000); /* 60 000 ms = 60 s */
+    pthread_once(&onceModulesReadyCond, initModulesReadyCond);
+    pthread_mutex_lock(&mutModulesReady);
+    bModulesReadyWaitStarted = 1;
+    bModulesReadyWaitActive = 1;
+    pthread_mutex_unlock(&mutModulesReady);
+
+    if (clock_gettime(clockModulesReady, &ts) != 0) {
+        LogError(errno, RS_RET_SYS_ERR, "rsyslogd: cannot compute module readiness timeout - sending READY=1 anyway");
+        pthread_mutex_lock(&mutModulesReady);
+        bModulesReadyWaitActive = 0;
+        pthread_mutex_unlock(&mutModulesReady);
+        return;
+    }
+    ts.tv_sec += 60;
     pthread_mutex_lock(&mutModulesReady);
     while (nModulesPendingReady > 0) {
         const int rc = pthread_cond_timedwait(&condModulesReady, &mutModulesReady, &ts);
@@ -132,6 +187,14 @@ void rsconfWaitForModulesReady(void) {
             break;
         }
     }
+    bModulesReadyWaitActive = 0;
+    pthread_mutex_unlock(&mutModulesReady);
+}
+
+void rsconfReadyNotifySent(void) {
+    pthread_once(&onceModulesReadyCond, initModulesReadyCond);
+    pthread_mutex_lock(&mutModulesReady);
+    bModulesReadyNotifySent = 1;
     pthread_mutex_unlock(&mutModulesReady);
 }
 #endif /* HAVE_LIBSYSTEMD */

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -30,6 +30,8 @@
 #include <pwd.h>
 #include <grp.h>
 #include <stdarg.h>
+#include <pthread.h>
+#include <time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/socket.h>
@@ -85,6 +87,54 @@ DEFobjCurrIf(ruleset) DEFobjCurrIf(module) DEFobjCurrIf(conf) DEFobjCurrIf(glbl)
     /* exported static data */
     rsconf_t *runConf = NULL; /* the currently running config */
 rsconf_t *loadConf = NULL; /* the config currently being loaded (no concurrent config load supported!) */
+
+#ifdef HAVE_LIBSYSTEMD
+/* module readiness barrier: modules that need startup time call rsconfRegisterReadiness(),
+ * then rsconfSignalReady() once initialised. rsconfWaitForModulesReady() blocks until all
+ * registered modules have signalled, then sd_notify(READY=1) can fire safely.
+ * The whole barrier is compiled only when systemd support is present; on non-systemd
+ * builds, rsconf.h provides inline no-ops for Register/Signal so opt-in modules
+ * (imfile, etc.) need no #ifdef guards of their own. */
+static pthread_mutex_t mutModulesReady = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t condModulesReady = PTHREAD_COND_INITIALIZER;
+static int nModulesPendingReady = 0;
+
+void rsconfRegisterReadiness(void) {
+    pthread_mutex_lock(&mutModulesReady);
+    ++nModulesPendingReady;
+    pthread_mutex_unlock(&mutModulesReady);
+}
+
+void rsconfSignalReady(void) {
+    pthread_mutex_lock(&mutModulesReady);
+    if (nModulesPendingReady > 0 && --nModulesPendingReady == 0) pthread_cond_broadcast(&condModulesReady);
+    pthread_mutex_unlock(&mutModulesReady);
+}
+
+/* Wait up to 60 s for all registered modules to signal readiness. */
+void rsconfWaitForModulesReady(void) {
+    struct timespec ts;
+    timeoutComp(&ts, 60000); /* 60 000 ms = 60 s */
+    pthread_mutex_lock(&mutModulesReady);
+    while (nModulesPendingReady > 0) {
+        const int rc = pthread_cond_timedwait(&condModulesReady, &mutModulesReady, &ts);
+        if (rc == ETIMEDOUT) {
+            LogError(0, RS_RET_TIMED_OUT,
+                     "rsyslogd: timed out waiting for input modules to signal readiness "
+                     "(%d module(s) outstanding) - sending READY=1 anyway",
+                     nModulesPendingReady);
+            break;
+        } else if (rc != 0) {
+            LogError(0, RS_RET_SYS_ERR,
+                     "rsyslogd: pthread_cond_timedwait error %d waiting for module "
+                     "readiness - sending READY=1 anyway",
+                     rc);
+            break;
+        }
+    }
+    pthread_mutex_unlock(&mutModulesReady);
+}
+#endif /* HAVE_LIBSYSTEMD */
 
 /* hardcoded standard templates (used for defaults) */
 static uchar template_DebugFormat[] =

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -113,6 +113,7 @@ struct globals_s {
     int compatConfigFormatSyslogd; /* policy for classic syslogd PRI selectors */
     int compatConfigFormatProperty; /* policy for classic property-based selector filters */
     int compatDefaultsSecure; /* policy for defaults that affect secure-by-default behavior */
+    int systemdNotifyReadyDelay; /* delay sd_notify READY=1 until opt-in modules report ready */
     int uidDropPriv; /* user-id to which priveleges should be dropped to */
     int gidDropPriv; /* group-id to which priveleges should be dropped to */
     int gidDropPrivKeepSupplemental; /* keep supplemental groups when dropping? */
@@ -320,6 +321,8 @@ int rsconfNeedDropPriv(rsconf_t *const cnf);
 void rsconfRegisterReadiness(void);
 void rsconfSignalReady(void);
 void rsconfWaitForModulesReady(void);
+void rsconfReadyNotifySent(void);
+int rsconfShouldDelayReadyNotify(rsconf_t *cnf);
 #else
 static inline void rsconfRegisterReadiness(void) {}
 static inline void rsconfSignalReady(void) {}

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -313,6 +313,18 @@ extern rsconf_t *loadConf; /* the config currently being loaded (no concurrent c
 
 int rsconfNeedDropPriv(rsconf_t *const cnf);
 
+/* module readiness barrier (see rsconf.c for details).
+ * Only meaningful when rsyslog is managed by systemd; stubs compile away
+ * otherwise so imfile and other opt-in modules need no #ifdef guards. */
+#ifdef HAVE_LIBSYSTEMD
+void rsconfRegisterReadiness(void);
+void rsconfSignalReady(void);
+void rsconfWaitForModulesReady(void);
+#else
+static inline void rsconfRegisterReadiness(void) {}
+static inline void rsconfSignalReady(void) {}
+#endif
+
 /* some defaults (to be removed?) */
 #define DFLT_bLogStatusMsgs 1
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -328,6 +328,7 @@ TESTS_DEFAULT = \
 	imdiag-proper-termination-timeoutguard.sh \
 	tcpflood-proper-termination.sh \
 	global-maxopenfiles-rainerscript.sh \
+	global-systemd-notifyreadydelay-rainerscript.sh \
 	compat-configformat-rainerscript.sh \
 	compat-defaults-secure-dynafile-rainerscript.sh \
 	abort-uncleancfg-goodcfg.sh \
@@ -654,6 +655,7 @@ TESTS_LIBYAML = \
 	compat-configformat-yaml.sh \
 	compat-defaults-secure-dynafile-yaml.sh \
 	global-maxopenfiles-yaml.sh \
+	global-systemd-notifyreadydelay-yaml.sh \
 	action-ratelimit-drop.sh \
 	action-ratelimit-pace.sh \
 	action-ratelimit-reload.sh \

--- a/tests/global-systemd-notifyreadydelay-rainerscript.sh
+++ b/tests/global-systemd-notifyreadydelay-rainerscript.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Validate the global(systemd.notifyReadyDelay=...) operator opt-in. The
+# oracle is config validation accepting both binary values, which exercises the
+# RainerScript global-parameter backend without depending on a systemd runtime.
+. ${srcdir:=.}/diag.sh init
+
+modpath="${RSYSLOG_MODDIR}"
+
+run_expect_success() {
+	local cfg="$1"
+	local log="$2"
+
+	../tools/rsyslogd -C -N1 -M"${modpath}" -f"${cfg}" >"${log}" 2>&1
+	local rc=$?
+	if [ $rc -ne 0 ]; then
+		echo "FAIL: expected ${cfg} to validate"
+		cat "${log}"
+		error_exit 1
+	fi
+}
+
+cat >"${RSYSLOG_DYNNAME}.off.conf" <<CONF_EOF
+global(systemd.notifyReadyDelay="off")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.off.conf" "${RSYSLOG_DYNNAME}.off.log"
+
+cat >"${RSYSLOG_DYNNAME}.on.conf" <<CONF_EOF
+global(systemd.notifyReadyDelay="on")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.on.conf" "${RSYSLOG_DYNNAME}.on.log"
+
+exit_test

--- a/tests/global-systemd-notifyreadydelay-yaml.sh
+++ b/tests/global-systemd-notifyreadydelay-yaml.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Validate YAML parity for global(systemd.notifyReadyDelay=...). The oracle is
+# config validation accepting both binary values through the YAML global
+# singleton object, independent of whether the test host runs under systemd.
+. ${srcdir:=.}/diag.sh init
+
+modpath="${RSYSLOG_MODDIR}"
+
+run_expect_success() {
+	local cfg="$1"
+	local log="$2"
+
+	../tools/rsyslogd -C -N1 -M"${modpath}" -f"${cfg}" >"${log}" 2>&1
+	local rc=$?
+	if [ $rc -ne 0 ]; then
+		echo "FAIL: expected ${cfg} to validate"
+		cat "${log}"
+		error_exit 1
+	fi
+}
+
+write_yaml_config() {
+	local cfg="$1"
+	local value="$2"
+
+	cat >"${cfg}" <<YAML_EOF
+version: 2
+global:
+  systemd.notifyReadyDelay: "${value}"
+rulesets:
+  - name: main
+    actions:
+      - type: omfile
+        file: "${RSYSLOG_DYNNAME}.out"
+YAML_EOF
+}
+
+write_yaml_config "${RSYSLOG_DYNNAME}.off.yaml" "off"
+run_expect_success "${RSYSLOG_DYNNAME}.off.yaml" "${RSYSLOG_DYNNAME}.off.log"
+
+write_yaml_config "${RSYSLOG_DYNNAME}.on.yaml" "on"
+run_expect_success "${RSYSLOG_DYNNAME}.on.yaml" "${RSYSLOG_DYNNAME}.on.log"
+
+exit_test

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -2666,12 +2666,17 @@ int main(int argc, char **argv) {
 
     initAll(argc, argv);
 #ifdef HAVE_LIBSYSTEMD
-    rsconfWaitForModulesReady();
+    if (rsconfShouldDelayReadyNotify(runConf)) {
+        rsconfWaitForModulesReady();
+    }
     if (sd_watchdog_enabled(0, &systemdWatchdogUsec) > 0) {
         systemdWatchdogEnabled = 1;
         dbgprintf("systemd watchdog enabled with interval %llu usec\n", (unsigned long long)systemdWatchdogUsec);
     }
     sd_notify(0, "READY=1");
+    if (rsconfShouldDelayReadyNotify(runConf)) {
+        rsconfReadyNotifySent();
+    }
     dbgprintf("done signaling to systemd that we are ready!\n");
 #endif
     DBGPRINTF("max message size: %d\n", glblGetMaxLine(runConf));

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -2666,6 +2666,7 @@ int main(int argc, char **argv) {
 
     initAll(argc, argv);
 #ifdef HAVE_LIBSYSTEMD
+    rsconfWaitForModulesReady();
     if (sd_watchdog_enabled(0, &systemdWatchdogUsec) > 0) {
         systemdWatchdogEnabled = 1;
         dbgprintf("systemd watchdog enabled with interval %llu usec\n", (unsigned long long)systemdWatchdogUsec);


### PR DESCRIPTION
### Summary (non-technical, complete)
When rsyslog is managed by systemd, it signals READY=1 to indicate it is fully operational. However, this signal was sent immediately after spawning input module threads, before those threads finished loading their state. For imfile, this means systemd considered rsyslog ready while it was still reading persisted file positions from disk. Services that depend on rsyslog, such as log shippers or monitoring agents, could start before rsyslog was actually processing files, silently dropping early log lines.

This change introduces an opt-in readiness barrier: modules register before their thread starts and signal when initialisation is complete. sd_notify is held until all registered modules have signalled, or a 60-second timeout expires. imfile is the first module to opt in. By default the barrier is disabled; operators enable it with global(systemd.notifyReadyDelay="on"). All other modules are unaffected.

### References
Fixes: https://github.com/rsyslog/rsyslog/issues/6810

### Notes
- Adds RainerScript and YAML parser coverage for global(systemd.notifyReadyDelay="on|off").
- Documents systemd.notifyReadyDelay under the global parameters.
- Other input modules with meaningful startup state, such as imjournal, imrelp, or imkafka, can opt in independently by calling rsconfRegisterReadiness() and rsconfSignalReady() following the same pattern as imfile.

---

#### Quick check
- [x] Commit message follows rules (ASCII; title ≤62 chars; `<component>:` prefix)
- [x] Commit message includes non-technical "why", Impact, and Before/After
- [x] Mirrored commit assistant structure