### PR TITLE
omelasticsearch: retry read-only bulk failures

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -1290,6 +1290,23 @@ static int checkReplyStatus(fjson_object *ok) {
             fjson_object_get_int(ok) > 299);
 }
 
+static int ATTR_NONNULL(1) isRetryableBulkStatus(fjson_object *response_body, const int status) {
+    fjson_object *error = NULL;
+    fjson_object *errtype = NULL;
+    const char *type = NULL;
+
+    if (status == 429 || status >= 500) return 1;
+
+    if (status != 403) return 0;
+
+    if (fjson_object_object_get_ex(response_body, "error", &error) &&
+        fjson_object_object_get_ex(error, "type", &errtype)) {
+        type = fjson_object_get_string(errtype);
+    }
+
+    return type != NULL && strcmp(type, "cluster_block_exception") == 0;
+}
+
 /*
  * Context object for error file content creation or status check
  * response_item - the full {"create":{"_index":"idxname",.....}}
@@ -1325,6 +1342,9 @@ static rsRetVal parseRequestAndResponseForContext(wrkrInstanceData_t *pWrkrData,
     int i;
     int numitems;
     fjson_object *items = NULL, *jo_errors = NULL;
+    int sawRetriableError = 0;
+    int sawPermanentError = 0;
+    int sawSuccess = 0;
 
     /*iterate over items*/
     if (!fjson_object_object_get_ex(replyRoot, "items", &items)) {
@@ -1381,6 +1401,18 @@ static rsRetVal parseRequestAndResponseForContext(wrkrInstanceData_t *pWrkrData,
 
         fjson_object_object_get_ex(result, "status", &ok);
         itemStatus = checkReplyStatus(ok);
+        const int status = (ok != NULL && fjson_object_is_type(ok, fjson_type_int)) ? fjson_object_get_int(ok) : 0;
+        if (ctx->statusCheckOnly) {
+            if (itemStatus) {
+                if (isRetryableBulkStatus(result, status)) {
+                    sawRetriableError = 1;
+                } else {
+                    sawPermanentError = 1;
+                }
+            } else {
+                sawSuccess = 1;
+            }
+        }
 
         char *request = 0;
         char *response = 0;
@@ -1389,9 +1421,11 @@ static rsRetVal parseRequestAndResponseForContext(wrkrInstanceData_t *pWrkrData,
                 DBGPRINTF(
                     "omelasticsearch: error in elasticsearch reply: item %d, "
                     "status is %d\n",
-                    i, fjson_object_get_int(ok));
-                DBGPRINTF("omelasticsearch: status check found error.\n");
-                ABORT_FINALIZE(RS_RET_DATAFAIL);
+                    i, status);
+                if (!ctx->statusCheckOnly) {
+                    DBGPRINTF("omelasticsearch: status check found error.\n");
+                    ABORT_FINALIZE(RS_RET_DATAFAIL);
+                }
             }
 
         } else {
@@ -1421,6 +1455,18 @@ static rsRetVal parseRequestAndResponseForContext(wrkrInstanceData_t *pWrkrData,
             }
         }
     }
+    if (ctx->statusCheckOnly && sawRetriableError) {
+        if (!sawPermanentError && !sawSuccess) {
+            LogError(0, RS_RET_SUSPENDED,
+                     "omelasticsearch: suspending action because bulk response contains only retryable item errors");
+            ABORT_FINALIZE(RS_RET_SUSPENDED);
+        }
+        DBGPRINTF(
+            "omelasticsearch: retryable bulk item errors are mixed with "
+            "successful or permanent responses; preserving per-item data-failure handling\n");
+        ABORT_FINALIZE(RS_RET_DATAFAIL);
+    }
+    if (ctx->statusCheckOnly && sawPermanentError) ABORT_FINALIZE(RS_RET_DATAFAIL);
 
 finalize_it:
     RETiRet;
@@ -1923,12 +1969,14 @@ static rsRetVal checkResultBulkmode(wrkrInstanceData_t *pWrkrData, fjson_object 
     ctx.statusCheckOnly = 1;
     ctx.jTokener = NULL;
     if (pWrkrData->pData->retryFailures) {
+        /* retryFailures owns per-item retry routing via retryRuleset. */
         ctx.statusCheckOnly = 0;
         CHKiRet(initializeRetryFailuresContext(pWrkrData, &ctx));
     }
-    if (parseRequestAndResponseForContext(pWrkrData, &root, reqmsg, &ctx) != RS_RET_OK) {
+    iRet = parseRequestAndResponseForContext(pWrkrData, &root, reqmsg, &ctx);
+    if (iRet != RS_RET_OK) {
         DBGPRINTF("omelasticsearch: error found in elasticsearch reply\n");
-        ABORT_FINALIZE(RS_RET_DATAFAIL);
+        if (iRet != RS_RET_SUSPENDED) ABORT_FINALIZE(RS_RET_DATAFAIL);
     }
 
 finalize_it:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -287,6 +287,7 @@ TESTS_DEFAULT = \
 	imudp_ratelimit_name.sh \
 	omfwd_ratelimit_name.sh \
 	omelasticsearch_ratelimit_name.sh \
+	omelasticsearch-bulk-readonly-retry.sh \
 	omelasticsearch-dynsearch-template.sh \
 	omelasticsearch-searchtype-deprecated.sh \
 	omhttp_ratelimit_name.sh \

--- a/tests/omelasticsearch-bulk-readonly-retry.sh
+++ b/tests/omelasticsearch-bulk-readonly-retry.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Regression test for Elasticsearch read-only-index bulk responses. A fake
+# Elasticsearch endpoint returns HTTP 200 with per-item status 403 and
+# cluster_block_exception, matching a read-only index. Success is proven by a
+# second POST to the fake endpoint before the normal startup/shutdown timeout.
+# The first POST returns only retryable per-item errors; the second succeeds, so
+# the action must suspend/retry the batch instead of treating the bulk item
+# failure as a handled permanent data error. The background helper writes its
+# port after bind and is killed on both failure and success paths.
+. ${srcdir:=.}/diag.sh init
+require_plugin omelasticsearch
+check_command_available python3
+
+PORT_FILE="$RSYSLOG_DYNNAME.esfake.port"
+COUNT_FILE="$RSYSLOG_DYNNAME.esfake.count"
+
+test_error_exit_handler() {
+	if [ -n "${SERVER_PID:-}" ]; then
+		kill "$SERVER_PID" 2>/dev/null || true
+	fi
+}
+
+python3 - "$PORT_FILE" "$COUNT_FILE" <<'PY' &
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+port_file, count_file = sys.argv[1:3]
+post_count = 0
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass
+
+    def send_json(self, payload):
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        self.send_json({
+            "version": {
+                "number": "8.15.0",
+                "distribution": "elasticsearch",
+            }
+        })
+
+    def do_POST(self):
+        global post_count
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length).decode("utf-8")
+        ops = max(1, len([line for line in body.splitlines() if line.strip()]) // 2)
+        post_count += 1
+        with open(count_file, "w", encoding="ascii") as fh:
+            fh.write(f"{post_count}\n")
+        if post_count >= 2:
+            self.send_json({
+                "errors": False,
+                "items": [{"index": {"status": 201}} for _ in range(ops)]
+            })
+        else:
+            self.send_json({
+                "errors": True,
+                "items": [{
+                    "index": {
+                        "status": 403,
+                        "error": {
+                            "type": "cluster_block_exception",
+                            "reason": "blocked by: [FORBIDDEN/12/index read-only / allow delete (api)];",
+                        },
+                    }
+                } for _ in range(ops)]
+            })
+
+
+server = HTTPServer(("127.0.0.1", 0), Handler)
+with open(port_file, "w", encoding="ascii") as fh:
+    fh.write(f"{server.server_port}\n")
+server.serve_forever()
+PY
+SERVER_PID=$!
+
+assign_file_content ES_PORT "$PORT_FILE"
+
+generate_conf
+add_conf '
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+
+template(name="msgTpl" type="string" string="{\"msg\":\"%msg%\"}")
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+action(type="omelasticsearch"
+       server="127.0.0.1"
+       serverport="'$ES_PORT'"
+       bulkmode="on"
+       searchIndex="rsyslog_testbench"
+       template="msgTpl"
+       action.reportSuspension="on"
+       action.resumeRetryCount="1"
+       action.resumeInterval="1")
+'
+
+startup
+injectmsg_literal '<167>1 2003-03-01T01:00:00.000Z host testprog - - - msgnum:0'
+
+count=0
+retry_timeout_seconds=$((TB_TIMEOUT_STARTSTOP / 10))
+if [ "$retry_timeout_seconds" -lt 1 ]; then
+	retry_timeout_seconds=1
+fi
+while [ "$count" -lt "$retry_timeout_seconds" ]; do
+	if [ -r "$COUNT_FILE" ] && [ "$(cat "$COUNT_FILE")" -ge 2 ]; then
+		break
+	fi
+	./msleep 1000
+	count=$((count + 1))
+done
+
+if [ ! -r "$COUNT_FILE" ] || [ "$(cat "$COUNT_FILE")" -lt 2 ]; then
+	echo "omelasticsearch did not retry the read-only bulk response"
+	error_exit 1
+fi
+
+shutdown_when_empty
+wait_shutdown
+
+content_check "msgnum:0" "$RSYSLOG_OUT_LOG"
+
+kill "$SERVER_PID" 2>/dev/null || true
+wait "$SERVER_PID" 2>/dev/null || true
+exit_test


### PR DESCRIPTION
## Summary
- classify all-retryable Elasticsearch bulk item failures as action suspension instead of handled data failure
- preserve existing data-failure behavior for permanent or mixed bulk results to avoid duplicating successful items
- add a fake Elasticsearch regression test for read-only-index bulk responses

Closes https://github.com/rsyslog/rsyslog/issues/3691

## Validation
- CC=gcc ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --enable-elasticsearch
- make -j60 check TESTS=""
- ./tests/omelasticsearch-bulk-readonly-retry.sh
- make check TESTS='omelasticsearch-bulk-readonly-retry.sh'
- shellcheck -S warning tests/omelasticsearch-bulk-readonly-retry.sh
- git diff --check
- cubic review --base cd7d709552b8913d558707aa8284dc749ee245b9 (clean after propagation fix)
- RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 devtools/local-validation-plan.sh --run

Local container image: rsyslog/rsyslog_dev_base_ubuntu:26.04, sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d

Lanes relaxed/skipped: none intentionally for Elasticsearch; the change-gated helper selected the required local path for this diff.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

