### PR TITLE
doc: clarify security release handling

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,18 @@ downstream distribution maintainers.
 The current stable release is listed on the
 [rsyslog download page](https://www.rsyslog.com/downloads/).
 
+rsyslog provides both daily stable builds and scheduled stable releases. Both
+tracks are intended to be stable, but they serve different update models. Daily
+stable receives validated bug fixes, hardening changes, and security-relevant
+fixes as soon as they are ready. Scheduled stable releases receive fixes on the
+regular release cadence, unless an issue requires an out-of-cycle scheduled
+stable release.
+
+Users who want the fastest access to bug fixes, hardening changes, and
+security-relevant fixes should consider daily stable. Users with strict change
+control may prefer scheduled stable, but should review advisories for affected
+components and configuration prerequisites.
+
 ## Response
 
 rsyslog is maintained by a small team. Security reports receive priority
@@ -84,6 +96,42 @@ rsyslog has a modular architecture. During triage, maintainers evaluate:
   proof
 - whether the issue affects released rsyslog software, repository automation,
   test infrastructure, packaging, or documentation only
+
+CVSS is one input to this process, but it is not the sole driver for release
+urgency. CVSS describes the technical severity of a vulnerable code path once
+its prerequisites are met. For rsyslog, maintainers also evaluate practical
+exposure: whether the affected component is built in, packaged, loaded by
+default, commonly configured, reachable from untrusted input, and whether common
+distribution hardening such as SELinux, AppArmor, systemd sandboxing, file
+permissions, or network defaults materially limits impact.
+
+Issues affecting default or common configurations, broad network exposure,
+active exploitation, or severe confidentiality or integrity impact may require
+coordinated disclosure and out-of-cycle scheduled stable releases. Issues
+limited to optional modules, uncommon settings, specialized deployments,
+malicious configuration control, or deployments that deliberately relax normal
+hardening are still fixed, but normally flow through daily stable and the next
+scheduled stable release, with advisory text documenting the affected
+configuration and mitigations.
+
+## Optional and Contributed Modules
+
+rsyslog includes many optional plugins and contributed modules. Some are widely
+used and actively maintained by the core team. Others have limited maintainer
+ownership, may not be packaged by all distributions, and are not loaded by
+default.
+
+Security advisories and release decisions take this component status into
+account. A vulnerability in an optional or contributed module can still be
+serious for affected deployments, but it is not automatically treated as
+affecting all rsyslog installations. Advisories should state whether the module
+must be installed, loaded, explicitly configured, or exposed to untrusted input.
+
+Contributed modules are welcome, but they require realistic maintenance
+expectations. If a contributed module has no active maintainer and repeatedly
+requires substantial security, compatibility, or release-engineering work from
+the core team, we may deprecate, disable, or remove it rather than continue to
+carry risk that the project cannot responsibly maintain.
 
 ## Advisory Scope and Wording
 

--- a/doc/source/about/release_versioning.rst
+++ b/doc/source/about/release_versioning.rst
@@ -70,6 +70,28 @@ successfully relied on for more than five years.
   change control a predictable update cadence. Every scheduled stable build is
   therefore a tested point-in-time capture of the daily stable branch.
 
+Security and hardening fixes
+============================
+
+Daily stable is the fastest track for validated bug fixes, hardening changes,
+and security-relevant fixes. This matters in modular deployments because
+rsyslog includes many optional inputs, outputs, parsers, and contributed
+modules. A fix for an optional component or unusual configuration may appear in
+daily stable before the next scheduled stable release.
+
+Scheduled stable remains supported and receives fixes on the regular release
+cadence. The project may publish an out-of-cycle scheduled stable release for
+issues with broad exposure, default reachability, active exploitation, or
+severe confidentiality or integrity impact. Issues limited to optional modules,
+uncommon settings, specialized deployments, malicious configuration control, or
+primarily denial-of-service impact normally ship first in daily stable and then
+in the next scheduled stable release.
+
+Users who want the fastest access to fixes should consider daily stable. Users
+with strict change-control requirements may prefer scheduled stable, but should
+review security advisories and check whether their configuration actually uses
+the affected component, module, or setting.
+
 Quick reference for newcomers
 =============================
 


### PR DESCRIPTION
## Summary

- document how daily stable and scheduled stable handle security-relevant fixes
- clarify that CVSS is one input and rsyslog also evaluates practical exposure
- document optional/contributed module expectations and possible deprecation/removal when maintenance burden exceeds ownership
- add user-facing release-track guidance for security and hardening fixes

## Validation

- `./devtools/local-validation-plan.sh` classified the change as `rendered-docs`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs "$(nproc)"` passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

