### PR TITLE
mmpstrucdata: document SD buffer invariant and malformed-input coverage

### DIFF
--- a/plugins/mmpstrucdata/mmpstrucdata.c
+++ b/plugins/mmpstrucdata/mmpstrucdata.c
@@ -359,6 +359,16 @@ static rsRetVal ATTR_NONNULL() parse_sd(instanceData *const pData, smsg_t *const
     if (sdLenbuf > INT_MAX) {
         ABORT_FINALIZE(RS_RET_OVERSIZE_MSG);
     }
+    /**
+     * MsgGetStructuredData() returns message-owned structured data created by
+     * MsgSetStructuredData(), which stores a NUL-terminated strdup() and a
+     * strlen() length. The parser below intentionally relies on that sentinel
+     * when rejecting malformed data at the exact logical end of the SD field.
+     * Do not add per-character defensive bounds checks unless a caller path is
+     * proven to pass non-sentinel storage; those checks would sit in the hot
+     * parsing path for high-throughput deployments.
+     */
+    assert(sdbuf != NULL && sdbuf[sdLenbuf] == '\0');
     lenbuf = (int)sdLenbuf;
     while (i < lenbuf) {
         CHKiRet(parseSD_ELEMENT(pData, sdbuf, lenbuf, &i, json));

--- a/tests/mmpstrucdata-invalid-vg.sh
+++ b/tests/mmpstrucdata-invalid-vg.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# the goal here is to detect memleaks when structured data is not
-# correctly parsed.
+# Verify malformed RFC5424 structured data is rejected without invalid memory
+# reads or leaks. The oracle is Valgrind; the malformed cases include
+# delimiter errors plus truncated wire messages so this CI path keeps covering
+# the module's invalid-SD handling.
 # This file is part of the rsyslog project, released  under ASL 2.0
 # rgerhards, 2015-04-30
 . ${srcdir:=.}/diag.sh init
@@ -28,6 +30,9 @@ tcpflood -m100 -M "\"<161>1 2003-03-01T01:00:00.000Z mymachine.example.com tcpfl
 tcpflood -m200 -M "\"<161>1 2003-03-01T01:00:00.000Z mymachine.example.com tcpflood - tag [tcpflood@32473 MSGNUM ] invalid structured data!\""
 tcpflood -m300 -M "\"<161>1 2003-03-01T01:00:00.000Z mymachine.example.com tcpflood - tag [tcpflood@32473 MSGNUM= ] invalid structured data!\""
 tcpflood -m400 -M "\"<161>1 2003-03-01T01:00:00.000Z mymachine.example.com tcpflood - tag [tcpflood@32473 = ] invalid structured data!\""
+tcpflood -m500 -M "\"<161>1 2003-03-01T01:00:00.000Z mymachine.example.com tcpflood - tag [tcpflood@32473 MSGNUM\""
+tcpflood -m600 -M "\"<161>1 2003-03-01T01:00:00.000Z mymachine.example.com tcpflood - tag [tcpflood@32473 MSGNUM=\""
+tcpflood -m700 -M "\"<161>1 2003-03-01T01:00:00.000Z mymachine.example.com tcpflood - tag [tcpflood@32473 MSGNUM=\\\"unterminated\""
 shutdown_when_empty
 wait_shutdown
 exit_test


### PR DESCRIPTION
## Summary

This documents the `mmpstrucdata` structured-data buffer invariant instead of adding defensive hot-path parser checks.

`MsgGetStructuredData()` returns message-owned structured-data storage created by `MsgSetStructuredData()`, which stores a NUL-terminated `strdup()` and records the `strlen()` length. The parser relies on that sentinel when malformed SD ends at the logical field boundary. An assertion now makes that contract explicit for debug/CI builds.

The invalid-SD Valgrind test now also sends truncated RFC5424 structured-data cases, sealing the observed normal ingress behavior without changing parser runtime logic.

## Validation

- `devtools/format-code.sh --git-changed --check --check-if-available`
- `devtools/check-test-antipatterns.sh tests/mmpstrucdata-invalid-vg.sh`
- `make -j${RSYSLOG_LOCAL_BUILD_JOBS:-10} check TESTS=""`
- `cd tests && ./mmpstrucdata-invalid-vg.sh`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

