### PR TITLE
runtime: guard against recursive YAML includes

### DIFF
--- a/runtime/yamlconf.c
+++ b/runtime/yamlconf.c
@@ -2079,6 +2079,8 @@ finalize_it:
     for (int ki = 0; ki < seen_count; ++ki) free(seen_keys[ki]);
     if (parserInit) yaml_parser_delete(&parser);
     if (fh) fclose(fh);
+    if (yamlIncludeStack == &frame) yamlIncludeStack = frame.prev;
+    free(frame.path);
     cnfcurrfn = prev_cnfcurrfn;
     RETiRet;
 }

--- a/runtime/yamlconf.c
+++ b/runtime/yamlconf.c
@@ -90,6 +90,19 @@ static rsRetVal expect_event(
     yaml_parser_t *parser, yaml_event_t *ev, yaml_event_type_t expected, const char *ctx, const char *fname);
 static void skip_node(yaml_parser_t *parser);
 
+typedef struct yamlIncludeFrame_s {
+    char *path;
+    struct yamlIncludeFrame_s *prev;
+} yamlIncludeFrame_t;
+
+static yamlIncludeFrame_t *yamlIncludeStack = NULL;
+
+static char *yamlconf_canonical_path(const char *fname) {
+    char *resolved = realpath(fname, NULL);
+    if (resolved != NULL) return resolved;
+    return strdup(fname);
+}
+
 /* --------------------------------------------------------------------------
  * Helpers
  * -------------------------------------------------------------------------- */
@@ -1936,6 +1949,20 @@ rsRetVal yamlconf_load(const char *fname) {
     int seen_count = 0;
     DEFiRet;
     char *prev_cnfcurrfn = cnfcurrfn;
+    yamlIncludeFrame_t frame = {0};
+
+    frame.path = yamlconf_canonical_path(fname);
+    if (frame.path == NULL) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    for (yamlIncludeFrame_t *it = yamlIncludeStack; it != NULL; it = it->prev) {
+        if (!strcmp(it->path, frame.path)) {
+            LogError(0, RS_RET_CONF_PARSE_ERROR,
+                     "yamlconf: trying to include file '%s', which is already included - ignored", fname);
+            iRet = RS_RET_OK;
+            goto finalize_it;
+        }
+    }
+    frame.prev = yamlIncludeStack;
+    yamlIncludeStack = &frame;
 
     cnfcurrfn = (char *)fname;
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -608,7 +608,6 @@ TESTS_LIBYAML = \
 	yaml-basic-yamlonly.sh \
 	yaml-omfile-dynafilecachesize-invalid.sh \
 	yaml-include.sh \
-	yaml-include-recursion.sh \
 	yaml-ruleset-script.sh \
 	yaml-error.sh \
 	yaml-filter-actions.sh \
@@ -1344,7 +1343,8 @@ TESTS_OMSTDOUT = \
 
 TESTS_LIBYAML_IMTCP = \
 	config-translate-rs-roundtrip.sh \
-	config-translate-yaml-roundtrip.sh
+	config-translate-yaml-roundtrip.sh \
+	yaml-include-recursion.sh
 
 TESTS_LIBYAML_IMHTTP = \
 	yaml-imhttp-apikeyfile.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -608,6 +608,7 @@ TESTS_LIBYAML = \
 	yaml-basic-yamlonly.sh \
 	yaml-omfile-dynafilecachesize-invalid.sh \
 	yaml-include.sh \
+	yaml-include-recursion.sh \
 	yaml-ruleset-script.sh \
 	yaml-error.sh \
 	yaml-filter-actions.sh \

--- a/tests/yaml-include-recursion.sh
+++ b/tests/yaml-include-recursion.sh
@@ -17,6 +17,9 @@ cat > "${RSYSLOG_DYNNAME}.yaml" << YAMLEOF
 include:
   - path: "${RSYSLOG_DYNNAME}.yaml"
 
+modules:
+  - load: "../plugins/imtcp/.libs/imtcp"
+
 templates:
   - name: outfmt
     type: string

--- a/tests/yaml-include-recursion.sh
+++ b/tests/yaml-include-recursion.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Regression test: YAML include recursion must be detected and ignored.
+# Setup: root YAML includes itself and also defines a ruleset that writes to
+# RSYSLOG_OUT_LOG. Oracle: rsyslog starts and processes messages (no crash /
+# stack exhaustion), proving the self-include was ignored rather than recursed.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+export NUMMESSAGES=20
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" << YAMLEOF
+include:
+  - path: "${RSYSLOG_DYNNAME}.yaml"
+
+templates:
+  - name: outfmt
+    type: string
+    string: "%msg:F,58:2%\\n"
+
+rulesets:
+  - name: main
+    script: |
+      :msg, contains, "msgnum:" action(type="omfile"
+          template="outfmt" file="${RSYSLOG_OUT_LOG}")
+YAMLEOF
+
+add_conf '
+input(type="imtcp" port="0" listenPortFileName="'${RSYSLOG_DYNNAME}'.tcpflood_port"
+      ruleset="main")
+'
+startup
+tcpflood -m $NUMMESSAGES
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test


### PR DESCRIPTION
### Motivation
- YAML include handling previously dispatched `.yaml/.yml` includes directly to `yamlconf_load()` without tracking active YAML includes, which allowed self-includes or cycles to recurse until stack/resource exhaustion. 

### Description
- Add a small per-load include stack (`yamlIncludeFrame_t` / `yamlIncludeStack`) and a `yamlconf_canonical_path()` helper that prefers `realpath()` to canonicalize include paths in `runtime/yamlconf.c`.
- In `yamlconf_load()` check the include stack for the canonical path before parsing and log/ignore any already-active include instead of re-entering the loader.
- Push a frame before parsing and pop/free it on all exit paths so the include stack remains balanced and memory is released.
- Add a regression test `tests/yaml-include-recursion.sh` and register it in `tests/Makefile.am` under `TESTS_LIBYAML` to ensure self-including YAML configs are detected and ignored.

### Testing
- Ran syntax checks on the new tests with `bash -n tests/yaml-include-recursion.sh` and `bash -n tests/yaml-include.sh`, both succeeded. 
- Attempted an automated test run with `make -j$(nproc) check ...` but the environment has no configured build tree and reported no `check` target, so full testbench execution was blocked. 
- A `gcc -fsyntax-only` attempt against `runtime/yamlconf.c` was blocked by a missing generated `config.h` in this environment. 
- The change is targeted, minimal, and marked as not fully container-validated due to the environment limitations described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16f6aa5b608332837f11f45bdc0800)