### PR TITLE
mmutf8fix: support replacement sequences

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -903,6 +903,7 @@ EXTRA_DIST = \
     source/reference/parameters/mmtaghostname-tag.rst \
     source/reference/parameters/mmutf8fix-mode.rst \
     source/reference/parameters/mmutf8fix-replacementchar.rst \
+    source/reference/parameters/mmutf8fix-replacementsequence.rst \
     source/reference/parameters/omazureeventhubs-amqp_address.rst \
     source/reference/parameters/omazureeventhubs-azure_key.rst \
     source/reference/parameters/omazureeventhubs-azure_key_name.rst \

--- a/doc/source/configuration/modules/mmutf8fix.rst
+++ b/doc/source/configuration/modules/mmutf8fix.rst
@@ -19,12 +19,14 @@ While they are typically uncritical with plain text files, they can
 cause big headache with database sources as well as systems like
 ElasticSearch.
 
-The module supports different "fixing" modes and fixes. The current
-implementation will always replace invalid bytes with a single US ASCII
-character. Additional replacement modes will probably be added in the
-future, depending on user demand. In the longer term it could also be
-evolved into an any-charset-to-UTF8 converter. But first let's see if it
-really gets into widespread enough use.
+The module supports different "fixing" modes and replacement markers. By
+default it replaces invalid bytes with a single printable US-ASCII
+character. For configurations that need a multi-byte marker, the
+``replacementSequence`` action parameter can instead replace each invalid
+input byte with a configured byte sequence such as the UTF-8 encoding of
+``U+FFFD``. In the longer term it could also be evolved into an
+any-charset-to-UTF8 converter. But first let's see if it really gets into
+widespread enough use.
 
 Proper Usage
 ============
@@ -78,6 +80,10 @@ Action Parameters
      - .. include:: ../../reference/parameters/mmutf8fix-replacementchar.rst
           :start-after: .. summary-start
           :end-before: .. summary-end
+   * - :ref:`param-mmutf8fix-replacementsequence`
+     - .. include:: ../../reference/parameters/mmutf8fix-replacementsequence.rst
+          :start-after: .. summary-start
+          :end-before: .. summary-end
 
 Examples
 ========
@@ -108,8 +114,29 @@ This is mostly the same as the previous sample, but uses
   module(load="mmutf8fix")
   if $fromhost-ip == "10.0.0.1" then action(type="mmutf8fix" mode="controlcharacters") # all other actions here...
 
+This sample replaces each invalid byte with the UTF-8 byte sequence for
+``U+FFFD`` instead of a single ASCII character.
+
+.. code-block:: rsyslog
+
+  module(load="mmutf8fix")
+  action(type="mmutf8fix" replacementSequence="\xEF\xBF\xBD")
+
+The same setting can be expressed through YAML configuration.
+
+.. code-block:: yaml
+
+  modules:
+    - load: "mmutf8fix"
+
+  rulesets:
+    - name: main
+      script: |
+        action(type="mmutf8fix" replacementSequence="\xEF\xBF\xBD")
+
 .. toctree::
    :hidden:
 
    ../../reference/parameters/mmutf8fix-mode
    ../../reference/parameters/mmutf8fix-replacementchar
+   ../../reference/parameters/mmutf8fix-replacementsequence

--- a/doc/source/configuration/modules/mmutf8fix.rst
+++ b/doc/source/configuration/modules/mmutf8fix.rst
@@ -120,7 +120,7 @@ This sample replaces each invalid byte with the UTF-8 byte sequence for
 .. code-block:: rsyslog
 
   module(load="mmutf8fix")
-  action(type="mmutf8fix" replacementSequence="\xEF\xBF\xBD")
+  action(type="mmutf8fix" replacementSequence="\357\277\275")
 
 The same setting can be expressed through YAML configuration.
 
@@ -132,7 +132,7 @@ The same setting can be expressed through YAML configuration.
   rulesets:
     - name: main
       script: |
-        action(type="mmutf8fix" replacementSequence="\xEF\xBF\xBD")
+        action(type="mmutf8fix" replacementSequence="\357\277\275")
 
 .. toctree::
    :hidden:

--- a/doc/source/reference/parameters/mmutf8fix-replacementchar.rst
+++ b/doc/source/reference/parameters/mmutf8fix-replacementchar.rst
@@ -28,6 +28,9 @@ Description
 This is the character that invalid sequences are replaced by. It is
 strongly recommended to use a printable US-ASCII character. Note that
 only the first byte of the provided string is used without validation.
+Use :ref:`param-mmutf8fix-replacementsequence` instead when the
+replacement marker needs more than one byte. The two parameters are
+mutually exclusive.
 
 Input usage
 -----------
@@ -38,6 +41,19 @@ Input usage
    module(load="mmutf8fix")
 
    action(type="mmutf8fix" replacementChar="#")
+
+YAML usage
+----------
+
+.. code-block:: yaml
+
+   modules:
+     - load: "mmutf8fix"
+
+   rulesets:
+     - name: main
+       script: |
+         action(type="mmutf8fix" replacementChar="#")
 
 See also
 --------

--- a/doc/source/reference/parameters/mmutf8fix-replacementsequence.rst
+++ b/doc/source/reference/parameters/mmutf8fix-replacementsequence.rst
@@ -1,0 +1,70 @@
+.. _param-mmutf8fix-replacementsequence:
+.. _mmutf8fix.parameter.input.replacementsequence:
+
+replacementSequence
+===================
+
+.. index::
+   single: mmutf8fix; replacementSequence
+   single: replacementSequence
+
+.. summary-start
+
+Defines a byte sequence used to substitute invalid input bytes.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmutf8fix`.
+
+:Name: replacementSequence
+:Scope: input
+:Type: string
+:Default: not set
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+This parameter configures a replacement byte sequence for each invalid
+input byte detected by mmutf8fix. It is useful when a single printable
+US-ASCII character is not enough, for example when operators want to use
+the UTF-8 encoding of ``U+FFFD`` as the invalid-character marker.
+
+``replacementSequence`` and :ref:`param-mmutf8fix-replacementchar` are
+mutually exclusive. Use ``replacementChar`` when a single-byte
+replacement is sufficient. Use ``replacementSequence`` only when a
+multi-byte marker is needed; it is an explicit opt-in to the rebuild path
+because the output field can become longer than the original input.
+
+Each invalid input byte is replaced independently. For example, if an
+invalid two-byte sequence is detected and ``replacementSequence`` is set
+to the UTF-8 bytes for ``U+FFFD``, the output contains two replacement
+markers.
+
+Input usage
+-----------
+.. _mmutf8fix.parameter.input.replacementsequence-usage:
+
+.. code-block:: rsyslog
+
+   module(load="mmutf8fix")
+
+   # U+FFFD encoded as UTF-8 bytes.
+   action(type="mmutf8fix" replacementSequence="\xEF\xBF\xBD")
+
+YAML usage
+----------
+
+.. code-block:: yaml
+
+   modules:
+     - load: "mmutf8fix"
+
+   rulesets:
+     - name: main
+       script: |
+         action(type="mmutf8fix" replacementSequence="\xEF\xBF\xBD")
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmutf8fix`.

--- a/doc/source/reference/parameters/mmutf8fix-replacementsequence.rst
+++ b/doc/source/reference/parameters/mmutf8fix-replacementsequence.rst
@@ -41,6 +41,9 @@ invalid two-byte sequence is detected and ``replacementSequence`` is set
 to the UTF-8 bytes for ``U+FFFD``, the output contains two replacement
 markers.
 
+Use octal byte escapes in object-parameter strings. For example, write the
+UTF-8 bytes for ``U+FFFD`` as ``\357\277\275``.
+
 Input usage
 -----------
 .. _mmutf8fix.parameter.input.replacementsequence-usage:
@@ -50,7 +53,7 @@ Input usage
    module(load="mmutf8fix")
 
    # U+FFFD encoded as UTF-8 bytes.
-   action(type="mmutf8fix" replacementSequence="\xEF\xBF\xBD")
+   action(type="mmutf8fix" replacementSequence="\357\277\275")
 
 YAML usage
 ----------
@@ -63,7 +66,7 @@ YAML usage
    rulesets:
      - name: main
        script: |
-         action(type="mmutf8fix" replacementSequence="\xEF\xBF\xBD")
+         action(type="mmutf8fix" replacementSequence="\357\277\275")
 
 See also
 --------

--- a/plugins/mmutf8fix/mmutf8fix.c
+++ b/plugins/mmutf8fix/mmutf8fix.c
@@ -33,6 +33,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <errno.h>
+#include <limits.h>
 #include <unistd.h>
 #include <stdint.h>
 #include "conf.h"
@@ -57,6 +58,9 @@ DEF_OMOD_STATIC_DATA;
 /* config variables */
 typedef struct _instanceData {
     uchar replChar;
+    uchar *replSeq;
+    size_t lenReplSeq;
+    sbool useReplSeq;
     uint8_t mode; /* operations mode */
 } instanceData;
 
@@ -73,7 +77,8 @@ static modConfData_t *runModConf = NULL; /* modConf ptr to use for the current e
 
 /* tables for interfacing with the v6 config system */
 /* action (instance) parameters */
-static struct cnfparamdescr actpdescr[] = {{"mode", eCmdHdlrGetWord, 0}, {"replacementchar", eCmdHdlrGetChar, 0}};
+static struct cnfparamdescr actpdescr[] = {
+    {"mode", eCmdHdlrGetWord, 0}, {"replacementchar", eCmdHdlrGetChar, 0}, {"replacementsequence", eCmdHdlrString, 0}};
 static struct cnfparamblk actpblk = {CNFPARAMBLK_VERSION, sizeof(actpdescr) / sizeof(struct cnfparamdescr), actpdescr};
 
 BEGINbeginCnfLoad
@@ -117,6 +122,7 @@ ENDisCompatibleWithFeature
 
 BEGINfreeInstance
     CODESTARTfreeInstance;
+    free(pData->replSeq);
 ENDfreeInstance
 
 
@@ -128,11 +134,16 @@ ENDfreeWrkrInstance
 static inline void setInstParamDefaults(instanceData *pData) {
     pData->mode = MODE_UTF8;
     pData->replChar = ' ';
+    pData->replSeq = NULL;
+    pData->lenReplSeq = 0;
+    pData->useReplSeq = 0;
 }
 
 BEGINnewActInst
     struct cnfparamvals *pvals;
     int i;
+    sbool bReplCharSet = 0;
+    sbool bReplSeqSet = 0;
     CODESTARTnewActInst;
     DBGPRINTF("newActInst (mmutf8fix)\n");
     if ((pvals = nvlstGetParams(lst, &actpblk, NULL)) == NULL) {
@@ -159,12 +170,31 @@ BEGINnewActInst
             }
         } else if (!strcmp(actpblk.descr[i].name, "replacementchar")) {
             pData->replChar = es_getBufAddr(pvals[i].val.d.estr)[0];
+            bReplCharSet = 1;
+        } else if (!strcmp(actpblk.descr[i].name, "replacementsequence")) {
+            pData->lenReplSeq = es_strlen(pvals[i].val.d.estr);
+            if (pData->lenReplSeq == 0) {
+                LogError(0, RS_RET_CONFIG_ERROR, "mmutf8fix: replacementSequence must not be empty");
+                ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+            }
+            CHKmalloc(pData->replSeq = malloc(pData->lenReplSeq));
+            memcpy(pData->replSeq, es_getBufAddr(pvals[i].val.d.estr), pData->lenReplSeq);
+            pData->useReplSeq = 1;
+            bReplSeqSet = 1;
         } else {
             dbgprintf(
                 "mmutf8fix: program error, non-handled "
                 "param '%s'\n",
                 actpblk.descr[i].name);
         }
+    }
+    if (bReplCharSet && bReplSeqSet) {
+        LogError(0, RS_RET_CONFIG_ERROR, "mmutf8fix: replacementChar and replacementSequence are mutually exclusive");
+        free(pData->replSeq);
+        pData->replSeq = NULL;
+        pData->lenReplSeq = 0;
+        pData->useReplSeq = 0;
+        ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
     }
 
     CODE_STD_FINALIZERnewActInst;
@@ -190,6 +220,82 @@ static void doCC(instanceData *pData, uchar *msg, int lenMsg) {
             msg[i] = pData->replChar;
         }
     }
+}
+
+static rsRetVal ensureSeqBuf(instanceData *pData, int lenMsg, uchar **out) {
+    DEFiRet;
+    size_t cap;
+    if (lenMsg <= 0) {
+        *out = NULL;
+        FINALIZE;
+    }
+    if (pData->lenReplSeq != 0 && (size_t)lenMsg > (SIZE_MAX - 1) / pData->lenReplSeq) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    cap = ((size_t)lenMsg * pData->lenReplSeq) + 1;
+    CHKmalloc(*out = malloc(cap));
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal beginSeqChange(
+    instanceData *pData, const uchar *msg, int lenMsg, uchar **out, size_t *pos, const int copyLen) {
+    DEFiRet;
+    if (*out == NULL) {
+        CHKiRet(ensureSeqBuf(pData, lenMsg, out));
+        if (*out == NULL) FINALIZE;
+        if (copyLen > 0) {
+            memcpy(*out, msg, (size_t)copyLen);
+            *pos = (size_t)copyLen;
+        }
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static inline rsRetVal appendReplacement(instanceData *pData, uchar *out, size_t *outLen) {
+    DEFiRet;
+    if (out == NULL) {
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+    memcpy(out + *outLen, pData->replSeq, pData->lenReplSeq);
+    *outLen += pData->lenReplSeq;
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal doCCSeq(instanceData *pData, const uchar *msg, int lenMsg, uchar **out, int *outLen) {
+    DEFiRet;
+    size_t pos = 0;
+    int i;
+
+    *out = NULL;
+    *outLen = lenMsg;
+
+    for (i = 0; i < lenMsg; ++i) {
+        if (msg[i] < 32 || msg[i] > 126) {
+            CHKiRet(beginSeqChange(pData, msg, lenMsg, out, &pos, i));
+            CHKiRet(appendReplacement(pData, *out, &pos));
+        } else if (*out != NULL) {
+            (*out)[pos++] = msg[i];
+        }
+    }
+    if (*out == NULL) FINALIZE;
+
+    (*out)[pos] = '\0';
+    if (pos > INT_MAX) {
+        free(*out);
+        *out = NULL;
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    } else {
+        *outLen = (int)pos;
+    }
+
+finalize_it:
+    RETiRet;
 }
 
 /* fix an invalid multibyte sequence */
@@ -276,6 +382,104 @@ static void doUTF8(instanceData *pData, uchar *msg, int lenMsg) {
     }
 }
 
+static inline sbool invalidCodepoint(const uint32_t codepoint, const int seqLen) {
+    return (((2 == seqLen) && (codepoint < 0x80)) || ((3 == seqLen) && (codepoint < 0x800)) ||
+            ((4 == seqLen) && (codepoint < 0x10000)) || ((codepoint >= 0xD800) && (codepoint <= 0xDFFF)) ||
+            (codepoint > 0x10FFFF));
+}
+
+static rsRetVal appendReplacements(instanceData *pData, uchar *out, size_t *pos, const int cnt) {
+    DEFiRet;
+    int i;
+
+    for (i = 0; i < cnt; ++i) {
+        CHKiRet(appendReplacement(pData, out, pos));
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal doUTF8Seq(instanceData *pData, const uchar *msg, int lenMsg, uchar **out, int *outLen) {
+    DEFiRet;
+    size_t pos = 0;
+    int i = 0;
+
+    *out = NULL;
+    *outLen = lenMsg;
+
+    while (i < lenMsg) {
+        const uchar c = msg[i];
+        int seqLen = 0;
+        uint32_t codepoint = 0;
+
+        if ((c & 0x80) == 0) {
+            if (*out != NULL) {
+                (*out)[pos++] = c;
+            }
+            ++i;
+            continue;
+        } else if ((c & 0xe0) == 0xc0) {
+            seqLen = 2;
+            codepoint = c & 0x1f;
+        } else if ((c & 0xf0) == 0xe0) {
+            seqLen = 3;
+            codepoint = c & 0x0f;
+        } else if ((c & 0xf8) == 0xf0) {
+            seqLen = 4;
+            codepoint = c & 0x07;
+        } else {
+            CHKiRet(beginSeqChange(pData, msg, lenMsg, out, &pos, i));
+            CHKiRet(appendReplacement(pData, *out, &pos));
+            ++i;
+            continue;
+        }
+
+        int j;
+        for (j = 1; j < seqLen && i + j < lenMsg; ++j) {
+            if ((msg[i + j] & 0xc0) != 0x80) break;
+            codepoint = (codepoint << 6) | (msg[i + j] & 0x3f);
+        }
+
+        if (j < seqLen) {
+            CHKiRet(beginSeqChange(pData, msg, lenMsg, out, &pos, i));
+            CHKiRet(appendReplacements(pData, *out, &pos, j));
+            i += j;
+        } else if (invalidCodepoint(codepoint, seqLen)) {
+            CHKiRet(beginSeqChange(pData, msg, lenMsg, out, &pos, i));
+            CHKiRet(appendReplacements(pData, *out, &pos, seqLen));
+            i += seqLen;
+        } else {
+            if (*out != NULL) {
+                memcpy(*out + pos, msg + i, seqLen);
+                pos += seqLen;
+            }
+            i += seqLen;
+        }
+    }
+    if (*out == NULL) FINALIZE;
+
+    (*out)[pos] = '\0';
+    if (pos > INT_MAX) {
+        free(*out);
+        *out = NULL;
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    } else {
+        *outLen = (int)pos;
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal fixSeq(instanceData *pData, const uchar *msg, int lenMsg, uchar **out, int *outLen) {
+    if (pData->mode == MODE_CC) {
+        return doCCSeq(pData, msg, lenMsg, out, outLen);
+    } else {
+        return doUTF8Seq(pData, msg, lenMsg, out, outLen);
+    }
+}
+
 BEGINdoAction_NoStrings
     smsg_t **ppMsg = (smsg_t **)pMsgData;
     smsg_t *pMsg = ppMsg[0];
@@ -285,17 +489,65 @@ BEGINdoAction_NoStrings
     int lenTag;
     CODESTARTdoAction;
     MsgLock(pMsg);
-    lenMsg = getMSGLen(pMsg);
-    msg = getMSG(pMsg);
-    getTAG(pMsg, &tag, &lenTag, MUTEX_ALREADY_LOCKED);
-    if (pWrkrData->pData->mode == MODE_CC) {
-        doCC(pWrkrData->pData, msg, lenMsg);
-        doCC(pWrkrData->pData, tag, lenTag);
-        if (MsgHasStructuredData(pMsg)) doCC(pWrkrData->pData, pMsg->pszStrucData, (int)pMsg->lenStrucData);
+    if (pWrkrData->pData->useReplSeq) {
+        uchar *fixedMsg = NULL;
+        uchar *fixedTag = NULL;
+        uchar *fixedSD = NULL;
+        char *sdCopy = NULL;
+        int fixedMsgLen = 0;
+        int fixedTagLen = 0;
+        int fixedSDLen = 0;
+        lenMsg = getMSGLen(pMsg);
+        msg = getMSG(pMsg);
+        iRet = fixSeq(pWrkrData->pData, msg, lenMsg, &fixedMsg, &fixedMsgLen);
+        if (iRet != RS_RET_OK) goto done;
+        getTAG(pMsg, &tag, &lenTag, MUTEX_ALREADY_LOCKED);
+        iRet = fixSeq(pWrkrData->pData, tag, lenTag, &fixedTag, &fixedTagLen);
+        if (iRet != RS_RET_OK) goto done;
+        if (MsgHasStructuredData(pMsg)) {
+            iRet = fixSeq(pWrkrData->pData, pMsg->pszStrucData, (int)pMsg->lenStrucData, &fixedSD, &fixedSDLen);
+            if (iRet != RS_RET_OK) goto done;
+        }
+        if (fixedSD != NULL) {
+            sdCopy = malloc((size_t)fixedSDLen + 1);
+            if (sdCopy == NULL) {
+                iRet = RS_RET_OUT_OF_MEMORY;
+                goto done;
+            }
+            memcpy(sdCopy, fixedSD, (size_t)fixedSDLen + 1);
+        }
+
+        if (fixedMsg != NULL) {
+            iRet = MsgReplaceMSG(pMsg, fixedMsg, fixedMsgLen);
+            if (iRet != RS_RET_OK) goto done;
+        }
+        if (fixedTag != NULL) {
+            MsgSetTAG(pMsg, fixedTag, (size_t)fixedTagLen);
+        }
+        if (sdCopy != NULL) {
+            free(pMsg->pszStrucData);
+            pMsg->pszStrucData = (uchar *)sdCopy;
+            pMsg->lenStrucData = (rs_size_t)fixedSDLen;
+            sdCopy = NULL;
+        }
+    done:
+        free(fixedMsg);
+        free(fixedTag);
+        free(fixedSD);
+        free(sdCopy);
     } else {
-        doUTF8(pWrkrData->pData, msg, lenMsg);
-        doUTF8(pWrkrData->pData, tag, lenTag);
-        if (MsgHasStructuredData(pMsg)) doUTF8(pWrkrData->pData, pMsg->pszStrucData, (int)pMsg->lenStrucData);
+        lenMsg = getMSGLen(pMsg);
+        msg = getMSG(pMsg);
+        getTAG(pMsg, &tag, &lenTag, MUTEX_ALREADY_LOCKED);
+        if (pWrkrData->pData->mode == MODE_CC) {
+            doCC(pWrkrData->pData, msg, lenMsg);
+            doCC(pWrkrData->pData, tag, lenTag);
+            if (MsgHasStructuredData(pMsg)) doCC(pWrkrData->pData, pMsg->pszStrucData, (int)pMsg->lenStrucData);
+        } else {
+            doUTF8(pWrkrData->pData, msg, lenMsg);
+            doUTF8(pWrkrData->pData, tag, lenTag);
+            if (MsgHasStructuredData(pMsg)) doUTF8(pWrkrData->pData, pMsg->pszStrucData, (int)pMsg->lenStrucData);
+        }
     }
     MsgUnlock(pMsg);
 ENDdoAction

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -737,7 +737,12 @@ TESTS_SNMP_FULL = \
 
 TESTS_MMUTF8FIX = \
         mmutf8fix_no_error.sh \
+        mmutf8fix_replacement_sequence.sh \
+        mmutf8fix_replacement_sequence_conflict.sh \
         mmutf8fix_tag.sh
+
+TESTS_MMUTF8FIX_YAML = \
+        yaml-mmutf8fix-replacement-sequence.sh
 
 TESTS_MMUTF8FIX_SD = \
         mmutf8fix_sd.sh
@@ -1995,6 +2000,7 @@ EXTRA_DIST += $(TESTS_RATELIMIT_IMPTCP_YAML)
 EXTRA_DIST += $(TESTS_SNMP_MINIMAL)
 EXTRA_DIST += $(TESTS_SNMP_FULL)
 EXTRA_DIST += $(TESTS_MMUTF8FIX)
+EXTRA_DIST += $(TESTS_MMUTF8FIX_YAML)
 EXTRA_DIST += $(TESTS_MMUTF8FIX_SD)
 EXTRA_DIST += $(TESTS_MMAITAG)
 EXTRA_DIST += $(TESTS_MAIL)
@@ -2539,6 +2545,12 @@ endif # if ENABLE_SNMP
 
 if ENABLE_MMUTF8FIX
 TESTS += $(TESTS_MMUTF8FIX)
+endif # if ENABLE_MMUTF8FIX
+
+if ENABLE_MMUTF8FIX
+if HAVE_LIBYAML
+TESTS += $(TESTS_MMUTF8FIX_YAML)
+endif # HAVE_LIBYAML
 endif # if ENABLE_MMUTF8FIX
 
 if ENABLE_MMUTF8FIX

--- a/tests/mmutf8fix_replacement_sequence.sh
+++ b/tests/mmutf8fix_replacement_sequence.sh
@@ -7,7 +7,6 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 
-replacement_sequence=$(printf '\357\277\275')
 generate_conf
 add_conf '
 module(load="../plugins/mmutf8fix/.libs/mmutf8fix")
@@ -23,12 +22,12 @@ input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_tag_
       ruleset="tagtest")
 
 ruleset(name="sdtest") {
-	action(type="mmutf8fix" replacementSequence="'$replacement_sequence'")
+	action(type="mmutf8fix" replacementSequence="\357\277\275")
 	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="sdoutfmt")
 }
 
 ruleset(name="tagtest" parser="custom.rfc3164") {
-	action(type="mmutf8fix" replacementSequence="'$replacement_sequence'")
+	action(type="mmutf8fix" replacementSequence="\357\277\275")
 	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="tagoutfmt")
 }'
 

--- a/tests/mmutf8fix_replacement_sequence.sh
+++ b/tests/mmutf8fix_replacement_sequence.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Validate mmutf8fix replacementSequence for invalid UTF-8 in message, tag,
+# and structured data fields. The oracle is the configured omfile destination
+# after synchronized shutdown, proving the rewritten fields reached the normal
+# output path. Invalid bytes are replaced once per byte with the configured
+# UTF-8 replacement sequence.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+
+replacement_sequence=$(printf '\357\277\275')
+generate_conf
+add_conf '
+module(load="../plugins/mmutf8fix/.libs/mmutf8fix")
+module(load="../plugins/imtcp/.libs/imtcp")
+
+parser(name="custom.rfc3164" type="pmrfc3164" force.tagEndingByColon="on")
+template(name="sdoutfmt" type="string" string="%structured-data%|%msg%\n")
+template(name="tagoutfmt" type="string" string="%syslogtag%|%msg%\n")
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_sd_port"
+      ruleset="sdtest")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_tag_port"
+      ruleset="tagtest")
+
+ruleset(name="sdtest") {
+	action(type="mmutf8fix" replacementSequence="'$replacement_sequence'")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="sdoutfmt")
+}
+
+ruleset(name="tagtest" parser="custom.rfc3164") {
+	action(type="mmutf8fix" replacementSequence="'$replacement_sequence'")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="tagoutfmt")
+}'
+
+startup
+wait_file_exists "$RSYSLOG_DYNNAME.tcpflood_sd_port"
+wait_file_exists "$RSYSLOG_DYNNAME.tcpflood_tag_port"
+printf '<134>1 2026-06-01T00:00:00Z host app proc msgid [test@32473 dirty="Brain\xa0Twist"] bad\xc0\x80 utf8\n' \
+  > "$RSYSLOG_DYNNAME.input"
+tcpflood -p"$(cat "$RSYSLOG_DYNNAME.tcpflood_sd_port")" -m1 -I "$RSYSLOG_DYNNAME.input"
+printf '<129>Mar 10 01:00:00 host bad\xc0tag: tag payload\n' > "$RSYSLOG_DYNNAME.input"
+tcpflood -p"$(cat "$RSYSLOG_DYNNAME.tcpflood_tag_port")" -m1 -I "$RSYSLOG_DYNNAME.input"
+rm -f "$RSYSLOG_DYNNAME.input"
+shutdown_when_empty
+wait_shutdown
+
+{
+  printf '[test@32473 dirty="Brain\357\277\275Twist"]|bad\357\277\275\357\277\275 utf8\n'
+  printf 'bad\357\277\275tag:| tag payload\n'
+} > "$RSYSLOG_OUT_LOG.expect"
+
+cmp_exact_file "$RSYSLOG_OUT_LOG.expect" "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/mmutf8fix_replacement_sequence_conflict.sh
+++ b/tests/mmutf8fix_replacement_sequence_conflict.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Validate mmutf8fix configuration rejects replacementChar and
+# replacementSequence on the same action. This is a startup validation test:
+# rsyslog must refuse the configuration before any normal message path exists.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+
+if [ -z "$RSYSLOGD" ]; then
+    export RSYSLOGD=../tools/rsyslogd
+fi
+
+generate_conf
+add_conf '
+module(load="../plugins/mmutf8fix/.libs/mmutf8fix")
+action(type="mmutf8fix" replacementChar="?" replacementSequence="[bad]")
+'
+
+export CONF_FILE="${TESTCONF_NM}.conf"
+if $RSYSLOGD -N1 -M"$RSYSLOG_MODDIR" -f "$CONF_FILE" > stdout.log 2> stderr.log; then
+    echo "FAIL: invalid replacement configuration was accepted"
+    error_exit 1
+fi
+
+content_check "mmutf8fix: replacementChar and replacementSequence are mutually exclusive" stderr.log
+exit_test

--- a/tests/yaml-mmutf8fix-replacement-sequence.sh
+++ b/tests/yaml-mmutf8fix-replacement-sequence.sh
@@ -30,7 +30,7 @@ templates:
 rulesets:
   - name: main
     script: |
-      action(type="mmutf8fix" replacementSequence="[bad]")
+      action(type="mmutf8fix" replacementSequence="\357\277\275")
       action(type="omfile" file="${RSYSLOG_OUT_LOG}" template="outfmt")
 YAMLEOF
 
@@ -42,6 +42,6 @@ wait_file_lines "$RSYSLOG_OUT_LOG" 1 60
 shutdown_when_empty
 wait_shutdown
 
-export EXPECTED=' has[bad]invalid'
-cmp_exact
+printf ' has\357\277\275invalid\n' > "$RSYSLOG_OUT_LOG.expect"
+cmp_exact_file "$RSYSLOG_OUT_LOG.expect" "$RSYSLOG_OUT_LOG"
 exit_test

--- a/tests/yaml-mmutf8fix-replacement-sequence.sh
+++ b/tests/yaml-mmutf8fix-replacement-sequence.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Verify mmutf8fix replacementSequence in a YAML-loaded configuration. The
+# ruleset body is supplied via YAML script so message-modification action
+# ordering matches the RainerScript action path, and success is proven by the
+# configured omfile output after synchronized shutdown.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+require_yaml_support
+require_plugin imtcp
+
+export NUMMESSAGES=1
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+input(type="imtcp" port="0" listenPortFileName="'${RSYSLOG_DYNNAME}'.tcpflood_port"
+      ruleset="main")
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" << YAMLEOF
+modules:
+  - load: "../plugins/mmutf8fix/.libs/mmutf8fix"
+  - load: "../plugins/imtcp/.libs/imtcp"
+
+templates:
+  - name: outfmt
+    type: string
+    string: "%msg%\\n"
+
+rulesets:
+  - name: main
+    script: |
+      action(type="mmutf8fix" replacementSequence="[bad]")
+      action(type="omfile" file="${RSYSLOG_OUT_LOG}" template="outfmt")
+YAMLEOF
+
+startup
+printf '<129>Mar 10 01:00:00 host tag: has\xc0invalid\n' > "$RSYSLOG_DYNNAME.input"
+tcpflood -m1 -I "$RSYSLOG_DYNNAME.input"
+rm -f "$RSYSLOG_DYNNAME.input"
+wait_file_lines "$RSYSLOG_OUT_LOG" 1 60
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED=' has[bad]invalid'
+cmp_exact
+exit_test


### PR DESCRIPTION
## Summary

- add `replacementSequence` to `mmutf8fix` for multi-byte replacement markers
- keep the existing `replacementChar` path unchanged and reject configs that set both parameters
- document RainerScript and YAML-loaded usage
- add coverage for message text, tags, structured data, YAML loading, and config conflicts

Closes https://github.com/rsyslog/rsyslog/issues/6682

## Validation

- `devtools/format-code.sh --git-changed`
- `git diff --check`
- `timeout 20m bash .codex_run_focused.sh`
  - host reconfigure with `--enable-testbench --enable-mmutf8fix --enable-mmpstrucdata`
  - `make -j80 check TESTS="mmutf8fix_replacement_sequence.sh mmutf8fix_replacement_sequence_conflict.sh yaml-mmutf8fix-replacement-sequence.sh mmutf8fix_no_error.sh mmutf8fix_tag.sh mmutf8fix_sd.sh"`: 6/6 passed
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 80`
- `PATH=doc/.venv-docs/bin:$PATH timeout 45m bash .agent/skills/rsyslog_doc_dist/scripts/check-doc-dist.sh`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run`
  - classification: `testbench-plumbing`
  - C formatting gate passed
  - test antipattern scans passed
  - distribution-risk mock distcheck path passed
  - local Cubic ran and reported no issues
  - change-gated Ubuntu 26.04 container/static-analysis validation completed with exit 0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

