### PR TITLE
tests: accept generic RELP TLS error code

### DIFF
--- a/tests/sndrcv_relp_tls-cfgcmd.sh
+++ b/tests/sndrcv_relp_tls-cfgcmd.sh
@@ -2,10 +2,13 @@
 # added 2019-11-13 by alorbach
 # Verify RELP TLS configuration command handling for incompatible receiver and
 # sender protocol constraints. The receiver binds an ephemeral IPv4 listener and
-# the testbench discovers that bound port after startup, avoiding the
-# get_free_port race before the sender connects. Success is the expected librelp
-# TLS failure on the sender side, with compatibility skips for unsupported TLS
-# libraries or OpenSSL versions.
+# the testbench discovers that bound port after startup, avoiding a
+# preselected-port race before the sender connects. Success is the expected
+# librelp TLS failure on the sender side, verified by the sender debug log after
+# both instances shut down. Different librelp/OpenSSL combinations may report
+# different RELP error codes for the same failed TLS negotiation, so the oracle
+# checks the generic librelp ecode prefix. Compatibility skips handle
+# unsupported TLS libraries or OpenSSL versions.
 . ${srcdir:=.}/diag.sh init
 require_relpEngineSetTLSLibByName
 export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
@@ -69,7 +72,7 @@ if [ $ret == 0 ]; then
 	skip_test
 else
 	# Kindly check for a failed session
-	content_check "librelp: generic error: ecode 10031" $RSYSLOG_DEBUGLOG
+	content_check "librelp: generic error: ecode" $RSYSLOG_DEBUGLOG
 #	content_check "OpenSSL Error Stack:"
 fi
 


### PR DESCRIPTION
## Summary
- accept generic librelp ecode diagnostics in sndrcv_relp_tls-cfgcmd.sh
- document the sender debug-log oracle and why the exact RELP code is intentionally not pinned

closes https://github.com/rsyslog/rsyslog/issues/4130

## Validation
- bash -n tests/sndrcv_relp_tls-cfgcmd.sh tests/imrelp-tls-cfgcmd.sh
- shellcheck -S warning tests/sndrcv_relp_tls-cfgcmd.sh tests/imrelp-tls-cfgcmd.sh
- devtools/check-test-antipatterns.sh tests/sndrcv_relp_tls-cfgcmd.sh
- git diff --check
- ./autogen.sh && ./configure --enable-debug --enable-testbench && make -j80 check TESTS=""
- ./tests/imrelp-tls-cfgcmd.sh and ./tests/sndrcv_relp_tls-cfgcmd.sh: skipped on host because local librelp lacks relpEngineSetTLSLibByName
- RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run
- cubic review

Local validation note: the Ubuntu 26.04 focused container lane passed sndrcv_relp_tls-cfgcmd.sh.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

