### PR TITLE
tests: sync mysql action queue checks with DB rows

### DIFF
--- a/tests/mysql-actq-mt-withpause.sh
+++ b/tests/mysql-actq-mt-withpause.sh
@@ -2,12 +2,40 @@
 # Verify that ommysql keeps multi-worker action queue delivery lossless across
 # worker idle timeout cycles.  The test injects three batches separated by
 # queue-empty waits and short sleeps so action workers can time out and be
-# restarted.  The 80s enqueue timeout is a CI tolerance budget: if a stressed
+# restarted.  Each batch wait is synchronized on the corresponding MySQL row
+# count and sequence range, not just the main queue, because a slow CI database
+# can still be draining the action queue after imdiag reports the main queue
+# empty.
+# The 80s enqueue timeout is a CI tolerance budget: if a stressed
 # MySQL service cannot drain the action queue in that time, the failure should
 # be reevaluated instead of masking a persistent service or test issue.
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=150000
+mysql_actq_count_ready() {
+	if [ "${MYSQL_ACTQ_LAST_MSG:-}" = "" ]; then
+		printf 'FAIL: MYSQL_ACTQ_LAST_MSG is unset before MySQL sequence check\n'
+		error_exit 1
+	fi
+	expected_count=$((MYSQL_ACTQ_LAST_MSG + 1))
+	count=$(mysql -N -s --user=rsyslog --password=testbench \
+		--database "$RSYSLOG_DYNNAME" \
+		-e "select count(*) from SystemEvents;" \
+		2> "$RSYSLOG_DYNNAME.mysqlerr")
+	ret=$?
+	grep -iv "Using a password on the command line interface can be insecure." \
+		< "$RSYSLOG_DYNNAME.mysqlerr"
+	if [ "$ret" -ne 0 ]; then
+		error_exit "$ret"
+	fi
+	[ "$count" -ge "$expected_count" ]
+}
+mysql_actq_data_ready() {
+	mysql_actq_count_ready || return 1
+	mysql_get_data
+	seq_check --check-only 0 "$MYSQL_ACTQ_LAST_MSG"
+}
+export QUEUE_EMPTY_CHECK_FUNC=mysql_actq_data_ready
 generate_conf
 add_conf '
 module(load="../plugins/ommysql/.libs/ommysql")
@@ -26,14 +54,17 @@ module(load="../plugins/ommysql/.libs/ommysql")
 mysql_prep_for_test
 startup
 injectmsg 0 50000
+MYSQL_ACTQ_LAST_MSG=49999
 wait_queueempty 
 echo waiting for worker threads to timeout
 ./msleep 3000
 injectmsg 50000 50000
+MYSQL_ACTQ_LAST_MSG=99999
 wait_queueempty 
 echo waiting for worker threads to timeout
 ./msleep 2000
 injectmsg 100000 50000
+MYSQL_ACTQ_LAST_MSG=149999
 shutdown_when_empty
 wait_shutdown 
 mysql_get_data

--- a/tests/mysql-actq-mt.sh
+++ b/tests/mysql-actq-mt.sh
@@ -2,12 +2,34 @@
 # Verify that ommysql preserves all messages when a bounded linked-list action
 # queue is drained by multiple worker threads.  The queue size is intentionally
 # small compared to the injected message count so the test covers backpressure.
+# Shutdown is synchronized on the final MySQL row count and sequence, not just
+# the main queue, because a slow CI database can still be draining the action
+# queue after imdiag reports the main queue empty.
 # The 80s enqueue timeout is a CI tolerance budget: if a stressed MySQL service
 # cannot drain the action queue in that time, the failure should be investigated
 # instead of silently turning the test into an unbounded wait.
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=150000
+mysql_actq_count_ready() {
+	count=$(mysql -N -s --user=rsyslog --password=testbench \
+		--database "$RSYSLOG_DYNNAME" \
+		-e "select count(*) from SystemEvents;" \
+		2> "$RSYSLOG_DYNNAME.mysqlerr")
+	ret=$?
+	grep -iv "Using a password on the command line interface can be insecure." \
+		< "$RSYSLOG_DYNNAME.mysqlerr"
+	if [ "$ret" -ne 0 ]; then
+		error_exit "$ret"
+	fi
+	[ "$count" -ge "$NUMMESSAGES" ]
+}
+mysql_actq_data_ready() {
+	mysql_actq_count_ready || return 1
+	mysql_get_data
+	seq_check --check-only
+}
+export QUEUE_EMPTY_CHECK_FUNC=mysql_actq_data_ready
 generate_conf
 add_conf '
 module(load="../plugins/ommysql/.libs/ommysql")


### PR DESCRIPTION
## Summary
- synchronize `mysql-actq-mt.sh` shutdown on the final MySQL sequence, not only imdiag main-queue emptiness
- synchronize each `mysql-actq-mt-withpause.sh` batch on the corresponding MySQL sequence before letting workers idle/restart
- keep the existing `seq_check` oracle and bounded enqueue timeout intact, so real delivery regressions still fail

## Rationale
Post-mitigation flake evidence still showed `mysql-actq-mt*` failures under CI. These tests use an external MySQL sink, but `shutdown_when_empty` only waits for the main rsyslog queue. On a slow database, the main queue can be empty while the ommysql action queue is still draining, so the test can shut down and snapshot MySQL before all rows are visible.

This follows the existing testbench pattern used by other MySQL action tests: set `QUEUE_EMPTY_CHECK_FUNC` to a sink-specific readiness predicate that refreshes MySQL data and runs `seq_check --check-only`.

## Validation
- `bash -n tests/mysql-actq-mt.sh tests/mysql-actq-mt-withpause.sh`
- `devtools/check-test-antipatterns.sh tests/mysql-actq-mt.sh tests/mysql-actq-mt-withpause.sh`
- `shellcheck -x -e SC2086 tests/mysql-actq-mt.sh tests/mysql-actq-mt-withpause.sh`
- focused Ubuntu 26.04 devcontainer: `CI_MAKE_CHECK_TESTS="mysql-actq-mt.sh mysql-actq-mt-withpause.sh" devtools/devcontainer.sh --rm devtools/run-ci.sh`
- `devtools/local-validation-plan.sh --run`
- `cubic review --base 226d87e79ce056bf582dbf95170c510762645117 --prompt ...` -> no issues found

Note: plain Shellcheck reports legacy SC2086 warnings for the existing `${srcdir:=.}` sourcing idiom and RainerScript interpolation inside `add_conf`; those are intentionally left unchanged here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

