### PR TITLE
parser: honor parseHostnameAndTag in RFC3164 parser

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -673,6 +673,7 @@ TESTS_IMTCP = \
 	allowed-sender-wildcard-invalid-bits.sh \
 	imtcp-discard-truncated-msg.sh \
 	imtcp-basic.sh \
+	rscript_parsehostnameandtag_off.sh \
 	imtcp_framing_regex.sh \
 	imtcp_framing_regex_maxmsg_overflow.sh \
 	imtcp-multiline.sh \

--- a/tests/rscript_parsehostnameandtag_off.sh
+++ b/tests/rscript_parsehostnameandtag_off.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Test global(parser.parseHostnameAndTag="off") for the RFC3164 parser.
+# The oracle is the configured omfile output after synchronized shutdown:
+# syslogtag must remain empty and the hostname/tag text must remain in %msg%.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+global(parser.parseHostnameAndTag="off")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="tag=[%syslogtag%] msg=[%msg%]\n")
+
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+
+startup
+tcpflood -m1 -M "\"<167>Mar 27 19:06:53 source_server sshd[123]: payload\""
+shutdown_when_empty
+wait_shutdown
+
+content_check "tag=[] msg=[source_server sshd[123]: payload]"
+exit_test

--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -60,10 +60,6 @@ DEFobjCurrIf(datetime);
 DEFobjCurrIf(ruleset);
 
 
-/* static data */
-static int bParseHOSTNAMEandTAG; /* cache for the equally-named global param - performance enhancement */
-
-
 /* parser instance parameters */
 static struct cnfparamdescr parserpdescr[] = {
     {"detect.yearaftertimestamp", eCmdHdlrBinary, 0},
@@ -99,6 +95,7 @@ struct instanceConf_s {
     FILE* fpHeaderlessErr; /**< file pointer for error file (headerless) */
     pthread_mutex_t mutErrFile;
     int bDropHeaderless;
+    int bParseHOSTNAMEandTAG;
 };
 
 
@@ -132,7 +129,7 @@ static rsRetVal createInstance(instanceConf_t** pinst) {
     inst->fpHeaderlessErr = NULL;
     pthread_mutex_init(&inst->mutErrFile, NULL);
     inst->bDropHeaderless = 0;
-    bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(loadConf);
+    inst->bParseHOSTNAMEandTAG = 1;
     *pinst = inst;
 finalize_it:
     RETiRet;
@@ -211,6 +208,8 @@ ENDfreeParserInst
 
 BEGINcheckParserInst
     CODESTARTcheckParserInst;
+
+    pInst->bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(loadConf);
 
     if (pInst->pszHeaderlessRulesetName != NULL) {
         ruleset_t* myRuleset = NULL;
@@ -381,7 +380,7 @@ BEGINparse2
      * machine that we received the message from and the tag will be empty. This
      * is meant to be an interim solution, but for now it is in the code.
      */
-    if (bParseHOSTNAMEandTAG && !(pMsg->msgFlags & INTERNAL_MSG)) {
+    if (pInst->bParseHOSTNAMEandTAG && !(pMsg->msgFlags & INTERNAL_MSG)) {
         /* parse HOSTNAME - but only if this is network-received!
          * rger, 2005-11-14: we still have a problem with BSD messages. These messages
          * do NOT include a host name. In most cases, this leads to the TAG to be treated
@@ -546,6 +545,4 @@ BEGINmodInit(pmrfc3164)
 
     DBGPRINTF("rfc3164 parser init called\n");
 
-    /* cache value, is set only during rsyslogd option processing */
-    bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(loadConf);
 ENDmodInit


### PR DESCRIPTION
## Summary
- make pmrfc3164 read `parser.parseHostnameAndTag` from the active runtime config during parsing
- remove the stale module-global cache used for that decision
- add a regression test for `global(parser.parseHostnameAndTag="off")` via imtcp and omfile output

Closes https://github.com/rsyslog/rsyslog/issues/1190

## Validation
- `bash -n tests/rscript_parsehostnameandtag_off.sh`
- `devtools/check-test-antipatterns.sh tests/rscript_parsehostnameandtag_off.sh`
- `git diff --check`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `make -j80 check TESTS=""`
- `./tests/rscript_parsehostnameandtag_off.sh`
- `make -j80 check TESTS="rscript_parsehostnameandtag_off.sh parsertest-parse1.sh"`
- `cubic review --print-logs --base upstream/main`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

