### PR TITLE
doc: clarify fromhost case handling

### DIFF
--- a/doc/source/reference/parameters/imtcp-preservecase.rst
+++ b/doc/source/reference/parameters/imtcp-preservecase.rst
@@ -26,7 +26,10 @@ This parameter applies to :doc:`../../configuration/modules/imtcp`.
 
 Description
 -----------
-This parameter is for controlling the case in fromhost.  If preservecase is set to "off", the case in fromhost is not preserved.  E.g., 'host1.example.org' the message was received from 'Host1.Example.Org'.  Default to "on" for the backward compatibility.
+This parameter controls the case in ``fromhost``. If ``PreserveCase`` is set to
+"off", rsyslog normalizes the resolved host name to lowercase, e.g.,
+``host1.example.org`` when the message was received from
+``Host1.Example.Org``. The default is "on" for backward compatibility.
 
 The same-named input parameter can override this module setting.
 
@@ -52,4 +55,3 @@ Input usage
 See also
 --------
 See also :doc:`../../configuration/modules/imtcp`.
-

--- a/doc/source/reference/parameters/imudp-preservecase.rst
+++ b/doc/source/reference/parameters/imudp-preservecase.rst
@@ -30,6 +30,10 @@ This parameter is for controlling the case in ``fromhost``. If
 ``Host1.Example.Org`` when the message was received from
 ``Host1.Example.Org``. Default is "off" for backward compatibility.
 
+Leave it at the default when existing rules rely on lowercase ``fromhost``
+values. Enable it when downstream systems must match the DNS spelling returned
+by reverse lookup.
+
 Module usage
 ------------
 .. _param-imudp-module-preservecase:

--- a/doc/source/reference/properties/message-fromhost.rst
+++ b/doc/source/reference/properties/message-fromhost.rst
@@ -30,6 +30,14 @@ has been disabled. Reverse lookup results are cached; see
 outbound connections are not cached by rsyslog and are resolved via the system
 resolver whenever a connection is made.
 
+Case handling is input-specific. Some network inputs normalize the resolved
+name to lowercase for backward compatibility, while others preserve the DNS
+result by default. For inputs that support it, use the module or input
+``PreserveCase`` parameter to choose the behavior:
+:ref:`imudp PreserveCase <param-imudp-preservecase>` defaults to lowercase
+output and :ref:`imtcp PreserveCase <param-imtcp-preservecase>` defaults to
+preserving case.
+
 Usage
 -----
 .. _properties.message.fromhost-usage:


### PR DESCRIPTION
## Summary
- clarify that `fromhost` case handling is input-specific
- link the existing imudp/imtcp `PreserveCase` controls and defaults
- tighten imtcp parameter wording around lowercasing behavior

Closes https://github.com/rsyslog/rsyslog/issues/3848

## Validation
- `git diff --check`
- `devtools/local-validation-plan.sh` -> `rendered-docs`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 60`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

