### PR TITLE
testbench: skip omfile read-only tests when not enforceable

### DIFF
--- a/tests/omfile-read-only-errmsg.sh
+++ b/tests/omfile-read-only-errmsg.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # addd 2017-03-01 by RGerhards, released under ASL 2.0
+# Verifies that omfile logs an open error for a read-only output file. The
+# oracle requires the current user and filesystem to reject appends to a 0400
+# file; if the platform still permits that write, the diagnostic cannot be
+# triggered and the test is skipped.
 
 . ${srcdir:=.}/diag.sh init
 skip_ASAN "omfile read-only error message format differs under ASan"
@@ -17,6 +21,10 @@ action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 '
 touch ${RSYSLOG2_OUT_LOG}
 chmod 0400 ${RSYSLOG2_OUT_LOG}
+if (: >> "${RSYSLOG2_OUT_LOG}") 2>/dev/null; then
+	echo "SKIP: environment can append to a 0400 file; read-only omfile error path is not testable"
+	skip_test
+fi
 ls -l rsyslog.ou*
 startup
 injectmsg 0 1

--- a/tests/omfile-read-only.sh
+++ b/tests/omfile-read-only.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # addd 2016-06-16 by RGerhards, released under ASL 2.0
+# Verifies that omfile suspends a read-only primary file action and then uses
+# the fallback action. The oracle requires the current user and filesystem to
+# reject appends to a 0400 file; if the platform still permits that write, the
+# test environment cannot exercise the intended failure path and is skipped.
 . ${srcdir:=.}/diag.sh init
 skip_ASAN "omfile read-only suspend behavior differs under ASan"
 messages=20000 # how many messages to inject?
@@ -20,6 +24,10 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 '
 touch ${RSYSLOG2_OUT_LOG}
 chmod 0400 ${RSYSLOG2_OUT_LOG}
+if (: >> "${RSYSLOG2_OUT_LOG}") 2>/dev/null; then
+	echo "SKIP: environment can append to a 0400 file; read-only omfile failure path is not testable"
+	skip_test
+fi
 ls -l rsyslog.ou*
 startup
 injectmsg 0 $messages


### PR DESCRIPTION
## Summary
- add explicit intent/oracle comments to the omfile read-only tests
- probe whether the current user/filesystem can append to a 0400 file
- skip with a clear reason when the read-only failure path cannot be exercised

## Validation
- bash -n tests/omfile-read-only.sh tests/omfile-read-only-errmsg.sh
- shellcheck -S warning tests/omfile-read-only.sh tests/omfile-read-only-errmsg.sh
- devtools/check-test-antipatterns.sh tests/omfile-read-only.sh tests/omfile-read-only-errmsg.sh
- ./tests/omfile-read-only.sh && ./tests/omfile-read-only-errmsg.sh
- cubic review --json --base upstream/main
- RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 90m devtools/local-validation-plan.sh --run

Closes https://github.com/rsyslog/rsyslog/issues/4311

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

