### PR TITLE
omhttp: own Splunk profile template names

### DIFF
--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -2360,7 +2360,7 @@ static rsRetVal applyProfileSettings(instanceData *const pData, const char *cons
 
                 /* Set a custom template */
                 if (pData->tplName == NULL) {
-                    pData->tplName = (uchar *)NAME_TPL_SPLK_RAW;
+                    CHKmalloc(pData->tplName = ustrdup((uchar *)NAME_TPL_SPLK_RAW));
                 }
             } else if (strcasecmp(endpoint, "event") == 0) {
                 LogMsg(0, RS_RET_OK, LOG_INFO, "omhttp: applying 'hec:splunk:event' profile");
@@ -2383,7 +2383,7 @@ static rsRetVal applyProfileSettings(instanceData *const pData, const char *cons
 
                 /* Set a custom template */
                 if (pData->tplName == NULL) {
-                    pData->tplName = (uchar *)NAME_TPL_SPLK_EVENT;
+                    CHKmalloc(pData->tplName = ustrdup((uchar *)NAME_TPL_SPLK_EVENT));
                 }
             } else {
                 LogError(0, RS_RET_PARAM_ERROR, "omhttp: unknown Splunk HEC endpoint '%s' in profile", endpoint);


### PR DESCRIPTION
### Motivation
- Fix an invalid-free crash during action teardown when `profile="hec:splunk:raw"` or `profile="hec:splunk:event"` is used without an explicit `template` by ensuring instance state owns the template name strings.

### Description
- Duplicate the built-in Splunk HEC template name literals with `ustrdup()` (wrapped by `CHKmalloc`) before assigning them to `pData->tplName` for both `raw` and `event` endpoints so `freeInstance()` can safely `free()` the field without causing an invalid free.

### Testing
- Ran `devtools/format-code.sh --git-changed` and `devtools/format-code.sh --git-changed --check --check-if-available`, both passed.
- Ran `devtools/local-validation-plan.sh --base HEAD --run`; deterministic checks completed successfully but container/Cubic lanes were skipped because Docker/Podman and `cubic` were not available (warnings emitted).
- Ran `./configure --cache-file=/dev/null --enable-omhttp --disable-testbench --disable-impstats-push` and `make -j$(nproc) check TESTS=""`, which built and ran the lightweight checks successfully including building `contrib/omhttp`.
- Performed `./tools/rsyslogd -N1` config-validation runs for both `profile="hec:splunk:raw"` and `profile="hec:splunk:event"` (with a dummy token) and both validation runs returned success (exit code 0).
- Note: `./autogen.sh --enable-omhttp --disable-testbench` failed in this environment due to a missing `libsnappy-dev` dependency, and full container-based PR-ready validation was not executed locally because Docker/Podman and `cubic` were unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a217fcb283c8332a247b4e335154020)