### PR TITLE
omuxsock: isolate action socket locks

### DIFF
--- a/plugins/omuxsock/omuxsock.c
+++ b/plugins/omuxsock/omuxsock.c
@@ -67,6 +67,8 @@ DEFobjCurrIf(glbl) DEFobjCurrIf(net)
     int sock; /**< Socket descriptor */
     struct sockaddr_un addr; /**< Unix socket address */
     socklen_t addrLen; /**< The socket address length */
+    pthread_mutex_t mutDoAct; /**< Serialize socket state for this action instance. */
+    int mutDoActInitialized; /**< True once mutDoAct may be destroyed. */
 } instanceData;
 
 
@@ -114,8 +116,6 @@ struct modConfData_s {
 
 static modConfData_t *loadModConf = NULL; /* modConf ptr to use for the current load process */
 static modConfData_t *runModConf = NULL; /* modConf ptr to use for the current exec process */
-
-static pthread_mutex_t mutDoAct = PTHREAD_MUTEX_INITIALIZER;
 
 /**
  * @brief A structure to map identifiers to socket information
@@ -316,9 +316,17 @@ BEGINfreeCnf
 ENDfreeCnf
 
 BEGINcreateInstance
+    int mutexErr;
     CODESTARTcreateInstance;
     pData->sock = INVLD_SOCK;
     pData->sockType = SOCK_DGRAM;
+    pData->mutDoActInitialized = 0;
+    if ((mutexErr = pthread_mutex_init(&pData->mutDoAct, NULL)) != 0) {
+        errno = mutexErr;
+        ABORT_FINALIZE(RS_RET_CONC_CTRL_ERR);
+    }
+    pData->mutDoActInitialized = 1;
+finalize_it:
 ENDcreateInstance
 
 BEGINcreateWrkrInstance
@@ -336,6 +344,7 @@ BEGINfreeInstance
     CODESTARTfreeInstance;
     /* final cleanup */
     closeSocket(pData);
+    if (pData->mutDoActInitialized) pthread_mutex_destroy(&pData->mutDoAct);
     free(pData->tplName);
     free(pData->sockName);
     free(pData->namespace);
@@ -546,7 +555,9 @@ static rsRetVal doTryResume(instanceData *pData) {
 
 BEGINtryResume
     CODESTARTtryResume;
+    pthread_mutex_lock(&pWrkrData->pData->mutDoAct);
     iRet = doTryResume(pWrkrData->pData);
+    pthread_mutex_unlock(&pWrkrData->pData->mutDoAct);
 ENDtryResume
 
 BEGINdoAction
@@ -554,7 +565,7 @@ BEGINdoAction
     register unsigned l;
     int iMaxLine;
     CODESTARTdoAction;
-    pthread_mutex_lock(&mutDoAct);
+    pthread_mutex_lock(&pWrkrData->pData->mutDoAct);
     CHKiRet(doTryResume(pWrkrData->pData));
 
     iMaxLine = glbl.GetMaxLine(runModConf->pConf);
@@ -568,7 +579,7 @@ BEGINdoAction
     CHKiRet(sendMsg(pWrkrData->pData, psz, l));
 
 finalize_it:
-    pthread_mutex_unlock(&mutDoAct);
+    pthread_mutex_unlock(&pWrkrData->pData->mutDoAct);
 ENDdoAction
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1679,6 +1679,7 @@ TESTS_GNUTLS_OPENSSL_INTEROP = \
 TESTS_OMUXSOCK = \
 	uxsock_simple.sh \
 	 uxsock_simple_abstract.sh \
+	 uxsock_action_isolation.sh \
 	 uxsock_multiple.sh \
 	 uxsock_multiple_netns.sh
 

--- a/tests/uxsock_action_isolation.sh
+++ b/tests/uxsock_action_isolation.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Regression test for omuxsock action isolation. One Unix datagram receiver is
+# intentionally left unread until the test releases it, which can block that
+# action's send path. Success is proven by a second omuxsock action continuing
+# to deliver messages to an independent receiver before the slow receiver is
+# released. The fast receiver only needs to reach FAST_MIN_LINES because Unix
+# datagram delivery can drop under burst pressure; the isolation invariant is
+# that it still makes substantial progress while the slow action is blocked.
+. ${srcdir:=.}/diag.sh init
+
+if [ "$(uname)" != "Linux" ]; then
+    echo "This test requires Linux AF_UNIX datagram socket behavior."
+    exit 77
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "This test requires python3."
+    exit 77
+fi
+
+FAST_SOCKET="${RSYSLOG_DYNNAME}-fast.sock"
+SLOW_SOCKET="${RSYSLOG_DYNNAME}-slow.sock"
+FAST_READY="${RSYSLOG_DYNNAME}.fast.ready"
+SLOW_READY="${RSYSLOG_DYNNAME}.slow.ready"
+SLOW_RELEASE="${RSYSLOG_DYNNAME}.slow.release"
+NUMMESSAGES=5000
+FAST_MIN_LINES=1000
+
+test_error_exit_handler() {
+    touch "$SLOW_RELEASE"
+    if [ -n "${FAST_PID:-}" ]; then
+        kill "$FAST_PID" 2>/dev/null || true
+    fi
+    if [ -n "${SLOW_PID:-}" ]; then
+        kill "$SLOW_PID" 2>/dev/null || true
+    fi
+}
+
+wait_ready_file() {
+    ready_file="$1"
+    count=1
+    max_attempts=$((TB_TIMEOUT_STARTSTOP * 10))
+    while [ "$count" -le "$max_attempts" ]; do
+        if [ -r "$ready_file" ]; then
+            return
+        fi
+        $TESTTOOL_DIR/msleep 100
+        count=$((count + 1))
+    done
+    echo "receiver did not report ready file $ready_file"
+    error_exit 1
+}
+
+python3 - "$SLOW_SOCKET" "$SLOW_READY" "$SLOW_RELEASE" <<'PY' &
+import os
+import socket
+import sys
+import time
+
+path, ready, release = sys.argv[1:4]
+try:
+    os.unlink(path)
+except FileNotFoundError:
+    pass
+
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)
+sock.bind(path)
+with open(ready, "w", encoding="ascii") as fh:
+    fh.write("ready\n")
+
+while not os.path.exists(release):
+    time.sleep(0.05)
+
+sock.settimeout(0.05)
+deadline = time.time() + 3
+while time.time() < deadline:
+    try:
+        sock.recv(65535)
+    except socket.timeout:
+        pass
+PY
+SLOW_PID=$!
+wait_ready_file "$SLOW_READY"
+
+./uxsockrcvr -s"$FAST_SOCKET" -o "$RSYSLOG_OUT_LOG" -r "$FAST_READY" -t 60 &
+FAST_PID=$!
+wait_ready_file "$FAST_READY"
+
+generate_conf
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+
+module(load="../plugins/omuxsock/.libs/omuxsock")
+$template outfmt,"%msg:F,58:2%\n"
+
+:msg, contains, "msgnum:" {
+    action(
+        type="omuxsock"
+        SocketName="'$SLOW_SOCKET'"
+        template="outfmt"
+        queue.type="LinkedList"
+        queue.timeoutEnqueue="0"
+        queue.size="10000"
+    )
+    action(
+        type="omuxsock"
+        SocketName="'$FAST_SOCKET'"
+        template="outfmt"
+        queue.type="LinkedList"
+        queue.timeoutEnqueue="0"
+        queue.size="10000"
+    )
+}
+'
+
+startup
+injectmsg 0 "$NUMMESSAGES"
+wait_file_lines "$RSYSLOG_OUT_LOG" "$FAST_MIN_LINES" 20
+
+touch "$SLOW_RELEASE"
+wait_queueempty
+shutdown_when_empty
+wait_shutdown
+
+kill "$FAST_PID"
+wait "$FAST_PID"
+wait "$SLOW_PID"
+
+seq_check 0 $((NUMMESSAGES - 1)) -d -m$((NUMMESSAGES - FAST_MIN_LINES))
+exit_test


### PR DESCRIPTION
## Summary
- move the omuxsock action mutex from module-global storage into each action instance
- keep tryResume/doAction serialized per destination socket without blocking unrelated omuxsock actions
- add a regression test that holds one Unix datagram receiver unread and verifies another omuxsock action still makes progress

## Issue
Closes https://github.com/rsyslog/rsyslog/issues/5444

## Local validation
- Host configure/build: `./autogen.sh && ./configure --enable-debug --enable-testbench --enable-omuxsock --enable-imptcp --enable-imdiag --disable-generate-man-pages`
- Baseline focused host tests before patch: `make -j60 check TESTS='uxsock_simple.sh uxsock_simple_abstract.sh uxsock_multiple.sh'` passed
- Focused host regression: `make -j60 check TESTS='uxsock_action_isolation.sh'` passed
- Focused host omuxsock set: `make -j60 check TESTS='uxsock_action_isolation.sh uxsock_simple.sh uxsock_simple_abstract.sh uxsock_multiple.sh'` passed
- Negative control: restoring the old module-global mutex made `uxsock_action_isolation.sh` fail after the 20s fast-receiver wait, as expected
- Formatting/lint: `devtools/format-code.sh --git-changed --check --check-if-available`, `git diff --check`, `devtools/check-test-antipatterns.sh tests/uxsock_action_isolation.sh`, and `shellcheck -S warning tests/uxsock_action_isolation.sh` passed
- Local Cubic: `cubic review --base upstream/main --print-logs` reported no issues
- Manual prompt audits: memory auditor and bug finder prompts found no issues in the mutex lifetime or lock/unlock paths

## Local container validation
Image: `rsyslog/rsyslog_dev_base_ubuntu:26.04`
Image ID: `sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`
Concurrency: `-j60` for normal build/check lanes; TSAN check concurrency limited to `-j10`.

- Static analyzer: `devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh` passed, scan-build reported no bugs
- Ubuntu 26.04 change-gated CI: `devtools/devcontainer.sh --rm devtools/run-ci.sh` passed, 1210 tests total, 1179 passed, 31 skipped
- TSAN specialist lane for lock/concurrency change: `devtools/devcontainer.sh --rm devtools/run-ci.sh` passed, 986 tests total, 949 passed, 37 skipped
- Mock distcheck for new distributed test: `devtools/devcontainer.sh --rm make distcheck TEST_RUN_TYPE=MOCK-OK -j60` passed

Lane relaxations: default PR service relevance suppressions disabled unrelated external service families. omuxsock tests remained enabled and the new regression ran. TSAN was run without Valgrind (`--without-valgrind-testbench --disable-valgrind`) because TSAN and Valgrind are incompatible.

With the help of AI-Agents: Codex


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

