### PR TITLE
omhiredis: fix TLS context error log

### DIFF
--- a/contrib/omhiredis/omhiredis.c
+++ b/contrib/omhiredis/omhiredis.c
@@ -288,7 +288,9 @@ static rsRetVal initHiredis(wrkrInstanceData_t *pWrkrData, int bSilent) {
         if (!pWrkrData->ssl_conn || pWrkrData->ssl_error != REDIS_SSL_CTX_NONE) {
             LogError(0, NO_ERRCODE, "omhiredis[%s]: SSL Context error: %s", actionGetName(pWrkrData->pData->pAction),
                      redisSSLContextGetError(pWrkrData->ssl_error));
-            if (!bSilent) LogError(0, RS_RET_SUSPENDED, "omhiredis[%s]: can not initialize TLS context");
+            if (!bSilent)
+                LogError(0, RS_RET_SUSPENDED, "omhiredis[%s]: can not initialize TLS context",
+                         actionGetName(pWrkrData->pData->pAction));
             ABORT_FINALIZE(RS_RET_SUSPENDED);
         }
         if (redisInitiateSSLWithContext(pWrkrData->conn, pWrkrData->ssl_conn) != REDIS_OK) {


### PR DESCRIPTION
### Motivation
- Fix undefined behavior introduced in the omhiredis TLS setup error path where a `LogError` format string containing `"%s"` did not receive a matching argument, which can cause crashes or corrupt logs when `redisCreateSSLContext()` fails.

### Description
- Add the missing `actionGetName(pWrkrData->pData->pAction)` argument to the `LogError` call in `initHiredis()` so the printf-style format string matches the supplied variadic arguments and preserve the original diagnostic intent.

### Testing
- Ran `git diff --check`, `devtools/format-code.sh --git-changed --check --check-if-available`, `./autogen.sh --enable-debug --enable-testbench --enable-omhiredis`, `./configure --cache-file=config.cache --enable-debug --enable-testbench --enable-omhiredis --enable-redis-ssl`, and `make -j$(nproc) check TESTS=""`, all of which completed successfully; also ran `devtools/local-validation-plan.sh --run` which executed available checks and format gates but reported the run is not fully container-validated because Docker and `cubic` are not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f05f13c608332805151f5c3b39aa7)