### PR TITLE
runtime/queue: reset sizeOnDisk after safe recovery

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -925,6 +925,9 @@ static void qqueueResetRecoveredQueueSize(qqueue_t *pThis, const sbool adjustOve
         pThis->iQueueSize = 0;
     }
     pThis->nLogDeq = 0;
+    if (pThis->qType == QUEUETYPE_DISK || pThis->bIsDA) {
+        pThis->tVars.disk.sizeOnDisk = 0;
+    }
 }
 
 static void qqueueSubtractOverallQueueSize(const int nElem) {


### PR DESCRIPTION
### Motivation
- Safe disk-queue recovery moved broken segment files aside and reconstructed fresh streams, but the recovery helper did not clear the persisted disk byte counter `tVars.disk.sizeOnDisk`, which could make a recovered empty queue appear full when `queue.maxDiskSpace` is configured.

### Description
- Add a reset of `pThis->tVars.disk.sizeOnDisk = 0` inside `qqueueResetRecoveredQueueSize()` for `QUEUETYPE_DISK` and disk-assisted (`bIsDA`) queues in `runtime/queue.c`, keeping the existing `iQueueSize` and `nLogDeq` resets unchanged.

### Testing
- Ran code formatting with `bash devtools/format-code.sh --git-changed`, which completed successfully; attempted `make -j$(nproc) check TESTS=""` but it failed in this environment because the tree is not configured and there is no `check` target available, so full CI-local checks were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16f6ab065883329b8a47e75eba1d42)