### PR TITLE
doc: clarify RainerScript semicolon use

### DIFF
--- a/doc/source/configuration/basic_structure.rst
+++ b/doc/source/configuration/basic_structure.rst
@@ -1,11 +1,20 @@
 Basic Structure
 ===============
 
+.. meta::
+   :description: Introduction to rsyslog configuration structure, formats,
+      rulesets, actions, and common RainerScript syntax.
+   :keywords: rsyslog, configuration, RainerScript, ruleset, action, input, semicolon
+
+.. summary-start
+
 This page introduces the core concepts and structure of rsyslog configuration.
 Rsyslog is best thought of as a **highly extensible logging and event
 processing framework**. While the general message flow is fixed, almost every
 aspect of its processing pipeline can be customized by configuring rsyslog
 objects.
+
+.. summary-end
 
 Message Flow Overview
 ---------------------
@@ -143,6 +152,14 @@ Example RainerScript rule:
    if $syslogfacility-text == 'mail' and $syslogseverity-text == 'err' then {
        action(type="omfile" file="/var/log/mail-errors.log")
    }
+
+Configuration objects such as ``action()``, ``module()``, and ``input()`` end
+at the closing parenthesis. Do not add a semicolon after them:
+
+.. code-block:: rsyslog
+
+   action(type="omfile" file="/var/log/messages")    # correct
+   action(type="omfile" file="/var/log/messages");   # invalid
 
 Comments
 --------

--- a/doc/source/faq/common-config-mistakes.rst
+++ b/doc/source/faq/common-config-mistakes.rst
@@ -1,12 +1,20 @@
 Common Configuration Mistakes and Misunderstandings
 ====================================================
 
+.. meta::
+   :description: Common rsyslog configuration mistakes when moving from legacy syntax to modern RainerScript.
+   :keywords: rsyslog, configuration mistakes, RainerScript, legacy syntax, action, stop, semicolon
+
+.. summary-start
+
 This section documents syntax patterns that are often misunderstood,
 invalid, or misused in rsyslog configurations — especially when transitioning
 from legacy syntax to modern RainerScript.
 
 It is intended to help both human users and automated tools avoid common traps
 when writing or validating rsyslog configuration files.
+
+.. summary-end
 
 .. list-table::
    :header-rows: 1
@@ -50,6 +58,16 @@ when writing or validating rsyslog configuration files.
      - There is no such module. ``stop`` is a statement, not an action.
      - Use bare ``stop`` as a control flow statement
 
+   * - ``action(type="omfile" file="/var/log/example.log");``
+     - Looks like C-style statement termination
+     - Modern RainerScript objects are not terminated by semicolons. The
+       trailing ``;`` is parsed as an invalid character.
+     - Remove the semicolon:
+
+       .. code-block:: rainerscript
+
+          action(type="omfile" file="/var/log/example.log")
+
    * - ``if (...) then stop();``
      - Combines multiple errors: function call and syntax mismatch
      - Parentheses are invalid, and ``stop`` is not a function
@@ -63,4 +81,3 @@ when writing or validating rsyslog configuration files.
    .. code-block:: bash
 
       rsyslogd -N1
-

--- a/doc/source/rainerscript/configuration_objects.rst
+++ b/doc/source/rainerscript/configuration_objects.rst
@@ -1,6 +1,18 @@
 configuration objects
 =====================
 
+.. meta::
+   :description: RainerScript configuration objects and common object syntax rules.
+   :keywords: rsyslog, RainerScript, configuration objects, action, module, input, semicolon
+
+.. summary-start
+
+RainerScript configuration objects define inputs, actions, modules, templates,
+rulesets, and other rsyslog configuration elements. Object parameters are
+case-insensitive, and objects are closed by their final parenthesis.
+
+.. summary-end
+
 .. note::
 
   Configuration object parameters are case-insensitive.
@@ -35,6 +47,24 @@ Then we can use this config construct:
         config.enabled=`echo $LOAD_IMPTCP`)
 
 If the variable is set to ``off``, the module will **not** be loaded.
+
+Statement Terminators
+---------------------
+
+Configuration objects are complete when their closing parenthesis is reached.
+Do not add a semicolon after object statements such as ``action()``,
+``module()``, ``input()``, ``template()``, or ``ruleset()``:
+
+.. code-block:: rsyslog
+
+   action(type="omfile" file="/var/log/messages")    # correct
+   action(type="omfile" file="/var/log/messages");   # invalid
+
+Semicolons are used by expression-style RainerScript statements where they are
+documented, for example ``set``, ``reset``, ``unset``, and
+``call_indirect``. Legacy selector and action syntax also has semicolon
+meanings of its own; those legacy uses do not make ``;`` a universal
+RainerScript statement terminator.
 
 Objects
 -------

--- a/doc/source/rainerscript/configuration_objects.rst
+++ b/doc/source/rainerscript/configuration_objects.rst
@@ -51,7 +51,9 @@ If the variable is set to ``off``, the module will **not** be loaded.
 Statement Terminators
 ---------------------
 
-Configuration objects are complete when their closing parenthesis is reached.
+Configuration objects without body blocks are complete when their closing
+parenthesis is reached. Objects with body blocks, such as ``ruleset()`` and
+list-type ``template()``, are complete at their closing curly brace ``}``.
 Do not add a semicolon after object statements such as ``action()``,
 ``module()``, ``input()``, ``template()``, or ``ruleset()``:
 


### PR DESCRIPTION
## Summary
- clarify that modern RainerScript objects such as `action()` are not terminated with semicolons
- add a common-mistakes entry for `action(...);`
- document the advanced distinction between object syntax and expression statement terminators

## Validation
- `./devtools/local-validation-plan.sh`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"`
- `git diff --check`
- `rsyslogd -N1` valid/invalid semicolon sanity checks


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

