### PR TITLE
testbench: cover remaining usage helpers

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -104,9 +104,11 @@ TESTS_DEFAULT = \
 	timestamp-subseconds.sh \
 	msleep_usage_output.sh \
 	mangle_qi_usage_output.sh \
+	chkseq_usage_output.sh \
 	minitcpsrv_usage_output.sh \
 	diagtalker-retry.sh \
 	test_id_usage_output.sh \
+	uxsockrcvr_usage_output.sh \
 	prop-programname.sh \
 	prop-programname-with-slashes.sh \
 	hostname-with-slash-pmrfc5424.sh \

--- a/tests/chkseq_usage_output.sh
+++ b/tests/chkseq_usage_output.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Covers the chkseq testbench helper usage path. The oracle is the diagnostic
+# text for an invalid option, proving the helper still prints actionable usage
+# output instead of failing silently.
+
+. ${srcdir:=.}/diag.sh init
+
+if ./chkseq -Z > "$RSYSLOG_OUT_LOG" 2>&1; then
+	echo "chkseq unexpectedly succeeded with an invalid option"
+	error_exit 1
+fi
+content_check 'Invalid call of chkseq'
+content_check 'Usage: chkseq'
+
+exit_test

--- a/tests/uxsockrcvr_usage_output.sh
+++ b/tests/uxsockrcvr_usage_output.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Test uxsockrcvr's standalone usage output when required options are missing.
+# The oracle is the helper process output because no rsyslog instance is
+# started; this covers the standalone testbench utility usage path from #3072.
+
+. ${srcdir:=.}/diag.sh init
+
+if ./uxsockrcvr > "$RSYSLOG_OUT_LOG" 2>&1; then
+	echo "uxsockrcvr unexpectedly succeeded without required options"
+	error_exit 1
+fi
+content_check 'usage: uxsockrcvr'
+content_check '-s MUST be specified'
+
+exit_test


### PR DESCRIPTION
## Summary

- add focused usage-output coverage for `chkseq` and `uxsockrcvr`
- register both tests in the default testbench set next to existing helper usage tests
- close the remaining current-code part of issue https://github.com/rsyslog/rsyslog/issues/3072

The issue checklist used the historical name `chksq.c`; that file no longer
exists in the current tree, and `chkseq` is the current sequence-checking
helper.

## Validation

- `bash -n tests/chkseq_usage_output.sh tests/uxsockrcvr_usage_output.sh`
- `shellcheck -S warning tests/chkseq_usage_output.sh tests/uxsockrcvr_usage_output.sh`
- `devtools/check-test-antipatterns.sh tests/chkseq_usage_output.sh tests/uxsockrcvr_usage_output.sh`
- `./tests/chkseq_usage_output.sh`
- `./tests/uxsockrcvr_usage_output.sh`
- `make -j80 check TESTS="chkseq_usage_output.sh uxsockrcvr_usage_output.sh"`
- `cubic review --print-logs --base upstream/main` -> no issues
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --base upstream/main --run`

The final local validation helper run classified the diff as
`testbench-plumbing` and completed successfully, including the mock
distribution gate, Ubuntu 26.04 change-gated container validation, static
analyzer path, late prompt audit, and Cubic.

The first full helper run exposed an unrelated
`template-property-transformations.sh` output-order mismatch in the broad
suite. The test passed immediately when run directly, and the full helper rerun
passed.
