### PR TITLE
config: warn on constant boolean operands

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -5448,6 +5448,15 @@ static struct cnfexpr *cnfexprOptimize_NOT(struct cnfexpr *expr) {
 static struct cnfexpr *cnfexprOptimize_AND_OR(struct cnfexpr *expr) {
     struct cnffunc *funcl, *funcr;
 
+    if (expr->l->nodetype == 'N' || expr->l->nodetype == 'S') {
+        parser_warnmsg("boolean operator '%s' has constant left operand; did you mean to repeat the comparison?",
+                       tokenToString(expr->nodetype));
+    }
+    if (expr->r->nodetype == 'N' || expr->r->nodetype == 'S') {
+        parser_warnmsg("boolean operator '%s' has constant right operand; did you mean to repeat the comparison?",
+                       tokenToString(expr->nodetype));
+    }
+
     if (expr->l->nodetype == 'F') {
         if (expr->r->nodetype == 'F') {
             funcl = (struct cnffunc *)expr->l;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -474,6 +474,7 @@ TESTS_DEFAULT = \
 	lookup_table_rscript_reload.sh \
 	lookup_table_rscript_reload_without_stub.sh \
 	config_multiple_include.sh \
+	rscript_bool_constant_warning.sh \
 	include-obj-text-from-file.sh \
 	include-obj-text-from-file-noexist.sh \
 	multiple_lookup_tables.sh \

--- a/tests/rscript_bool_constant_warning.sh
+++ b/tests/rscript_bool_constant_warning.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Verify that a common RainerScript boolean mistake logs a config warning:
+# `$msg contains "a" or "b"` keeps historical truthiness semantics, but the
+# bare string literal is probably a missing repeated comparison. The oracle is
+# rsyslogd config-check output because the warning is emitted while optimizing
+# the parsed configuration, before normal message routing is relevant.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+if $msg contains "alpha" or "beta" then {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+}
+'
+
+export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
+rsyslogd_config_check
+unset RS_REDIR
+
+content_check "boolean operator 'OR' has constant right operand" "${RSYSLOG_DYNNAME}.rsyslog.log"
+exit_test


### PR DESCRIPTION
## Summary
- warn during config processing when RainerScript `and`/`or` receives a bare string or number constant operand
- keep the existing accepted syntax and runtime truthiness behavior unchanged
- add a config-check regression test for the reported `$msg contains "a" or "b"` pattern

Closes https://github.com/rsyslog/rsyslog/issues/1046

## Validation
- `bash -n tests/rscript_bool_constant_warning.sh`
- `devtools/check-test-antipatterns.sh tests/rscript_bool_constant_warning.sh`
- `git diff --check`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `make -j80 check TESTS=""`
- `./tests/rscript_bool_constant_warning.sh`
- `make -j80 check TESTS="rscript_bool_constant_warning.sh"`
- `cubic review --print-logs --base upstream/main`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

