### PR TITLE
omfwd: use matching atomic mutex helper

### DIFF
--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -835,7 +835,7 @@ BEGINcreateInstance
     /* We always have at least one target and port */
     pData->nTargets = 1;
     pData->nActiveTargets = 0;
-    INIT_ATOMIC_HELPER_MUT64(pData->mut_nActiveTargets);
+    INIT_ATOMIC_HELPER_MUT(pData->mut_nActiveTargets);
     pData->nPorts = 1;
     pData->target_name = NULL;
     if (cs.pszStrmDrvr != NULL) CHKmalloc(pData->pszStrmDrvr = (uchar *)strdup((char *)cs.pszStrmDrvr));


### PR DESCRIPTION
## Summary
- make omfwd initialize mut_nActiveTargets with the same non-64-bit helper used for its declaration and destroy path
- fixes builds where HAVE_ATOMIC_BUILTINS is set but HAVE_ATOMIC_BUILTINS64 is not set

## Validation
- devtools/local-validation-plan.sh --run: passed code path, including format check, Ubuntu 26.04 run-ci.sh, static analyzer, and local Cubic review
- local Cubic review: No issues found
- Ubuntu 26.04 dev container run-ci.sh: passed
- Ubuntu 26.04 static analyzer: passed
- targeted no-64-bit-atomics validation: generated config.h with HAVE_ATOMIC_BUILTINS64 undefined, then dev container make -j80 passed and compiled tools/omfwd.c/rsyslogd
- devtools/format-code.sh --git-changed --check --check-if-available: passed

Closes https://github.com/rsyslog/rsyslog/issues/5597


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

