### PR TITLE
ommail: add SMTP mode test

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -748,6 +748,7 @@ TESTS_MMAITAG = \
 
 TESTS_MAIL = \
 	ommail_errmsg_no_params.sh \
+	ommail-smtp.sh \
 	ommail-sendmail.sh \
 	ommail-sendmail-body-off.sh \
 	ommail-sendmail-fail.sh \
@@ -3470,6 +3471,7 @@ EXTRA_DIST += \
 	omotel_proxy_server.py \
 	otel_collector_find_port.py \
 	testsuites/ommail-sendmail-bin.sh \
+	testsuites/ommail-smtp-server.py \
 	testsuites/imfile-old-state-file_imfile-state_.-rsyslog.input \
 	imfile-endmsg.regex.crio.rulebase \
 	imfile-endmsg.regex.json.rulebase \

--- a/tests/ommail-smtp.sh
+++ b/tests/ommail-smtp.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# This test covers ommail's SMTP mode against a deterministic local SMTP
+# helper. The helper writes its port file only after listen() succeeds and
+# writes a done file after QUIT, so success is proven by synchronized shutdown
+# plus the captured SMTP transcript instead of fixed sleeps.
+
+. ${srcdir:=.}/diag.sh init
+
+if ! command -v python3 >/dev/null 2>&1; then
+	echo "python3 not available, skipping ommail SMTP helper test"
+	skip_test
+fi
+
+PORT_FILE="$RSYSLOG_DYNNAME.ommail-smtp.port"
+SMTP_OUT="$RSYSLOG_DYNNAME.ommail-smtp.out"
+SMTP_DONE="$RSYSLOG_DYNNAME.ommail-smtp.done"
+
+python3 "$srcdir/testsuites/ommail-smtp-server.py" \
+	--port-file "$PORT_FILE" \
+	--output "$SMTP_OUT" \
+	--done-file "$SMTP_DONE" &
+SMTP_PID=$!
+trap 'kill "$SMTP_PID" 2>/dev/null' EXIT
+
+wait_file_exists "$PORT_FILE"
+SMTP_PORT=$(cat "$PORT_FILE")
+
+generate_conf
+add_conf '
+module(load="../plugins/ommail/.libs/ommail")
+
+template(name="mailBody" type="string" string="smtp alert %msg%\\r\\n")
+
+if $msg contains "msgnum:" then {
+    action(
+        type="ommail"
+        mode="smtp"
+        server="127.0.0.1"
+        port="'$SMTP_PORT'"
+        mailfrom="rsyslog@example.net"
+        mailto=["operator@example.net", "admin@example.net"]
+        subject.text="rsyslog smtp alert"
+        body.enable="on"
+        template="mailBody"
+    )
+}
+'
+
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+
+wait_file_exists "$SMTP_DONE"
+wait "$SMTP_PID"
+trap - EXIT
+
+content_check "CMD:HELO" "$SMTP_OUT"
+content_check "CMD:MAIL FROM:<rsyslog@example.net>" "$SMTP_OUT"
+content_check "CMD:RCPT TO:<operator@example.net>" "$SMTP_OUT"
+content_check "CMD:RCPT TO:<admin@example.net>" "$SMTP_OUT"
+content_check "CMD:DATA" "$SMTP_OUT"
+content_check "DATA_BEGIN" "$SMTP_OUT"
+content_check "From: <rsyslog@example.net>" "$SMTP_OUT"
+content_check "Subject: rsyslog smtp alert" "$SMTP_OUT"
+content_check "smtp alert  msgnum:00000000:" "$SMTP_OUT"
+content_check "DATA_END" "$SMTP_OUT"
+content_check "CMD:QUIT" "$SMTP_OUT"
+
+exit_test

--- a/tests/testsuites/ommail-smtp-server.py
+++ b/tests/testsuites/ommail-smtp-server.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Minimal one-shot SMTP server for ommail testbench coverage."""
+
+import argparse
+import socket
+import sys
+
+
+def recv_line(conn):
+    data = bytearray()
+    while True:
+        chunk = conn.recv(1)
+        if not chunk:
+            if data:
+                return bytes(data).decode("utf-8", "replace").rstrip("\r\n")
+            return None
+        data.extend(chunk)
+        if data.endswith(b"\n"):
+            return bytes(data).decode("utf-8", "replace").rstrip("\r\n")
+
+
+def send_line(conn, line):
+    conn.sendall((line + "\r\n").encode("ascii"))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port-file", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--done-file", required=True)
+    args = parser.parse_args()
+
+    transcript = []
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as srv:
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        port = srv.getsockname()[1]
+        with open(args.port_file, "w", encoding="ascii") as fh:
+            fh.write(f"{port}\n")
+
+        srv.settimeout(30)
+        conn, _addr = srv.accept()
+        with conn:
+            conn.settimeout(30)
+            send_line(conn, "220 rsyslog test SMTP ready")
+            in_data = False
+            data_lines = []
+            while True:
+                line = recv_line(conn)
+                if line is None:
+                    break
+                if in_data:
+                    if line == ".":
+                        transcript.append("DATA_BEGIN")
+                        transcript.extend(data_lines)
+                        transcript.append("DATA_END")
+                        data_lines = []
+                        in_data = False
+                        send_line(conn, "250 message accepted")
+                    else:
+                        data_lines.append(line)
+                    continue
+
+                transcript.append(f"CMD:{line}")
+                command = line.split(" ", 1)[0].upper()
+                if command == "DATA":
+                    in_data = True
+                    send_line(conn, "354 end data with <CR><LF>.<CR><LF>")
+                elif command == "QUIT":
+                    send_line(conn, "221 bye")
+                    break
+                elif command in ("HELO", "EHLO", "MAIL", "RCPT", "RSET"):
+                    send_line(conn, "250 ok")
+                else:
+                    send_line(conn, "500 unsupported command")
+
+    with open(args.output, "w", encoding="utf-8") as fh:
+        for line in transcript:
+            fh.write(line + "\n")
+    with open(args.done_file, "w", encoding="ascii") as fh:
+        fh.write("done\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add a deterministic local SMTP helper for ommail testbench coverage
- add `ommail-smtp.sh` to exercise SMTP mode end to end
- register the new test and helper in `tests/Makefile.am`

Closes https://github.com/rsyslog/rsyslog/issues/3141

## Validation

- `bash -n tests/ommail-smtp.sh`
- `python3 -m py_compile tests/testsuites/ommail-smtp-server.py`
- `shellcheck -S warning tests/ommail-smtp.sh`
- `devtools/format-python.sh --check-if-available tests/testsuites/ommail-smtp-server.py`
- `./tests/ommail-smtp.sh`
- `make -j80 check TESTS=ommail-smtp.sh` attempted after container validation; host rebuild failed due stale generated configure state for unrelated mongoc include paths
- `./tests/template-property-transformations.sh` passed on focused retry after an unrelated high-concurrency ordering flake in the first full local gate
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 90m devtools/local-validation-plan.sh --run`
- local Cubic: no issues found


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

