### PR TITLE
tests: guard override libs

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2145,21 +2145,6 @@ CLEANFILES+= \
 
 pkglib_LTLIBRARIES =
 
-pkglib_LTLIBRARIES += liboverride_gethostname.la
-liboverride_gethostname_la_SOURCES = override_gethostname.c
-liboverride_gethostname_la_CFLAGS =
-liboverride_gethostname_la_LDFLAGS = -avoid-version -shared
-
-pkglib_LTLIBRARIES += liboverride_gethostname_nonfqdn.la
-liboverride_gethostname_nonfqdn_la_SOURCES = override_gethostname_nonfqdn.c
-liboverride_gethostname_nonfqdn_la_CFLAGS =
-liboverride_gethostname_nonfqdn_la_LDFLAGS = -avoid-version -shared
-
-pkglib_LTLIBRARIES += liboverride_getaddrinfo.la
-liboverride_getaddrinfo_la_SOURCES = override_getaddrinfo.c
-liboverride_getaddrinfo_la_CFLAGS =
-liboverride_getaddrinfo_la_LDFLAGS = -avoid-version -shared
-
 # TODO: reenable TESTRUNS = rt_init rscript
 check_PROGRAMS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace
 TESTS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace
@@ -2223,6 +2208,21 @@ runtime_unit_msg_replace_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
 endif
 
 if ENABLE_TESTBENCH
+pkglib_LTLIBRARIES += liboverride_gethostname.la
+liboverride_gethostname_la_SOURCES = override_gethostname.c
+liboverride_gethostname_la_CFLAGS =
+liboverride_gethostname_la_LDFLAGS = -avoid-version -shared
+
+pkglib_LTLIBRARIES += liboverride_gethostname_nonfqdn.la
+liboverride_gethostname_nonfqdn_la_SOURCES = override_gethostname_nonfqdn.c
+liboverride_gethostname_nonfqdn_la_CFLAGS =
+liboverride_gethostname_nonfqdn_la_LDFLAGS = -avoid-version -shared
+
+pkglib_LTLIBRARIES += liboverride_getaddrinfo.la
+liboverride_getaddrinfo_la_SOURCES = override_getaddrinfo.c
+liboverride_getaddrinfo_la_CFLAGS =
+liboverride_getaddrinfo_la_LDFLAGS = -avoid-version -shared
+
 check_PROGRAMS += $(TESTRUNS) ourtail tcpflood chkseq msleep randomgen \
 	diagtalker uxsockrcvr syslog_caller inputfilegen minitcpsrv \
 	omrelp_dflt_port \
@@ -2562,7 +2562,7 @@ TESTS += $(TESTS_LIBFAKETIME)
 
 # now come faketime tests that utilize mmnormalize - aka "no endif here"
 if ENABLE_MMNORMALIZE
-TESTS += $(TESTS_MMNORMALIZE)
+TESTS += $(TESTS_MMNORMALIZE_FAKETIME)
 endif
 endif
 


### PR DESCRIPTION
### Motivation
- Prevent test-only interposition libraries from being built/installed when `--disable-testbench` is used by restoring the `ENABLE_TESTBENCH` scope for those `pkglib_LTLIBRARIES` entries.
- Restore intended faketime-specific coverage by ensuring faketime+`mmnormalize` uses the `TESTS_MMNORMALIZE_FAKETIME` test-list instead of duplicating the generic list.

### Description
- Moved `liboverride_gethostname`, `liboverride_gethostname_nonfqdn`, and `liboverride_getaddrinfo` `pkglib_LTLIBRARIES` entries back under the `if ENABLE_TESTBENCH` guard in `tests/Makefile.am` so they are only built/installed when the testbench is enabled.
- Updated the `ENABLE_LIBFAKETIME` + `ENABLE_MMNORMALIZE` block to append `$(TESTS_MMNORMALIZE_FAKETIME)` so faketime-specific `mmnormalize` tests are run instead of the generic `$(TESTS_MMNORMALIZE)` list.
- Kept unit `check_PROGRAMS` registration outside the testbench guard and left the test lists defined near the top and distributed via the unconditional `EXTRA_DIST` entries.

### Testing
- Ran `devtools/local-validation-plan.sh` and `NOCONFIGURE=1 ./autogen.sh` successfully to classify and prepare the change.
- Verified `./configure --disable-testbench ...` produced a `tests/Makefile` without the override pkglib libraries and `./configure --enable-testbench --enable-mmnormalize --enable-libfaketime ...` produced append mappings referencing `TESTS_MMNORMALIZE_FAKETIME` and the four `mmnormalize_processing_test[1-4].sh` entries as expected.
- Ran diff-scoped checks `shellcheck` on changed `*.sh` files and `git diff --check` which succeeded, and executed `devtools/local-validation-plan.sh --run` which progressed to the mock `distcheck` but failed during `configure` due to a missing system dependency (`libsnappy-dev` / `snappy-c.h`).
- Note: Docker/Podman and `cubic` were not available in this environment, so full PR-ready local container validation (change-gated Ubuntu 26.04 runs and clang static analyzer) was not performed and should be run by a container-capable runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2051ddbcc48332a35ec5941362c8e7)