### PR TITLE
omuxsock docs: correct template parameter

### DIFF
--- a/doc/source/reference/parameters/omuxsock-template.rst
+++ b/doc/source/reference/parameters/omuxsock-template.rst
@@ -1,4 +1,5 @@
 .. _param-omuxsock-template:
+.. _omuxsock.parameter.module.template:
 .. _omuxsock.parameter.action.template:
 
 template
@@ -10,23 +11,34 @@ template
 
 .. summary-start
 
-Sets the template for formatting messages sent to the program.
+Sets the template for formatting messages sent to Unix sockets.
 
 .. summary-end
 
 This parameter applies to :doc:`../../configuration/modules/omuxsock`.
 
 :Name: template
-:Scope: action
+:Scope: module, action
 :Type: word
-:Default: action=RSYSLOG_FileFormat
+:Default: RSYSLOG_TraditionalForwardFormat
 :Required?: no
 :Introduced: at least 5.x, possibly earlier
 
 Description
 -----------
-Name of the :doc:`template <../../configuration/templates>` to use to format the log messages
-passed to the external program.
+Name of the :doc:`template <../../configuration/templates>` to use to format log messages
+sent to Unix sockets. When set at module scope, it becomes the default for actions
+without an explicitly configured template. When set on an action, it overrides the
+module-level default for that action.
+
+Module usage
+------------
+.. _param-omuxsock-module-template:
+.. _omuxsock.parameter.module.template-usage:
+
+.. code-block:: rsyslog
+
+   module(load="omuxsock" template="RSYSLOG_TraditionalForwardFormat")
 
 Action usage
 ------------
@@ -35,7 +47,7 @@ Action usage
 
 .. code-block:: rsyslog
 
-   action(type="omuxsock" template="RSYSLOG_FileFormat")
+   action(type="omuxsock" template="RSYSLOG_TraditionalForwardFormat")
 
 See also
 --------


### PR DESCRIPTION
### Motivation
- Fix incorrect reference documentation for the `omuxsock` `template` parameter which claimed action-only scope, described messages as sent to an external program, and listed the wrong default template.
- Ensure the reference matches runtime behavior where `template` can be set at module scope (module default used by actions) and the unset fallback is `RSYSLOG_TraditionalForwardFormat`.

### Description
- Update `doc/source/reference/parameters/omuxsock-template.rst` to describe output as sent to Unix sockets instead of an external program. 
- Change the documented `:Scope:` to `module, action` and the `:Default:` to `RSYSLOG_TraditionalForwardFormat`. 
- Add a module-usage example and the module-scope anchor so the page aligns with how the plugin registers and consumes the `template` parameter.

### Testing
- Ran `devtools/local-validation-plan.sh` for classification which completed successfully and identified the change as documentation-scoped within a broader branch context. 
- Built the rendered docs with `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"` and the Sphinx build succeeded. 
- Ran `git diff --check` before committing and it reported no whitespace or formatting issues. 
- Note: `make -j16 json-formatter` is not available in this checkout and Docker/Podman was not usable in the environment, so full container-based PR validation was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a217bfde47c8332bdf537d0ad1295ea)