### PR TITLE
regexp: avoid per-thread shutdown double-free

### DIFF
--- a/runtime/regexp.c
+++ b/runtime/regexp.c
@@ -242,7 +242,13 @@ static void destroy_perthread_regexs(void) {
             pthread_mutex_unlock(&entry->lock);
             pthread_mutex_destroy(&entry->lock);
             regfree(&entry->preg);
-            free(entry);
+
+            /*
+             * perthread_regexs uses the perthread_regex_t object as both
+             * key and value. hashtable_destroy() always frees keys, so leave
+             * the entry allocation owned by the hash table after cleaning the
+             * resources embedded in it.
+             */
         } while (ret);
         free(itr);
     }


### PR DESCRIPTION
### Motivation
- Fix a double-free during lmregexp/module shutdown where `perthread_regexs` stored the same `perthread_regex_t *` as both key and value and the cleanup code freed the entry manually before the hashtable also freed the key. 
- Avoid heap corruption/abort on module/class unload while preserving the intent to release embedded resources (mutex and compiled `regex_t`).

### Description
- In `runtime/regexp.c` the `destroy_perthread_regexs()` loop no longer calls `free(entry)` after destroying the entry's mutex and calling `regfree()`; instead it leaves the allocation to the hashtable owner. 
- Added a clarifying comment documenting that `perthread_regexs` uses the `perthread_regex_t` pointer as both key and value and that `hashtable_destroy()` always frees keys. 
- The change preserves per-entry cleanup of `entry->lock` and `entry->preg` while avoiding double-free when `hashtable_destroy(perthread_regexs, 0)` runs.

### Testing
- Ran code formatting checks: `devtools/format-code.sh --git-changed` and `devtools/format-code.sh --git-changed --check --check-if-available` (both succeeded). 
- Ran configure/bootstrap steps: `./autogen.sh --enable-debug --enable-testbench` initially failed due to missing `snappy` headers; configured with `./configure --enable-debug --enable-testbench --disable-impstats-push` to proceed. 
- Built and smoke-tested locally with `make -j$(nproc) check TESTS=""` which completed successfully. 
- Executed an individual regex-related test `make check TESTS='rscript_re_match_i.sh'`, which passed. 
- Ran the local validation planner `devtools/local-validation-plan.sh`; attempted `devtools/local-validation-plan.sh --run` but it did not complete the full container-stage validation (blocked by pre-existing shellcheck warnings and because Docker/Podman/Cubic are not available locally). 
- Note: Docker/Podman and local Cubic were unavailable in this environment, so PR-ready local container validation and the container static-analyzer lane were not executed; this change is therefore documented as not fully container-validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f26677c9483329bf138bd98c10a54)