### PR TITLE
[codex] doc: explain service sandboxing for helpers

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1264,8 +1264,8 @@ EXTRA_DIST = \
     source/troubleshooting/file_not_written.rst \
     source/troubleshooting/howtodebug.rst \
     source/troubleshooting/index.rst \
-    source/troubleshooting/service_sandboxing.rst \
     source/troubleshooting/selinux.rst \
+    source/troubleshooting/service_sandboxing.rst \
     source/troubleshooting/troubleshoot.rst \
     source/tutorials/cert-script.tar.gz \
     source/tutorials/config_format_translation.rst \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1264,6 +1264,7 @@ EXTRA_DIST = \
     source/troubleshooting/file_not_written.rst \
     source/troubleshooting/howtodebug.rst \
     source/troubleshooting/index.rst \
+    source/troubleshooting/service_sandboxing.rst \
     source/troubleshooting/selinux.rst \
     source/troubleshooting/troubleshoot.rst \
     source/tutorials/cert-script.tar.gz \

--- a/doc/source/configuration/modules/omprog.rst
+++ b/doc/source/configuration/modules/omprog.rst
@@ -26,13 +26,14 @@ terminate. The message format passed to the program can, as usual, be
 modified by defining rsyslog templates.
 
 Note that in order to execute the given program, rsyslog needs to have
-sufficient permissions on the binary file. This is especially true if
-not running as root. Also, keep in mind that default SELinux policies
-most probably do not permit rsyslogd to execute arbitrary binaries. As
-such, permissions must be appropriately added. Note that SELinux
-restrictions also apply if rsyslogd runs under root. To check if a
-problem is SELinux-related, you can temporarily disable SELinux and
-retry. If it then works, you know for sure you have a SELinux issue.
+sufficient permissions on the binary file and on every resource the
+program uses. This is especially true if rsyslog is not running as root,
+but root is not always unrestricted either. When rsyslog is started as a
+system service, ``omprog`` children inherit the service's execution
+context. The systemd sandbox, Linux capabilities, AppArmor, SELinux, and
+private mount namespaces can restrict the child even when ``rsyslogd``
+runs as root. See :doc:`service sandboxing and external programs
+<../../troubleshooting/service_sandboxing>` for troubleshooting steps.
 
 Starting with 8.4.0, rsyslogd emits an error message via the ``syslog()``
 API call when there is a problem executing the binary. This can be

--- a/doc/source/configuration/modules/omprog.rst
+++ b/doc/source/configuration/modules/omprog.rst
@@ -32,8 +32,7 @@ but root is not always unrestricted either. When rsyslog is started as a
 system service, ``omprog`` children inherit the service's execution
 context. The systemd sandbox, Linux capabilities, AppArmor, SELinux, and
 private mount namespaces can restrict the child even when ``rsyslogd``
-runs as root. See :doc:`service sandboxing and external programs
-<../../troubleshooting/service_sandboxing>` for troubleshooting steps.
+runs as root. See :ref:`troubleshooting_service_sandboxing` for troubleshooting steps.
 
 Starting with 8.4.0, rsyslogd emits an error message via the ``syslog()``
 API call when there is a problem executing the binary. This can be

--- a/doc/source/faq/faq_overall.rst
+++ b/doc/source/faq/faq_overall.rst
@@ -33,6 +33,5 @@ child process may read, write, execute, or change into.
 This is also why ``sudo`` may fail inside an ``omprog`` helper even though
 ``rsyslogd`` is running as root and the command works from a root shell. Inspect
 the active ``rsyslog.service`` unit and security logs before changing the
-rsyslog configuration. See
-:doc:`service sandboxing and external programs <../troubleshooting/service_sandboxing>`
+rsyslog configuration. See :ref:`troubleshooting_service_sandboxing`
 for the diagnostic workflow.

--- a/doc/source/faq/faq_overall.rst
+++ b/doc/source/faq/faq_overall.rst
@@ -14,3 +14,25 @@ FAQ: Message Duplication with rsyslog
 One common scenario involves the `omfwd` module with TCP. If the connection breaks, `omfwd` cannot precisely determine which messages were successfully stored by the remote peer, leading to potential resending of more messages than necessary. To mitigate this, consider using the `omrelp` module, which provides reliable event logging protocol (RELP) and ensures exact message delivery without duplication.
 
 While the `omfwd` case is common, other configurations might also cause duplication. Always ensure that your queue and retry settings are properly configured to minimize this issue.
+
+
+.. _faq_root_command_fails_under_rsyslog:
+
+FAQ: A command works as root but fails when rsyslog starts it
+--------------------------------------------------------------
+
+**Q: Why does a script or command work from an interactive root shell but fail
+when rsyslog starts it, for example through** ``omprog`` **?**
+
+**A:** rsyslog usually runs inside a service context created by the init system
+and the distribution's security policy. Programs started by rsyslog inherit that
+context. The systemd sandbox, AppArmor, SELinux, Linux capabilities, private
+``/tmp`` directories, and home-directory protection can all change what the
+child process may read, write, execute, or change into.
+
+This is also why ``sudo`` may fail inside an ``omprog`` helper even though
+``rsyslogd`` is running as root and the command works from a root shell. Inspect
+the active ``rsyslog.service`` unit and security logs before changing the
+rsyslog configuration. See
+:doc:`service sandboxing and external programs <../troubleshooting/service_sandboxing>`
+for the diagnostic workflow.

--- a/doc/source/troubleshooting/index.rst
+++ b/doc/source/troubleshooting/index.rst
@@ -7,6 +7,7 @@ Typical Problems
    :maxdepth: 1
 
    file_not_written
+   service_sandboxing
    selinux
 
 General Procedure

--- a/doc/source/troubleshooting/index.rst
+++ b/doc/source/troubleshooting/index.rst
@@ -7,8 +7,8 @@ Typical Problems
    :maxdepth: 1
 
    file_not_written
-   service_sandboxing
    selinux
+   service_sandboxing
 
 General Procedure
 -----------------

--- a/doc/source/troubleshooting/selinux.rst
+++ b/doc/source/troubleshooting/selinux.rst
@@ -5,6 +5,11 @@ SELinux by its very nature can block many features of rsyslog (or any
 other process, of course), even when run under root. Actually, this is
 what it is supposed to do, so there is nothing bad about it.
 
+SELinux is one possible source of service confinement. The systemd sandbox,
+AppArmor, Linux capabilities, and private mount namespaces can cause similar
+symptoms. See :doc:`service sandboxing and external programs
+<service_sandboxing>` for the broader troubleshooting workflow.
+
 If you suspect that some issues stems back to SELinux configuration,
 do the following:
 

--- a/doc/source/troubleshooting/selinux.rst
+++ b/doc/source/troubleshooting/selinux.rst
@@ -7,8 +7,8 @@ what it is supposed to do, so there is nothing bad about it.
 
 SELinux is one possible source of service confinement. The systemd sandbox,
 AppArmor, Linux capabilities, and private mount namespaces can cause similar
-symptoms. See :doc:`service sandboxing and external programs
-<service_sandboxing>` for the broader troubleshooting workflow.
+symptoms. See :ref:`troubleshooting_service_sandboxing` for the broader
+troubleshooting workflow.
 
 If you suspect that some issues stems back to SELinux configuration,
 do the following:

--- a/doc/source/troubleshooting/service_sandboxing.rst
+++ b/doc/source/troubleshooting/service_sandboxing.rst
@@ -1,0 +1,104 @@
+.. meta::
+   :description: Troubleshoot rsyslog service sandboxing, AppArmor, SELinux, and permission issues affecting external programs and file access.
+   :keywords: rsyslog, troubleshooting, systemd, sandbox, AppArmor, SELinux, omprog, sudo, permissions
+
+.. _troubleshooting_service_sandboxing:
+
+Service sandboxing and external programs
+========================================
+
+.. summary-start
+
+rsyslog runs inside the execution context provided by the init system and
+distribution security policy. External programs started by modules such as
+``omprog`` inherit that context, so root inside ``rsyslog.service`` may still be
+restricted by systemd sandboxing, AppArmor, SELinux, Linux capabilities, or
+private mount namespaces.
+
+.. summary-end
+
+Why root may still be restricted
+--------------------------------
+
+Many distributions harden ``rsyslog.service`` with systemd options such as
+``NoNewPrivileges=``, ``ProtectHome=``, ``ProtectSystem=``, ``PrivateTmp=``,
+``PrivateDevices=``, ``SystemCallFilter=``, and ``CapabilityBoundingSet=``.
+These settings apply to rsyslog and to helper programs that rsyslog starts.
+
+This means that a command can work from an interactive root shell but fail when
+started by rsyslog. Common symptoms include:
+
+* an ``omprog`` helper cannot execute or cannot read files it needs;
+* ``sudo`` fails even though the sudoers rule looks correct;
+* a path under ``/home`` is not visible to the helper;
+* output written to ``/tmp`` does not appear in the host ``/tmp`` because the
+  service uses a private temporary directory;
+* file writes outside common log paths fail despite root ownership.
+
+The exact defaults are distribution-specific. Check the active unit on the
+affected host instead of assuming that it matches another system.
+
+Check the service context
+-------------------------
+
+Use systemd to inspect the active unit and its hardening settings:
+
+.. code-block:: bash
+
+   systemctl cat rsyslog.service
+   systemd-analyze security rsyslog.service
+
+Then inspect rsyslog and kernel security logs for the actual denial:
+
+.. code-block:: bash
+
+   journalctl -u rsyslog.service
+   journalctl -k
+
+On SELinux systems, also review audit denials. See
+:doc:`SELinux troubleshooting <selinux>` for the SELinux-specific workflow.
+On AppArmor systems, check the AppArmor status and kernel or journal messages
+for denied accesses.
+
+Using sudo from omprog
+----------------------
+
+Running ``sudo`` from an ``omprog`` helper can be convenient, but sudo is often
+affected by service hardening. A passwordless sudoers rule for a specific
+command is not enough if the systemd sandbox prevents privilege changes or
+blocks access to files that sudo needs.
+
+If you choose this approach, use both of these controls:
+
+* a narrow sudoers rule for the exact command and arguments; avoid broad
+  ``NOPASSWD: ALL`` rules;
+* a systemd drop-in that relaxes only the sandbox setting required by that
+  command.
+
+Create a drop-in with:
+
+.. code-block:: bash
+
+   sudo systemctl edit rsyslog.service
+
+Depending on the failure, ``NoNewPrivileges=no`` may be required for sudo. If
+the helper or its inputs are below a home directory, ``ProtectHome=`` may also
+be relevant. After changing the service unit, reload and restart:
+
+.. code-block:: bash
+
+   sudo systemctl daemon-reload
+   sudo systemctl restart rsyslog
+
+Prefer avoiding privilege changes
+---------------------------------
+
+The cleaner design is to avoid privilege transitions from inside rsyslog
+helpers. Place helper programs in a location intended for rsyslog-owned helper
+code, such as ``/usr/libexec/rsyslog``, and set file ownership and permissions
+so the helper can access only what it needs.
+
+For more isolated setups, run a small dedicated service as the target user and
+let rsyslog communicate with it through a file, pipe, socket, or another
+explicit interface. This usually takes more setup work, but it avoids weakening
+the rsyslog service sandbox.


### PR DESCRIPTION
## Summary

This PR documents how service confinement affects rsyslog helpers and other child processes.

It adds a troubleshooting page for systemd sandboxing, AppArmor, SELinux, Linux capabilities, private `/tmp`, and narrow `sudo` tradeoffs. The `omprog` module page, FAQ, and SELinux troubleshooting page now link users to that broader workflow.

## Why

GitHub Discussion #7235 showed a confusing case where an `omprog` helper using `sudo` failed under Debian's `rsyslog.service` sandbox even though the command worked from an interactive root shell:

https://github.com/rsyslog/rsyslog/discussions/7235

The key usability issue is that "rsyslog runs as root" does not mean helper programs inherit an unrestricted root environment.

## Validation

- `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"`
- `PATH="$PWD/doc/.venv-docs/bin:$PATH" make -C doc SPHINXBUILD="$PWD/doc/.venv-docs/bin/sphinx-build" json-formatter`
- `PATH="$PWD/doc/.venv-docs/bin:$PATH" bash .agent/skills/rsyslog_doc_dist/scripts/check-doc-dist.sh`
- `git diff --check`

The RAG formatter emitted an existing `docutils` deprecation warning from `build_rag_db.py`, but completed successfully.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

