### PR TITLE
mmjsonparse: reject trailing data beyond scan boundary when allow_trailing=off

### DIFF
--- a/plugins/mmjsonparse/mmjsonparse.c
+++ b/plugins/mmjsonparse/mmjsonparse.c
@@ -259,8 +259,8 @@ static int find_first_json_object(wrkrInstanceData_t *pWrkrData,
             /* Valid JSON object found */
             size_t parsed_len = pWrkrData->tokener->char_offset;
 
-            /* Check for trailing data if allow_trailing is false */
-            if (!allow_trailing && parsed_len < remaining) {
+            /* Check full message for trailing data if allow_trailing is false */
+            if (!allow_trailing) {
                 size_t check_pos = i + parsed_len;
                 while (check_pos < len && isspace(msg[check_pos])) {
                     check_pos++;

--- a/tests/mmjsonparse-find-json-trailing.sh
+++ b/tests/mmjsonparse-find-json-trailing.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-# Test mmjsonparse find-json mode with trailing data and allow_trailing parameter
+# Test mmjsonparse find-json mode with trailing data and allow_trailing parameter.
+# The oracle is the output template: allow_trailing=on must parse and ignore
+# suffix data, while allow_trailing=off must set parsesuccess=FAIL for any
+# non-whitespace suffix, including the regression case where the JSON object
+# ends exactly at max_scan_bytes and the suffix begins just outside the scan
+# window.
 # This file is part of the rsyslog project, released under ASL 2.0
 
 . ${srcdir:=.}/diag.sh init
@@ -22,14 +27,23 @@ if $msg contains "TRAILING_OFF" then {
     action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
     stop
 }
+
+# Test allow_trailing=off when JSON ends exactly at the scan boundary.
+if $msg contains "BOUNDARY" then {
+    action(type="mmjsonparse" mode="find-json" allow_trailing="off" max_scan_bytes="17")
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    stop
+}
 '
 startup
 injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: TRAILING_ON {"test":1} garbage after'
 injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: TRAILING_OFF {"test":2} garbage after'
+injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: BOUNDARY {"a":1}X'
 shutdown_when_empty
 wait_shutdown
 
 export EXPECTED=' TRAILING_ON {"test":1} garbage after parsesuccess=OK json={ "test": 1 }
- TRAILING_OFF {"test":2} garbage after parsesuccess=FAIL json={ "msg": " TRAILING_OFF {\"test\":2} garbage after" }'
+ TRAILING_OFF {"test":2} garbage after parsesuccess=FAIL json={ "msg": " TRAILING_OFF {\"test\":2} garbage after" }
+ BOUNDARY {"a":1}X parsesuccess=FAIL json={ "msg": " BOUNDARY {\"a\":1}X" }'
 cmp_exact
 exit_test


### PR DESCRIPTION
### Motivation
- Close a policy bypass in `find-json` mode where `allow_trailing="off"` could be bypassed if the parsed JSON ended exactly at the parser scan boundary and non-whitespace bytes followed outside that window.

### Description
- In `find_first_json_object()` always check the full message suffix for non-whitespace when `allow_trailing` is false, instead of only when `parsed_len < remaining` (leaving `json_tokener_parse_ex()` still bounded to `max_scan_bytes`).
- Preserve the bounded parse window (`json_tokener_parse_ex(..., remaining)`) so parsing cost and bounds remain unchanged while ensuring trailing-data policy is enforced against the whole message.
- Extend `tests/mmjsonparse-find-json-trailing.sh` with a documented regression case that injects a message whose JSON ends exactly at `max_scan_bytes` and asserts the message is rejected when `allow_trailing="off"`.

### Testing
- Configured and built with `--enable-mmjsonparse --enable-testbench` and focused configure options and ran `make -j$(nproc) check TESTS=""`, which completed successfully.
- Ran `./tests/mmjsonparse-find-json-trailing.sh` directly and `make -j$(nproc) check TESTS="mmjsonparse-find-json-trailing.sh"`, and the new boundary regression test passed.
- Ran code/style checks: `devtools/format-code.sh --git-changed --check`, `devtools/check-test-antipatterns.sh tests/mmjsonparse-find-json-trailing.sh`, and `shellcheck -S warning tests/mmjsonparse-find-json-trailing.sh`, all passed; `checkbashisms` was not installed so that optional check was skipped.
- Note: PR-ready local container validation (Ubuntu 26.04 lanes) and local Cubic review were not run because Docker/Podman and `cubic` are not available in this environment; those lanes are recommended as the next validation steps for a container-capable runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a204e1521ac8332b345c78c74b8d705)