### PR TITLE
runtime: include <limits.h> for INT_MAX in yamlconf

### DIFF
--- a/runtime/yamlconf.c
+++ b/runtime/yamlconf.c
@@ -55,6 +55,7 @@
     #include <stdlib.h>
     #include <string.h>
     #include <errno.h>
+    #include <limits.h>
     #include <yaml.h>
     #include <libestr.h>
 


### PR DESCRIPTION
### Motivation
- The YAML frontend uses `INT_MAX` in `estr_append_cstr()` but `runtime/yamlconf.c` did not include `<limits.h>`, creating a portability/build fragility when transitive headers don't provide the macro.

### Description
- Add `#include <limits.h>` to `runtime/yamlconf.c` alongside the other system headers to make the `INT_MAX` dependency explicit and standards-compliant.

### Testing
- Verified the `INT_MAX` use and the updated file contents with `nl -ba runtime/yamlconf.c | sed -n '45,120p'`, which showed the new include in place; attempted a targeted build with `make -C runtime yamlconf.o` and `make -C runtime librsyslog_la-yamlconf.lo` but both could not complete in this workspace because `config.h` is not generated and the specific make target is unavailable, so a full build was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16f6ab2018833294fd26f80c824835)