### PR TITLE
action: warn on duplicate action names

### DIFF
--- a/runtime/action.c
+++ b/runtime/action.c
@@ -399,6 +399,43 @@ finalize_it:
 }
 
 
+static rsRetVal actionRegisterName(action_t *const pThis) {
+    DEFiRet;
+    size_t i;
+    char *name = NULL;
+    char **names = NULL;
+    struct actions_s *const actions = &loadConf->actions;
+
+    if (pThis->pszName == NULL) {
+        FINALIZE;
+    }
+
+    for (i = 0; i < actions->n_action_names; ++i) {
+        if (!strcmp(actions->action_names[i], (char *)pThis->pszName)) {
+            LogMsg(0, RS_RET_OK, LOG_WARNING,
+                   "action: duplicate name '%s' in current config set; impstats counters may be ambiguous",
+                   pThis->pszName);
+            FINALIZE;
+        }
+    }
+
+    CHKmalloc(name = strdup((char *)pThis->pszName));
+    if (actions->n_action_names == actions->n_action_names_alloc) {
+        const size_t newAlloc = (actions->n_action_names_alloc == 0) ? 8 : actions->n_action_names_alloc * 2;
+        CHKmalloc(names = realloc(actions->action_names, newAlloc * sizeof(char *)));
+        actions->action_names = names;
+        actions->n_action_names_alloc = newAlloc;
+    }
+
+    actions->action_names[actions->n_action_names++] = name;
+    name = NULL;
+
+finalize_it:
+    free(name);
+    RETiRet;
+}
+
+
 /* action construction finalizer
  */
 rsRetVal actionConstructFinalize(action_t *__restrict__ const pThis, struct nvlst *lst) {
@@ -564,6 +601,8 @@ rsRetVal actionConstructFinalize(action_t *__restrict__ const pThis, struct nvls
 
     /* and now reset the queue params (see comment in its function header!) */
     actionResetQueueParams();
+
+    CHKiRet(actionRegisterName(pThis));
 
 finalize_it:
     RETiRet;

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -199,6 +199,9 @@ static void cnfSetDefaults(rsconf_t *pThis) {
     pThis->templates.lastStatic = NULL;
     pThis->actions.nbrActions = 0;
     pThis->actions.iActionNbr = 0;
+    pThis->actions.action_names = NULL;
+    pThis->actions.n_action_names = 0;
+    pThis->actions.n_action_names_alloc = 0;
     pThis->globals.pszWorkDir = NULL;
     pThis->globals.bDropMalPTRMsgs = 0;
     pThis->globals.operatingStateFile = NULL;
@@ -339,6 +342,19 @@ static void freeCnf(rsconf_t *pThis) {
     }
 }
 
+
+static void freeActionNames(rsconf_t *pThis) {
+    size_t i;
+
+    for (i = 0; i < pThis->actions.n_action_names; ++i) {
+        free(pThis->actions.action_names[i]);
+    }
+    free(pThis->actions.action_names);
+    pThis->actions.action_names = NULL;
+    pThis->actions.n_action_names = 0;
+    pThis->actions.n_action_names_alloc = 0;
+}
+
 /* destructor for the rsconf object */
 BEGINobjDestruct(rsconf) /* be sure to specify the object type also in END and CODESTART macros! */
     CODESTARTobjDestruct(rsconf);
@@ -366,6 +382,7 @@ BEGINobjDestruct(rsconf) /* be sure to specify the object type also in END and C
 #endif
     lookupDestroyCnf();
     ratelimit_cfgsDestruct(&pThis->ratelimit_cfgs);
+    freeActionNames(pThis);
     llDestroy(&(pThis->rulesets.llRulesets));
 ENDobjDestruct(rsconf)
 
@@ -1227,6 +1244,7 @@ static rsRetVal setMainMsgQueType(void __attribute__((unused)) * pVal, uchar *ps
 /* legacy config system: reset config variables to default values.  */
 static rsRetVal resetConfigVariables(uchar __attribute__((unused)) * pp, void __attribute__((unused)) * pVal) {
     free(loadConf->globals.mainQ.pszMainMsgQFName);
+    freeActionNames(loadConf);
 
     cnfSetDefaults(loadConf);
 

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -248,6 +248,9 @@ struct actions_s {
      * is no better name available.
      */
     int iActionNbr;
+    char **action_names;
+    size_t n_action_names;
+    size_t n_action_names_alloc;
 };
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -466,6 +466,7 @@ TESTS_DEFAULT = \
 	array_lookup_table.sh \
 	sparse_array_lookup_table.sh \
 	lookup_table_duplicate.sh \
+	action-duplicate-name.sh \
 	lookup_table_bad_configs.sh \
 	lookup_table_rscript_reload.sh \
 	lookup_table_rscript_reload_without_stub.sh \
@@ -644,7 +645,8 @@ TESTS_LIBYAML = \
 	$(TESTS_TEMPLATE_REGEX_BOUNDS_LIBYAML) \
 	yaml-template-subtree.sh \
 	yaml-statements-reload-lookup.sh \
-	yaml-lookup-table-duplicate.sh
+	yaml-lookup-table-duplicate.sh \
+	yaml-action-duplicate-name.sh
 
 TESTS_RATELIMIT_WATCH = \
 	ratelimit_policy_watch.sh \

--- a/tests/action-duplicate-name.sh
+++ b/tests/action-duplicate-name.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Verify that duplicate RainerScript action names produce a config warning.
+# The oracle is successful -N1 config validation plus the diagnostic;
+# no runtime message-processing output is involved.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+
+action(name="dup_action" type="omfile" file="'$RSYSLOG_OUT_LOG'.1" template="outfmt")
+action(name="dup_action" type="omfile" file="'$RSYSLOG_OUT_LOG'.2" template="outfmt")
+'
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -ne 0 ]; then
+    echo "FAIL: expected config validation to continue after duplicate action-name warning"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+fi
+
+content_check "action: duplicate name 'dup_action' in current config set; impstats counters may be ambiguous" \
+    "${RSYSLOG_DYNNAME}.log"
+
+exit_test

--- a/tests/yaml-action-duplicate-name.sh
+++ b/tests/yaml-action-duplicate-name.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Verify that duplicate YAML action names warn through the shared action
+# backend. The oracle is successful -N1 config validation plus duplicate-name
+# diagnostic; no runtime message-processing output is involved.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" << 'YAMLEOF'
+templates:
+  - name: outfmt
+    type: string
+    string: "%msg%\n"
+
+rulesets:
+  - name: main
+    filter: "*.*"
+    actions:
+      - name: dup_action
+        type: omfile
+        file: "${RSYSLOG_OUT_LOG}.1"
+        template: outfmt
+      - name: dup_action
+        type: omfile
+        file: "${RSYSLOG_OUT_LOG}.2"
+        template: outfmt
+YAMLEOF
+sed -i \
+    -e "s|\${RSYSLOG_OUT_LOG}|${RSYSLOG_OUT_LOG}|g" \
+    "${RSYSLOG_DYNNAME}.yaml"
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -ne 0 ]; then
+    echo "FAIL: expected YAML config validation to continue after duplicate action-name warning"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+fi
+
+content_check "action: duplicate name 'dup_action' in current config set; impstats counters may be ambiguous" \
+    "${RSYSLOG_DYNNAME}.log"
+
+exit_test


### PR DESCRIPTION
## Summary
- warn when a finalized action reuses an action name already seen in the current config
- keep duplicate names valid for compatibility with existing deployments
- cover the warning path for both RainerScript and YAML configs

## Validation
- `./tests/action-duplicate-name.sh`
- `./tests/yaml-action-duplicate-name.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 90m devtools/local-validation-plan.sh --run`
  - Ubuntu 26.04 broad run: 1338 total, 1310 pass, 27 skip, 1 fail
  - failing test: `pmrfc3164-AtSignsInHostname.sh`, unrelated parser test
  - immediate retry of `./tests/pmrfc3164-AtSignsInHostname.sh` passed
- Cubic final review against `upstream/main`: no findings (`null` JSON output, empty stderr)

closes https://github.com/rsyslog/rsyslog/issues/539


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

