### PR TITLE
rainerscript: add cbool function

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -449,6 +449,7 @@ EXTRA_DIST = \
     source/rainerscript/functions/mo-unflatten.rst \
     source/rainerscript/functions/rs-append_json.rst \
     source/rainerscript/functions/rs-cef_ext_escape.rst \
+    source/rainerscript/functions/rs-cbool.rst \
     source/rainerscript/functions/rs-cnum.rst \
     source/rainerscript/functions/rs-cstr.rst \
     source/rainerscript/functions/rs-dyn_inc.rst \

--- a/doc/source/rainerscript/functions/rs-cbool.rst
+++ b/doc/source/rainerscript/functions/rs-cbool.rst
@@ -1,0 +1,35 @@
+*******
+cbool()
+*******
+
+Purpose
+-------
+
+cbool(expr)
+
+Converts expr to a numeric boolean value. The result is ``0`` for false and
+``1`` for true.
+
+String input is trimmed before conversion. Empty strings, ``0``, ``false``,
+``off``, and ``no`` convert to ``0``. Other non-empty strings convert to ``1``.
+String matching is case-insensitive.
+
+This is useful when a value should later be rendered as a JSON boolean with a
+list template property that uses ``format="jsonf"`` and ``datatype="bool"``.
+
+Example
+-------
+
+.. code-block:: none
+
+   set $!enabled = cbool("false");
+
+   template(name="out" type="list" option.jsonf="on") {
+     property(outname="enabled" name="$!enabled" format="jsonf" datatype="bool")
+   }
+
+produces
+
+.. code-block:: json
+
+   {"enabled":false}

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -2218,6 +2218,71 @@ static void ATTR_NONNULL() doFunct_CNum(struct cnffunc *__restrict__ const func,
     DBGPRINTF("JSONorString: cnum node type %c result %d\n", func->expr[0]->nodetype, (int)ret->d.n);
 }
 
+static int rsyslogBoolTextToNumber(const uchar *const str) {
+    const uchar *p = str;
+    size_t len;
+
+    if (str == NULL) {
+        return 0;
+    }
+    while (isspace((int)*p)) {
+        ++p;
+    }
+    len = ustrlen(p);
+    while (len > 0 && isspace((int)p[len - 1])) {
+        --len;
+    }
+    if (len == 0) {
+        return 0;
+    }
+    if (len == 1 && p[0] == '0') {
+        return 0;
+    }
+    if (len == 2 && strncasecmp((char *)p, "no", 2) == 0) {
+        return 0;
+    }
+    if (len == 3 && strncasecmp((char *)p, "off", 3) == 0) {
+        return 0;
+    }
+    if (len == 5 && strncasecmp((char *)p, "false", 5) == 0) {
+        return 0;
+    }
+    return 1;
+}
+
+static void ATTR_NONNULL() doFunct_CBool(struct cnffunc *__restrict__ const func,
+                                         struct svar *__restrict__ const ret,
+                                         void *__restrict__ const usrptr,
+                                         wti_t *__restrict__ const pWti) {
+    struct svar srcVal;
+    uchar *str;
+    int bMustFree;
+
+    if (func->expr[0]->nodetype == 'N') {
+        ret->d.n = (((struct cnfnumval *)func->expr[0])->val != 0);
+    } else if (func->expr[0]->nodetype == 'S') {
+        str = (uchar *)es_str2cstr(((struct cnfstringval *)func->expr[0])->estr, NULL);
+        if (str == NULL) {
+            ret->d.n = 0;
+        } else {
+            ret->d.n = rsyslogBoolTextToNumber(str);
+            free(str);
+        }
+    } else {
+        cnfexprEval(func->expr[0], &srcVal, usrptr, pWti);
+        if (srcVal.datatype == 'N') {
+            ret->d.n = (srcVal.d.n != 0);
+        } else {
+            str = var2CString(&srcVal, &bMustFree);
+            ret->d.n = rsyslogBoolTextToNumber(str);
+            if (bMustFree) free(str);
+        }
+        varFreeMembers(&srcVal);
+    }
+    ret->datatype = 'N';
+    DBGPRINTF("JSONorString: cbool node type %c result %d\n", func->expr[0]->nodetype, (int)ret->d.n);
+}
+
 static void ATTR_NONNULL() doFunct_ReMatch(struct cnffunc *__restrict__ const func,
                                            struct svar *__restrict__ const ret,
                                            void *__restrict__ const usrptr,
@@ -4357,6 +4422,7 @@ static struct scriptFunct functions[] = {
     {"toupper", 1, 1, doFunct_ToUpper, NULL, NULL},
     {"cstr", 1, 1, doFunct_CStr, NULL, NULL},
     {"cnum", 1, 1, doFunct_CNum, NULL, NULL},
+    {"cbool", 1, 1, doFunct_CBool, NULL, NULL},
     {"ip42num", 1, 1, doFunct_Ipv42num, NULL, NULL},
     {"ipv42num", 1, 1, doFunct_Ipv42num, NULL, NULL},
     {"re_match", 2, 2, doFunct_ReMatch, initFunc_re_match, regex_destruct},

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -445,6 +445,7 @@ TESTS_DEFAULT = \
 	rscript_append_json.sh \
 	msg_json_set_regression.sh \
 	config_output-o-option.sh \
+	rs-cbool.sh \
 	rs-cnum.sh \
 	rs-substring.sh \
 	rs-int2hex.sh \

--- a/tests/rs-cbool.sh
+++ b/tests/rs-cbool.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Verify cbool() converts common string and numeric boolean inputs into
+# numeric 0/1 values that jsonf datatype="bool" renders as JSON booleans.
+# The oracle is the synchronized omfile output after shutdown.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="json" type="list" option.jsonf="on") {
+	property(outname="false_string" format="jsonf" name="$!false_string" datatype="bool")
+	property(outname="false_upper" format="jsonf" name="$!false_upper" datatype="bool")
+	property(outname="false_off" format="jsonf" name="$!false_off" datatype="bool")
+	property(outname="false_no" format="jsonf" name="$!false_no" datatype="bool")
+	property(outname="false_empty" format="jsonf" name="$!false_empty" datatype="bool")
+	property(outname="false_number" format="jsonf" name="$!false_number" datatype="bool")
+	property(outname="true_string" format="jsonf" name="$!true_string" datatype="bool")
+	property(outname="true_on" format="jsonf" name="$!true_on" datatype="bool")
+	property(outname="true_yes" format="jsonf" name="$!true_yes" datatype="bool")
+	property(outname="true_number" format="jsonf" name="$!true_number" datatype="bool")
+	property(outname="true_fallback" format="jsonf" name="$!true_fallback" datatype="bool")
+	property(outname="string_false_still_true" format="jsonf" name="$!plain_false" datatype="bool")
+}
+
+set $!false_string = cbool("false");
+set $!false_upper = cbool(" FALSE ");
+set $!false_off = cbool("off");
+set $!false_no = cbool("no");
+set $!false_empty = cbool("");
+set $!false_number = cbool(0);
+set $!true_string = cbool("true");
+set $!true_on = cbool("on");
+set $!true_yes = cbool("yes");
+set $!true_number = cbool(2);
+set $!true_fallback = cbool("maybe");
+set $!plain_false = "false";
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="json")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check '{"false_string":false, "false_upper":false, "false_off":false, "false_no":false, "false_empty":false, "false_number":false, "true_string":true, "true_on":true, "true_yes":true, "true_number":true, "true_fallback":true, "string_false_still_true":true}'
+exit_test


### PR DESCRIPTION
## Summary

- add built-in RainerScript `cbool(expr)` conversion function
- document `cbool()` for explicit JSON boolean rendering workflows
- add `rs-cbool.sh` regression coverage for false-like strings, numeric input, and unchanged legacy string-to-bool behavior

## Notes

This intentionally does not change existing `datatype="bool"` behavior for plain non-empty strings. The new function gives users an explicit conversion step for values such as `"false"` before rendering them through `format="jsonf"` and `datatype="bool"`.

Closes https://github.com/rsyslog/rsyslog/issues/3836

## Local Validation

- `devtools/format-code.sh --git-changed --check --check-if-available`
- `bash -n tests/rs-cbool.sh`
- `shellcheck -S warning tests/rs-cbool.sh`
- `devtools/check-test-antipatterns.sh tests/rs-cbool.sh`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 80`
- Ubuntu 26.04 devcontainer configure/build: `make -j80 check TESTS=`
- Ubuntu 26.04 devcontainer focused test: `./tests/rs-cbool.sh`
- Ubuntu 26.04 clang static analyzer: no bugs found
- local Cubic review: no issues found

The change-gated full local validation helper hit an unrelated `imdtls-sessionbreak-vg` failure/hang. The failing lane is DTLS/valgrind and not connected to this RainerScript/template conversion change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

