### PR TITLE
dynstats: warn on duplicate bucket names

### DIFF
--- a/runtime/dynstats.c
+++ b/runtime/dynstats.c
@@ -539,6 +539,11 @@ static rsRetVal dynstats_newBucket(const uchar *name,
     bkts = &loadConf->dynstats_buckets;
 
     if (bkts->initialized) {
+        if (dynstats_findBucket(name) != NULL) {
+            LogMsg(0, RS_RET_OK, LOG_WARNING,
+                   "dynstats: duplicate bucket name '%s' in current config set; impstats output may be ambiguous",
+                   name);
+        }
         CHKmalloc(b = calloc(1, sizeof(dynstats_bucket_t)));
         b->bkts = bkts;
         b->resettable = resettable;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1238,6 +1238,8 @@ TESTS_IMPSTATS = \
 	dynstats_reset_without_pstats_reset.sh \
 	dynstats_prevent_premature_eviction.sh \
 	dynstats-persist.sh \
+	dynstats-duplicate-name.sh \
+	yaml-dynstats-duplicate-name.sh \
 	omfwd-lb-2target-impstats.sh \
 	omfwd_fast_imuxsock.sh \
 	omfwd_impstats-udp.sh \

--- a/tests/dynstats-duplicate-name.sh
+++ b/tests/dynstats-duplicate-name.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Verify that duplicate RainerScript dyn_stats bucket names produce a config
+# warning while keeping the config valid for backward compatibility. The oracle
+# is successful -N1 config validation plus the diagnostic; no runtime message
+# processing output is involved.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+dyn_stats(name="dup_bucket" resettable="off" maxCardinality="3")
+dyn_stats(name="dup_bucket" resettable="off" maxCardinality="9")
+
+if $msg contains "never" then {
+    set $.inc = dyn_inc("dup_bucket", "unused");
+}
+'
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -ne 0 ]; then
+    echo "FAIL: expected config validation to continue after duplicate dyn_stats bucket warning"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+fi
+
+content_check "dynstats: duplicate bucket name 'dup_bucket' in current config set; impstats output may be ambiguous" \
+    "${RSYSLOG_DYNNAME}.log"
+
+exit_test

--- a/tests/yaml-dynstats-duplicate-name.sh
+++ b/tests/yaml-dynstats-duplicate-name.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Verify that duplicate YAML dyn_stats bucket names warn through the shared
+# dynstats backend while keeping the config valid. The oracle is successful
+# -N1 config validation plus the duplicate-name diagnostic; no runtime message
+# processing output is involved.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+require_yaml_support
+
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" << YAMLEOF
+dyn_stats:
+  - name: dup_bucket
+    resettable: off
+    maxCardinality: 3
+  - name: dup_bucket
+    resettable: off
+    maxCardinality: 9
+
+rulesets:
+  - name: main
+    filter: "*.*"
+    actions:
+      - type: omfile
+        file: "${RSYSLOG_OUT_LOG}"
+YAMLEOF
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -ne 0 ]; then
+    echo "FAIL: expected YAML config validation to continue after duplicate dyn_stats bucket warning"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+fi
+
+content_check "dynstats: duplicate bucket name 'dup_bucket' in current config set; impstats output may be ambiguous" \
+    "${RSYSLOG_DYNNAME}.log"
+
+exit_test


### PR DESCRIPTION
## Summary
- warn when a `dyn_stats` bucket name is reused in the current config
- preserve existing behavior by continuing to accept duplicate bucket names
- add RainerScript and YAML `-N1` regression coverage

## Validation
- `devtools/format-code.sh --git-changed`
- `bash -n tests/dynstats-duplicate-name.sh tests/yaml-dynstats-duplicate-name.sh`
- `shellcheck -S warning tests/dynstats-duplicate-name.sh tests/yaml-dynstats-duplicate-name.sh`
- `./autogen.sh --enable-debug --enable-testbench --enable-libyaml`
- `make -j80 check TESTS=`
- `./tests/dynstats-duplicate-name.sh`
- `./tests/yaml-dynstats-duplicate-name.sh`
- `make -j80 check TESTS="dynstats-duplicate-name.sh yaml-dynstats-duplicate-name.sh"`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 90m devtools/local-validation-plan.sh --run`
- local Cubic via the validation helper: no issues found

closes https://github.com/rsyslog/rsyslog/issues/1532


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

