### PR TITLE
pmrfc3164: honor parseHostnameAndTag at runtime

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -222,6 +222,7 @@ TESTS_DEFAULT = \
 	pmrfc3164-AtSignsInHostname.sh \
 	pmrfc3164-AtSignsInHostname_off.sh \
 	pmrfc3164-tagEndingByColon.sh \
+	pmrfc3164-parsehostnameandtag-off.sh \
 	pmrfc3164_force_tag_no_colon.sh \
 	pmrfc3164-defaultTag.sh \
 	pmrfc3164-headerless.sh \

--- a/tests/pmrfc3164-parsehostnameandtag-off.sh
+++ b/tests/pmrfc3164-parsehostnameandtag-off.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Regression test for parser.parseHostnameAndTag="off".
+# The global setting is parsed after the built-in RFC3164 parser is
+# initialized, so the parser must read the active config at parse time. The
+# oracle is the configured omfile output after shutdown: syslogtag and
+# programname stay empty, and the would-be hostname/tag text remains in MSG.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+generate_conf
+add_conf '
+global(parser.parseHostnameAndTag="off")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="r")
+
+template(name="outfmt" type="string"
+         string="tag=[%syslogtag%] prog=[%programname%] msg=[%msg%]\n")
+
+ruleset(name="r") {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+startup
+tcpflood -m1 -M "\"<34>Oct 11 22:14:15 testhost testapp: parse-off-message\""
+shutdown_when_empty
+wait_shutdown
+
+content_check "tag=[] prog=[]" "$RSYSLOG_OUT_LOG"
+content_check "testhost testapp: parse-off-message" "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -60,10 +60,6 @@ DEFobjCurrIf(datetime);
 DEFobjCurrIf(ruleset);
 
 
-/* static data */
-static int bParseHOSTNAMEandTAG; /* cache for the equally-named global param - performance enhancement */
-
-
 /* parser instance parameters */
 static struct cnfparamdescr parserpdescr[] = {
     {"detect.yearaftertimestamp", eCmdHdlrBinary, 0},
@@ -99,6 +95,7 @@ struct instanceConf_s {
     FILE* fpHeaderlessErr; /**< file pointer for error file (headerless) */
     pthread_mutex_t mutErrFile;
     int bDropHeaderless;
+    int bParseHOSTNAMEandTAG;
 };
 
 
@@ -132,7 +129,7 @@ static rsRetVal createInstance(instanceConf_t** pinst) {
     inst->fpHeaderlessErr = NULL;
     pthread_mutex_init(&inst->mutErrFile, NULL);
     inst->bDropHeaderless = 0;
-    bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(loadConf);
+    inst->bParseHOSTNAMEandTAG = 1;
     *pinst = inst;
 finalize_it:
     RETiRet;
@@ -211,6 +208,8 @@ ENDfreeParserInst
 
 BEGINcheckParserInst
     CODESTARTcheckParserInst;
+
+    pInst->bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(loadConf);
 
     if (pInst->pszHeaderlessRulesetName != NULL) {
         ruleset_t* myRuleset = NULL;
@@ -381,7 +380,7 @@ BEGINparse2
      * machine that we received the message from and the tag will be empty. This
      * is meant to be an interim solution, but for now it is in the code.
      */
-    if (bParseHOSTNAMEandTAG && !(pMsg->msgFlags & INTERNAL_MSG)) {
+    if (pInst->bParseHOSTNAMEandTAG && !(pMsg->msgFlags & INTERNAL_MSG)) {
         /* parse HOSTNAME - but only if this is network-received!
          * rger, 2005-11-14: we still have a problem with BSD messages. These messages
          * do NOT include a host name. In most cases, this leads to the TAG to be treated
@@ -546,6 +545,4 @@ BEGINmodInit(pmrfc3164)
 
     DBGPRINTF("rfc3164 parser init called\n");
 
-    /* cache value, is set only during rsyslogd option processing */
-    bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(loadConf);
 ENDmodInit


### PR DESCRIPTION
## Summary

- remove the stale pmrfc3164 `parser.parseHostnameAndTag` module cache
- read the active runtime config when deciding whether to parse HOSTNAME/TAG
- add a regression test for `global(parser.parseHostnameAndTag="off")`

Closes https://github.com/rsyslog/rsyslog/issues/1190

## Validation

- `bash -n tests/pmrfc3164-parsehostnameandtag-off.sh`
- `shellcheck -S warning tests/pmrfc3164-parsehostnameandtag-off.sh`
- `devtools/check-test-antipatterns.sh tests/pmrfc3164-parsehostnameandtag-off.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `./autogen.sh --enable-debug --enable-testbench --enable-imtcp --enable-imdiag --enable-omstdout`
- `make -j80 check TESTS=""`
- `./tests/pmrfc3164-parsehostnameandtag-off.sh`
- `make -j80 check TESTS="pmrfc3164-parsehostnameandtag-off.sh"`
- `timeout 20m make distcheck TEST_RUN_TYPE=MOCK-OK -j80`
- local Cubic review: no issues
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

