### PR TITLE
core: fix negated exact priority filters

### DIFF
--- a/runtime/conf.c
+++ b/runtime/conf.c
@@ -405,10 +405,12 @@ rsRetVal DecodePRIFilter(uchar *pline, uchar pmask[]) {
                         else
                             pmask[i] = TABLE_NOPRI;
                     } else if (singlpri) {
-                        if (ignorepri)
+                        if (ignorepri) {
+                            if (pmask[i] == TABLE_NOPRI) pmask[i] = TABLE_ALLPRI;
                             pmask[i] &= ~(1 << pri);
-                        else
+                        } else {
                             pmask[i] |= (1 << pri);
+                        }
                     } else {
                         if (pri == TABLE_ALLPRI) {
                             if (ignorepri)
@@ -416,10 +418,12 @@ rsRetVal DecodePRIFilter(uchar *pline, uchar pmask[]) {
                             else
                                 pmask[i] = TABLE_ALLPRI;
                         } else {
-                            if (ignorepri)
+                            if (ignorepri) {
+                                if (pmask[i] == TABLE_NOPRI) pmask[i] = TABLE_ALLPRI;
                                 for (i2 = 0; i2 <= pri; ++i2) pmask[i] &= ~(1 << i2);
-                            else
+                            } else {
                                 for (i2 = 0; i2 <= pri; ++i2) pmask[i] |= (1 << i2);
+                            }
                         }
                     }
                 }
@@ -437,10 +441,12 @@ rsRetVal DecodePRIFilter(uchar *pline, uchar pmask[]) {
                     else
                         pmask[i >> 3] = TABLE_NOPRI;
                 } else if (singlpri) {
-                    if (ignorepri)
+                    if (ignorepri) {
+                        if (pmask[i >> 3] == TABLE_NOPRI) pmask[i >> 3] = TABLE_ALLPRI;
                         pmask[i >> 3] &= ~(1 << pri);
-                    else
+                    } else {
                         pmask[i >> 3] |= (1 << pri);
+                    }
                 } else {
                     if (pri == TABLE_ALLPRI) {
                         if (ignorepri)
@@ -448,10 +454,12 @@ rsRetVal DecodePRIFilter(uchar *pline, uchar pmask[]) {
                         else
                             pmask[i >> 3] = TABLE_ALLPRI;
                     } else {
-                        if (ignorepri)
+                        if (ignorepri) {
+                            if (pmask[i >> 3] == TABLE_NOPRI) pmask[i >> 3] = TABLE_ALLPRI;
                             for (i2 = 0; i2 <= pri; ++i2) pmask[i >> 3] &= ~(1 << i2);
-                        else
+                        } else {
                             for (i2 = 0; i2 <= pri; ++i2) pmask[i >> 3] |= (1 << i2);
+                        }
                     }
                 }
             }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -380,6 +380,7 @@ TESTS_DEFAULT = \
 	rscript_stop.sh \
 	rscript_stop2.sh \
 	rscript_prifilt.sh \
+	rscript_prifilt_negated_exact.sh \
 	rscript_optimizer1.sh \
 	rscript_ruleset_call.sh \
 	rscript_ruleset_call-recursion-limit.sh \

--- a/tests/rscript_prifilt_negated_exact.sh
+++ b/tests/rscript_prifilt_negated_exact.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Regression test for issue #1030. A standalone negated exact-priority PRI
+# filter such as local4.!=debug must start from all priorities for the selected
+# facility before clearing the excluded one, without resetting masks built by
+# previous selectors in the same filter line. The oracle is omfile output after
+# synchronized shutdown: local4.notice/info are written by the standalone
+# selector, while a compound selector excludes both info and debug.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="list") {
+	property(name="msg" field.delimiter="58" field.number="2")
+	constant(value="\n")
+}
+
+if prifilt("local4.!=debug") then {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+
+if prifilt("local4.!=info;local4.!=debug") then {
+	action(type="omfile" file="'$RSYSLOG_DYNNAME'.compound.out.log" template="outfmt")
+}
+'
+startup
+tcpflood -m1 -P 165 -i0
+tcpflood -m1 -P 166 -i1
+tcpflood -m1 -P 167 -i2
+shutdown_when_empty
+wait_shutdown
+content_check "00000000"
+content_check "00000001"
+check_not_present "00000002"
+export RSYSLOG_OUT_LOG="$RSYSLOG_DYNNAME.compound.out.log"
+content_check "00000000"
+check_not_present "00000001"
+check_not_present "00000002"
+exit_test


### PR DESCRIPTION
## Summary
- fix standalone negated exact-priority PRI filters such as `local4.!=debug`
- initialize the selected facility mask before clearing excluded priorities
- add a regression test that verifies the configured omfile destination receives only the non-excluded priority

Closes https://github.com/rsyslog/rsyslog/issues/1030

## Validation
- `devtools/format-code.sh --git-changed`
- `bash -n tests/rscript_prifilt_negated_exact.sh`
- `devtools/check-test-antipatterns.sh tests/rscript_prifilt_negated_exact.sh`
- `git diff --check`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `./tests/rscript_prifilt_negated_exact.sh`
- `make -j80 check TESTS="rscript_prifilt_negated_exact.sh rscript_prifilt.sh rscript_optimizer1.sh"`
- `cubic review --print-logs --base upstream/main` (no issues found)
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run`

Note: the first full local validation attempt hit an unrelated `imfile-freshStartTail2.sh` timeout. The test passed immediately when retried directly, and the full local validation helper passed on rerun.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

