### PR TITLE
rainerscript: fold constant comparisons

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -5341,6 +5341,72 @@ static void constFoldConcat(struct cnfexpr *expr) {
     }
 }
 
+/* constant folding for literal string/number comparisons */
+static int constFoldCmp(struct cnfexpr *expr) {
+    long long ln, rn;
+    int convok_l, convok_r;
+    int folded = 0;
+    int result = 0;
+
+    if (expr->l->nodetype == 'S' && expr->r->nodetype == 'S') {
+        result = es_strcmp(((struct cnfstringval *)expr->l)->estr, ((struct cnfstringval *)expr->r)->estr);
+        if (expr->nodetype == CMP_EQ)
+            result = !result;
+        else
+            result = !!result;
+        folded = 1;
+    } else if (expr->l->nodetype == 'N' && expr->r->nodetype == 'N') {
+        ln = ((struct cnfnumval *)expr->l)->val;
+        rn = ((struct cnfnumval *)expr->r)->val;
+        result = (expr->nodetype == CMP_EQ) ? (ln == rn) : (ln != rn);
+        folded = 1;
+    } else if (expr->l->nodetype == 'S' && expr->r->nodetype == 'N') {
+        ln = str2num(((struct cnfstringval *)expr->l)->estr, &convok_l);
+        if (convok_l) {
+            rn = ((struct cnfnumval *)expr->r)->val;
+            result = (expr->nodetype == CMP_EQ) ? (ln == rn) : (ln != rn);
+            folded = 1;
+        } else {
+            es_str_t *numstr = es_newStrFromNumber(((struct cnfnumval *)expr->r)->val);
+            if (numstr != NULL) {
+                result = es_strcmp(((struct cnfstringval *)expr->l)->estr, numstr);
+                es_deleteStr(numstr);
+                if (expr->nodetype == CMP_EQ)
+                    result = !result;
+                else
+                    result = !!result;
+                folded = 1;
+            }
+        }
+    } else if (expr->l->nodetype == 'N' && expr->r->nodetype == 'S') {
+        rn = str2num(((struct cnfstringval *)expr->r)->estr, &convok_r);
+        if (convok_r) {
+            ln = ((struct cnfnumval *)expr->l)->val;
+            result = (expr->nodetype == CMP_EQ) ? (ln == rn) : (ln != rn);
+            folded = 1;
+        } else {
+            es_str_t *numstr = es_newStrFromNumber(((struct cnfnumval *)expr->l)->val);
+            if (numstr != NULL) {
+                result = es_strcmp(((struct cnfstringval *)expr->r)->estr, numstr);
+                es_deleteStr(numstr);
+                if (expr->nodetype == CMP_EQ)
+                    result = !result;
+                else
+                    result = !!result;
+                folded = 1;
+            }
+        }
+    }
+
+    if (folded) {
+        cnfexprDestruct(expr->l);
+        cnfexprDestruct(expr->r);
+        expr->nodetype = 'N';
+        ((struct cnfnumval *)expr)->val = result;
+    }
+    return folded;
+}
+
 
 /* optimize comparisons with syslog severity/facility. This is a special
  * handler as the numerical values also support GT, LT, etc ops.
@@ -5546,6 +5612,7 @@ struct cnfexpr *cnfexprOptimize(struct cnfexpr *expr) {
         case CMP_EQ:
             expr->l = cnfexprOptimize(expr->l);
             expr->r = cnfexprOptimize(expr->r);
+            if (constFoldCmp(expr)) break;
             if (expr->l->nodetype == 'A') {
                 if (expr->r->nodetype == 'A') {
                     parser_errmsg(
@@ -5649,6 +5716,18 @@ static void cnfstmtOptimizeIf(struct cnfstmt *stmt) {
         DBGPRINTF("optimizer: if with both empty then and else - remove\n");
         cnfexprDestruct(stmt->d.s_if.expr);
         /* set to NOP, this will be removed in later stage */
+        stmt->nodetype = S_NOP;
+        goto done;
+    }
+
+    assert(stmt->nodetype == S_IF);
+    if (stmt->d.s_if.expr->nodetype == 'N' && ((struct cnfnumval *)stmt->d.s_if.expr)->val == 0 &&
+        stmt->d.s_if.t_else == NULL) {
+        DBGPRINTF("optimizer: if with constant false expression and no else - remove\n");
+        cnfexprDestruct(stmt->d.s_if.expr);
+        cnfstmtDestructLst(stmt->d.s_if.t_then);
+        stmt->d.s_if.expr = NULL;
+        stmt->d.s_if.t_then = NULL;
         stmt->nodetype = S_NOP;
         goto done;
     }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -381,6 +381,7 @@ TESTS_DEFAULT = \
 	rscript_stop2.sh \
 	rscript_prifilt.sh \
 	rscript_optimizer1.sh \
+	rscript_optimizer_const_cmp.sh \
 	rscript_ruleset_call.sh \
 	rscript_ruleset_call-recursion-limit.sh \
 	rscript_ruleset_call_indirect-basic.sh \

--- a/tests/rscript_optimizer_const_cmp.sh
+++ b/tests/rscript_optimizer_const_cmp.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Verify that the RainerScript optimizer folds constant comparisons.
+# The oracle intentionally checks the internal debug log because this test is
+# about a config-optimizer transformation, not a message-processing diagnostic.
+# It also checks the normal output file to ensure the optimized-out branch did
+# not emit anything.
+# This file is part of the rsyslog project, released under ASL 2.0.
+echo ===============================================================================
+echo \[rscript_optimizer_const_cmp.sh\]: testing rainerscript constant comparison optimizer
+. ${srcdir:=.}/diag.sh init
+export RSYSLOG_DEBUG="debug nostdout"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+
+if "a" == "b" then
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+injectmsg 0 10
+shutdown_when_empty
+wait_shutdown
+touch "$RSYSLOG_OUT_LOG"
+check_not_present "msgnum:" "$RSYSLOG_OUT_LOG"
+content_check "optimizer: if with constant false expression and no else - remove" "$RSYSLOG_DEBUGLOG"
+exit_test


### PR DESCRIPTION
## Summary

- fold literal string/number `==` and `!=` comparisons during RainerScript config optimization
- remove `if <constant false> then ...` statements with no `else` as optimizer NOPs
- add focused coverage for the optimizer transformation and optimized-out output branch

## Validation

- `bash -n tests/rscript_optimizer_const_cmp.sh`
- `devtools/check-test-antipatterns.sh tests/rscript_optimizer_const_cmp.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `./autogen.sh --enable-debug --enable-testbench`
- `make -j80 check TESTS=`
- `./tests/rscript_optimizer_const_cmp.sh`
- `make -j80 check TESTS=rscript_optimizer_const_cmp.sh`
- `RSYSLOG_LOCAL_CHECK_JOBS=80 RSYSLOG_LOCAL_BUILD_JOBS=80 timeout 120m devtools/local-validation-plan.sh --run`

Closes https://github.com/rsyslog/rsyslog/issues/2423


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

