### PR TITLE
testbench: cover diagtalker retry

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -105,6 +105,7 @@ TESTS_DEFAULT = \
 	msleep_usage_output.sh \
 	mangle_qi_usage_output.sh \
 	minitcpsrv_usage_output.sh \
+	diagtalker-retry.sh \
 	test_id_usage_output.sh \
 	prop-programname.sh \
 	prop-programname-with-slashes.sh \

--- a/tests/diagtalker-retry.sh
+++ b/tests/diagtalker-retry.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# This test covers diagtalker's connection retry path. minitcpsrv binds an
+# ephemeral port and publishes it before listen(), so the port stays reserved
+# while diagtalker receives deterministic connection refusals. The retry
+# diagnostic proves the retry path ran; the later command file and fixed
+# response prove the same diagtalker process completed a real request after the
+# listener was released.
+
+. ${srcdir:=.}/diag.sh init
+
+LISTEN_RELEASE="$RSYSLOG_DYNNAME.diagtalker-listen-release"
+LISTEN_READY="$RSYSLOG_DYNNAME.diagtalker-listen-ready"
+ACCEPT_READY="$RSYSLOG_DYNNAME.diagtalker-accept-ready"
+DIAGTALKER_STDOUT="$RSYSLOG_DYNNAME.diagtalker.stdout"
+DIAGTALKER_STDERR="$RSYSLOG_DYNNAME.diagtalker.stderr"
+
+export MINITCPSRV_EXTRA_OPTS="-r imdiag::ok"
+start_minitcpsrvr "$RSYSLOG_OUT_LOG" 1 "$LISTEN_RELEASE" "$LISTEN_READY" "$ACCEPT_READY"
+unset MINITCPSRV_EXTRA_OPTS
+
+printf 'status\n' | "$TESTTOOL_DIR/diagtalker" -p"$MINITCPSRVR_PORT1" \
+	>"$DIAGTALKER_STDOUT" 2>"$DIAGTALKER_STDERR" &
+DIAGTALKER_PID=$!
+
+wait_content "connect failed, retrying" "$DIAGTALKER_STDERR"
+
+: > "$LISTEN_RELEASE"
+wait_file_exists "$LISTEN_READY"
+wait_file_exists "$ACCEPT_READY"
+
+wait "$DIAGTALKER_PID" || error_exit $?
+
+wait_file_lines "$RSYSLOG_OUT_LOG" 1 20
+content_check "status" "$RSYSLOG_OUT_LOG"
+content_check "connection established" "$DIAGTALKER_STDERR"
+content_check "imdiag[$MINITCPSRVR_PORT1]: imdiag::ok" "$DIAGTALKER_STDOUT"
+
+exit_test

--- a/tests/minitcpsrvr.c
+++ b/tests/minitcpsrvr.c
@@ -28,6 +28,7 @@
 #include <sys/socket.h>
 #include <poll.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <unistd.h>
 #include <arpa/inet.h>
 #if defined(__FreeBSD__)
@@ -57,6 +58,7 @@ char *portFileName = NULL;
 char *waitListenFileName = NULL;
 char *listenReadyFileName = NULL;
 char *acceptReadyFileName = NULL;
+char *fixedResponse = NULL;
 size_t totalWritten = 0;
 int listen_fd, conn_fd, fd, file_fd, nfds, port = 8080;
 struct sockaddr_in server_addr;
@@ -72,9 +74,27 @@ static void errout(char *reason) {
 
 static void usage(void) {
     fprintf(stderr,
-            "usage: minitcpsrv [-R] [-w listenFile] [-L listenReadyFile] [-A acceptReadyFile] "
+            "usage: minitcpsrv [-R] [-r response] [-w listenFile] [-L listenReadyFile] [-A acceptReadyFile] "
             "-t ip-addr -p port -P portFile -f outfile\n");
     exit(1);
+}
+
+static void sendFixedResponse(int fd) {
+    const char *response;
+    size_t len;
+
+    if (fixedResponse == NULL) return;
+
+    response = fixedResponse;
+    len = strlen(fixedResponse);
+    while (len > 0) {
+        const ssize_t nSent = send(fd, response, len, 0);
+        if (nSent <= 0) {
+            errout("send fixed response");
+        }
+        response += nSent;
+        len -= (size_t)nSent;
+    }
 }
 
 static void writeListenReadyMarker(void) {
@@ -219,7 +239,7 @@ int main(int argc, char *argv[]) {
     memset(fds, 0, sizeof(fds));
     memset(buffer_offs, 0, sizeof(buffer_offs));
 
-    while ((opt = getopt(argc, argv, "aA:B:D:L:Rt:p:P:f:s:S:w:")) != -1) {
+    while ((opt = getopt(argc, argv, "aA:B:D:L:Rr:t:p:P:f:s:S:w:")) != -1) {
         switch (opt) {
             case 'a':  // abort listener: act like the server has died (shutdown and re-open listen socket)
                 abortListener = 1;
@@ -229,6 +249,9 @@ int main(int argc, char *argv[]) {
                 break;
             case 'R':
                 useReusePort = 1;
+                break;
+            case 'r':
+                fixedResponse = optarg;
                 break;
             case 'S':  // sleep time after connection drop
                 sleepAfterConnDrop = atoi(optarg);
@@ -284,6 +307,9 @@ int main(int argc, char *argv[]) {
     if (fdf == -1) {
         fprintf(stderr, "-f parameter missing -- terminating\n");
         usage();
+    }
+    if (fixedResponse != NULL) {
+        signal(SIGPIPE, SIG_IGN);
     }
 
     if (sleepStartup) {
@@ -355,6 +381,7 @@ int main(int argc, char *argv[]) {
                         const int written_bytes = write(fdf, buffer[i], bytes_to_write);
                         if (written_bytes != bytes_to_write) errout("write");
                         totalWritten += bytes_to_write;
+                        sendFixedResponse(fd);
                         if (bytes_to_write == last_byte + 1) {
                             buffer_offs[i] = 0;
                         } else {


### PR DESCRIPTION
## Summary

- add a deterministic `diagtalker` retry regression test
- add `minitcpsrv -r` so the helper can send a fixed response after receiving a command
- use existing listen-release/readiness files to force at least one refused connection before the successful retry

closes https://github.com/rsyslog/rsyslog/issues/3149

## Validation

- `bash -n tests/diagtalker-retry.sh`
- `shellcheck -S warning tests/diagtalker-retry.sh`
- `devtools/check-test-antipatterns.sh tests/diagtalker-retry.sh` (background helper advisory is intentional and documented; readiness and cleanup are explicit)
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `make -j80 check TESTS=`
- `./tests/diagtalker-retry.sh`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 make check TESTS=diagtalker-retry.sh`
- `cubic review`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

