### PR TITLE
imkafka: stop workers on startup failure

### DIFF
--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -189,7 +189,7 @@ typedef struct modConfData_s {
 pthread_attr_t wrkrThrdAttr; /* Attribute for worker threads ; read only after startup */
 static int activeKafkaworkers = 0;
 static int stopKafkaWorkers = 0;
-DEF_ATOMIC_HELPER_MUT(mutStopKafkaWorkers);
+DEF_ATOMIC_HELPER_MUT(mutStopImkafkaWorkers);
 /* The following structure controls the worker threads. Global data is
  * needed for their access.
  */
@@ -1174,7 +1174,7 @@ static void shutdownKafkaWorkers(void) {
     instanceConf_t *inst;
 
     assert(kafkaWrkrInfo != NULL);
-    ATOMIC_STORE_1_TO_INT(&stopKafkaWorkers, &mutStopKafkaWorkers);
+    ATOMIC_STORE_1_TO_INT(&stopKafkaWorkers, &mutStopImkafkaWorkers);
     DBGPRINTF("imkafka: waiting on imkafka workerthread termination\n");
     for (i = 0; i < activeKafkaworkers; ++i) {
         pthread_join(kafkaWrkrInfo[i].tid, NULL);
@@ -1222,7 +1222,7 @@ BEGINrunInput
     CODESTARTrunInput;
     DBGPRINTF("imkafka: runInput loop started ...\n");
     activeKafkaworkers = 0;
-    ATOMIC_STORE_0_TO_INT(&stopKafkaWorkers, &mutStopKafkaWorkers);
+    ATOMIC_STORE_0_TO_INT(&stopKafkaWorkers, &mutStopImkafkaWorkers);
     for (inst = runModConf->root; inst != NULL; inst = inst->next) {
         if (inst->rk != NULL) {
             ++workerSlots;
@@ -1293,7 +1293,7 @@ ENDafterRun
 BEGINmodExit
     CODESTARTmodExit;
     pthread_attr_destroy(&wrkrThrdAttr);
-    DESTROY_ATOMIC_HELPER_MUT(mutStopKafkaWorkers);
+    DESTROY_ATOMIC_HELPER_MUT(mutStopImkafkaWorkers);
     /* release objects we used */
     if (kafkaStats) {
         statsobj.Destruct(&kafkaStats);
@@ -1335,7 +1335,7 @@ BEGINmodInit()
     /* initialize "read-only" thread attributes */
     pthread_attr_init(&wrkrThrdAttr);
     pthread_attr_setstacksize(&wrkrThrdAttr, 4096 * 1024);
-    INIT_ATOMIC_HELPER_MUT(mutStopKafkaWorkers);
+    INIT_ATOMIC_HELPER_MUT(mutStopImkafkaWorkers);
 
     DBGPRINTF("imkafka %s using librdkafka version %s, 0x%x\n", VERSION, rd_kafka_version_str(), rd_kafka_version());
 
@@ -1395,7 +1395,7 @@ static void *imkafkawrkr(void *myself) {
     DBGPRINTF("imkafka: started kafka consumer workerthread on group %s/%s with %d topics\n", me->inst->consumergroup,
               me->inst->brokers, me->inst->nTopics);
     do {
-        if (ATOMIC_FETCH_32BIT(&stopKafkaWorkers, &mutStopKafkaWorkers) || glbl.GetGlobalInputTermState() == 1) {
+        if (ATOMIC_FETCH_32BIT(&stopKafkaWorkers, &mutStopImkafkaWorkers) || glbl.GetGlobalInputTermState() == 1) {
             break; /* terminate input! */
         }
         if (me->inst->rk == NULL) {
@@ -1413,8 +1413,10 @@ static void *imkafkawrkr(void *myself) {
          * of 0 seconds. It doesn't hurt any other valid scenario. So do not remove.
          * rgerhards, 2008-02-14
          */
-        if (glbl.GetGlobalInputTermState() == 0) srSleep(0, 100000);
-    } while (!ATOMIC_FETCH_32BIT(&stopKafkaWorkers, &mutStopKafkaWorkers) && glbl.GetGlobalInputTermState() == 0);
+        if (glbl.GetGlobalInputTermState() == 0 && !ATOMIC_FETCH_32BIT(&stopKafkaWorkers, &mutStopImkafkaWorkers)) {
+            srSleep(0, 100000);
+        }
+    } while (!ATOMIC_FETCH_32BIT(&stopKafkaWorkers, &mutStopImkafkaWorkers) && glbl.GetGlobalInputTermState() == 0);
     DBGPRINTF("imkafka: stopped kafka consumer workerthread on group %s/%s with %d topics\n", me->inst->consumergroup,
               me->inst->brokers, me->inst->nTopics);
     return NULL;

--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -73,6 +73,8 @@ MODULE_CNFNAME("imkafka")
  * - JSON splitting (splitJsonRecords) operates on a per-message basis with
  *   no shared mutable state. Each split record is submitted independently
  *   to the rsyslog core, which handles its own queuing and threading.
+ * - A module-local atomic stop flag lets runInput() ask already-started
+ *   workers to exit during partial startup teardown before joining them.
  * - No additional locking required beyond existing instance-level processing
  *   and librdkafka's internal thread-safety guarantees.
  * ============================================================================= */
@@ -186,6 +188,8 @@ typedef struct modConfData_s {
 /* global data */
 pthread_attr_t wrkrThrdAttr; /* Attribute for worker threads ; read only after startup */
 static int activeKafkaworkers = 0;
+static int stopKafkaWorkers = 0;
+DEF_ATOMIC_HELPER_MUT(mutStopKafkaWorkers);
 /* The following structure controls the worker threads. Global data is
  * needed for their access.
  */
@@ -1170,6 +1174,7 @@ static void shutdownKafkaWorkers(void) {
     instanceConf_t *inst;
 
     assert(kafkaWrkrInfo != NULL);
+    ATOMIC_STORE_1_TO_INT(&stopKafkaWorkers, &mutStopKafkaWorkers);
     DBGPRINTF("imkafka: waiting on imkafka workerthread termination\n");
     for (i = 0; i < activeKafkaworkers; ++i) {
         pthread_join(kafkaWrkrInfo[i].tid, NULL);
@@ -1217,6 +1222,7 @@ BEGINrunInput
     CODESTARTrunInput;
     DBGPRINTF("imkafka: runInput loop started ...\n");
     activeKafkaworkers = 0;
+    ATOMIC_STORE_0_TO_INT(&stopKafkaWorkers, &mutStopKafkaWorkers);
     for (inst = runModConf->root; inst != NULL; inst = inst->next) {
         if (inst->rk != NULL) {
             ++workerSlots;
@@ -1287,6 +1293,7 @@ ENDafterRun
 BEGINmodExit
     CODESTARTmodExit;
     pthread_attr_destroy(&wrkrThrdAttr);
+    DESTROY_ATOMIC_HELPER_MUT(mutStopKafkaWorkers);
     /* release objects we used */
     if (kafkaStats) {
         statsobj.Destruct(&kafkaStats);
@@ -1328,6 +1335,7 @@ BEGINmodInit()
     /* initialize "read-only" thread attributes */
     pthread_attr_init(&wrkrThrdAttr);
     pthread_attr_setstacksize(&wrkrThrdAttr, 4096 * 1024);
+    INIT_ATOMIC_HELPER_MUT(mutStopKafkaWorkers);
 
     DBGPRINTF("imkafka %s using librdkafka version %s, 0x%x\n", VERSION, rd_kafka_version_str(), rd_kafka_version());
 
@@ -1387,7 +1395,9 @@ static void *imkafkawrkr(void *myself) {
     DBGPRINTF("imkafka: started kafka consumer workerthread on group %s/%s with %d topics\n", me->inst->consumergroup,
               me->inst->brokers, me->inst->nTopics);
     do {
-        if (glbl.GetGlobalInputTermState() == 1) break; /* terminate input! */
+        if (ATOMIC_FETCH_32BIT(&stopKafkaWorkers, &mutStopKafkaWorkers) || glbl.GetGlobalInputTermState() == 1) {
+            break; /* terminate input! */
+        }
         if (me->inst->rk == NULL) {
             continue;
         }
@@ -1404,7 +1414,7 @@ static void *imkafkawrkr(void *myself) {
          * rgerhards, 2008-02-14
          */
         if (glbl.GetGlobalInputTermState() == 0) srSleep(0, 100000);
-    } while (glbl.GetGlobalInputTermState() == 0);
+    } while (!ATOMIC_FETCH_32BIT(&stopKafkaWorkers, &mutStopKafkaWorkers) && glbl.GetGlobalInputTermState() == 0);
     DBGPRINTF("imkafka: stopped kafka consumer workerthread on group %s/%s with %d topics\n", me->inst->consumergroup,
               me->inst->brokers, me->inst->nTopics);
     return NULL;


### PR DESCRIPTION
### Motivation
- Prevent runInput from deadlocking during partial worker startup when `pthread_create` fails after one or more workers started by ensuring those workers are signaled to exit before being joined.

### Description
- Add a module-local atomic stop flag `stopKafkaWorkers` and an associated atomic helper `mutStopKafkaWorkers` to coordinate early worker teardown.
- Initialize (`INIT_ATOMIC_HELPER_MUT`) and destroy (`DESTROY_ATOMIC_HELPER_MUT`) the atomic helper in `modInit()`/`modExit()` and reset the flag at the start of `runInput()`.
- Set the stop flag in `shutdownKafkaWorkers()` before `pthread_join()`ing active workers so partial-startup cleanup requests worker exit prior to joining.
- Teach `imkafkawrkr()` to exit when the module-local stop flag is set in addition to the global input termination state, and update the worker loop condition accordingly.

### Testing
- Ran `./autogen.sh && ./configure --enable-testbench --enable-imkafka` (initial run failed due to missing system deps; installed `librdkafka-dev` and `libsnappy-dev` then re-ran successfully). — succeeded after installing packages.
- Built and exercised basic checks with `make -j$(nproc) check TESTS=""`. — succeeded.
- Ran formatting check `devtools/format-code.sh --git-changed --check --check-if-available`. — passed.
- Executed `devtools/local-validation-plan.sh --run` which performed diff-scoped checks and the format gate; Docker/Podman and local Cubic were not available so full container/static-analyzer/Cubic lanes were skipped (work is not fully container-validated). — diff-scoped validation passed, container/Cubic lanes skipped.
- Performed focused prompt audits using `ai/rsyslog_memory_auditor/base_prompt.txt` and `ai/rsyslog_bug_finder/base_prompt.txt` on the changed teardown/worker-exit paths and found no additional issues. — no further issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2051ddcec08332b5ef41c22aee7b87)