### PR TITLE
ci: keep imbeats tests for transport changes

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2804,7 +2804,11 @@ module_needs_testing() {
 			elasticsearch:tests/omelasticsearch*.sh)
 				return 0
 				;;
+			# imbeats listens directly through netstrm-backed TCP/TLS
+			# transports, so transport runtime changes must keep its
+			# service tests enabled.
 			imbeats:plugins/imbeats/*|imbeats:plugins/omelasticsearch/*|\
+			imbeats:runtime/net*|imbeats:runtime/nsd*|imbeats:runtime/tcps*|\
 			imbeats:tests/imbeats*.sh|\
 			imbeats:tests/yaml-imbeats*.sh)
 				return 0


### PR DESCRIPTION
### Motivation

- Fix a CI relevance regression where changes to runtime transport/TLS files (e.g., `runtime/netstrm.c`) could cause `imbeats` service tests to be configured out despite `imbeats` depending on the netstrm/tcpsrv/nsd transport subsystems.

### Description

- Add imbeats-specific runtime patterns to the service-relevance matrix in `tests/diag.sh` so transport and TLS runtime files keep `imbeats` enabled (`imbeats:runtime/net*`, `imbeats:runtime/nsd*`, `imbeats:runtime/tcps*`).
- Add an explanatory comment documenting why transport runtime changes are imbeats-relevant and preserve the narrowed broad-change fallback for unrelated helper-only runtime edits.

### Testing

- Ran a syntax check with `bash -n tests/diag.sh devtools/apply-service-relevance.sh` which succeeded.
- Verified module relevance by exercising `module-needs-testing` with `RSYSLOG_TESTBENCH_CHANGED_FILES=<file> tests/diag.sh module-needs-testing imbeats` across transport/TLS files and confirmed those files now return success (keep `imbeats`), while an unrelated helper (`runtime/lookup.c`) remains suppressed.
- Confirmed `devtools/apply-service-relevance.sh` no longer adds `--disable-imbeats` for `runtime/netstrm.c` using `RSYSLOG_TESTBENCH_CHANGED_FILES='runtime/netstrm.c' bash -c '. devtools/apply-service-relevance.sh; rsyslog_apply_default_pr_service_suppressions; printf "%s\n" "$RSYSLOG_CONFIGURE_OPTIONS_EXTRA"'`.
- Ran `devtools/local-validation-plan.sh` to classify the change (testbench-plumbing) and note recommended lanes; full PR-ready local container validation was not run in this environment because Docker/Podman/Cubic are unavailable, and a `shellcheck` stage surfaced existing warnings in the large `tests/diag.sh` baseline unrelated to this focused change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f266765888332a18fc1fbbe2d17a6)