### PR TITLE
errmsg: enrich oversize errorfile records

### DIFF
--- a/runtime/errmsg.c
+++ b/runtime/errmsg.c
@@ -37,6 +37,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>
+#include <limits.h>
 
 #include "rsyslog.h"
 #include "obj.h"
@@ -60,6 +61,107 @@ static int fdOversizeMsgLog = -1;
 static pthread_mutex_t oversizeMsgLogMut = PTHREAD_MUTEX_INITIALIZER;
 
 /* ------------------------------ methods ------------------------------ */
+
+static rsRetVal oversizeJsonAddStringLen(struct json_object *const json,
+                                         const char *const name,
+                                         const uchar *const value,
+                                         const rs_size_t valueLen) {
+    struct json_object *jval = NULL;
+    const uchar *const safeValue = (value == NULL) ? (const uchar *)"" : value;
+    const size_t safeLen = (valueLen == (rs_size_t)-1) ? strlen((const char *)safeValue) : (size_t)valueLen;
+    const int jsonLen = (safeLen > INT_MAX) ? INT_MAX : (int)safeLen;
+    DEFiRet;
+
+    CHKmalloc(jval = json_object_new_string_len((const char *)safeValue, jsonLen));
+    json_object_object_add(json, name, jval);
+
+finalize_it:
+    RETiRet;
+}
+
+
+static rsRetVal oversizeJsonAddProp(struct json_object *const json,
+                                    smsg_t *const pMsg,
+                                    const char *const name,
+                                    const propid_t propId,
+                                    struct templateEntry *const pTpe) {
+    msgPropDescr_t propDescr = {.id = propId, .name = NULL, .nameLen = 0};
+    struct syslogTime ttNow;
+    uchar *value = NULL;
+    rs_size_t valueLen = -1;
+    unsigned short mustBeFreed = 0;
+    DEFiRet;
+
+    memset(&ttNow, 0, sizeof(ttNow));
+    value = MsgGetProp(pMsg, pTpe, &propDescr, &valueLen, &mustBeFreed, &ttNow);
+    CHKiRet(oversizeJsonAddStringLen(json, name, value, valueLen));
+
+finalize_it:
+    if (mustBeFreed) {
+        free(value);
+    }
+    RETiRet;
+}
+
+
+static rsRetVal oversizeJsonAddMsg(struct json_object *const json, const smsg_t *const pMsg) {
+    uchar *msg = (uchar *)"";
+    rs_size_t msgLen = 0;
+
+    if (pMsg->pszRawMsg != NULL && pMsg->offMSG >= 0 && pMsg->offMSG <= pMsg->iLenRawMsg && pMsg->iLenMSG > 0 &&
+        pMsg->iLenMSG <= pMsg->iLenRawMsg - pMsg->offMSG) {
+        msg = pMsg->pszRawMsg + pMsg->offMSG;
+        msgLen = pMsg->iLenMSG;
+    }
+
+    return oversizeJsonAddStringLen(json, "msg", msg, msgLen);
+}
+
+
+static rsRetVal oversizeJsonFromMsg(struct json_object **const json, const smsg_t *const pMsg) {
+    struct templateEntry dateTpe;
+    uchar *value = NULL;
+    int valueLen = 0;
+    DEFiRet;
+
+    memset(&dateTpe, 0, sizeof(dateTpe));
+    dateTpe.data.field.eDateFormat = tplFmtRFC3339Date;
+
+    CHKmalloc(*json = json_object_new_object());
+    CHKiRet(oversizeJsonAddMsg(*json, pMsg));
+    getRawMsg(pMsg, &value, &valueLen);
+    CHKiRet(oversizeJsonAddStringLen(*json, "rawmsg", value, valueLen));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "timereported", PROP_TIMESTAMP, &dateTpe));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "hostname", PROP_HOSTNAME, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "syslogtag", PROP_SYSLOGTAG, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "inputname", PROP_INPUTNAME, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "fromhost", PROP_FROMHOST, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "fromhost-ip", PROP_FROMHOST_IP, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "fromhost-port", PROP_FROMHOST_PORT, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "pri", PROP_PRI, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "syslogfacility", PROP_SYSLOGFACILITY, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "syslogseverity", PROP_SYSLOGSEVERITY, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "timegenerated", PROP_TIMEGENERATED, &dateTpe));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "programname", PROP_PROGRAMNAME, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "protocol-version", PROP_PROTOCOL_VERSION, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "structured-data", PROP_STRUCTURED_DATA, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "app-name", PROP_APP_NAME, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "procid", PROP_PROCID, NULL));
+    CHKiRet(oversizeJsonAddProp(*json, (smsg_t *)pMsg, "msgid", PROP_MSGID, NULL));
+#ifdef USE_LIBUUID
+    if (pMsg->pszUUID == NULL) {
+        json_object_object_add(*json, "uuid", NULL);
+    } else {
+        CHKiRet(oversizeJsonAddStringLen(*json, "uuid", pMsg->pszUUID, (rs_size_t)-1));
+    }
+#endif
+    if (pMsg->json != NULL) {
+        json_object_object_add(*json, "$!", json_object_get(pMsg->json));
+    }
+
+finalize_it:
+    RETiRet;
+}
 
 /* Resets the error message flag. Must be done before processing config
  * files.
@@ -215,17 +317,13 @@ rsRetVal ATTR_NONNULL() writeOversizeMessageLog(const smsg_t *const pMsg) {
     }
 
     assert(fdOversizeMsgLog != -1);
-    json = json_object_new_object();
-    if (json == NULL) {
-        FINALIZE;
-    }
+    CHKiRet(oversizeJsonFromMsg(&json, pMsg));
 
-    getRawMsg(pMsg, &buf, &dummy);
-    jval = json_object_new_string((char *)buf);
-    json_object_object_add(json, "rawmsg", jval);
-
+    /* Preserve the historical oversize errorfile field name while also
+     * emitting the regular full-message JSON field "inputname".
+     */
     getInputName(pMsg, &buf, &dummy);
-    jval = json_object_new_string((char *)buf);
+    CHKmalloc(jval = json_object_new_string((char *)buf));
     json_object_object_add(json, "input", jval);
 
     CHKmalloc(rendered = strdup((char *)fjson_object_to_json_string(json)));

--- a/runtime/errmsg.h
+++ b/runtime/errmsg.h
@@ -109,7 +109,10 @@ void __attribute__((format(printf, 4, 5))) LogMsg(
  * - No-op if the oversize message error file is not configured.
  * - Lazily opens the file on first use and reuses the file descriptor.
  * - Access is serialized via oversizeMsgLogMut.
- * - Writes one JSON line per entry with fields: "rawmsg" (original raw bytes) and "input" (input name).
+ * - Writes one full-message JSON line per entry, including fields such as
+ *   "rawmsg", "msg", "inputname", "fromhost-ip", "timereported", and
+ *   "timegenerated".
+ * - Also writes "input" as a compatibility alias for "inputname".
  * - On open/write errors, emits LogError(...) but returns no error; no further recovery is attempted.
  *   The reason is that there is nothing useful that could be done in that case.
  *

--- a/tests/imptcp-oversize-errorfile-truncate.sh
+++ b/tests/imptcp-oversize-errorfile-truncate.sh
@@ -2,7 +2,12 @@
 # Regression test for oversizemsg.errorfile with imptcp truncation.
 # imptcp can detect and truncate an oversized TCP frame before core
 # submission sees rawmsg > maxMessageSize. The test passes only if that
-# pre-submit oversize detection still writes the configured JSON errorfile.
+# pre-submit oversize detection writes the configured JSON errorfile with the
+# expanded message-field schema operators need for triage. This path runs
+# before parser-derived field values such as msg and syslogtag are known, so
+# the oracle checks that those fields exist while expecting imptcp-populated
+# fields to carry values. It also proves the legacy "input" alias is preserved
+# for consumers of the older two-field record.
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
@@ -22,12 +27,13 @@ tcpflood -I $RSYSLOG_DYNNAME.inputfile
 shutdown_when_empty
 wait_shutdown
 
-grep '"rawmsg":.*way too long message.*"input": "imptcp"' "$RSYSLOG2_OUT_LOG" > /dev/null
-if [ $? -ne 0 ]; then
-	echo
-	echo "FAIL: expected oversize JSON record not found. $RSYSLOG2_OUT_LOG is:"
-	cat "$RSYSLOG2_OUT_LOG"
-	error_exit 1
-fi
+content_check --regex '"rawmsg":.*way too long message' "$RSYSLOG2_OUT_LOG"
+content_check '"msg":' "$RSYSLOG2_OUT_LOG"
+content_check '"inputname": "imptcp"' "$RSYSLOG2_OUT_LOG"
+content_check '"input": "imptcp"' "$RSYSLOG2_OUT_LOG"
+content_check '"fromhost-ip": "127.0.0.1"' "$RSYSLOG2_OUT_LOG"
+content_check '"timereported":' "$RSYSLOG2_OUT_LOG"
+content_check '"timegenerated":' "$RSYSLOG2_OUT_LOG"
+content_check '"syslogtag":' "$RSYSLOG2_OUT_LOG"
 
 exit_test


### PR DESCRIPTION
## Summary
- expand `oversizemsg.errorfile` JSON records with common message fields useful for triage
- preserve the historical `input` field as a compatibility alias for `inputname`
- strengthen the imptcp truncation regression with `diag.sh` `content_check` assertions

Fixes: https://github.com/rsyslog/rsyslog/issues/4378

## Validation
- `CC=gcc ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --enable-imptcp --disable-generate-man-pages`
- `make -j60 check TESTS=""`
- `./tests/imptcp-oversize-errorfile-truncate.sh`
- `make -j60 check TESTS='imptcp-oversize-errorfile-truncate.sh glbl-oversizeMsg-log-vg.sh'` (Valgrind test skipped on host where unavailable)
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `devtools/check-test-antipatterns.sh tests/imptcp-oversize-errorfile-truncate.sh`
- `cubic review --base 5262726977c8fca9ef0199cc7018098329380a12` (`No issues found` after fixes)
- Docker Hub image `rsyslog/rsyslog_dev_base_ubuntu:26.04`, image ID `sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`
- static analyzer container via `devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh`: PASS (`scan-build: No bugs found`)
- `RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 timeout 120m devtools/local-validation-plan.sh --run`: PASS on rerun (1348 PASS, 27 SKIP, 0 FAIL, static analyzer result 0, Cubic clean)

Note: the first full local validation attempt hit unrelated `rcvr_fail_restore.sh` timing/order behavior; the rerun passed without code changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

