### PR TITLE
diag.sh: fix content-pattern-check and assert-first-column-sum-greate…

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -5423,7 +5423,7 @@ make -j$(getconf _NPROCESSORS_ONLN) check TESTS="" || error_exit 100
 		if [ ! $sum -gt $5 ]; then
 		    echo sum of first column with edit-expr "'$2'" run over lines from file "'$4'" matched by "'$3'" equals "'$sum'" which is smaller than expected lower-limit of "'$5'"
 		    echo "file contents:"
-		    cat $4
+		    cat "$4"
 		    error_exit 1
 		fi
 		;;
@@ -5431,7 +5431,7 @@ make -j$(getconf _NPROCESSORS_ONLN) check TESTS="" || error_exit 100
 		if ! grep -q "$2" < ${RSYSLOG_OUT_LOG}; then
 		    echo content-check failed, not every line matched pattern "'$2'"
 		    echo "file contents:"
-		    cat -n $4
+		    cat -n "$4"
 		    error_exit 1
 		fi
 		;;


### PR DESCRIPTION
### Summary (non-technical, complete)

This change improves test suite robustness by adding quotes around `$4` in `cat` commands. Previously, filenames with spaces would cause command failures and mask real test errors. Now such filenames are handled correctly.

### References

Refs: none (test hardening)

### Notes

Defensive quoting fix; no behavior change for normal filenames.