### PR TITLE
tests: stabilize imrelp random disconnect oracle

### DIFF
--- a/tests/imrelp-tls-randconn-drop.sh
+++ b/tests/imrelp-tls-randconn-drop.sh
@@ -4,9 +4,13 @@
 # Regression coverage for GitHub issue #4724. A RELP/TLS client using
 # tcpflood -D randomly closes connections while sending, which used to make
 # the imrelp receiver exit silently under flood load. The oracle is that
-# rsyslogd survives the broken client sessions and can still shut down through
-# the normal testbench path. Message sequence checks are intentionally not used:
-# random client-side disconnects can legitimately lose in-flight messages.
+# tcpflood uses an aggressive random-close threshold, rsyslogd records a broken
+# RELP session in its configured internal-message output while it is still
+# active, and rsyslogd can still shut down through the normal testbench path.
+# The wait on the .started file synchronizes with the omfile action that records
+# rsyslogd diagnostics; stdout/stderr alone are not the oracle. Message sequence
+# checks are intentionally not used: random client-side disconnects can
+# legitimately lose in-flight messages.
 . ${srcdir:=.}/diag.sh init
 require_plugin imrelp
 export NUMMESSAGES=50
@@ -35,7 +39,7 @@ ruleset(name="discard_relp") {
 '
 startup
 assign_single_tcp_listener_port TCPFLOOD_PORT
-tcpflood -D -l0.90 -Trelp-tls -acertvalid -p"$TCPFLOOD_PORT" -m"$NUMMESSAGES" \
+tcpflood -D -l0.10 -Trelp-tls -acertvalid -p"$TCPFLOOD_PORT" -m"$NUMMESSAGES" \
 	-x "$srcdir/tls-certs/ca.pem" \
 	-z "$srcdir/tls-certs/key.pem" \
 	-Z "$srcdir/tls-certs/cert.pem" \
@@ -47,11 +51,13 @@ cat -n "$RSYSLOG_DYNNAME.tcpflood"
 if [ "$tcpflood_rc" -ne 0 ]; then
 	printf 'tcpflood exited with rc=%s after the intentional random disconnects\n' "$tcpflood_rc"
 fi
-cat "$RSYSLOG_DYNNAME.tcpflood" "$RSYSLOG_DYNNAME.started" >"$RSYSLOG_DYNNAME.disconnect.log"
-content_check "session broken" "$RSYSLOG_DYNNAME.disconnect.log"
+wait_content "session broken" "$RSYSLOG_DYNNAME.started"
 
 check_rsyslog_active ""
 
 shutdown_when_empty
 wait_shutdown
+
+cat "$RSYSLOG_DYNNAME.tcpflood" "$RSYSLOG_DYNNAME.started" >"$RSYSLOG_DYNNAME.disconnect.log"
+content_check "session broken" "$RSYSLOG_DYNNAME.disconnect.log"
 exit_test


### PR DESCRIPTION
Summary: Stabilizes imrelp-tls-randconn-drop.sh by making random disconnects aggressive enough to exercise the RELP TLS broken-session path, then waiting for session broken in the rsyslog testbench started output while rsyslogd is still active. Validation: shellcheck passed, test-antipattern scan passed with one expected advisory from the explanatory header, focused host test passed, five focused host repeats passed, local-validation-plan --run passed including focused container PASS for imrelp-tls-randconn-drop.sh. Additional review: Cubic flagged the pre-shutdown started wait as potentially timing-sensitive, but checking only after teardown would weaken the oracle. The pre-shutdown wait is intentional because the test should prove rsyslog recorded the broken session while alive. Broad lane note: Ubuntu 26.04 broad container validation was attempted. The changed imrelp test passed there. The broad lane failed on unrelated pmrfc3164-tagEndingByColon.sh ordering output, tag2 tag1 tag5 instead of expected tag1 tag2 tag5.