### PR TITLE
imfile: deliver same-file monitors independently

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -1574,13 +1574,12 @@ finalize_it:
 static rsRetVal ATTR_NONNULL(1, 2)
     enqLine(act_obj_t *const act, cstr_t *const __restrict__ cstrLine, const int64 strtOffs, const uint64_t lineNum) {
     DEFiRet;
-    const instanceConf_t *const inst = act->edge->instarr[0];  // TODO: same file, multiple instances?
-    smsg_t *pMsg;
     uchar file_offset[MAX_OFFSET_REPRESENTATION_NUM_BYTES + 1];
     uchar line_number[MAX_LINENUM_REPRESENTATION_NUM_BYTES + 1];
     const uchar *metadata_names[3] = {(uchar *)"filename", (uchar *)"fileoffset", (uchar *)"line_number"};
     const uchar *metadata_values[3];
     const size_t msgLen = cstrLen(cstrLine);
+    smsg_t **msgs = NULL;
     int lenBuf;
 
     if (msgLen == 0) {
@@ -1588,61 +1587,92 @@ static rsRetVal ATTR_NONNULL(1, 2)
         FINALIZE;
     }
 
-    CHKiRet(msgConstruct(&pMsg));
-    MsgSetFlowControlType(pMsg, eFLOWCTL_FULL_DELAY);
-    MsgSetInputName(pMsg, pInputName);
-    if (inst->addCeeTag) {
-        /* Make sure we account for terminating null byte */
-        size_t ceeMsgSize = msgLen + CONST_LEN_CEE_COOKIE + 1;
-        char *ceeMsg;
-        CHKmalloc(ceeMsg = malloc(ceeMsgSize));
-        memcpy(ceeMsg, CONST_CEE_COOKIE, CONST_LEN_CEE_COOKIE);
-        memcpy(ceeMsg + CONST_LEN_CEE_COOKIE, rsCStrGetSzStrNoNULL(cstrLine), msgLen + 1);
-        MsgSetRawMsg(pMsg, ceeMsg, ceeMsgSize);
-        free(ceeMsg);
-    } else {
-        MsgSetRawMsg(pMsg, (char *)rsCStrGetSzStrNoNULL(cstrLine), msgLen);
-    }
-    MsgSetMSGoffs(pMsg, 0); /* we do not have a header... */
-    MsgSetHOSTNAME(pMsg, glbl.GetLocalHostName(), ustrlen(glbl.GetLocalHostName()));
-    MsgSetTAG(pMsg, inst->pszTag, inst->lenTag);
-    msgSetPRI(pMsg, inst->iFacility | inst->iSeverity);
-    MsgSetRuleset(pMsg, inst->pBindRuleset);
-    if (inst->addMetadata) {
-        if (act->source_name) {
-            metadata_values[0] = (const uchar *)act->source_name;
+    CHKmalloc(msgs = calloc(act->edge->ninst, sizeof(smsg_t *)));
+
+    for (int inst_idx = 0; inst_idx < act->edge->ninst; ++inst_idx) {
+        const instanceConf_t *const inst = act->edge->instarr[inst_idx];
+
+        CHKiRet(msgConstruct(&msgs[inst_idx]));
+        MsgSetFlowControlType(msgs[inst_idx], eFLOWCTL_FULL_DELAY);
+        MsgSetInputName(msgs[inst_idx], pInputName);
+        if (inst->addCeeTag) {
+            /* Make sure we account for terminating null byte */
+            size_t ceeMsgSize = msgLen + CONST_LEN_CEE_COOKIE + 1;
+            char *ceeMsg;
+            CHKmalloc(ceeMsg = malloc(ceeMsgSize));
+            memcpy(ceeMsg, CONST_CEE_COOKIE, CONST_LEN_CEE_COOKIE);
+            memcpy(ceeMsg + CONST_LEN_CEE_COOKIE, rsCStrGetSzStrNoNULL(cstrLine), msgLen + 1);
+            MsgSetRawMsg(msgs[inst_idx], ceeMsg, ceeMsgSize);
+            free(ceeMsg);
         } else {
-            metadata_values[0] = (const uchar *)act->name;
+            MsgSetRawMsg(msgs[inst_idx], (char *)rsCStrGetSzStrNoNULL(cstrLine), msgLen);
         }
-        lenBuf = snprintf((char *)file_offset, sizeof(file_offset), "%lld", strtOffs);
-        if (lenBuf < 0) {
-            msgDestruct(&pMsg);
-            ABORT_FINALIZE(RS_RET_ERR);
+        MsgSetMSGoffs(msgs[inst_idx], 0); /* we do not have a header... */
+        MsgSetHOSTNAME(msgs[inst_idx], glbl.GetLocalHostName(), ustrlen(glbl.GetLocalHostName()));
+        MsgSetTAG(msgs[inst_idx], inst->pszTag, inst->lenTag);
+        msgSetPRI(msgs[inst_idx], inst->iFacility | inst->iSeverity);
+        MsgSetRuleset(msgs[inst_idx], inst->pBindRuleset);
+        if (inst->addMetadata) {
+            if (act->source_name) {
+                metadata_values[0] = (const uchar *)act->source_name;
+            } else {
+                metadata_values[0] = (const uchar *)act->name;
+            }
+            lenBuf = snprintf((char *)file_offset, sizeof(file_offset), "%lld", strtOffs);
+            if (lenBuf < 0) {
+                ABORT_FINALIZE(RS_RET_ERR);
+            }
+            file_offset[MAX_OFFSET_REPRESENTATION_NUM_BYTES] = '\0';
+            metadata_values[1] = file_offset;
+            lenBuf = snprintf((char *)line_number, sizeof(line_number), "%llu", (unsigned long long)lineNum);
+            if (lenBuf < 0) {
+                ABORT_FINALIZE(RS_RET_ERR);
+            }
+            line_number[MAX_LINENUM_REPRESENTATION_NUM_BYTES] = '\0';
+            metadata_values[2] = line_number;
+            msgAddMultiMetadata(msgs[inst_idx], metadata_names, metadata_values, 3);
         }
-        file_offset[MAX_OFFSET_REPRESENTATION_NUM_BYTES] = '\0';
-        metadata_values[1] = file_offset;
-        lenBuf = snprintf((char *)line_number, sizeof(line_number), "%llu", (unsigned long long)lineNum);
-        if (lenBuf < 0) {
-            msgDestruct(&pMsg);
-            ABORT_FINALIZE(RS_RET_ERR);
-        }
-        line_number[MAX_LINENUM_REPRESENTATION_NUM_BYTES] = '\0';
-        metadata_values[2] = line_number;
-        msgAddMultiMetadata(pMsg, metadata_names, metadata_values, 3);
+
+        msgs[inst_idx]->msgFlags = msgs[inst_idx]->msgFlags | inst->msgFlag;
     }
 
-    if (inst->perMinuteRateLimits.maxBytesPerMinute || inst->perMinuteRateLimits.maxLinesPerMinute) {
-        CHKiRet(checkPerMinuteRateLimits((per_minute_rate_limit_t *)&inst->perMinuteRateLimits, msgLen));
+    for (int inst_idx = 0; inst_idx < act->edge->ninst; ++inst_idx) {
+        const instanceConf_t *const inst = act->edge->instarr[inst_idx];
+
+        if (inst->perMinuteRateLimits.maxBytesPerMinute || inst->perMinuteRateLimits.maxLinesPerMinute) {
+            const rsRetVal localRet =
+                checkPerMinuteRateLimits((per_minute_rate_limit_t *)&inst->perMinuteRateLimits, msgLen);
+            if (localRet == RS_RET_RATE_LIMITED && act->edge->ninst > 1) {
+                msgDestruct(&msgs[inst_idx]);
+                continue;
+            } else if (localRet != RS_RET_OK) {
+                if (inst->delay_perMsg) {
+                    srSleep(inst->delay_perMsg % 1000000, inst->delay_perMsg / 1000000);
+                }
+                ABORT_FINALIZE(localRet);
+            }
+        }
+
+        if (inst->delay_perMsg) {
+            srSleep(inst->delay_perMsg % 1000000, inst->delay_perMsg / 1000000);
+        }
     }
 
-    if (inst->delay_perMsg) {
-        srSleep(inst->delay_perMsg % 1000000, inst->delay_perMsg / 1000000);
+    for (int inst_idx = 0; inst_idx < act->edge->ninst; ++inst_idx) {
+        if (msgs[inst_idx] != NULL) {
+            ratelimitAddMsg(act->ratelimiter, &act->multiSub, msgs[inst_idx]);
+            msgs[inst_idx] = NULL;
+        }
     }
-
-    pMsg->msgFlags = pMsg->msgFlags | inst->msgFlag;
-
-    ratelimitAddMsg(act->ratelimiter, &act->multiSub, pMsg);
 finalize_it:
+    if (msgs != NULL) {
+        for (int inst_idx = 0; inst_idx < act->edge->ninst; ++inst_idx) {
+            if (msgs[inst_idx] != NULL) {
+                msgDestruct(&msgs[inst_idx]);
+            }
+        }
+    }
+    free(msgs);
     RETiRet;
 }
 /* try to open a file which has a state file. If the state file does not

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1837,6 +1837,7 @@ TESTS_IMFILE = \
 	imfile-wildcards-dirs-multi4.sh \
 	imfile-wildcards-dirs-multi5.sh \
 	imfile-wildcards-dirs-multi5-polling.sh \
+	imfile-same-file-monitors.sh \
 	imfile-old-state-file.sh \
 	imfile-rename-while-stopped.sh \
 	imfile-rename.sh \

--- a/tests/imfile-same-file-monitors.sh
+++ b/tests/imfile-same-file-monitors.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Verifies that multiple imfile monitors configured for the same file receive
+# each completed line independently. The oracle is the final omfile output
+# after synchronized shutdown: the two unrestricted monitors must both receive
+# a startup canary and both test lines. A third rate-limited monitor consumes
+# its quota on the canary and must then drop only its own later copies without
+# suppressing the unrestricted monitors.
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+. $srcdir/diag.sh check-inotify
+
+mkdir "$RSYSLOG_DYNNAME.work"
+generate_conf
+add_conf '
+global(workDirectory="./'$RSYSLOG_DYNNAME'.work")
+module(load="../plugins/imfile/.libs/imfile" mode="inotify")
+
+input(type="imfile" File="./'$RSYSLOG_DYNNAME'.input" Tag="first:")
+input(type="imfile" File="./'$RSYSLOG_DYNNAME'.input" Tag="second:")
+input(type="imfile" File="./'$RSYSLOG_DYNNAME'.input" Tag="limited:" maxLinesPerMinute="1")
+
+template(name="outfmt" type="list") {
+	property(name="syslogtag")
+	constant(value=" ")
+	property(name="msg")
+	constant(value="\n")
+}
+
+if $msg contains "same-file-monitor-" then {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+
+touch "$RSYSLOG_DYNNAME.input"
+startup
+
+printf 'same-file-monitor-canary\n' >> "$RSYSLOG_DYNNAME.input"
+content_check_with_count "same-file-monitor-canary" 3 60
+
+printf 'same-file-monitor-1\nsame-file-monitor-2\n' >> "$RSYSLOG_DYNNAME.input"
+
+content_check_with_count "same-file-monitor-" 7 60
+shutdown_when_empty
+wait_shutdown
+
+presort
+# EXPECTED is consumed by cmp_exact.
+# shellcheck disable=SC2034
+EXPECTED='first: same-file-monitor-1
+first: same-file-monitor-2
+first: same-file-monitor-canary
+limited: same-file-monitor-canary
+second: same-file-monitor-1
+second: same-file-monitor-2
+second: same-file-monitor-canary'
+cmp_exact "$RSYSLOG_DYNNAME.presort"
+
+exit_test


### PR DESCRIPTION
Closes https://github.com/rsyslog/rsyslog/issues/2532.

## Why
- issue #2532 asked for coverage of conflicting `imfile` monitors that watch the same file
- current `imfile` already groups same-file monitor instances on one filesystem edge, but the delivery path used only the first instance (`instarr[0]`)
- that meant a line read from a shared file could be delivered only to the first configured monitor, with the other monitors silently missing their copy

## Summary
- fan out each imfile line to all monitors configured for the same file edge
- build all per-monitor messages before submitting them, so construction errors do not partially deliver a line
- keep per-monitor rate limiting isolated so a limited monitor does not suppress unrestricted monitors
- add `imfile-same-file-monitors.sh` regression coverage

## Validation
- `bash -n tests/imfile-same-file-monitors.sh`
- `shellcheck -S warning tests/imfile-same-file-monitors.sh`
- `devtools/check-test-antipatterns.sh tests/imfile-same-file-monitors.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `./configure --enable-debug --enable-testbench --enable-imfile`
- `make -j80 check TESTS=""`
- `./tests/imfile-same-file-monitors.sh`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 make -j80 check TESTS=imfile-same-file-monitors.sh`
- `cubic review`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run`

Note: an earlier full local helper run failed once in unrelated `omfwd-suspended-no-early-commit`; immediate direct retry passed, and the final full helper rerun passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
