### PR TITLE
CI: guard apt variables for fork PRs

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -766,10 +766,13 @@ jobs:
       - name: Build Ubuntu package
         if: steps.package_changes.outputs.any_changed == 'true'
         env:
-          RSYSLOG_APT_PROXY: ${{ vars.RSYSLOG_APT_PROXY }}
-          RSYSLOG_UBUNTU_ARCHIVE_MIRROR: ${{ vars.RSYSLOG_UBUNTU_ARCHIVE_MIRROR }}
-          RSYSLOG_UBUNTU_SECURITY_MIRROR: ${{ vars.RSYSLOG_UBUNTU_SECURITY_MIRROR }}
-          RSYSLOG_APT_RETRIES: ${{ vars.RSYSLOG_APT_RETRIES }}
+          # The following values tune only trusted in-repository PR runs. Fork
+          # pull_request jobs execute PR-controlled scripts from the checkout,
+          # so do not expose repository/organization Actions variables there.
+          RSYSLOG_APT_PROXY: ${{ github.event.pull_request.head.repo.full_name == github.repository && vars.RSYSLOG_APT_PROXY || '' }}
+          RSYSLOG_UBUNTU_ARCHIVE_MIRROR: ${{ github.event.pull_request.head.repo.full_name == github.repository && vars.RSYSLOG_UBUNTU_ARCHIVE_MIRROR || '' }}
+          RSYSLOG_UBUNTU_SECURITY_MIRROR: ${{ github.event.pull_request.head.repo.full_name == github.repository && vars.RSYSLOG_UBUNTU_SECURITY_MIRROR || '' }}
+          RSYSLOG_APT_RETRIES: ${{ github.event.pull_request.head.repo.full_name == github.repository && vars.RSYSLOG_APT_RETRIES || '' }}
         run: bash devtools/run-deb-ubuntu-build.sh ${{ matrix.suite }}
 
       - name: List built packages


### PR DESCRIPTION
### Motivation
- Prevent non-sensitive-but-sensitive-in-practice CI variables (apt proxy/mirror/retry settings) from being exposed to untrusted fork `pull_request` checkouts that run repository scripts from the PR tree.

### Description
- Add a repository-identity guard in ` .github/workflows/run_checks.yml` so `RSYSLOG_APT_PROXY`, `RSYSLOG_UBUNTU_ARCHIVE_MIRROR`, `RSYSLOG_UBUNTU_SECURITY_MIRROR`, and `RSYSLOG_APT_RETRIES` are populated only when `github.event.pull_request.head.repo.full_name == github.repository`, otherwise they are empty, and leave `packaging/ubuntu/build-ubuntu.sh` unchanged.

### Testing
- Ran `git diff --check` (no issues) and `./devtools/local-validation-plan.sh` and `./devtools/local-validation-plan.sh --run`, with the latter reporting Docker is not installed so the run is **not fully container-validated**; all available non-container checks passed.
- Ran workflow linting and audits via `actionlint` (installed via `go install`) and `zizmor` (`python3 -m venv .zizmor-venv && .zizmor-venv/bin/python -m pip install -r .github/requirements-zizmor.txt && .zizmor-venv/bin/zizmor --strict-collection .github/workflows`) and received no findings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f03cd473c8332b6617e0de1a51c36)