### PR TITLE
doc: modernize GELF forwarding tutorial

### DIFF
--- a/doc/source/tutorials/gelf_forwarding.rst
+++ b/doc/source/tutorials/gelf_forwarding.rst
@@ -1,13 +1,24 @@
 GELF forwarding in rsyslog
 ==========================
 
+.. meta::
+   :description: Forward rsyslog messages to Graylog in GELF format.
+   :keywords: rsyslog, GELF, Graylog, omfwd, jsonf, template
+
+.. summary-start
+
+Forward rsyslog messages to Graylog by rendering a GELF JSON template and
+using ``omfwd`` with UDP or TCP framing.
+
+.. summary-end
+
 *Written by Florian Riedl*
 
 Situation
 ---------
 
 The current setup has a system with rsyslog as the central syslog server
-and a system with Graylog for storage and analyzing the log messages. 
+and a system with Graylog for storage and analyzing the log messages.
 Graylog expects the log messages to arrive in GELF (Graylog Extended Log
 Format).
 
@@ -15,26 +26,29 @@ Changing the default log format to GELF
 ---------------------------------------
 
 To make rsyslog send GELF we basically need to create a custom template.
-This template will define the format in which the log messages will get 
+This template will define the format in which the log messages will get
 sent to Graylog.
 
-::
+.. code-block:: none
 
-    template(name="gelf" type="list") {
-        constant(value="{\"version\":\"1.1\",")
-        constant(value="\"host\":\"")
-        property(name="hostname")
-        constant(value="\",\"short_message\":\"")
-        property(name="msg" format="json")
-        constant(value="\",\"timestamp\":")
-        property(name="timegenerated" dateformat="unixtimestamp")
-        constant(value=",\"level\":\"")
-        property(name="syslogseverity")
-        constant(value="\"}")
+    template(name="gelf" type="list" option.jsonf="on") {
+        constant(outname="version" value="1.1" format="jsonf")
+        property(outname="host" name="hostname" format="jsonf")
+        property(outname="short_message" name="msg" format="jsonf")
+        property(outname="timestamp" name="timegenerated"
+                 dateformat="unixtimestamp" datatype="number" format="jsonf")
+        property(outname="level" name="syslogseverity"
+                 datatype="number" format="jsonf")
+        property(outname="_app_name" name="app-name" format="jsonf")
+        property(outname="_syslog_facility" name="syslogfacility-text"
+                 format="jsonf")
     }
 
-This is a typical representation in the list format with all the necessary
-fields and format definitions that Graylog expects.
+This list template uses ``option.jsonf="on"`` and ``format="jsonf"`` so
+rsyslog adds JSON braces, commas, field names, and string escaping. The
+``timestamp`` and ``level`` fields are emitted as JSON numbers, which avoids
+Graylog warnings about string-typed GELF fields. The ``_app_name`` and
+``_syslog_facility`` fields are optional GELF additional fields.
 
 Applying the template to a syslog action
 ----------------------------------------
@@ -43,19 +57,21 @@ The next step is applying the template to our output action. Since we
 are forwarding log messages to Graylog, this is usually a syslog sending
 action.
 
-::
+.. code-block:: none
 
     # syslog forwarder via UDP
     action(type="omfwd" target="graylogserver" port="12201" protocol="udp" template="gelf")
 
 We now have a syslog forwarding action. This uses the omfwd module. Please
-note that the case above only works for UDP transport. When using TCP, 
-Graylog expects a Nullbyte as message delimiter. So, to use TCP, you need to change delimiter via `TCP_FrameDelimiter <../configuration/modules/omfwd.html#tcp-framedelimiter>`_ option.
+note that the case above only works for UDP transport. When using TCP,
+Graylog expects a null byte as message delimiter. To use TCP, configure the
+delimiter via the ``TCP_FrameDelimiter`` parameter of the :doc:`omfwd
+module <../configuration/modules/omfwd>`.
 
-::
+.. code-block:: none
 
     # syslog forwarder via TCP
-    action(type="omfwd" target="graylogserver" port="12201" protocol="tcp" template="gelf" TCP_FrameDelimiter="0" KeepAlive="on")
+    action(type="omfwd" target="graylogserver" port="12201" protocol="tcp" template="gelf" TCP_FrameDelimiter=0 KeepAlive="on")
 
 Conclusion
 ----------
@@ -66,5 +82,3 @@ a lot of different scenarios as well, but with different templates.
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.
-
-


### PR DESCRIPTION
## Summary
- modernize the GELF forwarding tutorial to use list-template JSONF output
- emit GELF timestamp and level as JSON numbers to avoid Graylog type warnings
- add metadata/summary text and link the TCP delimiter note to the omfwd docs

## Validation
- git diff --check
- ./doc/tools/build-doc-linux.sh --clean --format html --jobs 80

Closes https://github.com/rsyslog/rsyslog/issues/292

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

