### PR TITLE
doc: fix database tutorial SQL template option

### DIFF
--- a/doc/source/tutorials/database.rst
+++ b/doc/source/tutorials/database.rst
@@ -126,9 +126,10 @@ like this:
    template(
        name="sqlInsertMessage"
        type="list"
+       option.sql="on"
    ) {
        constant(value="insert into syslog(message) values ('")
-       property(name="msg" sql="on")
+       property(name="msg")
        constant(value="')")
    }
 


### PR DESCRIPTION
### Motivation
- Correct an invalid Rainerscript example in `doc/source/tutorials/database.rst` that placed `sql="on"` on `property()` (not a supported property parameter) which yields a configuration error or a disabled database action when copied verbatim.

### Description
- Update the tutorial list template to set SQL escaping at the template level by adding `option.sql="on"` and remove the unsupported `sql="on"` from `property(name="msg")`, preserving the original insert example and behavior.

### Testing
- Ran `devtools/local-validation-plan.sh --base HEAD`, which classified the change as `rendered-docs` and completed successfully.
- Ran the C/H formatting check `devtools/format-code.sh --git-changed --check --check-if-available` and it passed.
- Built the HTML docs with `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a216add19f88332b62c0d4fd24421f9)