### PR TITLE
ci: enable verbose make check output

### DIFF
--- a/.github/workflows/daily_focused_tests.yml
+++ b/.github/workflows/daily_focused_tests.yml
@@ -374,7 +374,7 @@ jobs:
         env:
           CFLAGS: ${{ env.CFLAGS }}
           LDFLAGS: ${{ env.LDFLAGS }}
-        run: make -j10 check
+        run: make -j10 check VERBOSE=1
 
       - name: generate coverage
         if: ${{ always() && steps.prepare_build.outcome == 'success' }}

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -1047,7 +1047,7 @@ jobs:
           fi
 
           set +e
-          make -j10 check
+          make -j10 check VERBOSE=1
           EXIT_CODE=$?
           STATUS=success
           if [ "$EXIT_CODE" -ne 0 ]; then STATUS=failure; fi
@@ -1636,7 +1636,7 @@ jobs:
                 --disable-elasticsearch-tests \
                 --disable-kafka-tests --disable-snmp-tests
               time_phase build make -j8
-              time_phase check make -j10 check
+              time_phase check make -j10 check VERBOSE=1
             '
 
       - name: Skip arm64 CI, no relevant changes
@@ -1777,7 +1777,7 @@ jobs:
                 --disable-journal-tests"
               time_su_phase "config sanity" "grep -q \"^#define HAVE_LIBYAML 1\" config.h"
               time_su_phase build "make -j8"
-              time_su_phase check "timeout 45m make -j10 check"
+              time_su_phase check "timeout 45m make -j10 check VERBOSE=1"
             '
 
       - name: Skip i386 CI, no relevant changes

--- a/.github/workflows/run_cross_arch_weekly.yml
+++ b/.github/workflows/run_cross_arch_weekly.yml
@@ -130,7 +130,7 @@ jobs:
               if [ "$ARCH" = "armhf" ]; then
                 make_check_jobs=3
               fi
-              su rsyslogci -c "make -j8 && timeout 100m make -j${make_check_jobs} check"
+              su rsyslogci -c "make -j8 && timeout 100m make -j${make_check_jobs} check VERBOSE=1"
             '
           EXIT_CODE=$?
           STATUS=success

--- a/.github/workflows/run_macos_weekly.yml
+++ b/.github/workflows/run_macos_weekly.yml
@@ -112,7 +112,7 @@ jobs:
               detect_deadlocks=1:history_size=7:suppressions=$PWD/tests/tsan-rt.supp"
           fi
           set +e
-          make -j8 check
+          make -j8 check VERBOSE=1
           EXIT_CODE=$?
           STATUS=success
           if [ "$EXIT_CODE" -ne 0 ]; then STATUS=failure; fi

--- a/devtools/run-ci.sh
+++ b/devtools/run-ci.sh
@@ -38,9 +38,9 @@ set +e
 echo CI_CHECK_CMD: "$CI_CHECK_CMD"
 if [ "$CI_MAKE_CHECK_TESTS" != "" ]; then
 	echo CI_MAKE_CHECK_TESTS: "$CI_MAKE_CHECK_TESTS"
-	make $CI_MAKE_CHECK_OPT TESTS="$CI_MAKE_CHECK_TESTS" "${CI_CHECK_CMD:-check}"
+	make $CI_MAKE_CHECK_OPT VERBOSE=1 TESTS="$CI_MAKE_CHECK_TESTS" "${CI_CHECK_CMD:-check}"
 else
-	make $CI_MAKE_CHECK_OPT "${CI_CHECK_CMD:-check}"
+	make $CI_MAKE_CHECK_OPT VERBOSE=1 "${CI_CHECK_CMD:-check}"
 fi
 rc=$?
 


### PR DESCRIPTION
## Summary
- add VERBOSE=1 to CI make check invocations
- apply the same verbosity setting in devtools/run-ci.sh for shared container CI paths

## Validation
- git diff --check
- actionlint .github/workflows/run_checks.yml .github/workflows/run_macos_weekly.yml .github/workflows/daily_focused_tests.yml .github/workflows/run_cross_arch_weekly.yml

Not fully container-validated; this is a CI workflow diagnostic-output change.