### PR TITLE
impstats docs: fix dotted log parameters

### DIFF
--- a/doc/source/configuration/modules/impstats.rst
+++ b/doc/source/configuration/modules/impstats.rst
@@ -108,7 +108,7 @@ The configuration parameters are grouped below by use case.
 .. note::
 
    Parameter names are case-insensitive, but punctuation such as dots is
-   significant. Use dotted names exactly as shown.
+   significant. Use the parameter names exactly as shown.
 
 .. note::
 

--- a/doc/source/configuration/modules/impstats.rst
+++ b/doc/source/configuration/modules/impstats.rst
@@ -107,7 +107,8 @@ The configuration parameters are grouped below by use case.
 
 .. note::
 
-   Parameter names are case-insensitive; camelCase is recommended for improved readability.
+   Parameter names are case-insensitive, but punctuation such as dots is
+   significant. Use dotted names exactly as shown.
 
 .. note::
 
@@ -295,7 +296,7 @@ Caveats/Known Bugs
 -  This module MUST be loaded right at the top of rsyslog.conf,
    otherwise stats may not get turned on in all places.
 -  When using the format "zabbix", it is not recommended to use
-   logSyslog="on". This can cause message truncation in stats.
+   log.syslog="on". This can cause message truncation in stats.
 
 
 Examples
@@ -325,8 +326,8 @@ Load module, format the output to Zabbix, and output to a local file
           interval="60"
           severity="7"
           format="zabbix"
-          logSyslog="off"
-          logFile="/var/log/stats.log")
+          log.syslog="off"
+          log.file="/var/log/stats.log")
 
 
 Load module, send stats data to local file
@@ -340,9 +341,9 @@ data is NOT emitted to the syslog stream but to a local file instead.
    module(load="impstats"
           interval="600"
           severity="7"
-          logSyslog="off"
+          log.syslog="off"
           # need to turn log stream logging off!
-          logFile="/path/to/local/stats.log")
+          log.file="/path/to/local/stats.log")
 
 
 Load module, send stats data to local file and syslog stream
@@ -357,7 +358,7 @@ server:
    module(load="impstats"
           interval="600"
           severity="7"
-          logFile="/path/to/local/stats.log")
+          log.file="/path/to/local/stats.log")
 
    syslog.=debug @central.example.net
 
@@ -373,7 +374,7 @@ VictoriaMetrics using Prometheus Remote Write:
    module(load="impstats"
           interval="30"
           format="json"
-          logFile="/var/log/rsyslog-stats.log"
+          log.file="/var/log/rsyslog-stats.log"
           push.url="http://localhost:8428/api/v1/write"
           push.labels=["env=prod", "cluster=edge"]
           push.label.origin="on"

--- a/doc/source/reference/parameters/impstats-log-file-overwrite.rst
+++ b/doc/source/reference/parameters/impstats-log-file-overwrite.rst
@@ -43,8 +43,8 @@ Module usage
 
 .. code-block:: rsyslog
 
-   module(load="impstats" 
-          logFile="/var/log/rsyslog-stats"
+   module(load="impstats"
+          log.file="/var/log/rsyslog-stats"
           log.file.overwrite="on")
 
 See also

--- a/doc/source/reference/parameters/impstats-log-file.rst
+++ b/doc/source/reference/parameters/impstats-log-file.rst
@@ -34,7 +34,7 @@ go wrong stats records will probably be lost. Logging to file can be a useful
 alternative if for some reasons (e.g. full queues) the regular syslog stream
 method shall not be used solely. Note that turning on file logging does NOT turn
 off syslog logging. If that is desired, :ref:`param-impstats-log-syslog`
-(``logSyslog`` in camelCase examples) must be explicitly set to ``off``.
+(``log.syslog``) must be explicitly set to ``off``.
 
 Module usage
 ------------
@@ -42,7 +42,7 @@ Module usage
 
 .. code-block:: rsyslog
 
-   module(load="impstats" logFile="/var/log/rsyslog-stats")
+   module(load="impstats" log.file="/var/log/rsyslog-stats")
 
 See also
 --------

--- a/doc/source/reference/parameters/impstats-log-syslog.rst
+++ b/doc/source/reference/parameters/impstats-log-syslog.rst
@@ -39,7 +39,7 @@ Module usage
 
 .. code-block:: rsyslog
 
-   module(load="impstats" logSyslog="off")
+   module(load="impstats" log.syslog="off")
 
 See also
 --------

--- a/doc/source/reference/parameters/impstats-ruleset.rst
+++ b/doc/source/reference/parameters/impstats-ruleset.rst
@@ -29,7 +29,7 @@ Description
 Binds the listener to a specific :doc:`ruleset <../../concepts/multi_ruleset>`.
 
 **Note** that setting ``ruleset`` and setting :ref:`param-impstats-log-syslog`
-(``logSyslog`` in camelCase examples) to ``off`` are mutually exclusive because
+(``log.syslog``) to ``off`` are mutually exclusive because
 syslog stream processing must be enabled to use a ruleset.
 
 Module usage


### PR DESCRIPTION
### Motivation

- Documentation examples for the `impstats` module used unsupported camelCase parameter spellings (`logSyslog`, `logFile`) which are not registered by the module and therefore break config validation.
- Clarify the parameter-name guidance so readers understand that matching is case-insensitive but punctuation (dots) is significant.

### Description

- Replaced unsupported `logSyslog` → `log.syslog` and `logFile` → `log.file` examples across `doc/source/configuration/modules/impstats.rst` and the parameter reference pages to match the module descriptors.
- Updated the parameter-name note in `doc/source/configuration/modules/impstats.rst` to state that punctuation such as dots is significant while matching remains case-insensitive.
- Updated reference pages `doc/source/reference/parameters/impstats-log-syslog.rst`, `doc/source/reference/parameters/impstats-log-file.rst`, `doc/source/reference/parameters/impstats-log-file-overwrite.rst`, and `doc/source/reference/parameters/impstats-ruleset.rst` to use `log.syslog`, `log.file`, and `log.file.overwrite` consistently.
- This is a documentation-only change; no runtime or plugin C code was modified.

### Testing

- Ran `devtools/local-validation-plan.sh` which classified the change as `testbench-plumbing` and recommended doc and container lanes where applicable, and it completed successfully.
- Verified no remaining incorrect examples with `rg -n "logSyslog|logFile" doc/source/...` which returned no matches for the old spellings.
- Ran `git diff --check` and committed the doc changes without whitespace errors.
- Built the rendered documentation with `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"` and the Sphinx HTML build succeeded.
- Attempted `make -j16 json-formatter` and `make -C doc -j16 json-formatter` but those targets were unavailable in this unconfigured checkout, so JSON/RAG-format generation was not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a216f4c5d388332b1f35f48435ace99)