### PR TITLE
testbench: harden da-mainmsg-q drain wait

### DIFF
--- a/tests/da-mainmsg-q.sh
+++ b/tests/da-mainmsg-q.sh
@@ -3,14 +3,47 @@
 # in-memory main queue so the 2000-message burst must spill to disk and then
 # drain back into the configured omfile action. imdiag injection is marked fully
 # delayable so the diagnostic injector does not overrun the intentionally tiny
-# queue; the behavior under test is DA queue persistence and recovery, not
-# non-delayable input loss. The oracle is the complete output sequence 0..2099:
-# first the pre-DA messages, then the DA-triggering burst, then a final small
-# post-DA burst that proves normal processing resumed.
+# queue. The disk-assisted path can drain slowly under sanitizer/Valgrind CI, so
+# the test allows up to four minutes per drain point and waits for the complete
+# expected sequence instead of only a line count. The oracle is the complete
+# output sequence 0..2099: first the pre-DA messages, then the DA-triggering
+# burst, then a final small post-DA burst that proves normal processing resumed.
 # added 2009-04-22 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 export RSTB_IMDIAG_INJECT_DELAY_MODE=full
+DA_MAINMSG_Q_TIMEOUT=${DA_MAINMSG_Q_TIMEOUT:-240}
+
+wait_da_mainmsg_q_seq() {
+	local endnum="$1"
+	local timeout="${2:-$DA_MAINMSG_Q_TIMEOUT}"
+	local timeoutend=$(( SECONDS + timeout ))
+	local count=0
+
+	while true ; do
+		if seq_check --check-only 0 "$endnum" >/dev/null 2>&1 ; then
+			printf 'wait_da_mainmsg_q_seq success, sequence 0..%s complete\n' "$endnum"
+			return
+		fi
+		if [ -f "$RSYSLOG_OUT_LOG" ]; then
+			count=$(wc -l < "$RSYSLOG_OUT_LOG")
+		fi
+		if [ "$SECONDS" -ge "$timeoutend" ]; then
+			printf 'FAIL: wait_da_mainmsg_q_seq timed out waiting for sequence 0..%s, have %s lines\n' \
+				"$endnum" "$count"
+			seq_check 0 "$endnum"
+			error_exit 1
+		fi
+		printf 'wait_da_mainmsg_q_seq waiting for sequence 0..%s, have %s lines\n' \
+			"$endnum" "$count"
+		"$TESTTOOL_DIR"/msleep 500
+	done
+}
+
+da_mainmsg_q_complete() {
+	seq_check --check-only 0 2099 >/dev/null 2>&1
+}
+export QUEUE_EMPTY_CHECK_FUNC=da_mainmsg_q_complete
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
@@ -35,16 +68,16 @@ startup
 
 # part1: send first 50 messages (in memory, only)
 injectmsg 0 50
-wait_file_lines $RSYSLOG_OUT_LOG 50 # let queue drain for this test case
+wait_da_mainmsg_q_seq 49 # let queue drain for this test case
 
 # part 2: send bunch of messages. This should trigger DA mode
 injectmsg 50 2000
 ls -l ${RSYSLOG_DYNNAME}.spool	 # for manual review
-wait_file_lines $RSYSLOG_OUT_LOG 2050 # wait to ensure DA queue is "empty"
+wait_da_mainmsg_q_seq 2049 # wait to ensure DA queue is "empty"
 
 # send another handful
 injectmsg 2050 50
-wait_file_lines $RSYSLOG_OUT_LOG 2100
+wait_da_mainmsg_q_seq 2099
 
 shutdown_when_empty
 wait_shutdown


### PR DESCRIPTION
## Summary
- harden `da-mainmsg-q.sh` to wait for the expected message sequence instead of only output line counts
- allow the disk-assisted drain path up to four minutes per checkpoint under sanitizer/Valgrind CI
- use the same final sequence predicate while shutting down after the main queue reports empty

## Why
Recent flake evidence shows `da-mainmsg-q.sh` timing out while the disk-assisted main queue is still draining under slower CI lanes. The test's real oracle is the complete `0..2099` message sequence, so the synchronization should wait for that oracle directly and give the DA queue enough time under instrumentation.

## Validation
- `bash -n tests/da-mainmsg-q.sh`
- `devtools/check-test-antipatterns.sh tests/da-mainmsg-q.sh` *(advisory timeout class noted; header documents the oracle and sanitizer/Valgrind rationale)*
- `shellcheck -x -e SC2016,SC2086 tests/da-mainmsg-q.sh`
- `git diff --check`
- default devcontainer focused run: `CI_MAKE_CHECK_TESTS=da-mainmsg-q.sh ./devtools/devcontainer.sh --rm ./devtools/run-ci.sh`
- Ubuntu 26.04 TSAN focused run with workflow TSAN settings: `PASS: da-mainmsg-q.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j10`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

