### PR TITLE
sidecar: cap UDP burst buffer memory in UDP mode

### DIFF
--- a/sidecar/docker-compose-udp.yml
+++ b/sidecar/docker-compose-udp.yml
@@ -28,8 +28,10 @@ services:
       LISTEN_ADDR: 0.0.0.0
       LISTEN_PORT: 9898
       LOG_LEVEL: INFO
-      # Optional: restrict UDP sources (comma-separated IPs)
-      # ALLOWED_UDP_SOURCES: "127.0.0.1,10.0.1.50"
+      # Strongly recommended for externally reachable UDP: restrict sources
+      # ALLOWED_UDP_SOURCES: "10.0.1.50"
+      # Optional: tighten burst payload memory cap (bytes, default 8388608)
+      # MAX_BURST_BUFFER_BYTES: "2097152"
       # Note: UDP mode requires a single gunicorn worker (default in image).
       # Increase workers only for file mode.
     ports:

--- a/sidecar/rsyslog_exporter.py
+++ b/sidecar/rsyslog_exporter.py
@@ -39,7 +39,8 @@ Configuration via environment variables:
 Security configuration (UDP mode):
 - ALLOWED_UDP_SOURCES: Comma-separated list of allowed source IPs (default: empty = allow all)
 - MAX_UDP_MESSAGE_SIZE: Maximum UDP packet size in bytes (default: 65535)
-- MAX_BURST_BUFFER_LINES: Maximum lines in burst buffer (default: 10000, prevents DoS)
+- MAX_BURST_BUFFER_LINES: Maximum lines in burst buffer (default: 10000)
+- MAX_BURST_BUFFER_BYTES: Maximum total buffered burst payload bytes (default: 8388608)
 
 Security Notes:
 - IMPSTATS_UDP_ADDR: Defaults to 127.0.0.1 (loopback). Use this for same-host rsyslog.
@@ -108,7 +109,8 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 
 # Security limits
 MAX_UDP_MESSAGE_SIZE = _int_env("MAX_UDP_MESSAGE_SIZE", "65535")  # Max UDP packet size
-MAX_BURST_BUFFER_LINES = _int_env("MAX_BURST_BUFFER_LINES", "10000")  # Prevent memory exhaustion
+MAX_BURST_BUFFER_LINES = _int_env("MAX_BURST_BUFFER_LINES", "10000")  # Prevent line-buffer exhaustion
+MAX_BURST_BUFFER_BYTES = _int_env("MAX_BURST_BUFFER_BYTES", "8388608")  # 8MiB total buffered payload cap
 ALLOWED_UDP_SOURCES = os.getenv("ALLOWED_UDP_SOURCES", "")  # Comma-separated IPs, empty = allow all
 
 # Logging setup
@@ -419,6 +421,7 @@ class UdpStatsListener:
 
         # Burst handling
         self.burst_buffer: List[str] = []
+        self.burst_buffer_bytes = 0
         self.last_receive_time = 0
         self.dropped_messages = 0  # Track dropped messages for security monitoring
 
@@ -503,18 +506,28 @@ class UdpStatsListener:
     def _handle_message(self, message: str):
         """Handle received UDP message (may contain multiple lines)."""
         lines = message.splitlines()
+        line_count = len(lines)
+        payload_bytes = len(message.encode("utf-8"))
 
         with self.metrics_lock:
             # Prevent buffer overflow attacks
-            if len(self.burst_buffer) + len(lines) > MAX_BURST_BUFFER_LINES:
-                logger.warning(f"Burst buffer limit reached ({MAX_BURST_BUFFER_LINES} lines), "
-                               f"dropping {len(lines)} new lines. Possible DoS attempt or misconfiguration.")
+            if len(self.burst_buffer) + line_count > MAX_BURST_BUFFER_LINES:
+                logger.warning(f"Burst buffer line limit reached ({MAX_BURST_BUFFER_LINES}), "
+                               f"dropping {line_count} new lines.")
+                self.dropped_messages += 1
+                return
+
+            if self.burst_buffer_bytes + payload_bytes > MAX_BURST_BUFFER_BYTES:
+                logger.warning(f"Burst buffer byte limit reached ({MAX_BURST_BUFFER_BYTES} bytes), "
+                               f"dropping {payload_bytes} new bytes.")
                 self.dropped_messages += 1
                 return
 
             self.burst_buffer.extend(lines)
+            self.burst_buffer_bytes += payload_bytes
             self.last_receive_time = time.time()
-            logger.debug(f"Received {len(lines)} lines, buffer now has {len(self.burst_buffer)} lines")
+            logger.debug(f"Received {line_count} lines/{payload_bytes} bytes, "
+                         f"buffer now has {len(self.burst_buffer)} lines/{self.burst_buffer_bytes} bytes")
 
     def _check_burst_completion(self):
         """Check if burst is complete and process if so."""
@@ -530,6 +543,7 @@ class UdpStatsListener:
             # Burst is complete, copy buffer and release lock before parsing
             burst_lines = self.burst_buffer
             self.burst_buffer = []
+            self.burst_buffer_bytes = 0
 
         logger.debug(f"Burst complete ({len(burst_lines)} lines), processing...")
 


### PR DESCRIPTION
### Motivation
- The UDP ingestion path only limited buffered line count, allowing attackers to send large newline-free datagrams that exhaust process memory despite the line-count guard. 
- The default docker-compose example binds the UDP listener to `0.0.0.0` and left `ALLOWED_UDP_SOURCES` unset, making the path remotely reachable and increasing attack surface. 

### Description
- Add a new environment knob `MAX_BURST_BUFFER_BYTES` (default `8388608`, 8 MiB) to bound total retained UDP burst payload bytes. 
- Track per-burst payload bytes with `self.burst_buffer_bytes` in `UdpStatsListener` and compute `payload_bytes = len(message.encode('utf-8'))` for each datagram. 
- Enforce the byte cap before extending `burst_buffer` (dropping the packet and incrementing `dropped_messages` when the cap would be exceeded) while keeping the existing `MAX_BURST_BUFFER_LINES` line-count guard. 
- Reset `burst_buffer_bytes` when a burst is processed, and update `docker-compose-udp.yml` comments to recommend `ALLOWED_UDP_SOURCES` for externally reachable UDP and show the new byte-cap tuning knob. 

### Testing
- Ran `python3 -m py_compile sidecar/rsyslog_exporter.py` which succeeded. 
- Ran the sidecar parser validation with `PYTHONPATH=sidecar python3 sidecar/tests/validate.py` which completed and all parser tests passed. 
- Verified the UDP listener starts and the new guards exercise the intended drop paths (observed startup logs and debug messages during validate run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f591861e88332a34a55c566d4d52c)