### PR TITLE
rainerscript: keep random result non-negative

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -2007,6 +2007,12 @@ finalize_it:
     varFreeMembers(&srcVal[1]);
 }
 
+static unsigned long randomNumberMagnitude(void) {
+    const long n = randomNumber();
+    if (n >= 0) return (unsigned long)n;
+    return (unsigned long)(-(n + 1)) + 1;
+}
+
 static void ATTR_NONNULL() doFunct_RandomGen(struct cnffunc *__restrict__ const func,
                                              struct svar *__restrict__ const ret,
                                              void *__restrict__ const usrptr,
@@ -2014,7 +2020,7 @@ static void ATTR_NONNULL() doFunct_RandomGen(struct cnffunc *__restrict__ const 
     int success = 0;
     struct svar srcVal;
     long long retVal;
-    long int x;
+    unsigned long x;
 
     cnfexprEval(func->expr[0], &srcVal, usrptr, pWti);
     long long max = var2Number(&srcVal, &success);
@@ -2030,7 +2036,10 @@ static void ATTR_NONNULL() doFunct_RandomGen(struct cnffunc *__restrict__ const 
         retVal = 0;
         goto done;
     }
-    x = labs(randomNumber());
+    if (max < 0) {
+        max = (max == LLONG_MIN) ? LLONG_MAX : -max;
+    }
+    x = randomNumberMagnitude();
     if (max > MAX_RANDOM_NUMBER) {
         DBGPRINTF(
             "rainerscript: desired random-number range [0 - %lld] "

--- a/tests/rscript_random.sh
+++ b/tests/rscript_random.sh
@@ -1,25 +1,29 @@
 #!/bin/bash
 # added 2015-06-22 by singh.janmejay
+# Verifies that random(max) emits bounded non-negative values. The oracle is
+# the omfile output after synchronized shutdown, so the check covers the value
+# that rsyslog delivered to the configured action destination.
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_random.sh\]: test for random-number-generator script-function
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
-template(name="outfmt" type="string" string="%$.random_no%\n")
+template(name="outfmt" type="string" string="%$.random_no% %$.random_neg%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $.random_no = random(10);
+set $.random_neg = random(-10);
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 '
 startup
-tcpflood -m 20
+tcpflood -m 200
 echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown 
-. $srcdir/diag.sh content-pattern-check "^[0-9]$"
+. $srcdir/diag.sh content-pattern-check "^[0-9] [0-9]$"
 exit_test


### PR DESCRIPTION
## Summary
- avoid signed absolute-value overflow in RainerScript `random(max)`
- strengthen the existing `rscript_random.sh` regression test with a documented output-file oracle and more samples

## Validation
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `devtools/check-test-antipatterns.sh tests/rscript_random.sh`
- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout`
- `RSYSLOG_LOCAL_BUILD_JOBS=80 RSYSLOG_LOCAL_CHECK_JOBS=80 make -j80 check TESTS=`
- `./tests/rscript_random.sh`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 make check TESTS=rscript_random.sh`
- `cubic review`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run`

Closes https://github.com/rsyslog/rsyslog/issues/3039


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

