### PR TITLE
glbl: keep debug logfile notice informational

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -1410,7 +1410,7 @@ rsRetVal glblDoneLoadCnf(void) {
             free((void *)tmp);
         } else if (!strcmp(paramblk.descr[i].name, "debug.onshutdown")) {
             loadConf->globals.debugOnShutdown = (int)cnfparamvals[i].val.d.n;
-            LogError(0, RS_RET_OK, "debug: onShutdown set to %d", loadConf->globals.debugOnShutdown);
+            LogMsg(0, RS_RET_OK, LOG_INFO, "debug: onShutdown set to %d", loadConf->globals.debugOnShutdown);
         } else if (!strcmp(paramblk.descr[i].name, "debug.gnutls")) {
             loadConf->globals.iGnuTLSLoglevel = (int)cnfparamvals[i].val.d.n;
         } else if (!strcmp(paramblk.descr[i].name, "debug.abortonprogramerror")) {
@@ -1456,7 +1456,7 @@ rsRetVal glblDoneLoadCnf(void) {
                     LogError(0, RS_RET_ERR, "debug log file '%s' could not be opened", pszAltDbgFileName);
                 }
             }
-            LogError(0, RS_RET_OK, "debug log file is '%s', fd %d", pszAltDbgFileName, altdbg);
+            LogMsg(0, RS_RET_OK, LOG_INFO, "debug log file is '%s', fd %d", pszAltDbgFileName, altdbg);
         } else if (!strcmp(paramblk.descr[i].name, "janitor.interval")) {
             loadConf->globals.janitorInterval = (int)cnfparamvals[i].val.d.n;
         } else if (!strcmp(paramblk.descr[i].name, "net.ipprotocol")) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -462,6 +462,7 @@ TESTS_DEFAULT = \
 	lookup_table-hup-backgrounded.sh \
 	lookup_table_no_hup_reload.sh \
 	container-noise-drop.sh \
+	debug-logfile-config-check.sh \
 	key_dereference_on_uninitialized_variable_space.sh \
 	array_lookup_table.sh \
 	sparse_array_lookup_table.sh \

--- a/tests/debug-logfile-config-check.sh
+++ b/tests/debug-logfile-config-check.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Regression coverage for issue #1129: setting debug globals during -N1 config
+# validation must not make the config checker return failure when their setup
+# messages are informational.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+global(
+	debug.logFile="'"$RSYSLOG_DYNNAME"'.debug.log"
+	debug.onShutdown="on"
+)
+'
+
+export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
+rsyslogd_config_check
+unset RS_REDIR
+
+content_check "End of config validation run" "${RSYSLOG_DYNNAME}.rsyslog.log"
+check_file_exists "${RSYSLOG_DYNNAME}.debug.log"
+
+exit_test


### PR DESCRIPTION
## Summary
- keep the successful `debug.logFile` setup notice informational instead of logging it via `LogError`
- add `debug-logfile-config-check.sh` to cover `rsyslogd -N1` with `global(debug.logFile=...)`

## Validation
- `bash -n tests/debug-logfile-config-check.sh`
- `shellcheck -S warning tests/debug-logfile-config-check.sh`
- `devtools/check-test-antipatterns.sh tests/debug-logfile-config-check.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout`
- `make -j80 check TESTS=""`
- `./tests/debug-logfile-config-check.sh`
- `make -j80 check TESTS="debug-logfile-config-check.sh"`
- `cubic review --json --base upstream/main`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run`

Closes https://github.com/rsyslog/rsyslog/issues/1129


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

