### PR TITLE
[codex] testbench: wait for omfwd lb receiver output

### DIFF
--- a/tests/omfwd-lb-2target-basic.sh
+++ b/tests/omfwd-lb-2target-basic.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-# added 2024-02-24 by rgerhards. Released under ASL 2.0
+# Verify that native omfwd load balancing splits a single message burst evenly
+# across two healthy TCP targets. The oracle is exact: each minitcpsrv receiver
+# must persist half of the messages, and the combined output must contain the
+# full sequence. Wait for the receiver files before shutdown so the test does
+# not mistake an action/output drain still in progress for a load-balancing
+# failure.
+# Added 2024-02-24 by rgerhards. Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 generate_conf
 export NUMMESSAGES=1000  # MUST be an EVEN number!
@@ -28,16 +34,23 @@ if $msg contains "msgnum:" then {
 # now do the usual run
 startup
 injectmsg
+
+expected_per_target=$(( NUMMESSAGES / 2 ))
+wait_file_lines --abort-on-oversize "$RSYSLOG_OUT_LOG" "$expected_per_target"
+wait_file_lines --abort-on-oversize "$RSYSLOG2_OUT_LOG" "$expected_per_target"
+
 shutdown_when_empty
 wait_shutdown
 
-if [ "$(wc -l < $RSYSLOG_OUT_LOG)" != "$(( NUMMESSAGES / 2 ))" ]; then
-	echo "ERROR: RSYSLOG_OUT_LOG has invalid number of messages $(( NUMMESSAGES / 2 ))"
+target1_actual="$(wc -l < "$RSYSLOG_OUT_LOG")"
+if [ "$target1_actual" -ne "$expected_per_target" ]; then
+	echo "ERROR: RSYSLOG_OUT_LOG has invalid number of messages $target1_actual, expected $expected_per_target"
 	error_exit 100
 fi
 
-if [ "$(wc -l < $RSYSLOG2_OUT_LOG)" != "$(( NUMMESSAGES / 2 ))" ]; then
-	echo "ERROR: RSYSLOG2_OUT_LOG has invalid number of messages $(( NUMMESSAGES / 2 ))"
+target2_actual="$(wc -l < "$RSYSLOG2_OUT_LOG")"
+if [ "$target2_actual" -ne "$expected_per_target" ]; then
+	echo "ERROR: RSYSLOG2_OUT_LOG has invalid number of messages $target2_actual, expected $expected_per_target"
 	error_exit 100
 fi
 


### PR DESCRIPTION
## Summary
- wait for both `omfwd-lb-2target-basic.sh` minitcpsrv output files to reach the exact half-burst message count before shutting rsyslog down
- keep the final exact 500/500 count checks and combined `seq_check` oracle intact
- improve failure diagnostics to report the actual observed count instead of repeating the expected count

## Why
Recent flake evidence showed `omfwd-lb-2target-basic.sh` failing after imdiag reported the main queue empty, with one receiver output file failing the count check. The test's real oracle is the receiver output files, not only rsyslog main-queue emptiness, so shutdown could race a slow TCP receiver/output drain and make that look like an uneven load-balancing failure.

This keeps the original invariant: a healthy two-target native omfwd load-balanced burst must split evenly and preserve the full sequence across both receivers.

## Validation
- `bash -n tests/omfwd-lb-2target-basic.sh`
- `devtools/check-test-antipatterns.sh tests/omfwd-lb-2target-basic.sh`
- `shellcheck -x -e SC2016,SC2086 tests/omfwd-lb-2target-basic.sh`
- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag`
- `make -j$(nproc) check TESTS=""`
- focused host loop: `./tests/omfwd-lb-2target-basic.sh` passed 10/10
- `devtools/local-validation-plan.sh --run` passed, including focused container `PASS: omfwd-lb-2target-basic.sh`
- local Cubic review: no issues found

Broad Ubuntu 26.04 container validation was also started with `devtools/devcontainer.sh --rm devtools/run-ci.sh`. The changed target test passed in that broad run, but the broad lane exited non-zero on an unrelated `omfwd_fast_imuxsock.sh` impstats content assertion:

```text
FAIL: content_check failed to find "action-1-builtin:omfwd queue: origin=core.queue size=.* enqueued=100000 size.enqueued=.* full=0 discarded.full=0 discarded.nf=.* maxqsize=100"
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

