### PR TITLE
rainerscript: accept optimizer NOP statements

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -5584,11 +5584,9 @@ struct cnfstmt *cnfstmtOptimize(struct cnfstmt *root) {
                 cnfstmtOptimizeReloadLookupTable(stmt);
                 break;
             case S_NOP:
-                // TODO: fix optimizer, re-enable. see:
-                // https://github.com/rsyslog/rsyslog/issues/2524
-                // LogError(0, RS_RET_INTERNAL_ERROR,
-                //	"optimizer error: we see a NOP, how come?");
-                dbgprintf("optimizer error: we see a NOP, how come?");
+                /* NOPs are normal optimizer intermediates, for example when
+                 * a user intentionally writes "continue" inside an if branch.
+                 * removeNOPs() drops them after this traversal. */
                 break;
             default:
                 LogError(0, RS_RET_INTERNAL_ERROR, "internal error: unknown stmt type %u during optimizer run\n",

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -306,6 +306,7 @@ TESTS_DEFAULT = \
 	compat-defaults-secure-dynafile-rainerscript.sh \
 	abort-uncleancfg-goodcfg.sh \
 	abort-uncleancfg-goodcfg-check.sh \
+	abort-uncleancfg-continue-nop.sh \
 	abort-uncleancfg-badcfg-check.sh \
 	abort-uncleancfg-badcfg-check_1.sh \
 	variable_leading_underscore.sh \

--- a/tests/abort-uncleancfg-continue-nop.sh
+++ b/tests/abort-uncleancfg-continue-nop.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# add 2026-06-02 by OpenAI Codex
+# Regression test for issues #2524 and #2568.  An explicit "continue" inside
+# an if branch is a user-requested NOP, and the optimizer must not make a
+# strict AbortOnUncleanConfig validation run fail or report the historical
+# "we see a NOP" diagnostic.  Success is proven by rsyslogd -N1 exiting
+# cleanly and by checking its captured validation output.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+global(abortOnUncleanConfig="on")
+
+if re_match($msg, "whitelist.*") then {
+	continue
+} else {
+	stop
+}
+'
+
+out="${RSYSLOG_DYNNAME}.config-check.log"
+../tools/rsyslogd -C -N1 -f"${TESTCONF_NM}.conf" -M../runtime/.libs:../.libs >"$out" 2>&1
+if [ $? -ne 0 ]; then
+	echo "Error: config check failed for intentional continue/NOP"
+	cat "$out"
+	error_exit 1
+fi
+
+check_not_present "optimizer error: we see a NOP" "$out"
+check_not_present 'global(AbortOnUncleanConfig="on") is set' "$out"
+
+exit_test


### PR DESCRIPTION
Fixes #2524.
Fixes #2568.

## Summary
- treat optimizer `S_NOP` nodes as expected intermediate statements
- keep `removeNOPs()` responsible for dropping them after optimization
- add an `AbortOnUncleanConfig` regression test for explicit `continue`

## Validation
- local Cubic review: clean
- `bash devtools/format-code.sh --git-changed --check --check-if-available`
- `shellcheck tests/abort-uncleancfg-continue-nop.sh`
- `devtools/check-test-antipatterns.sh tests/abort-uncleancfg-continue-nop.sh`
- `git diff --check`
- `make -j60 check TESTS='abort-uncleancfg-continue-nop.sh'`
- `make -j60 check TESTS='abort-uncleancfg-goodcfg-check.sh abort-uncleancfg-badcfg-check.sh abort-uncleancfg-badcfg-check_1.sh rscript_optimizer1.sh validation-run.sh'`
- Ubuntu 26.04 dev container static analyzer: passed
- Ubuntu 26.04 dev container `run-ci.sh`: passed
- Ubuntu 26.04 dev container SAN lane: passed
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j60`: passed
