### PR TITLE
testbench: harden startup pid wait diagnostics

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -625,20 +625,27 @@ rsyslogd_config_check() {
 
 # wait for appearance of a specific pid file, given as $1
 wait_startup_pid() {
+	local pid
+
 	if [ "$1" == "" ]; then
 		echo "FAIL: testbench bug: wait_startup_called without \$1"
 		error_exit 100
 	fi
-	while test ! -f $1; do
+	while test ! -f "$1"; do
 		$TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
-		if [ $(date +%s) -gt $(( TB_STARTTEST + TB_STARTUP_MAX_RUNTIME )) ]; then
+		if [ "$(date +%s)" -gt $(( TB_STARTTEST + TB_STARTUP_MAX_RUNTIME )) ]; then
 		   printf '%s ABORT! Timeout waiting on startup (pid file %s) after %d seconds\n' "$(tb_timestamp)" "$1" $TB_STARTUP_MAX_RUNTIME
 		   ls -l "$1"
-		   ps -fp $($SUDO cat "$1")
+		   if [ -f "$1" ]; then
+			   pid=$($SUDO cat "$1")
+			   if [[ "$pid" =~ ^[0-9]+$ ]]; then
+				   ps -fp "$pid"
+			   fi
+		   fi
 		   error_exit 1
 		fi
 	done
-	printf '%s %s found, pid %s\n' "$(tb_timestamp)" "$1" "$(cat $1)"
+	printf '%s %s found, pid %s\n' "$(tb_timestamp)" "$1" "$(cat "$1")"
 }
 
 # special version of wait_startup_pid() for rsyslog startup


### PR DESCRIPTION
## Summary
- quote the pidfile path in wait_startup_pid()
- avoid running ps with an empty PID when startup times out before the pidfile exists or is populated
- keep the timeout diagnostic focused on the startup failure reported in #4579

## Validation
- bash -n tests/diag.sh
- shellcheck -S error tests/diag.sh
- devtools/check-test-antipatterns.sh tests/diag.sh (baseline advisory findings only)
- local Cubic review: No issues found
- Ubuntu 26.04 dev container run-ci.sh with -j80: 1336 total, 1242 pass, 94 skip, 0 fail, 0 error

Closes https://github.com/rsyslog/rsyslog/issues/4579


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

