### PR TITLE
msg: invalidate programname when tag changes

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2261,6 +2261,11 @@ void MsgSetTAG(smsg_t *__restrict__ const pMsg, const uchar *pszBuf, const size_
     assert(pMsg != NULL);
 
     freeTAG(pMsg);
+    if (pMsg->iLenPROGNAME >= CONF_PROGNAME_BUFSIZE) {
+        free(pMsg->PROGNAME.ptr);
+        pMsg->PROGNAME.ptr = NULL;
+    }
+    pMsg->iLenPROGNAME = -1;
 
     pMsg->iLenTAG = lenBuf;
     if (pMsg->iLenTAG < CONF_TAG_BUFSIZE) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -279,6 +279,7 @@ TESTS_DEFAULT = \
 	sndrcv_udp_nonstdpt_v6.sh \
 	imudp_thread_hang.sh \
 	imudp-listenportfilename-secure.sh \
+	imudp-ratelimit-programname.sh \
 	imudp_ratelimit_name.sh \
 	omfwd_ratelimit_name.sh \
 	omelasticsearch_ratelimit_name.sh \

--- a/tests/imudp-ratelimit-programname.sh
+++ b/tests/imudp-ratelimit-programname.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+## Regression test for imudp interval ratelimiting preserving parsed identity
+## properties. The rate limiter consults APP-NAME for diagnostics before the
+## message reaches the main queue; for RFC5424 messages this must not cache an
+## empty derived programname before normal parsing. The input allows only one
+## message per interval and receives two messages, so the test exercises the
+## interval limiter and its drop path. The oracle is the final omfile output
+## after shutdown, proving the accepted message reached its configured
+## destination with both programname and app-name intact.
+
+. ${srcdir:=.}/diag.sh init
+skip_ARM "ratelimit timing flaky on ARM"
+export NUMMESSAGES=1
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
+
+generate_conf
+add_conf '
+module(load="../plugins/imudp/.libs/imudp")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'"
+      ratelimit.interval="5" ratelimit.burst="1")
+
+template(name="outfmt" type="string" string="prog=[%programname%] app=[%app-name%] msg=[%msg%]\n")
+
+if $msg contains "rate-limit identity" then {
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
+
+./tcpflood -Tudp -p"$PORT_RCVR" -m2 -M "<29>1 2026-02-19T13:00:00.000Z router1 rpd 1234 TEST_MSG - rate-limit identity"
+
+shutdown_when_empty
+wait_shutdown
+
+content_check "prog=[rpd] app=[rpd] msg=[rate-limit identity]"
+exit_test


### PR DESCRIPTION
## Summary
- invalidate cached programname whenever MsgSetTAG changes the tag
- add an imudp interval-ratelimit regression test for RFC5424 programname/app-name

## Validation
- `bash -n tests/imudp-ratelimit-programname.sh`
- `devtools/check-test-antipatterns.sh tests/imudp-ratelimit-programname.sh`
- `devtools/format-code.sh --git-changed`
- `make -j80 check TESTS=""`
- `./tests/imudp-ratelimit-programname.sh`
- `cubic review --json --base upstream/main`: clean
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 90m devtools/local-validation-plan.sh --run`: pass

closes https://github.com/rsyslog/rsyslog/issues/4313


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

