### PR TITLE
mmdblookup: preserve uint64 values

### DIFF
--- a/plugins/mmdblookup/mmdblookup.c
+++ b/plugins/mmdblookup/mmdblookup.c
@@ -361,7 +361,10 @@ static json_object *entry_data_to_json(const MMDB_entry_data_s *data) {
             }
 
             char uint64Buf[sizeof("18446744073709551615")];
-            snprintf(uint64Buf, sizeof(uint64Buf), "%" PRIu64, data->uint64);
+            if (snprintf(uint64Buf, sizeof(uint64Buf), "%" PRIu64, data->uint64) < 0) {
+                return NULL;
+            }
+            uint64Buf[sizeof(uint64Buf) - 1] = '\0';
             return json_object_new_string(uint64Buf);
 #endif
         case MMDB_DATA_TYPE_BOOLEAN:

--- a/plugins/mmdblookup/mmdblookup.c
+++ b/plugins/mmdblookup/mmdblookup.c
@@ -32,6 +32,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <pthread.h>
 #include "conf.h"
 #include "syslogd-types.h"
@@ -352,7 +353,17 @@ static json_object *entry_data_to_json(const MMDB_entry_data_s *data) {
         case MMDB_DATA_TYPE_INT32:
             return json_object_new_int(data->int32);
         case MMDB_DATA_TYPE_UINT64:
-            return json_object_new_int64((int64_t)data->uint64);
+#ifdef json_type_uint64
+            return json_object_new_uint64(data->uint64);
+#else
+            if (data->uint64 <= (uint64_t)INT64_MAX) {
+                return json_object_new_int64((int64_t)data->uint64);
+            }
+
+            char uint64Buf[sizeof("18446744073709551615")];
+            snprintf(uint64Buf, sizeof(uint64Buf), "%" PRIu64, data->uint64);
+            return json_object_new_string(uint64Buf);
+#endif
         case MMDB_DATA_TYPE_BOOLEAN:
             return json_object_new_boolean(data->boolean);
         default:


### PR DESCRIPTION
### Motivation
- Ensure MMDB `UINT64` leaf values that exceed `INT64_MAX` are preserved when converted to JSON instead of being misrepresented as negative signed integers by an unconditional cast to `int64_t`.

### Description
- Use `json_object_new_uint64` when the JSON layer exposes unsigned-64 support, otherwise emit values that fit in `INT64_MAX` via `json_object_new_int64` and format out-of-range `uint64` values into a decimal string; also include `<inttypes.h>` to portably format `PRIu64`.

### Testing
- Ran `devtools/format-code.sh --git-changed` and its read-only check, `./configure --cache-file=config.cache --enable-debug --enable-testbench --enable-mmdblookup --enable-mmnormalize --enable-imptcp`, `make -j$(nproc) check TESTS=""`, `./tests/mmdb-compound.sh`, and a compiled libfastjson PoC that verifies large-`uint64` serialization behaviour, all of which passed locally; PR-ready container/static-analyzer lanes were not executed locally (Docker/Cubic unavailable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2051e065908332a6a97a28ab51d0ce)