### PR TITLE
doc: clarify ommysql data failures

### DIFF
--- a/doc/source/configuration/modules/ommysql.rst
+++ b/doc/source/configuration/modules/ommysql.rst
@@ -84,6 +84,30 @@ Action Parameters
    ../../reference/parameters/ommysql-template
 
 
+Failure and retry behavior
+==========================
+
+``ommysql`` treats MariaDB/MySQL client and connection failures differently
+from SQL data errors returned by the server.
+
+Connection-level failures, such as an unavailable server or a broken
+connection, suspend the action. In that state, the usual action retry settings,
+including ``action.resumeInterval`` and ``action.resumeRetryCount``, control
+when rsyslog tries to resume delivery.
+
+Server-side SQL errors, such as a rejected ``INSERT`` or stored procedure call,
+are treated as permanent data failures for the affected messages. rsyslog logs
+the MySQL error and the failed SQL statement, then handles the failed message
+through the action error-file path. These failures are not retried (and thus not
+throttled by ``action.resumeInterval``) because retrying the same malformed
+statement later would normally fail in the same way.
+
+For production setups, configure ``action.errorfile`` on the ``ommysql`` action
+when failed messages must be retained for inspection or replay. Without an error
+file, permanently failed messages are discarded after rsyslog reports the action
+failure.
+
+
 Examples
 ========
 


### PR DESCRIPTION
## Summary
- clarify that `ommysql` distinguishes connection/client failures from server-side SQL data errors
- document that `action.resumeInterval` applies to suspended/recoverable connection failures, not permanent rejected SQL statements
- point operators to `action.errorfile` when failed records need to be retained for inspection or replay

## Issue
Closes https://github.com/rsyslog/rsyslog/issues/5285

## Local validation
- `git diff --check` passed
- `devtools/local-validation-plan.sh` classified the change as `rendered-docs`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 60` passed

Additional triage evidence:
- Static review of `plugins/ommysql/ommysql.c` and `runtime/action.c` shows MySQL server-side SQL errors return `RS_RET_DATAFAIL`, while connection/client failures return `RS_RET_SUSPENDED` and enter the normal action retry path.
- `make -j60 check TESTS='action-tx-errfile.sh mysql-unavailable-transaction.sh'` passed `mysql-unavailable-transaction.sh`; `action-tx-errfile.sh` was skipped by service relevance with no MySQL diff.
- A forced local `action-tx-errfile.sh` run was blocked by the host MySQL account setup (`Access denied for user 'rsyslog'@'localhost'`) and could not be repaired without interactive sudo. The existing test remains the code coverage for ommysql `RS_RET_DATAFAIL`/`action.errorfile` behavior.

Validation scope: documentation-only. No local runtime container or Cubic gate is required for this rendered documentation change.

With the help of AI-Agents: Codex


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

