### PR TITLE
omazureeventhubs docs: fix underscored parameters

### DIFF
--- a/doc/source/configuration/modules/omazureeventhubs.rst
+++ b/doc/source/configuration/modules/omazureeventhubs.rst
@@ -49,7 +49,9 @@ Configuration Parameters
 
 .. note::
 
-   Parameter names are case-insensitive; camelCase is recommended for readability.
+   Parameter names are case-insensitive. Keep documented underscores in names such
+   as ``amqp_address``, ``azure_key_name``, and ``azure_key``; camelCase
+   spellings are not aliases for underscore-separated parameters.
 
 .. warning::
 

--- a/doc/source/reference/parameters/omazureeventhubs-amqp_address.rst
+++ b/doc/source/reference/parameters/omazureeventhubs-amqp_address.rst
@@ -28,7 +28,7 @@ Description
 Specifies the "Event Hubs connection string", a full AMQPS URL used to connect
 to the target Event Hubs instance. When this parameter is set, the host, key
 name, and key are parsed from the URL, overriding ``azureHost``,
-``azureKeyName``, and ``azureKey``. The port is not parsed from the URL; it
+``azure_key_name``, and ``azure_key``. The port is not parsed from the URL; it
 always defaults to ``5671`` and any configured ``azurePort`` value is ignored.
 
 A sample Event Hubs connection string URL is:
@@ -43,7 +43,7 @@ Input usage
 
 .. code-block:: rsyslog
 
-   action(type="omazureeventhubs" amqpAddress="amqps://user:key@namespace.servicebus.windows.net/hub" ...)
+   action(type="omazureeventhubs" amqp_address="amqps://user:key@namespace.servicebus.windows.net/hub" ...)
 
 See also
 --------

--- a/doc/source/reference/parameters/omazureeventhubs-azure_key.rst
+++ b/doc/source/reference/parameters/omazureeventhubs-azure_key.rst
@@ -27,7 +27,7 @@ Description
 -----------
 Specifies the value of the "Event Hubs shared access key". This secret key
 string authenticates the connection and signs requests to the Event Hubs
-instance. Supply it unless ``amqpAddress`` already embeds the key.
+instance. Supply it unless ``amqp_address`` already embeds the key.
 
 Input usage
 -----------
@@ -35,7 +35,7 @@ Input usage
 
 .. code-block:: rsyslog
 
-   action(type="omazureeventhubs" azureKeyName="MyPolicy" azureKey="MySecretKey" ...)
+   action(type="omazureeventhubs" azure_key_name="MyPolicy" azure_key="MySecretKey" ...)
 
 See also
 --------

--- a/doc/source/reference/parameters/omazureeventhubs-azure_key_name.rst
+++ b/doc/source/reference/parameters/omazureeventhubs-azure_key_name.rst
@@ -27,7 +27,7 @@ Description
 -----------
 Specifies the "Event Hubs shared access key name" (the shared access policy
 name) used to authenticate and authorize connections to the Event Hubs
-instance. Provide this value unless ``amqpAddress`` already supplies the
+instance. Provide this value unless ``amqp_address`` already supplies the
 credentials.
 
 Input usage
@@ -36,7 +36,7 @@ Input usage
 
 .. code-block:: rsyslog
 
-   action(type="omazureeventhubs" azureKeyName="MyPolicy" ...)
+   action(type="omazureeventhubs" azure_key_name="MyPolicy" ...)
 
 See also
 --------

--- a/doc/source/reference/parameters/omazureeventhubs-azurehost.rst
+++ b/doc/source/reference/parameters/omazureeventhubs-azurehost.rst
@@ -29,7 +29,7 @@ Specifies the fully qualified domain name (FQDN) of the Event Hubs instance that
 rsyslog output plugin should connect to. The format of the hostname should be
 ``<namespace>.servicebus.windows.net``, where ``<namespace>`` is the name of the
 Event Hubs namespace that was created in Microsoft Azure. This setting is required
-unless ``amqpAddress`` supplies the complete connection string.
+unless ``amqp_address`` supplies the complete connection string.
 
 Input usage
 -----------

--- a/doc/source/reference/parameters/omazureeventhubs-azureport.rst
+++ b/doc/source/reference/parameters/omazureeventhubs-azureport.rst
@@ -29,7 +29,7 @@ Specifies the TCP port number used by the Event Hubs instance for incoming
 connections. The default port number for Event Hubs is 5671 for connections over
 the AMQP Secure Sockets Layer (SSL) protocol. This property is usually optional
 in the configuration file of the rsyslog output plugin, as the default value of
-5671 is typically used. When ``amqpAddress`` is specified, the module ignores
+5671 is typically used. When ``amqp_address`` is specified, the module ignores
 ``azurePort`` and always uses the default.
 
 Input usage

--- a/doc/source/reference/parameters/omazureeventhubs-container.rst
+++ b/doc/source/reference/parameters/omazureeventhubs-container.rst
@@ -27,7 +27,7 @@ Description
 -----------
 Specifies the name of the "Event Hubs Instance"—the specific event hub within
 the namespace—that should receive the forwarded log data. Define it unless
-``amqpAddress`` already points at the desired event hub.
+``amqp_address`` already points at the desired event hub.
 
 Input usage
 -----------


### PR DESCRIPTION
### Motivation
- The omazureeventhubs reference pages contained camelCase examples (`amqpAddress`, `azureKeyName`, `azureKey`) even though the module registers underscore-separated names (`amqp_address`, `azure_key_name`, `azure_key`), which can cause configuration load failures when operators copy examples.

### Description
- Clarify the module note to state that parameter names are case-insensitive but underscore spellings such as `amqp_address`, `azure_key_name`, and `azure_key` must be used and camelCase is not an alias. 
- Update usage snippets and prose in `doc/source/reference/parameters/omazureeventhubs-amqp_address.rst`, `omazureeventhubs-azure_key_name.rst`, `omazureeventhubs-azure_key.rst`, and supporting pages (`azurehost.rst`, `azureport.rst`, `container.rst`) to use the registered underscore-separated names. 
- No runtime/source changes were required; the fix is documentation-only after verifying accepted parameter names in `plugins/omazureeventhubs/omazureeventhubs.c` and lookup behavior in `grammar/rainerscript.c`. 
- Changes committed on this branch as `72fe813 omazureeventhubs docs: fix underscored parameters`.

### Testing
- Ran `devtools/local-validation-plan.sh` and the planner completed successfully. 
- Built the rendered docs with `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"` and the Sphinx build succeeded. 
- Performed diff and lint checks including `git diff --check`, `git diff --cached --check`, and `rg -n "amqpAddress|azureKeyName|azureKey"` to confirm no remaining camelCase examples, all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a28905e08332b6ca85564616211f)