### PR TITLE
tests: always ship override_epoll_ctl.c in dist tarballs

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2226,6 +2226,10 @@ runtime_unit_parser_pri_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
 runtime_unit_msg_replace_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
 endif
 
+# Shipped even when testbench is disabled: dist tarballs are often built with
+# --disable-testbench, but downstream builds may enable testbench + imptcp.
+EXTRA_DIST += override_epoll_ctl.c
+
 if ENABLE_TESTBENCH
 pkglib_LTLIBRARIES += liboverride_gethostname.la
 liboverride_gethostname_la_SOURCES = override_gethostname.c
@@ -2241,8 +2245,6 @@ pkglib_LTLIBRARIES += liboverride_getaddrinfo.la
 liboverride_getaddrinfo_la_SOURCES = override_getaddrinfo.c
 liboverride_getaddrinfo_la_CFLAGS =
 liboverride_getaddrinfo_la_LDFLAGS = -avoid-version -shared
-
-EXTRA_DIST += override_epoll_ctl.c
 
 if ENABLE_IMPTCP
 check_DATA += liboverride_epoll_ctl.so


### PR DESCRIPTION
Why: Release tarballs are often built with --disable-testbench, but imptcp-epoll-add-failure.sh is always distributed via TESTS_IMPTCP. The helper source must be in the tarball too.

Impact: make dist with --disable-testbench now includes the epoll preload helper; later testbench+imptcp builds can run the test.

Before/After: override_epoll_ctl.c was only in EXTRA_DIST inside ENABLE_TESTBENCH; it is now listed unconditionally before that block.

closes https://github.com/rsyslog/rsyslog/issues/7196

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

