### PR TITLE
Potential fixes for 2 code quality findings

### DIFF
--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -85,7 +85,7 @@ struct instanceConf_s {
     int bPermitAtSignsInHostname;
     int bForceTagEndingByColon;
     int bRemoveMsgFirstSpace;
-    int bHdrLessMode; /** < is headerless mode activated? 0 - no, other - yes */
+    int bHdrLessMode; /**< is headerless mode activated? 0 - no, other - yes */
     uchar* pszHeaderlessHostname; /** < HOSTNAME to use for headerless messages */
     uchar* pszHeaderlessTag; /** < TAG to use for headerless messages */
     uchar* pszHeaderlessRulesetName; /** < name of Ruleset to use for headerless messages */

--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -287,7 +287,7 @@ finalize_it:
     RETiRet;
 }
 
-/* parse a legay-formatted syslog message.
+/* parse a legacy-formatted syslog message.
  * We apply heuristics during header detection. These are not 100% failure
  * prove, but the best compromise we came up within 20+ years of adapting
  * the heuristics.


### PR DESCRIPTION
_This PR applies 2/2 suggestions from code quality [AI findings](https://github.com/rsyslog/rsyslog/security/quality/ai-findings)._

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

