### PR TITLE
mmsnareparse: honor searchWindow in tab-delimited trailing scans

### DIFF
--- a/plugins/mmsnareparse/mmsnareparse.c
+++ b/plugins/mmsnareparse/mmsnareparse.c
@@ -5174,20 +5174,29 @@ static char *detect_and_truncate_trailing_extradata(instanceData *pData, char *m
 
     /* Pattern must appear after the last tab to be considered trailing */
     char *searchStart = lastTab + 1;
-    size_t msgLenVal = strlen(mutableMsg);
-    size_t trailingTokenLen = strlen(searchStart);
-    size_t trailingSearchLen = msgLenVal / 5; /* Last 20% of whole message */
-    if (trailingSearchLen > pData->searchLimit) {
-        trailingSearchLen = pData->searchLimit;
-    }
+    const size_t trailingTokenLen = strlen(searchStart);
+    size_t trailingSearchLen = pData->searchLimit;
     if (trailingSearchLen > trailingTokenLen) {
         trailingSearchLen = trailingTokenLen;
     }
     char *cappedSearchStart = searchStart + trailingTokenLen - trailingSearchLen;
 
     if (pData->ignoreTrailingPattern_isRegex) {
-        /* Regex mode: apply regexec to the capped trailing window */
-        const int isMatch = !regexec(&pData->ignoreTrailingPattern_preg, cappedSearchStart, 0, NULL, 0);
+        /* Regex mode: bound regex input to searchLimit trailing bytes to
+         * reduce risk from expensive non-matching expressions on untrusted
+         * message content while preserving start-anchored token patterns. */
+        char savedChar = '\0';
+        const sbool tokenWasTruncated = trailingTokenLen > pData->searchLimit;
+        if (tokenWasTruncated) {
+            savedChar = searchStart[pData->searchLimit];
+            searchStart[pData->searchLimit] = '\0';
+        }
+
+        const int regexecFlags = tokenWasTruncated ? REG_NOTEOL : 0;
+        const int isMatch = !regexec(&pData->ignoreTrailingPattern_preg, searchStart, 0, NULL, regexecFlags);
+        if (tokenWasTruncated) {
+            searchStart[pData->searchLimit] = savedChar;
+        }
         if (isMatch) {
             /* Pattern found in trailing position - truncate at the start of the last token
              * (after the last tab) to remove the entire enrichment section including any

--- a/plugins/mmsnareparse/mmsnareparse.c
+++ b/plugins/mmsnareparse/mmsnareparse.c
@@ -5174,24 +5174,20 @@ static char *detect_and_truncate_trailing_extradata(instanceData *pData, char *m
 
     /* Pattern must appear after the last tab to be considered trailing */
     char *searchStart = lastTab + 1;
+    size_t msgLenVal = strlen(mutableMsg);
+    size_t trailingTokenLen = strlen(searchStart);
+    size_t trailingSearchLen = msgLenVal / 5; /* Last 20% of whole message */
+    if (trailingSearchLen > pData->searchLimit) {
+        trailingSearchLen = pData->searchLimit;
+    }
+    if (trailingSearchLen > trailingTokenLen) {
+        trailingSearchLen = trailingTokenLen;
+    }
+    char *cappedSearchStart = searchStart + trailingTokenLen - trailingSearchLen;
 
     if (pData->ignoreTrailingPattern_isRegex) {
-        /* Regex mode: bound regex input to searchLimit trailing bytes to
-         * reduce risk from expensive non-matching expressions on untrusted
-         * message content while preserving start-anchored token patterns. */
-        const size_t trailingTokenLen = strlen(searchStart);
-        char savedChar = '\0';
-        const sbool tokenWasTruncated = trailingTokenLen > pData->searchLimit;
-        if (tokenWasTruncated) {
-            savedChar = searchStart[pData->searchLimit];
-            searchStart[pData->searchLimit] = '\0';
-        }
-
-        const int regexecFlags = tokenWasTruncated ? REG_NOTEOL : 0;
-        const int isMatch = !regexec(&pData->ignoreTrailingPattern_preg, searchStart, 0, NULL, regexecFlags);
-        if (tokenWasTruncated) {
-            searchStart[pData->searchLimit] = savedChar;
-        }
+        /* Regex mode: apply regexec to the capped trailing window */
+        const int isMatch = !regexec(&pData->ignoreTrailingPattern_preg, cappedSearchStart, 0, NULL, 0);
         if (isMatch) {
             /* Pattern found in trailing position - truncate at the start of the last token
              * (after the last tab) to remove the entire enrichment section including any
@@ -5212,8 +5208,9 @@ static char *detect_and_truncate_trailing_extradata(instanceData *pData, char *m
         /* Static pattern mode: use strstr */
         const char *pattern = (const char *)pData->ignoreTrailingPattern;
         /* Defensive check: ensure pattern is not empty to avoid unintended matches */
-        if (strlen(pattern) > 0) {
-            char *patternPos = strstr(searchStart, pattern);
+        size_t patternLen = strlen(pattern);
+        if (patternLen > 0 && trailingSearchLen >= patternLen) {
+            char *patternPos = strstr(cappedSearchStart, pattern);
 
             if (patternPos != NULL) {
                 /* Pattern found in trailing position - truncate at the start of the last token


### PR DESCRIPTION
### Motivation
- The `ignoreTrailingPattern.searchWindow` parameter was intended to bound how many characters are searched at the end of messages, but the tab-delimited (normal Snare) path did not enforce that cap, allowing unbounded regex/literal work on the final token.
- Enforce the configured bound for the primary parsing path so operators can reliably limit CPU work on untrusted input.

### Description
- Apply the same trailing-window policy used by the no-tab fallback to the tab-delimited path in `detect_and_truncate_trailing_extradata()` in `plugins/mmsnareparse/mmsnareparse.c` by computing a `trailingSearchLen = last 20% of message` capped by `pData->searchLimit` and by the trailing token length.
- Derive `cappedSearchStart` inside the trailing token and run `regexec()` against that capped window instead of the full token to ensure regex cost honors `searchWindow`.
- For literal matching, use `strstr()` on the capped window and require `trailingSearchLen >= patternLen` before searching to avoid false-positive matches caused by overly small windows.
- Preserve existing truncation semantics: when a match is found, save the full trailing token as extra-data and truncate the message at the last tab.

### Testing
- Ran code formatting with `devtools/format-code.sh --git-changed` which completed successfully. 
- Attempted to run the module trailing-extradata regex test `./tests/mmsnareparse-trailing-extradata-regex.sh`, but the test harness failed to complete because `configure` aborted due to a missing system dependency (`libsnappy-dev`), so the test binaries could not be built and the test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f9cf5cb08332a080f2b46a34e1d8)