### PR TITLE
runtime: fix YAML promotion OOM ownership

### DIFF
--- a/runtime/translate.c
+++ b/runtime/translate.c
@@ -671,6 +671,7 @@ static void yamlStatementsAppend(struct rsconfTranslateYamlStatement_s **dst,
 
 static int promoteSimpleYamlToStatements(struct rsconfTranslateItem_s *it, int *oom) {
     char *if_expr;
+    struct rsconfTranslateYamlAction_s *actions;
     struct rsconfTranslateYamlStatement_s *stmt;
 
     if (it->yaml_ruleset_kind == RS_TRANSLATE_YAML_RULESET_STATEMENTS) return 1;
@@ -683,10 +684,11 @@ static int promoteSimpleYamlToStatements(struct rsconfTranslateItem_s *it, int *
         *oom = 1;
         return 0;
     }
-    stmt = newYamlStatement(if_expr, it->yaml_actions, oom);
+    actions = it->yaml_actions;
+    it->yaml_actions = NULL;
+    stmt = newYamlStatement(if_expr, actions, oom);
     if (stmt == NULL) return 0;
 
-    it->yaml_actions = NULL;
     free(it->yaml_filter);
     it->yaml_filter = NULL;
     it->yaml_statements = stmt;


### PR DESCRIPTION
### Motivation
- Fix an OOM-only robustness bug where `newYamlStatement()` can free the caller-supplied `actions` on allocation failure while the caller still kept `it->yaml_actions` pointing at it, which could cause a later double-free during cleanup.

### Description
- Detach `it->yaml_actions` into a local `actions` variable and set `it->yaml_actions = NULL` before calling `newYamlStatement(if_expr, actions, oom)`, so the constructor either owns the list on success or consumes/frees it on failure without leaving a dangling owner pointer.

### Testing
- Ran `devtools/format-code.sh --git-changed` and the read-only `--check` pass, `./tests/config-translate-legacy-file-action.sh`, `./tests/config-translate-legacy-debian-default.sh`, `make -j$(nproc) check TESTS=""`, and `devtools/local-validation-plan.sh --run`, and the local checks and unit/test scripts completed successfully; the container-based static-analyzer and local Cubic lanes were skipped because Docker/Podman/Cubic were not available locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2176209a3c833284aa8fe82ca1b8f8)