### PR TITLE
parser: preserve first sanitize offset with SpaceLF

### DIFF
--- a/runtime/parser.c
+++ b/runtime/parser.c
@@ -336,6 +336,7 @@ static rsRetVal SanitizeMsg(smsg_t *pMsg) {
     size_t iDst;
     size_t iMaxLine;
     size_t maxDest;
+    size_t iFirstSanitize;
     uchar pc;
     sbool bUpdatedLen = RSFALSE;
     uchar szSanBuf[32 * 1024]; /* buffer used for sanitizing a string */
@@ -386,19 +387,24 @@ static rsRetVal SanitizeMsg(smsg_t *pMsg) {
      * need below (but it then still will work perfectly well!). -- rgerhards, 2009-11-27
      */
     int bNeedSanitize = 0;
+    iFirstSanitize = lenMsg;
     for (iSrc = 0; iSrc < lenMsg; iSrc++) {
         if (pszMsg[iSrc] < 32) {
             if (glbl.GetParserSpaceLFOnReceive(runConf) && pszMsg[iSrc] == '\n') {
                 pszMsg[iSrc] = ' ';
             } else if (pszMsg[iSrc] == '\0' || glbl.GetParserEscapeControlCharactersOnReceive(runConf)) {
                 bNeedSanitize = 1;
+                if (iFirstSanitize == lenMsg) iFirstSanitize = iSrc;
                 if (!glbl.GetParserSpaceLFOnReceive(runConf)) {
                     break;
                 }
             }
         } else if (pszMsg[iSrc] > 127 && glbl.GetParserEscape8BitCharactersOnReceive(runConf)) {
             bNeedSanitize = 1;
-            break;
+            if (iFirstSanitize == lenMsg) iFirstSanitize = iSrc;
+            if (!glbl.GetParserSpaceLFOnReceive(runConf)) {
+                break;
+            }
         }
     }
 
@@ -406,6 +412,7 @@ static rsRetVal SanitizeMsg(smsg_t *pMsg) {
         if (bUpdatedLen == RSTRUE) MsgSetRawMsgSize(pMsg, lenMsg);
         FINALIZE;
     }
+    iSrc = iFirstSanitize;
 
     /* now copy over the message and sanitize it. Note that up to iSrc-1 there was
      * obviously no need to sanitize, so we can go over that quickly...
@@ -432,6 +439,11 @@ static rsRetVal SanitizeMsg(smsg_t *pMsg) {
     iDst = iSrc;
     while (iSrc < lenMsg && iDst < maxDest - 3) { /* leave some space if last char must be escaped */
         if ((pszMsg[iSrc] < 32) && (pszMsg[iSrc] != '\t' || glbl.GetParserEscapeControlCharacterTab(runConf))) {
+            if (glbl.GetParserSpaceLFOnReceive(runConf) && pszMsg[iSrc] == '\n') {
+                pDst[iDst++] = ' ';
+                iSrc++;
+                continue;
+            }
             /* note: \0 must always be escaped, the rest of the code currently
              * can not handle it! -- rgerhards, 2009-08-26
              */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -700,6 +700,7 @@ TESTS_IMTCP = \
 	imtcp_framing_regex.sh \
 	imtcp_framing_regex_maxmsg_overflow.sh \
 	imtcp-multiline.sh \
+	imtcp-spacelf-escape.sh \
 	imtcp-basic-hup.sh \
 	imtcp-impstats-single-thread.sh \
 	imtcp-starvation-0.sh \
@@ -767,6 +768,7 @@ TESTS_IMTCP_YAML = \
 	yaml-parser-drop-trailing-cr.sh \
 	yaml-imtcp-ruleset-no-queue-warning.sh \
 	yaml-imtcp-stream-always-zlib-basic.sh \
+	yaml-imtcp-spacelf-escape.sh \
 	imtcp-persource-ratelimit.sh \
 	ratelimit-legacy-persource-discard.sh \
 	ratelimit-persource-repeat-summary.sh \

--- a/tests/imtcp-spacelf-escape.sh
+++ b/tests/imtcp-spacelf-escape.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Verifies that parser.spaceLFOnReceive does not mask other sanitization.
+# The octet-counted input contains an embedded LF, other control bytes, and an
+# 8-bit UTF-8 byte sequence. Success is proven by the configured omfile output:
+# LF is rewritten to a space, while tab, CR, BEL, BS, and 8-bit bytes are still
+# escaped after synchronized shutdown.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(
+	parser.spaceLFOnReceive="on"
+	parser.escapeControlCharactersOnReceive="on"
+	parser.escapeControlCharacterTab="on"
+	parser.escape8BitCharactersOnReceive="on"
+	parser.escapeControlCharactersCStyle="off"
+)
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	supportOctetCountedFraming="on" ruleset="remote")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+ruleset(name="remote") {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+
+payload=$'<13>Oct 11 22:14:15 host tag: tab\tline carriage\rtest beep\abackspace\btest high \302\251 later\nlf'
+tcpflood_bin="${TCPFLOOD_BIN:-./tcpflood}"
+
+startup
+assign_tcpflood_port "$RSYSLOG_DYNNAME.tcpflood_port"
+"$tcpflood_bin" -p"$TCPFLOOD_PORT" -m1 -O -M "$payload"
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED=' tab#011line carriage#015test beep#007backspace#010test high #302#251 later lf'
+cmp_exact
+exit_test

--- a/tests/yaml-imtcp-spacelf-escape.sh
+++ b/tests/yaml-imtcp-spacelf-escape.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# YAML companion for imtcp-spacelf-escape.sh. The parser options are loaded
+# from a YAML include, while success is proven by the configured omfile output
+# after synchronized shutdown: LF is rewritten to a space, and the earlier tab,
+# CR, BEL, BS, and 8-bit bytes still escape correctly.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" <<YAMLEOF
+global:
+  parser.spaceLFOnReceive: "on"
+  parser.escapeControlCharactersOnReceive: "on"
+  parser.escapeControlCharacterTab: "on"
+  parser.escape8BitCharactersOnReceive: "on"
+  parser.escapeControlCharactersCStyle: "off"
+
+modules:
+  - load: "../plugins/imtcp/.libs/imtcp"
+
+inputs:
+  - type: imtcp
+    port: "0"
+    listenPortFileName: "${RSYSLOG_DYNNAME}.tcpflood_port"
+    supportOctetCountedFraming: "on"
+    ruleset: remote
+
+templates:
+  - name: outfmt
+    type: string
+    string: "%msg%\n"
+
+rulesets:
+  - name: remote
+    script: |
+      action(type="omfile" file="${RSYSLOG_OUT_LOG}" template="outfmt")
+YAMLEOF
+
+payload=$'<13>Oct 11 22:14:15 host tag: tab\tline carriage\rtest beep\abackspace\btest high \302\251 later\nlf'
+tcpflood_bin="${TCPFLOOD_BIN:-./tcpflood}"
+
+startup
+assign_tcpflood_port "$RSYSLOG_DYNNAME.tcpflood_port"
+"$tcpflood_bin" -p"$TCPFLOOD_PORT" -m1 -O -M "$payload"
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED=' tab#011line carriage#015test beep#007backspace#010test high #302#251 later lf'
+cmp_exact
+exit_test


### PR DESCRIPTION
## Summary
- remember the first byte that requires sanitizer output while `SpaceLFOnReceive` continues scanning for LF rewrites
- add an octet-counted imtcp regression test covering SpaceLF together with control-character, tab, and 8-bit escaping

## Validation
- `bash -n tests/imtcp-spacelf-escape.sh`
- `shellcheck -S warning tests/imtcp-spacelf-escape.sh`
- `devtools/check-test-antipatterns.sh tests/imtcp-spacelf-escape.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `./autogen.sh --enable-debug --enable-testbench --enable-imtcp --enable-imdiag --enable-omstdout`
- `RSYSLOG_LOCAL_BUILD_JOBS=80 RSYSLOG_LOCAL_CHECK_JOBS=80 make -j80 check TESTS=`
- `./tests/imtcp-spacelf-escape.sh`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 make check TESTS=imtcp-spacelf-escape.sh`
- `cubic review`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run`

Closes https://github.com/rsyslog/rsyslog/issues/3236


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

