### PR TITLE
doc: clarify partial config validation

### DIFF
--- a/doc/source/troubleshooting/troubleshoot.rst
+++ b/doc/source/troubleshooting/troubleshoot.rst
@@ -78,6 +78,12 @@ value   meaning
 Where 2 automatically turns on config checking mode, if not given. In that
 sense ``-N2`` and ``-N3`` are equivalent.
 
+``-N2`` and ``-N3`` are **partial configuration** checks. They are useful when
+checking one include file without the rest of the configuration, but they are
+not stricter or more complete variants of ``-N1``. Some full-configuration
+checks are intentionally relaxed in this mode, so a file can pass ``-N2`` or
+``-N3`` while the complete configuration still fails under ``-N1``.
+
 Values other than given in the table above are **not** supported and may lead
 to unpredictable results.
 


### PR DESCRIPTION
## Summary
- Clarify that `rsyslogd -N2` and `-N3` are partial configuration checks for include-file validation.
- Make explicit that they are not stricter or more complete variants of `-N1`.
- Explain why a file may pass `-N2`/`-N3` while the full configuration still fails under `-N1`.

## Validation
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 80`

closes https://github.com/rsyslog/rsyslog/issues/5147


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

