### PR TITLE
[Modernization] Replace Internal Backticks with Shell Expansion: Rscript 

### DIFF
--- a/tests/rscript_faup_fragment.sh
+++ b/tests/rscript_faup_fragment.sh
@@ -19,7 +19,7 @@ set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/fu
 
 set $.faup = faup_fragment($!url);
 set $.ret = script_error();
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 tcpflood -m 1

--- a/tests/rscript_gt.sh
+++ b/tests/rscript_gt.sh
@@ -14,7 +14,7 @@ template(name="outfmt" type="list") {
 if $msg contains "msgnum" then {
 	set $!usr!msgnum = field($msg, 58, 2);
 	if $!usr!msgnum > "00004999" then
-		action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+		action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 startup

--- a/tests/rscript_hash32.sh
+++ b/tests/rscript_hash32.sh
@@ -15,7 +15,7 @@ input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port
 set $.hash_no_1 = hash32("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e");
 set $.hash_no_2 = hash32mod("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e", 100);
 
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 tcpflood -m 20

--- a/tests/rscript_ne_var.sh
+++ b/tests/rscript_ne_var.sh
@@ -62,7 +62,7 @@ if $/var1 != $/var2 then {
 
 if $msg contains "msgnum" then {
 	set $!usr!msgnum = field($msg, 58, 2);
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 startup

--- a/tests/rscript_previous_action_suspended.sh
+++ b/tests/rscript_previous_action_suspended.sh
@@ -8,8 +8,8 @@ module(load="../plugins/omtesting/.libs/omtesting")
 input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
-ruleset(name="output_writer") {
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	ruleset(name="output_writer") {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 
 :msg, contains, "msgnum:" {

--- a/tests/rscript_re_extract.sh
+++ b/tests/rscript_re_extract.sh
@@ -13,7 +13,7 @@ input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port
 add_conf "
 set \$.number = re_extract(\$msg, '.* ([0-9]+)$', 0, 1, 'none');"
 add_conf '
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 tcpflood -m 1 -I $srcdir/testsuites/date_time_msg

--- a/tests/rscript_ruleset_call_indirect-basic.sh
+++ b/tests/rscript_ruleset_call_indirect-basic.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="list") {
 }
 
 ruleset(name="rs") {
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 
 if $msg contains "msgnum" then call_indirect "r" & "s";

--- a/tests/rscript_ruleset_call_indirect-var.sh
+++ b/tests/rscript_ruleset_call_indirect-var.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="list") {
 }
 
 ruleset(name="rs") {
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 
 set $.var = "rs";

--- a/tests/rscript_str2num_negative.sh
+++ b/tests/rscript_str2num_negative.sh
@@ -10,7 +10,7 @@ set $.n = "-1";
 set $!ip!v1 = 1 + $.n;
 
 template(name="outfmt" type="string" string="%!ip%\n")
-local4.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+local4.* action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 tcpflood -m1

--- a/tests/rscript_unflatten_arg1_unsuitable.sh
+++ b/tests/rscript_unflatten_arg1_unsuitable.sh
@@ -17,7 +17,7 @@ if (not($msg contains "msgnum:")) then
 
 set $.unflatten = unflatten($!, ".");
 set $.ret = script_error();
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 tcpflood -m 1

--- a/tests/rscript_unflatten_conflict1.sh
+++ b/tests/rscript_unflatten_conflict1.sh
@@ -19,7 +19,7 @@ set $!a!b = "foo";
 set $!a.b.c = "bar";
 set $.unflatten = unflatten($!, ".");
 set $.ret = script_error();
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 tcpflood -m 1

--- a/tests/rscript_unflatten_non_object.sh
+++ b/tests/rscript_unflatten_non_object.sh
@@ -23,7 +23,7 @@ else
 
 set $.unflatten = unflatten($!, ".");
 set $.ret = script_error();
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 tcpflood -m 2


### PR DESCRIPTION
[Modernization] Replace Internal Backticks with Shell Expansion: Rscript 
This modernizes the rscript test suite by replacing legacy backtick-based file expansions
(e.g. file=echo $RSYSLOG_OUT_LOG) with explicit quoted shell variable expansion
(e.g. file="'$RSYSLOG_OUT_LOG'"). This improves maintainability and aligns with
current shell best practices for CI and container environments.

Before: tests relied on backtick command substitution with inconsistent quoting
and limited nesting semantics.
After: tests pass the expanded filename via a quoted shell variable literal,
making the expansion semantics explicit and more predictable.

Impact: test execution semantics may change slightly where previous backtick/quoting
behavior masked word-splitting or nesting edge cases. No rsyslog runtime logic,
message flow, or module behavior is modified — the updates are limited to test
scripts (12 rscript tests updated). This change reduces ambiguity and improves
reproducibility across environments.

Fixes: https://github.com/rsyslog/rsyslog/issues/6523