### PR TITLE
mmjsonparse: modernize test output paths

### DIFF
--- a/tests/mmjsonparse-find-json-basic.sh
+++ b/tests/mmjsonparse-find-json-basic.sh
@@ -12,14 +12,14 @@ template(name="outfmt" type="string" string="%msg% parsesuccess=%parsesuccess% j
 # Legacy cookie mode (default) - should NOT parse text with JSON
 if $msg contains "LEGACY" then {
     action(type="mmjsonparse")
-    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
     stop
 }
 
 # Find-JSON mode - should parse text with embedded JSON
 if $msg contains "FINDJSON" then {
     action(type="mmjsonparse" mode="find-json")
-    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
     stop
 }
 '

--- a/tests/mmjsonparse-find-json-conflict.sh
+++ b/tests/mmjsonparse-find-json-conflict.sh
@@ -16,7 +16,7 @@ template(name="outfmt" type="string" string="%msg% parsesuccess=%parsesuccess% j
 if $msg contains "CONFLICT" then {
     set $!conflict = "scalar";
     action(type="mmjsonparse" mode="find-json" container="$!conflict!parsed")
-    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 startup

--- a/tests/mmjsonparse-find-json-invalid-mode.sh
+++ b/tests/mmjsonparse-find-json-invalid-mode.sh
@@ -10,7 +10,7 @@ module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 template(name="outfmt" type="string" string="%msg%\n")
 
 action(type="mmjsonparse" mode="INVALID")
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 
 startup

--- a/tests/mmjsonparse-find-json-invalid.sh
+++ b/tests/mmjsonparse-find-json-invalid.sh
@@ -12,14 +12,14 @@ template(name="outfmt" type="string" string="%msg% parsesuccess=%parsesuccess% j
 # Test invalid JSON
 if $msg contains "INVALID" then {
     action(type="mmjsonparse" mode="find-json")
-    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
     stop
 }
 
 # Test no JSON present
 if $msg contains "NOJSON" then {
     action(type="mmjsonparse" mode="find-json")
-    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
     stop
 }
 '

--- a/tests/mmjsonparse-find-json-parser-validation.sh
+++ b/tests/mmjsonparse-find-json-parser-validation.sh
@@ -12,7 +12,7 @@ template(name="outfmt" type="string" string="%msg% parsesuccess=%parsesuccess% j
 # Test various JSON edge cases that manual brace counting might miss
 if $msg contains "TEST" then {
     action(type="mmjsonparse" mode="find-json")
-    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
     stop
 }
 '

--- a/tests/mmjsonparse-find-json-scan-limit.sh
+++ b/tests/mmjsonparse-find-json-scan-limit.sh
@@ -12,14 +12,14 @@ template(name="outfmt" type="string" string="%msg% parsesuccess=%parsesuccess% j
 # Test with very small max_scan_bytes to force truncation
 if $msg contains "SCAN_LIMIT" then {
     action(type="mmjsonparse" mode="find-json" max_scan_bytes="10")
-    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
     stop
 }
 
 # Test with sufficient max_scan_bytes
 if $msg contains "SCAN_OK" then {
     action(type="mmjsonparse" mode="find-json" max_scan_bytes="100")
-    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
     stop
 }
 '

--- a/tests/mmjsonparse-find-json-trailing.sh
+++ b/tests/mmjsonparse-find-json-trailing.sh
@@ -17,21 +17,21 @@ template(name="outfmt" type="string" string="%msg% parsesuccess=%parsesuccess% j
 # Test allow_trailing=on (default)
 if $msg contains "TRAILING_ON" then {
     action(type="mmjsonparse" mode="find-json" allow_trailing="on")
-    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
     stop
 }
 
 # Test allow_trailing=off
 if $msg contains "TRAILING_OFF" then {
     action(type="mmjsonparse" mode="find-json" allow_trailing="off")
-    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
     stop
 }
 
 # Test allow_trailing=off when JSON ends exactly at the scan boundary.
 if $msg contains "BOUNDARY" then {
     action(type="mmjsonparse" mode="find-json" allow_trailing="off" max_scan_bytes="17")
-    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
     stop
 }
 '

--- a/tests/mmjsonparse-invalid-containerName.sh
+++ b/tests/mmjsonparse-invalid-containerName.sh
@@ -9,7 +9,7 @@ module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 
 action(name="fooname" type="mmjsonparse" container="foobar")
 
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
 shutdown_when_empty

--- a/tests/mmjsonparse-w-o-cookie-multi-spaces.sh
+++ b/tests/mmjsonparse-w-o-cookie-multi-spaces.sh
@@ -13,7 +13,7 @@ input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port
 
 action(type="mmjsonparse" cookie="")
 if $parsesuccess == "OK" then {
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 rm -f $RSYSLOG_OUT_LOG	# do cleanup of previous subtest

--- a/tests/mmjsonparse-w-o-cookie.sh
+++ b/tests/mmjsonparse-w-o-cookie.sh
@@ -13,7 +13,7 @@ input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port
 
 action(type="mmjsonparse" cookie="")
 if $parsesuccess == "OK" then {
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 rm -f $RSYSLOG_OUT_LOG	# do cleanup of previous subtest

--- a/tests/mmjsonparse_cim.sh
+++ b/tests/mmjsonparse_cim.sh
@@ -15,7 +15,7 @@ input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_por
 
 action(type="mmjsonparse" cookie="@cim:" container="!cim")
 if $parsesuccess == "OK" then {
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 startup

--- a/tests/mmjsonparse_cim2.sh
+++ b/tests/mmjsonparse_cim2.sh
@@ -13,7 +13,7 @@ input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_por
 
 action(type="mmjsonparse" cookie="@cim:" container="$!cim")
 if $parsesuccess == "OK" then {
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 startup

--- a/tests/mmjsonparse_localvar.sh
+++ b/tests/mmjsonparse_localvar.sh
@@ -13,7 +13,7 @@ input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_por
 
 action(type="mmjsonparse" cookie="@cim:" container="$.")
 if $parsesuccess == "OK" then {
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 startup

--- a/tests/mmjsonparse_simple.sh
+++ b/tests/mmjsonparse_simple.sh
@@ -15,7 +15,7 @@ input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_por
 
 action(type="mmjsonparse")
 if $parsesuccess == "OK" then {
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 startup


### PR DESCRIPTION
Summary: Modernizes the mmjsonparse batch for issue 6523 by replacing legacy internal echo expansion in 14 tests while keeping behavior, assertions, and backtick feature coverage unchanged. This references but does not close the umbrella issue. Refs: https://github.com/rsyslog/rsyslog/issues/6523 Validation: bash -n passed; shellcheck -S warning passed; git diff --check passed; autogen/configure/build passed; all 14 changed tests passed directly after enabling imptcp for local focused coverage; RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run passed; local Cubic reported no issues.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

