### PR TITLE
docker: gate collector imtcp module

### DIFF
--- a/packaging/docker/rsyslog/collector/10-collector.conf
+++ b/packaging/docker/rsyslog/collector/10-collector.conf
@@ -4,9 +4,9 @@
 
 # Load input modules
 module(load="imudp" config.enabled=`echo $ENABLE_UDP`)
-# Always load imtcp module - it's required for both plain TCP (port 514) and TLS (port 6514).
-# The module is lightweight and harmless if not used (inputs are controlled separately).
-module(load="imtcp")
+# Load imtcp only when either TCP-based listener is enabled.
+# The entrypoint derives ENABLE_IMTCP from ENABLE_TCP and ENABLE_TLS.
+module(load="imtcp" config.enabled=`echo $ENABLE_IMTCP`)
 module(load="imrelp" config.enabled=`echo $ENABLE_RELP`)
 
 # UDP input (unencrypted, port 514)

--- a/packaging/docker/rsyslog/collector/10-collector.conf
+++ b/packaging/docker/rsyslog/collector/10-collector.conf
@@ -6,7 +6,7 @@
 module(load="imudp" config.enabled=`echo $ENABLE_UDP`)
 # Load imtcp once when either TCP-based listener is enabled.
 # The entrypoint derives NEED_IMTCP from ENABLE_TCP and ENABLE_TLS.
-module(load="imtcp" config.enabled=`echo ${NEED_IMTCP:-off}`)
+module(load="imtcp" config.enabled=`echo $NEED_IMTCP`)
 module(load="imrelp" config.enabled=`echo $ENABLE_RELP`)
 
 # UDP input (unencrypted, port 514)

--- a/packaging/docker/rsyslog/collector/10-collector.conf
+++ b/packaging/docker/rsyslog/collector/10-collector.conf
@@ -4,9 +4,9 @@
 
 # Load input modules
 module(load="imudp" config.enabled=`echo $ENABLE_UDP`)
-# Load imtcp only when either TCP-based listener is enabled.
-# The entrypoint derives ENABLE_IMTCP from ENABLE_TCP and ENABLE_TLS.
-module(load="imtcp" config.enabled=`echo $ENABLE_IMTCP`)
+# Load imtcp once when either TCP-based listener is enabled.
+# The entrypoint derives NEED_IMTCP from ENABLE_TCP and ENABLE_TLS.
+module(load="imtcp" config.enabled=`echo ${NEED_IMTCP:-off}`)
 module(load="imrelp" config.enabled=`echo $ENABLE_RELP`)
 
 # UDP input (unencrypted, port 514)

--- a/packaging/docker/rsyslog/collector/Dockerfile
+++ b/packaging/docker/rsyslog/collector/Dockerfile
@@ -76,6 +76,7 @@ ENV ENABLE_UDP=on
 ENV ENABLE_TCP=on
 ENV ENABLE_RELP=off
 ENV ENABLE_TLS=off
+ENV NEED_IMTCP=off
 ENV WRITE_ALL_FILE=on
 ENV WRITE_JSON_FILE=on
 # TLS configuration paths (can be overridden via volume mounts or environment)

--- a/packaging/docker/rsyslog/minimal/start.sh
+++ b/packaging/docker/rsyslog/minimal/start.sh
@@ -6,7 +6,8 @@ if [ -n "$RSYSLOG_HOSTNAME" ]; then
     echo "Using pre-set container hostname"
 else
     echo "Obtaining RSYSLOG_HOSTNAME from /etc/hostname"
-    export RSYSLOG_HOSTNAME="$(cat /etc/hostname)"
+    RSYSLOG_HOSTNAME="$(cat /etc/hostname)"
+    export RSYSLOG_HOSTNAME
 fi
 echo "rsyslog uses hostname '$RSYSLOG_HOSTNAME'"
 
@@ -28,7 +29,12 @@ case "$RSYSLOG_ROLE" in
   collector)
     : "${VESPA_USE_HTTPS:=on}"
     : "${VESPA_ALLOW_UNSIGNED_CERTS:=off}"
-    export VESPA_USE_HTTPS VESPA_ALLOW_UNSIGNED_CERTS
+    if [ "$ENABLE_TCP" = "on" ] || [ "$ENABLE_TLS" = "on" ]; then
+        ENABLE_IMTCP=on
+    else
+        ENABLE_IMTCP=off
+    fi
+    export VESPA_USE_HTTPS VESPA_ALLOW_UNSIGNED_CERTS ENABLE_IMTCP
     ;;
   minimal|*)
     ;;

--- a/packaging/docker/rsyslog/minimal/start.sh
+++ b/packaging/docker/rsyslog/minimal/start.sh
@@ -6,7 +6,7 @@ if [ -n "$RSYSLOG_HOSTNAME" ]; then
     echo "Using pre-set container hostname"
 else
     echo "Obtaining RSYSLOG_HOSTNAME from /etc/hostname"
-    RSYSLOG_HOSTNAME="$(cat /etc/hostname)"
+    RSYSLOG_HOSTNAME="$(cat /etc/hostname 2>/dev/null || echo "${HOSTNAME:-rsyslog}")"
     export RSYSLOG_HOSTNAME
 fi
 echo "rsyslog uses hostname '$RSYSLOG_HOSTNAME'"
@@ -30,11 +30,11 @@ case "$RSYSLOG_ROLE" in
     : "${VESPA_USE_HTTPS:=on}"
     : "${VESPA_ALLOW_UNSIGNED_CERTS:=off}"
     if [ "$ENABLE_TCP" = "on" ] || [ "$ENABLE_TLS" = "on" ]; then
-        ENABLE_IMTCP=on
+        NEED_IMTCP=on
     else
-        ENABLE_IMTCP=off
+        NEED_IMTCP=off
     fi
-    export VESPA_USE_HTTPS VESPA_ALLOW_UNSIGNED_CERTS ENABLE_IMTCP
+    export VESPA_USE_HTTPS VESPA_ALLOW_UNSIGNED_CERTS NEED_IMTCP
     ;;
   minimal|*)
     ;;


### PR DESCRIPTION
### Motivation
- A recent change made `imtcp` load unconditionally in the collector snippet, which causes config validation (`rsyslogd -N1`) to fail when both TCP-based listeners are intentionally disabled. 
- The intent is to preserve TLS-only support while avoiding a module-load-without-listeners availability regression for UDP-only or RELP-only deployments.

### Description
- Gate the `imtcp` module load on an internal `ENABLE_IMTCP` flag in `packaging/docker/rsyslog/collector/10-collector.conf` by changing `module(load="imtcp")` to `module(load="imtcp" config.enabled=\\`echo $ENABLE_IMTCP\\`)`.
- Derive `ENABLE_IMTCP` in the collector entrypoint (`packaging/docker/rsyslog/minimal/start.sh`) so it is set to `on` when either `ENABLE_TCP` or `ENABLE_TLS` is `on`, and `off` otherwise, before `rsyslogd -N1` runs.
- Split the hostname assignment and export in `start.sh` to address a shell-lint warning and keep the script lint-clean.
- Preserve TLS-only behavior because `ENABLE_TLS=on` now causes `ENABLE_IMTCP=on` so the TLS listener still works when plain TCP is disabled.

### Testing
- Ran `bash -n packaging/docker/rsyslog/minimal/start.sh` which reported no syntax errors.
- Ran `shellcheck -S warning packaging/docker/rsyslog/minimal/start.sh` and fixed the `SC2155` style warning by splitting assignment and export, eliminating the lint finding.
- Executed a stubbed entrypoint env check (simulating `rsyslogd` via a no-op in `PATH`) to validate derived `ENABLE_IMTCP` under `ENABLE_TCP=off/ENABLE_TLS=off`, `ENABLE_TCP=off/ENABLE_TLS=on`, and `ENABLE_TCP=on/ENABLE_TLS=off`, which produced `ENABLE_IMTCP=off`, `on`, and `on` respectively.
- Ran `git diff --check` (no whitespace/merge problems) and `./devtools/local-validation-plan.sh --run --base HEAD`, which passed the available diff-scoped checks but warned that Docker is not available so the change is **not fully container-validated** and hosted CI or a container-capable agent should run the change-gated Ubuntu 26.04 container lane.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f2462d5a4833295dc6aabb3140bb2)