### PR TITLE
omfwd: add TCP user timeout option

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -985,6 +985,7 @@ EXTRA_DIST = \
     source/reference/parameters/omelasticsearch-usehttps.rst \
     source/reference/parameters/omelasticsearch-writeoperation.rst \
     source/reference/parameters/omfwd-ratelimit-name.rst \
+    source/reference/parameters/omfwd-tcp-user-timeout.rst \
     source/reference/parameters/omfile-addlf.rst \
     source/reference/parameters/omfile-asyncwriting.rst \
     source/reference/parameters/omfile-closetimeout.rst \

--- a/doc/source/configuration/modules/omfwd.rst
+++ b/doc/source/configuration/modules/omfwd.rst
@@ -535,6 +535,13 @@ The default, 0, means that the operating system defaults are used.
 This has only effect if keep-alive is enabled. The functionality may
 not be available on all platforms.
 
+tcp_user_timeout
+^^^^^^^^^^^^^^^^
+
+.. include:: ../../reference/parameters/omfwd-tcp-user-timeout.rst
+   :start-after: .. summary-start
+   :end-before: .. summary-end
+
 ConErrSkip
 ^^^^^^^^^^
 

--- a/doc/source/reference/parameters/omfwd-tcp-user-timeout.rst
+++ b/doc/source/reference/parameters/omfwd-tcp-user-timeout.rst
@@ -18,7 +18,7 @@ connections. A value of ``0`` leaves the operating system default unchanged.
 This option is independent of TCP keepalive and may not be available on all
 platforms.
 
-.. versionadded:: 8.2606.0
+.. versionadded:: 8.2608.0
 
 .. summary-end
 

--- a/doc/source/reference/parameters/omfwd-tcp-user-timeout.rst
+++ b/doc/source/reference/parameters/omfwd-tcp-user-timeout.rst
@@ -1,0 +1,47 @@
+.. index:: ! omfwd; tcp_user_timeout
+
+.. _param-omfwd-tcp-user-timeout:
+
+tcp_user_timeout
+================
+
+.. summary-start
+
+**Default:** 0
+
+**Type:** integer
+
+**Description:**
+
+Sets the TCP_USER_TIMEOUT socket option, in milliseconds, for TCP-based omfwd
+connections. A value of ``0`` leaves the operating system default unchanged.
+This option is independent of TCP keepalive and may not be available on all
+platforms.
+
+.. versionadded:: 8.2606.0
+
+.. summary-end
+
+Examples
+--------
+
+RainerScript:
+
+.. code-block:: rsyslog
+
+   action(type="omfwd"
+          target="central.example.net"
+          port="6514"
+          protocol="tcp"
+          tcp_user_timeout="10000")
+
+YAML:
+
+.. code-block:: yaml
+
+   actions:
+     - type: omfwd
+       target: central.example.net
+       port: 6514
+       protocol: tcp
+       tcp_user_timeout: 10000

--- a/runtime/netstrm.c
+++ b/runtime/netstrm.c
@@ -390,6 +390,17 @@ finalize_it:
     RETiRet;
 }
 
+/* TCP user timeout option
+ */
+static rsRetVal SetTcpUserTimeout(netstrm_t *pThis, int tcpUserTimeout) {
+    DEFiRet;
+    NULL_CHECK(pThis);
+    iRet = pThis->Drvr.SetTcpUserTimeout(pThis->pDrvrData, tcpUserTimeout);
+
+finalize_it:
+    RETiRet;
+}
+
 /* gnutls priority string */
 static rsRetVal SetGnutlsPriorityString(netstrm_t *pThis, uchar *gnutlsPriorityString) {
     DEFiRet;
@@ -509,6 +520,7 @@ BEGINobjQueryInterface(netstrm)
     pIf->SetKeepAliveProbes = SetKeepAliveProbes;
     pIf->SetKeepAliveTime = SetKeepAliveTime;
     pIf->SetKeepAliveIntvl = SetKeepAliveIntvl;
+    pIf->SetTcpUserTimeout = SetTcpUserTimeout;
     pIf->SetGnutlsPriorityString = SetGnutlsPriorityString;
     pIf->SetDrvrCheckExtendedKeyUsage = SetDrvrCheckExtendedKeyUsage;
     pIf->SetDrvrPrioritizeSAN = SetDrvrPrioritizeSAN;

--- a/runtime/netstrm.h
+++ b/runtime/netstrm.h
@@ -76,6 +76,7 @@ BEGINinterface(netstrm) /* name must also be changed in ENDinterface macro! */
     rsRetVal (*SetKeepAliveProbes)(netstrm_t *pThis, int keepAliveProbes);
     rsRetVal (*SetKeepAliveTime)(netstrm_t *pThis, int keepAliveTime);
     rsRetVal (*SetKeepAliveIntvl)(netstrm_t *pThis, int keepAliveIntvl);
+    rsRetVal (*SetTcpUserTimeout)(netstrm_t *pThis, int tcpUserTimeout);
     rsRetVal (*SetGnutlsPriorityString)(netstrm_t *pThis, uchar *priorityString);
     /* v11 -- Parameter pszLstnFileName added to LstnInit*/
     rsRetVal(ATTR_NONNULL(1, 3, 5) * LstnInit)(netstrms_t * pNS, void *pUsr, rsRetVal (*)(void *, netstrm_t *),
@@ -96,7 +97,7 @@ BEGINinterface(netstrm) /* name must also be changed in ENDinterface macro! */
     /* v18 -- allow remote server's TLS SNI to be set manually */
     rsRetVal (*SetDrvrRemoteSNI)(netstrm_t *pThis, uchar *pszRemoteSNI);
 ENDinterface(netstrm)
-#define netstrmCURR_IF_VERSION 18 /* increment whenever you change the interface structure! */
+#define netstrmCURR_IF_VERSION 19 /* increment whenever you change the interface structure! */
 /* interface version 3 added GetRemAddr()
  * interface version 4 added EnableKeepAlive() -- rgerhards, 2009-06-02
  * interface version 5 changed return of CheckConnection from void to rsRetVal -- alorbach, 2012-09-06
@@ -108,6 +109,7 @@ ENDinterface(netstrm)
  * interface version 16 CRL file -- Oracle, 2022-01-16
  * interface version 17 added nextIODirection parameter to Rcv() -- rgehards, 2025-04-17
  * interface version 18 added SetDrvrRemoteSNI -- jfcantu, 2020-01-15
+ * interface version 19 added SetTcpUserTimeout
  * */
 
 /* prototypes */

--- a/runtime/nsd.h
+++ b/runtime/nsd.h
@@ -67,6 +67,7 @@ BEGINinterface(nsd) /* name must also be changed in ENDinterface macro! */
     rsRetVal (*SetKeepAliveIntvl)(nsd_t *pThis, int keepAliveIntvl);
     rsRetVal (*SetKeepAliveProbes)(nsd_t *pThis, int keepAliveProbes);
     rsRetVal (*SetKeepAliveTime)(nsd_t *pThis, int keepAliveTime);
+    rsRetVal (*SetTcpUserTimeout)(nsd_t *pThis, int tcpUserTimeout);
     rsRetVal (*SetGnutlsPriorityString)(nsd_t *pThis, uchar *gnutlsPriorityString);
     /* v12 -- parameter pszLstnPortFileName added to LstnInit()*/
     rsRetVal(ATTR_NONNULL(1, 3, 5) * LstnInit)(netstrms_t * pNS, void *pUsr, rsRetVal (*)(void *, netstrm_t *),
@@ -97,7 +98,7 @@ BEGINinterface(nsd) /* name must also be changed in ENDinterface macro! */
     rsRetVal (*SetTlsRevocationCheck)(nsd_t *pThis, int enabled);
 
 ENDinterface(nsd)
-#define nsdCURR_IF_VERSION 19 /* increment whenever you change the interface structure! */
+#define nsdCURR_IF_VERSION 20 /* increment whenever you change the interface structure! */
     /* interface version 4 added GetRemAddr()
      * interface version 5 added EnableKeepAlive() -- rgerhards, 2009-06-02
      * interface version 6 changed return of CheckConnection from void to rsRetVal -- alorbach, 2012-09-06
@@ -107,6 +108,7 @@ ENDinterface(nsd)
      * interface version 10 added SetGnutlsPriorityString() -- PascalWithopf, 2017-08-08
      * interface version 11 added oserr to Rcv() signature -- rgerhards, 2017-09-04
      * interface version 18 added SetRemoteSNI -- jfcantu, 2020-01-15
+     * interface version 20 added SetTcpUserTimeout
      */
 
 #endif /* #ifndef INCLUDED_NSD_H */

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1966,6 +1966,21 @@ static rsRetVal SetKeepAliveTime(nsd_t *pNsd, int keepAliveTime) {
 }
 
 
+/* TCP user timeout option
+ */
+static rsRetVal SetTcpUserTimeout(nsd_t *pNsd, int tcpUserTimeout) {
+    DEFiRet;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
+
+    ISOBJ_TYPE_assert((pThis), nsd_gtls);
+    assert(tcpUserTimeout >= 0);
+
+    nsd_ptcp.SetTcpUserTimeout(pThis->pTcp, tcpUserTimeout);
+
+    RETiRet;
+}
+
+
 /* abort a connection. This is meant to be called immediately
  * before the Destruct call. -- rgerhards, 2008-03-24
  */
@@ -2579,6 +2594,7 @@ BEGINobjQueryInterface(nsd_gtls)
     pIf->SetKeepAliveIntvl = SetKeepAliveIntvl;
     pIf->SetKeepAliveProbes = SetKeepAliveProbes;
     pIf->SetKeepAliveTime = SetKeepAliveTime;
+    pIf->SetTcpUserTimeout = SetTcpUserTimeout;
     pIf->SetGnutlsPriorityString = SetGnutlsPriorityString;
     pIf->SetCheckExtendedKeyUsage = SetCheckExtendedKeyUsage;
     pIf->SetPrioritizeSAN = SetPrioritizeSAN;

--- a/runtime/nsd_mbedtls.c
+++ b/runtime/nsd_mbedtls.c
@@ -665,6 +665,20 @@ static rsRetVal SetKeepAliveTime(nsd_t *pNsd, int keepAliveTime) {
     RETiRet;
 }
 
+/* TCP user timeout option
+ */
+static rsRetVal SetTcpUserTimeout(nsd_t *pNsd, int tcpUserTimeout) {
+    DEFiRet;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
+
+    ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
+    assert(tcpUserTimeout >= 0);
+
+    nsd_ptcp.SetTcpUserTimeout(pThis->pTcp, tcpUserTimeout);
+
+    RETiRet;
+}
+
 /* abort a connection. This is meant to be called immediately
  * before the Destruct call. -- rgerhards, 2008-03-24
  */
@@ -1477,6 +1491,7 @@ BEGINobjQueryInterface(nsd_mbedtls)
     pIf->SetKeepAliveIntvl = SetKeepAliveIntvl;
     pIf->SetKeepAliveProbes = SetKeepAliveProbes;
     pIf->SetKeepAliveTime = SetKeepAliveTime;
+    pIf->SetTcpUserTimeout = SetTcpUserTimeout;
     pIf->SetGnutlsPriorityString = SetGnutlsPriorityString;
     pIf->SetCheckExtendedKeyUsage = SetCheckExtendedKeyUsage;
     pIf->SetPrioritizeSAN = SetPrioritizeSAN;

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -793,6 +793,21 @@ static rsRetVal SetKeepAliveTime(nsd_t *pNsd, int keepAliveTime) {
     RETiRet;
 }
 
+/* TCP user timeout option
+ */
+static rsRetVal SetTcpUserTimeout(nsd_t *pNsd, int tcpUserTimeout) {
+    DEFiRet;
+    nsd_ossl_t *pThis = (nsd_ossl_t *)pNsd;
+
+    ISOBJ_TYPE_assert((pThis), nsd_ossl);
+    assert(tcpUserTimeout >= 0);
+
+    dbgprintf("SetTcpUserTimeout: tcpUserTimeout=%d\n", tcpUserTimeout);
+    nsd_ptcp.SetTcpUserTimeout(pThis->pTcp, tcpUserTimeout);
+
+    RETiRet;
+}
+
 
 /* abort a connection. This is meant to be called immediately
  * before the Destruct call. -- rgerhards, 2008-03-24
@@ -1697,6 +1712,7 @@ BEGINobjQueryInterface(nsd_ossl)
     pIf->SetKeepAliveIntvl = SetKeepAliveIntvl;
     pIf->SetKeepAliveProbes = SetKeepAliveProbes;
     pIf->SetKeepAliveTime = SetKeepAliveTime;
+    pIf->SetTcpUserTimeout = SetTcpUserTimeout;
     pIf->SetGnutlsPriorityString = SetGnutlsPriorityString; /* we don't NEED this interface! */
     pIf->SetCheckExtendedKeyUsage = SetCheckExtendedKeyUsage; /* we don't NEED this interface! */
     pIf->SetPrioritizeSAN = SetPrioritizeSAN;

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -393,6 +393,19 @@ static rsRetVal SetKeepAliveTime(nsd_t *pNsd, int keepAliveTime) {
     RETiRet;
 }
 
+/* TCP user timeout option
+ */
+static rsRetVal SetTcpUserTimeout(nsd_t *pNsd, int tcpUserTimeout) {
+    nsd_ptcp_t *pThis = (nsd_ptcp_t *)pNsd;
+    DEFiRet;
+
+    ISOBJ_TYPE_assert((pThis), nsd_ptcp);
+
+    pThis->tcp_user_timeout_ms = tcpUserTimeout;
+
+    RETiRet;
+}
+
 /* abort a connection. This is meant to be called immediately
  * before the Destruct call. -- rgerhards, 2008-03-24
  */
@@ -956,6 +969,41 @@ finalize_it:
 }
 
 
+/* Set TCP_USER_TIMEOUT on platforms that support it.
+ */
+static rsRetVal ApplyTcpUserTimeout(nsd_ptcp_t *pThis) {
+    static int bWarned = 0;
+    DEFiRet;
+    ISOBJ_TYPE_assert(pThis, nsd_ptcp);
+
+    if (pThis->tcp_user_timeout_ms <= 0) {
+        FINALIZE;
+    }
+
+#if defined(IPPROTO_TCP) && defined(TCP_USER_TIMEOUT)
+    int ret;
+    int optval;
+    socklen_t optlen;
+
+    optval = pThis->tcp_user_timeout_ms;
+    optlen = sizeof(optval);
+    ret = setsockopt(pThis->sock, IPPROTO_TCP, TCP_USER_TIMEOUT, &optval, optlen);
+    if (ret < 0 && !bWarned) {
+        LogError(errno, NO_ERRCODE, "nsd_ptcp cannot set TCP_USER_TIMEOUT - ignored");
+        bWarned = 1;
+    }
+#else
+    if (!bWarned) {
+        LogError(0, NO_ERRCODE, "nsd_ptcp cannot set TCP_USER_TIMEOUT on this platform - ignored");
+        bWarned = 1;
+    }
+#endif
+
+finalize_it:
+    RETiRet;
+}
+
+
 /* open a connection to a remote host (server).
  * rgerhards, 2008-03-19
  */
@@ -1015,6 +1063,7 @@ static rsRetVal Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char 
 #endif
         }
 
+        CHKiRet(ApplyTcpUserTimeout(pThis));
         if (connect(pThis->sock, currAddr->ai_addr, currAddr->ai_addrlen) == 0) {
             break;
         }
@@ -1217,6 +1266,7 @@ BEGINobjQueryInterface(nsd_ptcp)
     pIf->SetKeepAliveIntvl = SetKeepAliveIntvl;
     pIf->SetKeepAliveProbes = SetKeepAliveProbes;
     pIf->SetKeepAliveTime = SetKeepAliveTime;
+    pIf->SetTcpUserTimeout = SetTcpUserTimeout;
     pIf->SetCheckExtendedKeyUsage = SetCheckExtendedKeyUsage;
     pIf->SetPrioritizeSAN = SetPrioritizeSAN;
     pIf->SetTlsVerifyDepth = SetTlsVerifyDepth;

--- a/runtime/nsd_ptcp.h
+++ b/runtime/nsd_ptcp.h
@@ -39,6 +39,7 @@ struct nsd_ptcp_s {
         int iKeepAliveIntvl; /**< socket layer KEEPALIVE interval */
         int iKeepAliveProbes; /**< socket layer KEEPALIVE probes */
         int iKeepAliveTime; /**< socket layer KEEPALIVE timeout */
+        int tcp_user_timeout_ms; /**< socket layer TCP_USER_TIMEOUT in milliseconds */
 };
 
 /* interface is defined in nsd.h, we just implement it! */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -153,6 +153,8 @@ TESTS_DEFAULT = \
 	omfwd-suspended-no-early-commit.sh \
 	omfwd-tls-invalid-permitExpiredCerts.sh \
 	omfwd-keepalive.sh \
+	omfwd-tcp-user-timeout.sh \
+	yaml-omfwd-tcp-user-timeout.sh \
 	omfwd-subtree-tpl.sh \
 	omfwd-errfile-maxsize.sh \
 	omfwd-errfile-maxsize-filled.sh \

--- a/tests/omfwd-tcp-user-timeout.sh
+++ b/tests/omfwd-tcp-user-timeout.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Verify omfwd accepts tcp_user_timeout and still forwards over TCP. The oracle
+# is the message received by minitcpsrvr, proving the configured action wrote to
+# its destination after the socket option path was exercised.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if $msg contains "msgnum:" then
+	action(type="omfwd" template="outfmt"
+	       target="127.0.0.1" port="'$TCPFLOOD_PORT'" protocol="tcp"
+	       tcp_user_timeout="10000")
+'
+
+start_minitcpsrv_ready "$RSYSLOG_OUT_LOG" "$TCPFLOOD_PORT"
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+
+seq_check 0 0
+exit_test

--- a/tests/yaml-omfwd-tcp-user-timeout.sh
+++ b/tests/yaml-omfwd-tcp-user-timeout.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Verify the YAML frontend accepts omfwd tcp_user_timeout and forwards over TCP.
+# The receiver output is the oracle so the test covers the configured output
+# destination, not rsyslog startup diagnostics.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+call main
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" << 'YAMLEOF'
+templates:
+  - name: outfmt
+    type: string
+    string: "%msg:F,58:2%\n"
+
+rulesets:
+  - name: main
+    filter: ':msg, contains, "msgnum:"'
+    actions:
+      - type: omfwd
+        template: outfmt
+        target: 127.0.0.1
+        port: "@TCPFLOOD_PORT@"
+        protocol: tcp
+        tcp_user_timeout: 10000
+YAMLEOF
+
+sed -i "s|@TCPFLOOD_PORT@|${TCPFLOOD_PORT}|g" "${RSYSLOG_DYNNAME}.yaml"
+
+start_minitcpsrv_ready "$RSYSLOG_OUT_LOG" "$TCPFLOOD_PORT"
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+
+seq_check 0 0
+exit_test

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -125,6 +125,7 @@ typedef struct _instanceData {
     int iKeepAliveIntvl;
     int iKeepAliveProbes;
     int iKeepAliveTime;
+    int tcp_user_timeout_ms;
     int iConErrSkip; /* skipping excessive connection errors */
     uchar *gnutlsPriorityString;
     int ipfreebind;
@@ -236,6 +237,7 @@ static struct cnfparamdescr actpdescr[] = {
     {"keepalive.probes", eCmdHdlrNonNegInt, 0},
     {"keepalive.time", eCmdHdlrNonNegInt, 0},
     {"keepalive.interval", eCmdHdlrNonNegInt, 0},
+    {"tcp_user_timeout", eCmdHdlrNonNegInt, 0},
     {"conerrskip", eCmdHdlrNonNegInt, 0},
     {"gnutlsprioritystring", eCmdHdlrString, 0},
     {"streamdriver", eCmdHdlrGetWord, 0},
@@ -1353,6 +1355,7 @@ static rsRetVal TCPSendInitTarget(targetData_t *const pTarget) {
         if (pData->gnutlsPriorityString != NULL) {
             CHKiRet(netstrm.SetGnutlsPriorityString(pTarget->pNetstrm, pData->gnutlsPriorityString));
         }
+        CHKiRet(netstrm.SetTcpUserTimeout(pTarget->pNetstrm, pData->tcp_user_timeout_ms));
         CHKiRet(netstrm.Connect(pTarget->pNetstrm, glbl.GetDefPFFamily(runModConf->pConf), (uchar *)pTarget->port,
                                 (uchar *)pTarget->target_name, pData->device));
 
@@ -1922,6 +1925,7 @@ static void setInstParamDefaults(instanceData *pData) {
     pData->iKeepAliveProbes = 0;
     pData->iKeepAliveIntvl = 0;
     pData->iKeepAliveTime = 0;
+    pData->tcp_user_timeout_ms = 0;
     pData->iConErrSkip = 0;
     pData->gnutlsPriorityString = NULL;
     pData->bResendLastOnRecon = 0;
@@ -2139,6 +2143,8 @@ BEGINnewActInst
             pData->iKeepAliveIntvl = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "keepalive.time")) {
             pData->iKeepAliveTime = (int)pvals[i].val.d.n;
+        } else if (!strcmp(actpblk.descr[i].name, "tcp_user_timeout")) {
+            pData->tcp_user_timeout_ms = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "conerrskip")) {
             pData->iConErrSkip = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "gnutlsprioritystring")) {


### PR DESCRIPTION
## Summary

- add omfwd `tcp_user_timeout` action parameter for TCP/TLS forwarding
- pass the setting through `netstrm`/`nsd` and apply `TCP_USER_TIMEOUT` in `nsd_ptcp`
- document the option with RainerScript and YAML examples
- add RainerScript and YAML forwarding tests that assert receiver output

Closes https://github.com/rsyslog/rsyslog/issues/6696

## Validation

- `devtools/format-code.sh --git-changed`
- `bash -n tests/omfwd-tcp-user-timeout.sh tests/yaml-omfwd-tcp-user-timeout.sh`
- `shellcheck -S warning tests/omfwd-tcp-user-timeout.sh tests/yaml-omfwd-tcp-user-timeout.sh`
- `devtools/check-test-antipatterns.sh tests/omfwd-tcp-user-timeout.sh tests/yaml-omfwd-tcp-user-timeout.sh`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 80`
- Ubuntu 26.04 devcontainer configure/build:
  `RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 devtools/devcontainer.sh --rm devtools/run-configure.sh`
- Ubuntu 26.04 devcontainer compile-only:
  `RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 devtools/devcontainer.sh --rm make -j80 check TESTS=`
- Ubuntu 26.04 devcontainer focused tests:
  `./tests/omfwd-tcp-user-timeout.sh`
  `./tests/yaml-omfwd-tcp-user-timeout.sh`
- local Cubic: no issues
- clang static analyzer: no bugs found
- PR-ready local gate:
  `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 devtools/local-validation-plan.sh --run`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

