### PR TITLE
template: add octal control character escape

### DIFF
--- a/doc/source/configuration/property_replacer.rst
+++ b/doc/source/configuration/property_replacer.rst
@@ -300,6 +300,16 @@ options are defined:
   :doc:`$EscapeControlCharactersOnReceive </configuration/input_directives/rsconf1_escapecontrolcharactersonreceive>`
   is set to off.
 
+**escape-cc-octal**
+  replace control characters with an escape sequence whose value is the
+  3-digit octal value of the control character. This matches the octal
+  escaping used by
+  :doc:`$EscapeControlCharactersOnReceive </configuration/input_directives/rsconf1_escapecontrolcharactersonreceive>`.
+  For example, a carriage return would be replaced by "#015".
+  Note: using this option requires that
+  :doc:`$EscapeControlCharactersOnReceive </configuration/input_directives/rsconf1_escapecontrolcharactersonreceive>`
+  is set to off.
+
 **space-cc**
   replace control characters by spaces
   Note: using this option requires that

--- a/doc/source/configuration/property_replacer.rst
+++ b/doc/source/configuration/property_replacer.rst
@@ -300,16 +300,6 @@ options are defined:
   :doc:`$EscapeControlCharactersOnReceive </configuration/input_directives/rsconf1_escapecontrolcharactersonreceive>`
   is set to off.
 
-**escape-cc-octal**
-  replace control characters with an escape sequence whose value is the
-  3-digit octal value of the control character. This matches the octal
-  escaping used by
-  :doc:`$EscapeControlCharactersOnReceive </configuration/input_directives/rsconf1_escapecontrolcharactersonreceive>`.
-  For example, a carriage return would be replaced by "#015".
-  Note: using this option requires that
-  :doc:`$EscapeControlCharactersOnReceive </configuration/input_directives/rsconf1_escapecontrolcharactersonreceive>`
-  is set to off.
-
 **space-cc**
   replace control characters by spaces
   Note: using this option requires that

--- a/doc/source/reference/templates/templates-statement-property.rst
+++ b/doc/source/reference/templates/templates-statement-property.rst
@@ -40,6 +40,29 @@ Parameters
   ``escape-octal``, ``space``, or ``drop``. ``escape`` keeps the legacy
   decimal ``#010`` style, while ``escape-octal`` uses the octal ``#012`` style
   used by receive-time control-character escaping.
+
+  RainerScript example:
+
+  .. code-block:: none
+
+     template(name="octal-control" type="list") {
+         property(name="msg" controlCharacters="escape-octal")
+         constant(value="\n")
+     }
+
+  YAML example:
+
+  .. code-block:: yaml
+
+     templates:
+       - name: octal-control
+         type: list
+         elements:
+           - property:
+               name: msg
+               controlCharacters: escape-octal
+           - constant:
+               value: "\n"
 - ``securePath`` – create safe paths for dynafile templates; ``drop`` or
   ``replace``
 - ``format`` – field format. Supported values:

--- a/doc/source/reference/templates/templates-statement-property.rst
+++ b/doc/source/reference/templates/templates-statement-property.rst
@@ -36,8 +36,10 @@ Parameters
 
 - ``date.inUTC`` – show date in UTC. Available since 8.18.0.
 - ``caseConversion`` – convert text case; ``lower`` or ``upper``
-- ``controlCharacters`` – handle control characters: ``escape``, ``space``,
-  or ``drop``
+- ``controlCharacters`` – handle control characters: ``escape``,
+  ``escape-octal``, ``space``, or ``drop``. ``escape`` keeps the legacy
+  decimal ``#010`` style, while ``escape-octal`` uses the octal ``#012`` style
+  used by receive-time control-character escaping.
 - ``securePath`` – create safe paths for dynafile templates; ``drop`` or
   ``replace``
 - ``format`` – field format. Supported values:
@@ -88,4 +90,3 @@ Parameters
 
 - ``onEmpty`` – for ``jsonf`` format only; handling of empty values:
   ``keep``, ``skip``, or ``null``
-

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -4219,7 +4219,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg,
                 pRes = pDstStart;
                 *pbMustBeFreed = 1;
             }
-        } else if (pTpe->data.field.options.bEscapeCC) {
+        } else if (pTpe->data.field.options.bEscapeCC || pTpe->data.field.options.bEscapeCCOctal) {
             /* we must first count how many control charactes are
              * present, because we need this to compute the new string
              * buffer length. While doing so, we also compute the string
@@ -4249,7 +4249,17 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg,
                 }
                 for (pSrc = pRes; *pSrc; pSrc++) {
                     if (iscntrl((int)*pSrc)) {
-                        snprintf((char *)szCCEsc, sizeof(szCCEsc), "#%3.3d", *pSrc);
+                        const unsigned cc = (unsigned char)*pSrc;
+                        szCCEsc[0] = '#';
+                        if (pTpe->data.field.options.bEscapeCCOctal) {
+                            szCCEsc[1] = (uchar)('0' + ((cc >> 6) & 7));
+                            szCCEsc[2] = (uchar)('0' + ((cc >> 3) & 7));
+                            szCCEsc[3] = (uchar)('0' + (cc & 7));
+                        } else {
+                            szCCEsc[1] = (uchar)('0' + (cc / 100));
+                            szCCEsc[2] = (uchar)('0' + ((cc / 10) % 10));
+                            szCCEsc[3] = (uchar)('0' + (cc % 10));
+                        }
                         for (i = 0; i < 4; ++i) *pB++ = szCCEsc[i];
                     } else {
                         *pB++ = *pSrc;

--- a/runtime/template.c
+++ b/runtime/template.c
@@ -1465,10 +1465,24 @@ static void doOptions(unsigned char **pp, struct templateEntry *pTpe) {
             pTpe->data.field.options.bCompressSP = 1;
         } else if (!strcmp((char *)Buf, "escape-cc")) {
             pTpe->data.field.options.bEscapeCC = 1;
+            pTpe->data.field.options.bEscapeCCOctal = 0;
+            pTpe->data.field.options.bDropCC = 0;
+            pTpe->data.field.options.bSpaceCC = 0;
+        } else if (!strcmp((char *)Buf, "escape-cc-octal")) {
+            pTpe->data.field.options.bEscapeCCOctal = 1;
+            pTpe->data.field.options.bEscapeCC = 0;
+            pTpe->data.field.options.bDropCC = 0;
+            pTpe->data.field.options.bSpaceCC = 0;
         } else if (!strcmp((char *)Buf, "drop-cc")) {
             pTpe->data.field.options.bDropCC = 1;
+            pTpe->data.field.options.bEscapeCC = 0;
+            pTpe->data.field.options.bEscapeCCOctal = 0;
+            pTpe->data.field.options.bSpaceCC = 0;
         } else if (!strcmp((char *)Buf, "space-cc")) {
             pTpe->data.field.options.bSpaceCC = 1;
+            pTpe->data.field.options.bEscapeCC = 0;
+            pTpe->data.field.options.bEscapeCCOctal = 0;
+            pTpe->data.field.options.bDropCC = 0;
         } else if (!strcmp((char *)Buf, "drop-last-lf")) {
             pTpe->data.field.options.bDropLastLF = 1;
         } else if (!strcmp((char *)Buf, "secpath-drop")) {
@@ -2245,7 +2259,7 @@ static rsRetVal createPropertyTpe(struct template *pTpl, struct cnfobj *o) {
     char *re_expr = NULL;
     struct cnfparamvals *pvals = NULL;
     enum { F_NONE, F_CSV, F_JSON, F_JSONF, F_JSONR, F_JSONFR } formatType = F_NONE;
-    enum { CC_NONE, CC_ESCAPE, CC_SPACE, CC_DROP } controlchr = CC_NONE;
+    enum { CC_NONE, CC_ESCAPE, CC_ESCAPE_OCTAL, CC_SPACE, CC_DROP } controlchr = CC_NONE;
     enum { SP_NONE, SP_DROP, SP_REPLACE } secpath = SP_NONE;
     enum tplFormatCaseConvTypes caseconv = tplCaseConvNo;
     enum tplFormatTypes datefmt = tplFmtDefault;
@@ -2387,6 +2401,8 @@ static rsRetVal createPropertyTpe(struct template *pTpl, struct cnfobj *o) {
             bComplexProcessing = 1;
             if (!es_strbufcmp(pvals[i].val.d.estr, (uchar *)"escape", sizeof("escape") - 1)) {
                 controlchr = CC_ESCAPE;
+            } else if (!es_strbufcmp(pvals[i].val.d.estr, (uchar *)"escape-octal", sizeof("escape-octal") - 1)) {
+                controlchr = CC_ESCAPE_OCTAL;
             } else if (!es_strbufcmp(pvals[i].val.d.estr, (uchar *)"space", sizeof("space") - 1)) {
                 controlchr = CC_SPACE;
             } else if (!es_strbufcmp(pvals[i].val.d.estr, (uchar *)"drop", sizeof("drop") - 1)) {
@@ -2567,6 +2583,9 @@ static rsRetVal createPropertyTpe(struct template *pTpl, struct cnfobj *o) {
             break;
         case CC_ESCAPE:
             pTpe->data.field.options.bEscapeCC = 1;
+            break;
+        case CC_ESCAPE_OCTAL:
+            pTpe->data.field.options.bEscapeCCOctal = 1;
             break;
         case CC_SPACE:
             pTpe->data.field.options.bSpaceCC = 1;

--- a/runtime/template.c
+++ b/runtime/template.c
@@ -1468,11 +1468,6 @@ static void doOptions(unsigned char **pp, struct templateEntry *pTpe) {
             pTpe->data.field.options.bEscapeCCOctal = 0;
             pTpe->data.field.options.bDropCC = 0;
             pTpe->data.field.options.bSpaceCC = 0;
-        } else if (!strcmp((char *)Buf, "escape-cc-octal")) {
-            pTpe->data.field.options.bEscapeCCOctal = 1;
-            pTpe->data.field.options.bEscapeCC = 0;
-            pTpe->data.field.options.bDropCC = 0;
-            pTpe->data.field.options.bSpaceCC = 0;
         } else if (!strcmp((char *)Buf, "drop-cc")) {
             pTpe->data.field.options.bDropCC = 1;
             pTpe->data.field.options.bEscapeCC = 0;

--- a/runtime/template.h
+++ b/runtime/template.h
@@ -151,6 +151,7 @@ struct templateEntry {
                 unsigned bDropCC : 1; /* drop control characters? */
                 unsigned bSpaceCC : 1; /* change control characters to spaceescape? */
                 unsigned bEscapeCC : 1; /* escape control characters? */
+                unsigned bEscapeCCOctal : 1; /* escape control characters as octal values? */
                 unsigned bCompressSP : 1; /* compress multiple spaces to a single one? */
                 unsigned bDropLastLF : 1; /* drop last LF char in msg (PIX!) */
                 unsigned bSecPathDrop : 1; /* drop slashes, replace dots, empty string */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -641,6 +641,7 @@ TESTS_LIBYAML = \
 	yaml-statements-stop.sh \
 	yaml-statements-call.sh \
 	yaml-statements-unset.sh \
+	yaml-template-controlcharacters.sh \
 	yaml-template-list.sh \
 	$(TESTS_TEMPLATE_REGEX_BOUNDS_LIBYAML) \
 	yaml-template-subtree.sh \

--- a/tests/template-property-transformations.sh
+++ b/tests/template-property-transformations.sh
@@ -170,9 +170,6 @@ template(name="outfmt" type="list") {
 	constant(value="\n")
 }
 
-template(name="legacyfmt" type="string"
-	 string="legacy_cc_decimal=%$!control:::escape-cc%\nlegacy_cc_octal=%$!control:::escape-cc-octal%\nlegacy_cc_octal_then_space=%$!control:::escape-cc-octal,space-cc%\nlegacy_cc_space_then_octal=%$!control:::space-cc,escape-cc-octal%\n")
-
 template(name="shapefmt" type="list") {
 	constant(value="shape_msg=")
 	property(name="msg")
@@ -218,7 +215,6 @@ local4.* {
 		set $!jsonsrc = "a \\ \"b\"";
 		set $!jsonrsrc = "a \\n b";
 		action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
-		action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="legacyfmt")
 	}
 }
 '
@@ -228,7 +224,7 @@ injectmsg_literal '<167>1 2003-08-24T05:14:15.000003-07:00 host app proc msgid -
 injectmsg_literal '<167>Aug 24 05:14:15 legacyhost legacyprog[42]: shape3164'
 injectmsg_literal '<167>1 2003-08-24T05:14:15.000003-07:00 nilhost - - - - shape5424nil'
 injectmsg_literal '<167>Aug 24 05:14:15 oddhost shape3164notag'
-wait_file_lines --abort-on-oversize "$RSYSLOG_OUT_LOG" 95
+wait_file_lines --abort-on-oversize "$RSYSLOG_OUT_LOG" 91
 shutdown_when_empty
 wait_shutdown
 
@@ -293,10 +289,6 @@ reported_local_subseconds=000003
 reported_local_misc=Sun/0/07:00/-/236/35
 reported_utc_formats=20030824121415/2003-08-24 12:14:15/Aug 24 12:14:15/1061727255/000003
 reported_parts=2003-08-24T12:14:15
-legacy_cc_decimal=a#010b#009c
-legacy_cc_octal=a#012b#011c
-legacy_cc_octal_then_space=a b c
-legacy_cc_space_then_octal=a#012b#011c
 shape_msg= shape3164
 shape_hostname=legacyhost
 shape_syslogtag=legacyprog[42]:

--- a/tests/template-property-transformations.sh
+++ b/tests/template-property-transformations.sh
@@ -59,6 +59,8 @@ template(name="outfmt" type="list") {
 	property(name="$!control" controlcharacters="space")
 	constant(value="\ncc_escape=")
 	property(name="$!control" controlcharacters="escape")
+	constant(value="\ncc_escape_octal=")
+	property(name="$!control" controlcharacters="escape-octal")
 	constant(value="\nsec_drop=")
 	property(name="$!path" securepath="drop")
 	constant(value="\nsec_replace=")
@@ -168,6 +170,9 @@ template(name="outfmt" type="list") {
 	constant(value="\n")
 }
 
+template(name="legacyfmt" type="string"
+	 string="legacy_cc_decimal=%$!control:::escape-cc%\nlegacy_cc_octal=%$!control:::escape-cc-octal%\nlegacy_cc_octal_then_space=%$!control:::escape-cc-octal,space-cc%\nlegacy_cc_space_then_octal=%$!control:::space-cc,escape-cc-octal%\n")
+
 template(name="shapefmt" type="list") {
 	constant(value="shape_msg=")
 	property(name="msg")
@@ -213,6 +218,7 @@ local4.* {
 		set $!jsonsrc = "a \\ \"b\"";
 		set $!jsonrsrc = "a \\n b";
 		action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+		action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="legacyfmt")
 	}
 }
 '
@@ -222,7 +228,7 @@ injectmsg_literal '<167>1 2003-08-24T05:14:15.000003-07:00 host app proc msgid -
 injectmsg_literal '<167>Aug 24 05:14:15 legacyhost legacyprog[42]: shape3164'
 injectmsg_literal '<167>1 2003-08-24T05:14:15.000003-07:00 nilhost - - - - shape5424nil'
 injectmsg_literal '<167>Aug 24 05:14:15 oddhost shape3164notag'
-wait_file_lines --abort-on-oversize "$RSYSLOG_OUT_LOG" 90
+wait_file_lines --abort-on-oversize "$RSYSLOG_OUT_LOG" 95
 shutdown_when_empty
 wait_shutdown
 
@@ -248,6 +254,7 @@ spif_space=<>
 cc_drop=abc
 cc_space=a b c
 cc_escape=a#010b#009c
+cc_escape_octal=a#012b#011c
 sec_drop=abc
 sec_replace=a_b_c
 sec_empty=_
@@ -286,6 +293,10 @@ reported_local_subseconds=000003
 reported_local_misc=Sun/0/07:00/-/236/35
 reported_utc_formats=20030824121415/2003-08-24 12:14:15/Aug 24 12:14:15/1061727255/000003
 reported_parts=2003-08-24T12:14:15
+legacy_cc_decimal=a#010b#009c
+legacy_cc_octal=a#012b#011c
+legacy_cc_octal_then_space=a b c
+legacy_cc_space_then_octal=a#012b#011c
 shape_msg= shape3164
 shape_hostname=legacyhost
 shape_syslogtag=legacyprog[42]:

--- a/tests/yaml-template-controlcharacters.sh
+++ b/tests/yaml-template-controlcharacters.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Tests YAML list-template control-character handling for the modern
+# property() parameter surface. The oracle is exact omfile output: a newline
+# and tab in a message variable must be emitted as octal #012 and #011 when
+# controlCharacters is set to escape-octal from YAML.
+#
+# Added 2026, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+export NUMMESSAGES=1
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" << 'YAMLEOF'
+modules:
+  - load: "../plugins/imtcp/.libs/imtcp"
+
+templates:
+  - name: outfmt
+    type: list
+    elements:
+      - constant:
+          value: "cc_escape_octal="
+      - property:
+          name: "$!control"
+          controlCharacters: escape-octal
+      - constant:
+          value: "\n"
+
+rulesets:
+  - name: main
+    script: |
+      set $!control = "a\nb\tc";
+      action(type="omfile" template="outfmt" file="${RSYSLOG_OUT_LOG}")
+YAMLEOF
+sed -i "s|\${RSYSLOG_OUT_LOG}|${RSYSLOG_OUT_LOG}|g" "${RSYSLOG_DYNNAME}.yaml"
+
+add_conf '
+input(type="imtcp" port="0" listenPortFileName="'${RSYSLOG_DYNNAME}'.tcpflood_port"
+      ruleset="main")
+'
+startup
+tcpflood -m $NUMMESSAGES
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='cc_escape_octal=a#012b#011c'
+cmp_exact
+exit_test


### PR DESCRIPTION
## Summary

Add an opt-in octal control-character escape mode for modern list templates
while preserving the legacy decimal behavior of `escape-cc`.

This addresses the compatibility concern from the issue: existing configs that
use `escape-cc` continue to emit decimal values such as `#010`, while users who
need receive-style octal escaping can use:

- list template property option: `controlCharacters="escape-octal"`
- YAML list template property option: `controlCharacters: escape-octal`

The legacy string-template property replacer option set is intentionally not
extended. It remains compatibility-only surface.

Closes https://github.com/rsyslog/rsyslog/issues/496

## Validation

- `./tests/template-property-transformations.sh` passed.
- `./tests/yaml-template-controlcharacters.sh` passed.
- `bash -n tests/yaml-template-controlcharacters.sh tests/template-property-transformations.sh` passed.
- `shellcheck -S warning tests/yaml-template-controlcharacters.sh tests/template-property-transformations.sh` passed.
- `devtools/check-test-antipatterns.sh tests/yaml-template-controlcharacters.sh tests/template-property-transformations.sh` passed with only existing timestamp literal review notes in expected output.
- `bash devtools/format-code.sh --git-changed --check --check-if-available` passed.
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 60` passed.
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j60` passed after a timestamp-only local workaround for stale `tests/Makefile.in`; the host lacks Automake 1.18.
- `cubic review --print-logs --base upstream/main` reported no issues.
- Full local validation helper was attempted twice with `RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 devtools/local-validation-plan.sh --base upstream/main --run`, but the broad container suite was blocked by unrelated failures:
  - first run: `pmsnare-ccbackslash-udp.sh` produced no output;
  - second run: `imdtls-basic-vg.sh` received 445/1000 DTLS messages under Valgrind, with Valgrind reporting 0 errors.

So the touched behavior is locally targeted-tested, docs-built, mock-distchecked,
and Cubic-reviewed, but the final broad container helper did not complete green
because of unrelated lanes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
