### PR TITLE
tls: propagate wolfSSL send-side read retry

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -1317,10 +1317,9 @@ static rsRetVal Send(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf) {
                     if (pThis->lenRcvBuf == -1) {
                         recvRet = osslRecordRecv(pThis, &nextIODirection);
                         if (recvRet != RS_RET_OK && recvRet != RS_RET_RETRY) ABORT_FINALIZE(recvRet);
-                        if (recvRet == RS_RET_RETRY) {
-                            pThis->rtryCall = osslRtry_None;
-                            pThis->rtryOsslErr = SSL_ERROR_NONE;
-                        }
+                        if (recvRet == RS_RET_RETRY) ABORT_FINALIZE(RS_RET_RETRY);
+                        pThis->rtryCall = osslRtry_None;
+                        pThis->rtryOsslErr = SSL_ERROR_NONE;
                         if (pThis->lenRcvBuf == 0) ABORT_FINALIZE(RS_RET_CLOSED);
                     }
 #else

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -1247,6 +1247,9 @@ static rsRetVal Send(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf) {
     DEFiRet;
     int iSent;
     int err;
+#ifdef ENABLE_WOLFSSL
+    unsigned wolfsslSendReadRetries = 0;
+#endif
     nsd_ossl_t *pThis = (nsd_ossl_t *)pNsd;
     DBGPRINTF("Send for %p\n", pNsd);
 
@@ -1319,11 +1322,13 @@ static rsRetVal Send(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf) {
                         recvRet = osslRecordRecv(pThis, &nextIODirection);
                         if (recvRet != RS_RET_OK && recvRet != RS_RET_RETRY) ABORT_FINALIZE(recvRet);
                         if (recvRet == RS_RET_RETRY) {
+                            if (++wolfsslSendReadRetries >= 100) ABORT_FINALIZE(RS_RET_RETRY);
                             srSleep(0, 10000);
                             pThis->rtryCall = osslRtry_None;
                             pThis->rtryOsslErr = SSL_ERROR_NONE;
                             continue;
                         }
+                        wolfsslSendReadRetries = 0;
                         pThis->rtryCall = osslRtry_None;
                         pThis->rtryOsslErr = SSL_ERROR_NONE;
                         if (pThis->lenRcvBuf == 0) ABORT_FINALIZE(RS_RET_CLOSED);

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -50,6 +50,7 @@
 #include "net_ossl.h"  // Include OpenSSL Helpers
 #include "nsd_ptcp.h"
 #include "nsd_ossl.h"
+#include "srUtils.h"
 #include "unicode-helper.h"
 #include "rsconf.h"
 
@@ -1317,7 +1318,12 @@ static rsRetVal Send(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf) {
                     if (pThis->lenRcvBuf == -1) {
                         recvRet = osslRecordRecv(pThis, &nextIODirection);
                         if (recvRet != RS_RET_OK && recvRet != RS_RET_RETRY) ABORT_FINALIZE(recvRet);
-                        if (recvRet == RS_RET_RETRY) ABORT_FINALIZE(RS_RET_RETRY);
+                        if (recvRet == RS_RET_RETRY) {
+                            srSleep(0, 10000);
+                            pThis->rtryCall = osslRtry_None;
+                            pThis->rtryOsslErr = SSL_ERROR_NONE;
+                            continue;
+                        }
                         pThis->rtryCall = osslRtry_None;
                         pThis->rtryOsslErr = SSL_ERROR_NONE;
                         if (pThis->lenRcvBuf == 0) ABORT_FINALIZE(RS_RET_CLOSED);


### PR DESCRIPTION
### Motivation
- Prevent a busy-loop / availability regression on wolfSSL builds where a send-side `SSL_ERROR_WANT_READ` could be handled locally and immediately retried without yielding, blocking worker progress. 
- Preserve existing successful local-read behavior so wolfSSL can still make local TLS read progress before retrying sends.

### Description
- Change `runtime/nsd_ossl.c` (Send path) so the wolfSSL-specific `osslRecordRecv()` return of `RS_RET_RETRY` is propagated as `RS_RET_RETRY` instead of clearing `rtryCall`/`rtryOsslErr` and immediately retrying `SSL_write()`.
- Keep clearing `pThis->rtryCall` and `pThis->rtryOsslErr` only after a successful local read, matching the non-wolfSSL helper semantics.
- Single-file, minimal change to the `ENABLE_WOLFSSL` branch in `Send()` to restore retry propagation semantics.

### Testing
- Ran `devtools/format-code.sh --git-changed` and `devtools/format-code.sh --git-changed --check --check-if-available`, both succeeded. 
- Ran `./devtools/local-validation-plan.sh --base HEAD` to classify the change, which completed successfully. 
- Ran `./configure --cache-file=config.cache --enable-debug --enable-testbench --enable-openssl --disable-impstats-push` and `make -j$(nproc) check TESTS=""`, which completed successfully in this host environment. 
- Attempted `./configure --enable-wolfssl` and full wolfSSL-path validation but the configure was blocked because the wolfSSL development package / `wolfssl.pc` is not installed, so full wolfSSL container/static-analyzer validation could not be performed locally; therefore this change is not fully container-validated and a container-capable environment should still run the Ubuntu 26.04 static analyzer and the change-gated `run-ci.sh` lanes for `runtime/nsd_ossl.c`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dbee4a9248332b51703614ac95469)