### PR TITLE
rainerscript: escape embedded NULs at C-string boundary

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -1510,11 +1510,28 @@ static es_str_t *var2String(struct svar *__restrict__ const r, int *__restrict__
     return estr;
 }
 
+/**
+ * Convert a script value to a newly allocated C string.
+ *
+ * This function is intentionally a C-string boundary, not a byte-string
+ * preserving conversion. Received messages are sanitized before script
+ * evaluation and config literals are parsed through C-string based lexer paths.
+ * Internally, however, some length-aware script functions may produce string
+ * values that contain embedded NUL bytes. Those bytes are escaped as "#000",
+ * matching rsyslog's established message-content convention, so callers do not
+ * silently operate on a truncated prefix. Callers that need to preserve such
+ * bytes must use var2String() and length-aware APIs instead.
+ *
+ * We deliberately do not scan for embedded NUL bytes here: this routine is on
+ * hot script evaluation paths, and the libestr conversion already performs the
+ * required escape while callers opt into C-string semantics by using this
+ * helper.
+ */
 uchar *var2CString(struct svar *__restrict__ const r, int *__restrict__ const bMustFree) {
     uchar *cstr;
     es_str_t *estr;
     estr = var2String(r, bMustFree);
-    cstr = (uchar *)es_str2cstr(estr, NULL);
+    cstr = (uchar *)es_str2cstr(estr, "#000");
     if (*bMustFree) es_deleteStr(estr);
     *bMustFree = 1;
     return cstr;
@@ -3424,7 +3441,6 @@ static void ATTR_NONNULL() doFunct_is_in_subnet(struct cnffunc *__restrict__ con
 
     ip_str = (char *)var2CString(&srcVal[0], &bMustFree1);
     cidr_str = (char *)var2CString(&srcVal[1], &bMustFree2);
-
     if (ip_str == NULL || cidr_str == NULL) {
         goto finalize_it;
     }

--- a/tests/rscript_b64_decode.sh
+++ b/tests/rscript_b64_decode.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-# test for b64_decode function in rainerscript
+# Test the b64_decode() RainerScript function, including binary output.
+# The var10 case routes a decoded NUL byte through re_match(), a C-string
+# consumer. This documents the intentional C-string truncation boundary and
+# catches debug-build assertions that incorrectly assume all script string
+# values are NUL-free after length-aware functions have produced them.
 # added 2024-06-11 by KGuillemot
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
@@ -16,6 +20,7 @@ set $!str!var6 = b64_decode("AQI=");      # \x01\x02 base64 (binary) - with padd
 set $!str!var7 = b64_decode("dGVzdA==dGVzdA==");  # Early ended payload
 set $!str!var8 = b64_decode("YWJjZAplZmdoCg==");  # \n in encoded data
 set $!str!var9 = b64_decode("YWJjZA1lZmdoCg==");  # \r in encoded data
+set $!str!var10 = re_match(b64_decode("AA=="), ".*");  # decoded NUL consumed as a C string
 template(name="outfmt" type="string" string="%!str%\n")
 local4.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 '
@@ -25,6 +30,6 @@ shutdown_when_empty
 wait_shutdown
 # var1 is empty
 # var2 is empty (invalid base64)
-export EXPECTED='{ "var1": "", "var2": "", "var3": "test", "var4": "test", "var5": "\u0001\u0002", "var6": "\u0001\u0002", "var7": "test", "var8": "abcd\nefgh\n", "var9": "abcd\refgh\n" }'
+export EXPECTED='{ "var1": "", "var2": "", "var3": "test", "var4": "test", "var5": "\u0001\u0002", "var6": "\u0001\u0002", "var7": "test", "var8": "abcd\nefgh\n", "var9": "abcd\refgh\n", "var10": 1 }'
 cmp_exact
 exit_test

--- a/tests/rscript_is_in_subnet.sh
+++ b/tests/rscript_is_in_subnet.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Test is_in_subnet() with IPv4, IPv6, invalid text, and binary strings.
+# The nul_* cases use b64_decode() to create length-counted strings with
+# embedded NUL bytes and valid textual prefixes. The oracle is rejection: the
+# function must not silently truncate at the C-string boundary and accept the
+# prefix as a complete IP or CIDR value.
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
@@ -22,6 +27,8 @@ set $!res!inv_1 = is_in_subnet("192.168.1.1", "2001:db8::/32");
 set $!res!inv_2 = is_in_subnet("invalid", "192.168.1.0/24");
 set $!res!inv_3 = is_in_subnet("192.168.1.1", "invalid");
 set $!res!inv_4 = is_in_subnet("192.168.1.1", "192.168.1.0/33"); # Invalid mask
+set $!res!nul_ip = is_in_subnet(b64_decode("MTkyLjE2OC4xLjUAZXZpbA=="), "192.168.1.0/24");
+set $!res!nul_cidr = is_in_subnet("192.168.1.5", b64_decode("MTkyLjE2OC4xLjAvMjQAZXZpbA=="));
 
 template(name="outfmt" type="string" string="%!res%\n")
 local4.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
@@ -31,6 +38,6 @@ tcpflood -m1 -y
 shutdown_when_empty
 wait_shutdown
 
-export EXPECTED='{ "v4_1": 1, "v4_2": 0, "v4_3": 1, "v4_4": 1, "v6_1": 1, "v6_2": 0, "v6_3": 1, "v6_4": 1, "inv_1": 0, "inv_2": 0, "inv_3": 0, "inv_4": 0 }'
+export EXPECTED='{ "v4_1": 1, "v4_2": 0, "v4_3": 1, "v4_4": 1, "v6_1": 1, "v6_2": 0, "v6_3": 1, "v6_4": 1, "inv_1": 0, "inv_2": 0, "inv_3": 0, "inv_4": 0, "nul_ip": 0, "nul_cidr": 0 }'
 cmp_exact
 exit_test


### PR DESCRIPTION
## Summary

Follow-up to Aardvark PR #7026.

Aardvark's subnet-specific NUL-byte hardening pass identified a real reachable case, but the source path needed correction. Raw message input and config literals are not expected to inject unescaped NUL bytes into ordinary script strings, but length-aware script functions can produce string values containing embedded NUL bytes internally.

Concrete case: `b64_decode("MTkyLjE2OC4xLjUAZXZpbA==")` produces `192.168.1.5\0evil`. Before this change, conversion through `var2CString()` dropped the embedded NUL, so downstream C-string parsers only saw the valid prefix `192.168.1.5`; `is_in_subnet()` could therefore match it against `192.168.1.0/24`.

This PR fixes the issue at the common RainerScript C-string boundary. `var2CString()` now calls `es_str2cstr(..., "#000")`, using rsyslog's established NUL escape instead of dropping embedded NUL bytes. That prevents callers from silently operating on a truncated prefix while preserving the intended C-string API. Callers that need byte-preserving semantics must still use `var2String()` and length-aware APIs.

With that common behavior in place, `is_in_subnet()` remains simple and uses `var2CString()` normally. Embedded-NUL inputs become visible as `#000` in the textual IP/CIDR value and are rejected by the existing IP/CIDR parsing checks.

## Tests

- `./devtools/format-code.sh --git-changed --check --check-if-available`
- `CC=gcc ./autogen.sh --enable-debug --enable-testbench --enable-imdiag`
- `make -j${RSYSLOG_LOCAL_BUILD_JOBS:-10} check TESTS=""`
- `./tests/rscript_is_in_subnet.sh`
- `./tests/rscript_b64_decode.sh`
- `make -j${RSYSLOG_LOCAL_CHECK_JOBS:-10} check` initially hit the known-slow `incltest_dir.sh` broad-filesystem scan timeout on this WSL host; isolated `./tests/incltest_dir.sh` passed.
- `TEST_MAX_RUNTIME=1800 make -j${RSYSLOG_LOCAL_CHECK_JOBS:-10} check` passed: 624 total, 615 passed, 9 skipped, 0 failed.
- `./devtools/local-validation-plan.sh --run`
