### PR TITLE
imdiag: fix stats reporting gate

### DIFF
--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -90,12 +90,12 @@ STATSCOUNTER_DEF(potentialArtificialDelayMs, mutPotentialArtificialDelayMs)
 STATSCOUNTER_DEF(actualArtificialDelayMs, mutActualArtificialDelayMs)
 STATSCOUNTER_DEF(delayInvocationCount, mutDelayInvocationCount)
 
-/* statsReportingBlocker gates impstats reads across imdiag command and stats
+/* stats_reporting_blocker gates impstats reads across imdiag command and stats
  * callback threads; use a condition variable instead of mutex ownership
  * handoff so the command thread can unblock a callback thread safely. */
-static pthread_mutex_t statsReportingBlockerMut;
-static pthread_cond_t statsReportingBlockerCond;
-static int statsReportingBlocked = 0;
+static pthread_mutex_t stats_reporting_blocker_mut;
+static pthread_cond_t stats_reporting_blocker_cond;
+static int stats_reporting_blocked = 0;
 static long long statsReportingBlockStartTimeMs = 0;
 static int allowOnlyOnce = 0;
 DEF_ATOMIC_HELPER_MUT(mutAllowOnlyOnce);
@@ -494,23 +494,23 @@ finalize_it:
 static void imdiag_statsReadCallback(statsobj_t __attribute__((unused)) *const ignore_stats,
                                      void __attribute__((unused)) *const ignore_ctx) {
     long long waitStartTimeMs = currentTimeMills();
-    if (pthread_mutex_lock(&statsReportingBlockerMut) != 0) {
+    if (pthread_mutex_lock(&stats_reporting_blocker_mut) != 0) {
         return;
     }
-    while (statsReportingBlocked) {
-        if (pthread_cond_wait(&statsReportingBlockerCond, &statsReportingBlockerMut) != 0) {
-            pthread_mutex_unlock(&statsReportingBlockerMut);
+    while (stats_reporting_blocked) {
+        if (pthread_cond_wait(&stats_reporting_blocker_cond, &stats_reporting_blocker_mut) != 0) {
+            pthread_mutex_unlock(&stats_reporting_blocker_mut);
             return;
         }
     }
     long delta = currentTimeMills() - waitStartTimeMs;
     if ((int)ATOMIC_DEC_AND_FETCH(&allowOnlyOnce, &mutAllowOnlyOnce) >= 0) {
-        statsReportingBlocked = 1;
+        stats_reporting_blocked = 1;
         LogError(0, RS_RET_OK,
                  "imdiag(stats-read-callback): current stats-reporting "
                  "cycle will proceed now, next reporting cycle will again be blocked");
     }
-    pthread_mutex_unlock(&statsReportingBlockerMut);
+    pthread_mutex_unlock(&stats_reporting_blocker_mut);
 
     if (pthread_mutex_lock(&mutStatsReporterWatch) == 0) {
         statsReported = 1;
@@ -526,9 +526,9 @@ static void imdiag_statsReadCallback(statsobj_t __attribute__((unused)) *const i
 static rsRetVal blockStatsReporting(tcps_sess_t *pSess) {
     DEFiRet;
 
-    CHKiConcCtrl(pthread_mutex_lock(&statsReportingBlockerMut));
-    statsReportingBlocked = 1;
-    CHKiConcCtrl(pthread_mutex_unlock(&statsReportingBlockerMut));
+    CHKiConcCtrl(pthread_mutex_lock(&stats_reporting_blocker_mut));
+    stats_reporting_blocked = 1;
+    CHKiConcCtrl(pthread_mutex_unlock(&stats_reporting_blocker_mut));
     CHKiConcCtrl(pthread_mutex_lock(&mutStatsReporterWatch));
     statsReported = 0;
     CHKiConcCtrl(pthread_mutex_unlock(&mutStatsReporterWatch));
@@ -562,10 +562,10 @@ static rsRetVal awaitStatsReport(uchar *pszCmd, tcps_sess_t *pSess) {
             statsReportingBlockStartTimeMs = 0;
             LogError(0, RS_RET_OK, "imdiag: un-blocking stats reporting");
         }
-        CHKiConcCtrl(pthread_mutex_lock(&statsReportingBlockerMut));
-        statsReportingBlocked = 0;
-        CHKiConcCtrl(pthread_cond_signal(&statsReportingBlockerCond));
-        CHKiConcCtrl(pthread_mutex_unlock(&statsReportingBlockerMut));
+        CHKiConcCtrl(pthread_mutex_lock(&stats_reporting_blocker_mut));
+        stats_reporting_blocked = 0;
+        pthread_cond_signal(&stats_reporting_blocker_cond);
+        CHKiConcCtrl(pthread_mutex_unlock(&stats_reporting_blocker_mut));
         LogError(0, RS_RET_OK, "imdiag: stats reporting unblocked");
         STATSCOUNTER_ADD(potentialArtificialDelayMs, mutPotentialArtificialDelayMs, delta);
         STATSCOUNTER_INC(delayInvocationCount, mutDelayInvocationCount);
@@ -1119,8 +1119,8 @@ BEGINmodExit
     free(pszStrmDrvrAuthMode);
 
     statsobj.Destruct(&diagStats);
-    pthread_cond_destroy(&statsReportingBlockerCond);
-    pthread_mutex_destroy(&statsReportingBlockerMut);
+    pthread_cond_destroy(&stats_reporting_blocker_cond);
+    pthread_mutex_destroy(&stats_reporting_blocker_mut);
     DESTROY_ATOMIC_HELPER_MUT(mutAllowOnlyOnce);
     pthread_cond_destroy(&statsReporterWatch);
     pthread_mutex_destroy(&mutStatsReporterWatch);
@@ -1237,9 +1237,9 @@ BEGINmodInit()
     CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("resetconfigvariables"), 1, eCmdHdlrCustomHandler, resetConfigVariables,
                                NULL, STD_LOADABLE_MODULE_ID));
 
-    CHKiConcCtrl(pthread_mutex_init(&statsReportingBlockerMut, NULL));
-    CHKiConcCtrl(pthread_cond_init(&statsReportingBlockerCond, NULL));
-    statsReportingBlocked = 0;
+    CHKiConcCtrl(pthread_mutex_init(&stats_reporting_blocker_mut, NULL));
+    CHKiConcCtrl(pthread_cond_init(&stats_reporting_blocker_cond, NULL));
+    stats_reporting_blocked = 0;
     INIT_ATOMIC_HELPER_MUT(mutAllowOnlyOnce);
     CHKiConcCtrl(pthread_mutex_init(&mutStatsReporterWatch, NULL));
     CHKiConcCtrl(pthread_cond_init(&statsReporterWatch, NULL));

--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -90,7 +90,12 @@ STATSCOUNTER_DEF(potentialArtificialDelayMs, mutPotentialArtificialDelayMs)
 STATSCOUNTER_DEF(actualArtificialDelayMs, mutActualArtificialDelayMs)
 STATSCOUNTER_DEF(delayInvocationCount, mutDelayInvocationCount)
 
-static pthread_mutex_t statsReportingBlocker;
+/* statsReportingBlocker gates impstats reads across imdiag command and stats
+ * callback threads; use a condition variable instead of mutex ownership
+ * handoff so the command thread can unblock a callback thread safely. */
+static pthread_mutex_t statsReportingBlockerMut;
+static pthread_cond_t statsReportingBlockerCond;
+static int statsReportingBlocked = 0;
 static long long statsReportingBlockStartTimeMs = 0;
 static int allowOnlyOnce = 0;
 DEF_ATOMIC_HELPER_MUT(mutAllowOnlyOnce);
@@ -489,17 +494,23 @@ finalize_it:
 static void imdiag_statsReadCallback(statsobj_t __attribute__((unused)) *const ignore_stats,
                                      void __attribute__((unused)) *const ignore_ctx) {
     long long waitStartTimeMs = currentTimeMills();
-    if (pthread_mutex_lock(&statsReportingBlocker) != 0) {
+    if (pthread_mutex_lock(&statsReportingBlockerMut) != 0) {
         return;
     }
+    while (statsReportingBlocked) {
+        if (pthread_cond_wait(&statsReportingBlockerCond, &statsReportingBlockerMut) != 0) {
+            pthread_mutex_unlock(&statsReportingBlockerMut);
+            return;
+        }
+    }
     long delta = currentTimeMills() - waitStartTimeMs;
-    if ((int)ATOMIC_DEC_AND_FETCH(&allowOnlyOnce, &mutAllowOnlyOnce) < 0) {
-        (void)pthread_mutex_unlock(&statsReportingBlocker);
-    } else {
+    if ((int)ATOMIC_DEC_AND_FETCH(&allowOnlyOnce, &mutAllowOnlyOnce) >= 0) {
+        statsReportingBlocked = 1;
         LogError(0, RS_RET_OK,
                  "imdiag(stats-read-callback): current stats-reporting "
                  "cycle will proceed now, next reporting cycle will again be blocked");
     }
+    pthread_mutex_unlock(&statsReportingBlockerMut);
 
     if (pthread_mutex_lock(&mutStatsReporterWatch) == 0) {
         statsReported = 1;
@@ -515,7 +526,9 @@ static void imdiag_statsReadCallback(statsobj_t __attribute__((unused)) *const i
 static rsRetVal blockStatsReporting(tcps_sess_t *pSess) {
     DEFiRet;
 
-    CHKiConcCtrl(pthread_mutex_lock(&statsReportingBlocker));
+    CHKiConcCtrl(pthread_mutex_lock(&statsReportingBlockerMut));
+    statsReportingBlocked = 1;
+    CHKiConcCtrl(pthread_mutex_unlock(&statsReportingBlockerMut));
     CHKiConcCtrl(pthread_mutex_lock(&mutStatsReporterWatch));
     statsReported = 0;
     CHKiConcCtrl(pthread_mutex_unlock(&mutStatsReporterWatch));
@@ -549,7 +562,10 @@ static rsRetVal awaitStatsReport(uchar *pszCmd, tcps_sess_t *pSess) {
             statsReportingBlockStartTimeMs = 0;
             LogError(0, RS_RET_OK, "imdiag: un-blocking stats reporting");
         }
-        CHKiConcCtrl(pthread_mutex_unlock(&statsReportingBlocker));
+        CHKiConcCtrl(pthread_mutex_lock(&statsReportingBlockerMut));
+        statsReportingBlocked = 0;
+        CHKiConcCtrl(pthread_cond_signal(&statsReportingBlockerCond));
+        CHKiConcCtrl(pthread_mutex_unlock(&statsReportingBlockerMut));
         LogError(0, RS_RET_OK, "imdiag: stats reporting unblocked");
         STATSCOUNTER_ADD(potentialArtificialDelayMs, mutPotentialArtificialDelayMs, delta);
         STATSCOUNTER_INC(delayInvocationCount, mutDelayInvocationCount);
@@ -1103,7 +1119,8 @@ BEGINmodExit
     free(pszStrmDrvrAuthMode);
 
     statsobj.Destruct(&diagStats);
-    pthread_mutex_destroy(&statsReportingBlocker);
+    pthread_cond_destroy(&statsReportingBlockerCond);
+    pthread_mutex_destroy(&statsReportingBlockerMut);
     DESTROY_ATOMIC_HELPER_MUT(mutAllowOnlyOnce);
     pthread_cond_destroy(&statsReporterWatch);
     pthread_mutex_destroy(&mutStatsReporterWatch);
@@ -1220,7 +1237,9 @@ BEGINmodInit()
     CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("resetconfigvariables"), 1, eCmdHdlrCustomHandler, resetConfigVariables,
                                NULL, STD_LOADABLE_MODULE_ID));
 
-    CHKiConcCtrl(pthread_mutex_init(&statsReportingBlocker, NULL));
+    CHKiConcCtrl(pthread_mutex_init(&statsReportingBlockerMut, NULL));
+    CHKiConcCtrl(pthread_cond_init(&statsReportingBlockerCond, NULL));
+    statsReportingBlocked = 0;
     INIT_ATOMIC_HELPER_MUT(mutAllowOnlyOnce);
     CHKiConcCtrl(pthread_mutex_init(&mutStatsReporterWatch, NULL));
     CHKiConcCtrl(pthread_cond_init(&statsReporterWatch, NULL));


### PR DESCRIPTION
### Motivation
- A semaphore-to-`pthread_mutex_t` replacement left imdiag using a mutex like a semaphore across threads, which can cause undefined behavior, non-owner unlocks, or deadlocks in the optional diagnostic `imdiag` stats-control path. 
- The module is testbench/diagnostic-only (disabled by default) but this change restores correct cross-thread handoff semantics to avoid undefined pthread mutex ownership violations when `imdiag` is exercised.

### Description
- Replace the single `statsReportingBlocker` mutex handoff with an explicit `statsReportingBlocked` flag protected by `statsReportingBlockerMut` and `statsReportingBlockerCond` so threads use a condition-variable wait/signal pattern instead of non-owner mutex unlocks. 
- Update `imdiag_statsReadCallback()` to wait on the condition variable while blocked and to safely re-arm the blocked state for the `block_again` path without retaining mutex ownership. 
- Update `blockStatsReporting()` and `awaitStatsReport()` so command threads set/clear the `statsReportingBlocked` flag and signal the condition variable instead of unlocking a mutex owned by another thread. 
- Initialize and destroy the new `pthread_cond_t` and renamed blocker mutex in module init/exit and add a short top-of-file comment describing the intent.

### Testing
- Ran `devtools/format-code.sh --git-changed` and the formatting check completed successfully. 
- Executed `devtools/local-validation-plan.sh --base HEAD --run` (format gate passed) but the run reported that local Cubic and container lanes could not run because `cubic` and `docker`/`podman` are not available in this environment. 
- Performed configure/build: `./configure --disable-impstats-push --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --enable-compile-warnings=error` completed and `make -j... check TESTS=""` completed successfully. 
- Exercised the focused test `PYTHON=python3 ./tests/perctile-simple.sh` which passed, and ran a Helgrind-style `startup_vgthread` execution of the same test which completed and did not report the previous imdiag non-owner-unlock/recursive-lock issue (Helgrind still produced unrelated existing perctile/stats lock-order reports). 
- Note: full PR-ready local container validation (Ubuntu 26.04 static analyzer and change-gated `run-ci.sh` lanes) was not completed locally due to missing Docker/Podman and should be covered in hosted CI or by a container-capable agent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dc26e69488332825aa5a915cef1d9)