### PR TITLE
tests: make ommail SMTP helper portable

### DIFF
--- a/tests/testsuites/ommail-smtp-server.py
+++ b/tests/testsuites/ommail-smtp-server.py
@@ -37,7 +37,7 @@ def main():
         srv.listen(1)
         port = srv.getsockname()[1]
         with open(args.port_file, "w", encoding="ascii") as fh:
-            fh.write(f"{port}\n")
+            fh.write("{}\n".format(port))
 
         srv.settimeout(30)
         conn, _addr = srv.accept()
@@ -62,7 +62,7 @@ def main():
                         data_lines.append(line)
                     continue
 
-                transcript.append(f"CMD:{line}")
+                transcript.append("CMD:{}".format(line))
                 command = line.split(" ", 1)[0].upper()
                 if command == "DATA":
                     in_data = True


### PR DESCRIPTION
## Summary

- replace f-strings in the `ommail-smtp-server.py` test helper with Python 3.5-compatible `str.format()` calls
- keep the existing SMTP helper behavior, readiness port file, transcript capture, and done-file oracle unchanged

## Issues

Closes https://github.com/rsyslog/rsyslog/issues/7224
Closes https://github.com/rsyslog/rsyslog/issues/7229
Closes https://github.com/rsyslog/rsyslog/issues/7232

## Validation

- `python3 -m py_compile tests/testsuites/ommail-smtp-server.py`
- Python 3.5 grammar parse via `ast.parse(..., feature_version=(3, 5))`
- `devtools/format-python.sh --check-if-available tests/testsuites/ommail-smtp-server.py`
- `git diff --check`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run`

The local validation helper completed successfully, including the change-gated Ubuntu 26.04 container run, static analyzer path, and local Cubic review. Cubic reported no issues.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

