### PR TITLE
parser: add optional trailing CR stripping

### DIFF
--- a/doc/source/configuration/input_directives/rsconf1_droptrailinglfonreception.rst
+++ b/doc/source/configuration/input_directives/rsconf1_droptrailinglfonreception.rst
@@ -7,6 +7,12 @@ $DropTrailingLFOnReception
 
 **Description:**
 
+This is a legacy directive. For new configurations, prefer the modern
+``global(parser.dropTrailingLFOnReception="...")`` form. To remove a trailing
+carriage return (CR) after LF handling, use
+``global(parser.dropTrailingCROnReception="on")`` or the legacy
+``$DropTrailingCROnReception on`` directive.
+
 Syslog messages frequently have the line feed character (LF) as the last
 character of the message. In almost all cases, this LF should not really
 become part of the message. However, recent IETF syslog standardization

--- a/doc/source/rainerscript/global.rst
+++ b/doc/source/rainerscript/global.rst
@@ -252,6 +252,16 @@ The following parameters can be set:
   If "off", suppress warnings issued when messages are received
   from non-authorized machines (those, that are in no AllowedSender list).
 
+- **parser.dropTrailingCROnReception** [on/off] available 8.2606.0+
+
+  **Default:** off
+
+  If "on", remove a single carriage return (CR) character from the end
+  of each received message after the normal trailing LF handling has run.
+  This is useful for senders that include CRLF line endings in the message
+  payload. The default is "off" so existing configurations keep the CR
+  byte when it is part of the original message.
+
 - **parser.parseHostnameAndTag** [on/off] available 8.6.0+
 
   **Default:** on

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -141,6 +141,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
     {"action.reportsuspensioncontinuation", eCmdHdlrBinary, 0},
     {"parser.controlcharacterescapeprefix", eCmdHdlrGetChar, 0},
     {"parser.droptrailinglfonreception", eCmdHdlrBinary, 0},
+    {"parser.droptrailingcronreception", eCmdHdlrBinary, 0},
     {"parser.escapecontrolcharactersonreceive", eCmdHdlrBinary, 0},
     {"parser.spacelfonreceive", eCmdHdlrBinary, 0},
     {"parser.escape8bitcharactersonreceive", eCmdHdlrBinary, 0},
@@ -278,6 +279,7 @@ SIMP_PROP_GET(DfltNetstrmDrvrKeyFile, pszDfltNetstrmDrvrKeyFile, uchar *)
 SIMP_PROP_GET(NetstrmDrvrCAExtraFiles, pszNetstrmDrvrCAExtraFiles, uchar *)
 SIMP_PROP_GET(ParserControlCharacterEscapePrefix, parser.cCCEscapeChar, uchar)
 SIMP_PROP_GET(ParserDropTrailingLFOnReception, parser.bDropTrailingLF, int)
+SIMP_PROP_GET(ParserDropTrailingCROnReception, parser.bDropTrailingCR, int)
 SIMP_PROP_GET(ParserEscapeControlCharactersOnReceive, parser.bEscapeCCOnRcv, int)
 SIMP_PROP_GET(ParserSpaceLFOnReceive, parser.bSpaceLFOnRcv, int)
 SIMP_PROP_GET(ParserEscape8BitCharactersOnReceive, parser.bEscape8BitChars, int)
@@ -604,6 +606,12 @@ static rsRetVal setParserControlCharacterEscapePrefix(void __attribute__((unused
 static rsRetVal setParserDropTrailingLFOnReception(void __attribute__((unused)) * pVal, int pNewVal) {
     DEFiRet;
     loadConf->globals.parser.bDropTrailingLF = pNewVal;
+    RETiRet;
+}
+
+static rsRetVal setParserDropTrailingCROnReception(void __attribute__((unused)) * pVal, int pNewVal) {
+    DEFiRet;
+    loadConf->globals.parser.bDropTrailingCR = pNewVal;
     RETiRet;
 }
 
@@ -1087,6 +1095,7 @@ BEGINobjQueryInterface(glbl)
     pIf->GetNetstrmDrvrCAExtraFiles = GetNetstrmDrvrCAExtraFiles;
     pIf->GetParserControlCharacterEscapePrefix = GetParserControlCharacterEscapePrefix;
     pIf->GetParserDropTrailingLFOnReception = GetParserDropTrailingLFOnReception;
+    pIf->GetParserDropTrailingCROnReception = GetParserDropTrailingCROnReception;
     pIf->GetParserEscapeControlCharactersOnReceive = GetParserEscapeControlCharactersOnReceive;
     pIf->GetParserSpaceLFOnReceive = GetParserSpaceLFOnReceive;
     pIf->GetParserEscape8BitCharactersOnReceive = GetParserEscape8BitCharactersOnReceive;
@@ -1142,6 +1151,7 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) * pp, void __
     loadConf->globals.reportOversizeMsg = 1;
     loadConf->globals.parser.cCCEscapeChar = '#';
     loadConf->globals.parser.bDropTrailingLF = 1;
+    loadConf->globals.parser.bDropTrailingCR = 0;
     loadConf->globals.parser.bEscapeCCOnRcv = 1; /* default is to escape control characters */
     loadConf->globals.parser.bSpaceLFOnRcv = 0;
     loadConf->globals.parser.bEscape8BitChars = 0; /* default is not to escape control characters */
@@ -1424,6 +1434,9 @@ rsRetVal glblDoneLoadCnf(void) {
         } else if (!strcmp(paramblk.descr[i].name, "parser.droptrailinglfonreception")) {
             const int tmp = (int)cnfparamvals[i].val.d.n;
             setParserDropTrailingLFOnReception(NULL, tmp);
+        } else if (!strcmp(paramblk.descr[i].name, "parser.droptrailingcronreception")) {
+            const int tmp = (int)cnfparamvals[i].val.d.n;
+            setParserDropTrailingCROnReception(NULL, tmp);
         } else if (!strcmp(paramblk.descr[i].name, "parser.escapecontrolcharactersonreceive")) {
             const int tmp = (int)cnfparamvals[i].val.d.n;
             setParserEscapeControlCharactersOnReceive(NULL, tmp);
@@ -1640,6 +1653,8 @@ BEGINAbstractObjClassInit(glbl, 1, OBJ_IS_CORE_MODULE) /* class, version */
                              setParserControlCharacterEscapePrefix, NULL, NULL));
     CHKiRet(regCfSysLineHdlr((uchar *)"droptrailinglfonreception", 0, eCmdHdlrBinary,
                              setParserDropTrailingLFOnReception, NULL, NULL));
+    CHKiRet(regCfSysLineHdlr((uchar *)"droptrailingcronreception", 0, eCmdHdlrBinary,
+                             setParserDropTrailingCROnReception, NULL, NULL));
     CHKiRet(regCfSysLineHdlr((uchar *)"escapecontrolcharactersonreceive", 0, eCmdHdlrBinary,
                              setParserEscapeControlCharactersOnReceive, NULL, NULL));
     CHKiRet(regCfSysLineHdlr((uchar *)"spacelfonreceive", 0, eCmdHdlrBinary, setParserSpaceLFOnReceive, NULL, NULL));

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -101,6 +101,7 @@ BEGINinterface(glbl) /* name must also be changed in ENDinterface macro! */
     SIMP_PROP(NetstrmDrvrCAExtraFiles, uchar *);
     SIMP_PROP(ParserControlCharacterEscapePrefix, uchar);
     SIMP_PROP(ParserDropTrailingLFOnReception, int);
+    SIMP_PROP(ParserDropTrailingCROnReception, int);
     SIMP_PROP(ParserEscapeControlCharactersOnReceive, int);
     SIMP_PROP(ParserSpaceLFOnReceive, int);
     SIMP_PROP(ParserEscape8BitCharactersOnReceive, int);
@@ -111,7 +112,7 @@ BEGINinterface(glbl) /* name must also be changed in ENDinterface macro! */
 
 #undef SIMP_PROP
 ENDinterface(glbl)
-#define glblCURR_IF_VERSION 10 /* increment whenever you change the interface structure! */
+#define glblCURR_IF_VERSION 11 /* increment whenever you change the interface structure! */
 /* version 2 had PreserveFQDN added - rgerhards, 2008-12-08 */
 
 /* the remaining prototypes */

--- a/runtime/parser.c
+++ b/runtime/parser.c
@@ -367,6 +367,13 @@ static rsRetVal SanitizeMsg(smsg_t *pMsg) {
         bUpdatedLen = RSTRUE;
     }
 
+    if (glbl.GetParserDropTrailingCROnReception(runConf) && lenMsg > 0 && pszMsg[lenMsg - 1] == '\r') {
+        DBGPRINTF("dropped CR at very end of message (DropTrailingCR is set)\n");
+        lenMsg--;
+        pszMsg[lenMsg] = '\0';
+        bUpdatedLen = RSTRUE;
+    }
+
     /* it is much quicker to sweep over the message and see if it actually
      * needs sanitation than to do the sanitation in any case. So we first do
      * this and terminate when it is not needed - which is expectedly the case

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -287,6 +287,7 @@ static void cnfSetDefaults(rsconf_t *pThis) {
 
     pThis->globals.parser.cCCEscapeChar = '#';
     pThis->globals.parser.bDropTrailingLF = 1;
+    pThis->globals.parser.bDropTrailingCR = 0;
     pThis->globals.parser.bEscapeCCOnRcv = 1;
     pThis->globals.parser.bSpaceLFOnRcv = 0;
     pThis->globals.parser.bEscape8BitChars = 0;

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -78,6 +78,7 @@ struct queuecnf_s {
 struct parsercnf_s {
     uchar cCCEscapeChar; /* character to be used to start an escape sequence for control chars */
     int bDropTrailingLF; /* drop trailing LF's on reception? */
+    int bDropTrailingCR; /* drop trailing CR's on reception? */
     int bEscapeCCOnRcv; /* escape control characters on reception: 0 - no, 1 - yes */
     int bSpaceLFOnRcv; /* replace newlines with spaces on reception: 0 - no, 1 - yes */
     int bEscape8BitChars; /* escape characters > 127 on reception: 0 - no, 1 - yes */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -681,6 +681,7 @@ TESTS_IMTCP = \
 	imtcp-netns.sh \
 	imtcp-NUL.sh \
 	imtcp-NUL-rawmsg.sh \
+	parser-drop-trailing-cr.sh \
 	omfwd-rebind-tcp.sh \
 	imtcp_incomplete_frame_at_end.sh \
 	imtcp-multiport.sh \
@@ -699,6 +700,7 @@ TESTS_IMTCP = \
 	sndrcv_udp_nonstdpt.sh \
 	sndrcv_udp_nonstdpt_v6.sh
 TESTS_IMTCP_YAML = \
+	yaml-parser-drop-trailing-cr.sh \
 	imtcp-persource-ratelimit.sh \
 	ratelimit-legacy-persource-discard.sh \
 	ratelimit-persource-repeat-summary.sh \

--- a/tests/parser-drop-trailing-cr.sh
+++ b/tests/parser-drop-trailing-cr.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Verify that parser.dropTrailingCROnReception removes an explicit carriage
+# return left in the message payload after the normal LF framing byte is
+# stripped. The oracle is the final omfile output after synchronized shutdown;
+# without the option, the CR would be escaped as #015 in %msg%.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+global(parser.dropTrailingCROnReception="on")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="rs")
+
+template(name="outfmt" type="string" string="%msg%\n")
+ruleset(name="rs") {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+
+startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
+cr_msg=$(printf '"<167>Mar  6 16:57:54 172.20.245.8 test: payload\r"')
+tcpflood -m1 -M "$cr_msg"
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED=' payload'
+cmp_exact
+
+exit_test

--- a/tests/yaml-parser-drop-trailing-cr.sh
+++ b/tests/yaml-parser-drop-trailing-cr.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Verify YAML support for parser.dropTrailingCROnReception using the same
+# receive-path oracle as the RainerScript test: final omfile output after
+# synchronized shutdown must not contain the escaped trailing CR.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+require_yaml_support
+
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" << YAMLEOF
+global:
+  parser.dropTrailingCROnReception: "on"
+modules:
+  - load: "../plugins/imtcp/.libs/imtcp"
+inputs:
+  - type: imtcp
+    port: "0"
+    listenPortFileName: "${RSYSLOG_DYNNAME}.tcpflood_port"
+    ruleset: rs
+templates:
+  - name: outfmt
+    type: string
+    string: "%msg%\\n"
+rulesets:
+  - name: rs
+    script: |
+      action(type="omfile" file="${RSYSLOG_OUT_LOG}" template="outfmt")
+YAMLEOF
+
+startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
+cr_msg=$(printf '"<167>Mar  6 16:57:54 172.20.245.8 test: payload\r"')
+tcpflood -m1 -M "$cr_msg"
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED=' payload'
+cmp_exact
+
+exit_test


### PR DESCRIPTION
## Summary
- add `parser.dropTrailingCROnReception` for opt-in trailing CR removal
- keep existing behavior unchanged by default
- support the legacy `$DropTrailingCROnReception` directive
- add RainerScript and YAML imtcp receive-path regression tests

## Validation
- `devtools/format-code.sh --git-changed`
- `bash -n tests/parser-drop-trailing-cr.sh tests/yaml-parser-drop-trailing-cr.sh`
- `shellcheck -S warning tests/parser-drop-trailing-cr.sh tests/yaml-parser-drop-trailing-cr.sh`
- `devtools/check-test-antipatterns.sh tests/parser-drop-trailing-cr.sh tests/yaml-parser-drop-trailing-cr.sh`
- `git diff --check`
- `./autogen.sh --enable-debug --enable-testbench --enable-imtcp --enable-libyaml`
- `make -j80 check TESTS=`
- `./tests/parser-drop-trailing-cr.sh`
- `./tests/yaml-parser-drop-trailing-cr.sh`
- `make -j80 check TESTS='parser-drop-trailing-cr.sh yaml-parser-drop-trailing-cr.sh'`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 80`
- `cubic review --base upstream/main --json` (`issues: []`)
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 90m devtools/local-validation-plan.sh --run`

closes https://github.com/rsyslog/rsyslog/issues/241


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

