### PR TITLE
omfile: control symlink following

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1054,6 +1054,7 @@ EXTRA_DIST = \
     source/reference/parameters/omfile-fileownernum.rst \
     source/reference/parameters/omfile-flushinterval.rst \
     source/reference/parameters/omfile-flushontxend.rst \
+    source/reference/parameters/omfile-followsymlinks.rst \
     source/reference/parameters/omfile-iobuffersize.rst \
     source/reference/parameters/omfile-rotation-sizelimit.rst \
     source/reference/parameters/omfile-rotation-sizelimitcommand.rst \

--- a/doc/source/configuration/modules/omfile.rst
+++ b/doc/source/configuration/modules/omfile.rst
@@ -83,6 +83,7 @@ about different configuration languages in use by rsyslog.
    ../../reference/parameters/omfile-filegroupnum
    ../../reference/parameters/omfile-fileowner
    ../../reference/parameters/omfile-fileownernum
+   ../../reference/parameters/omfile-followsymlinks
    ../../reference/parameters/omfile-flushinterval
    ../../reference/parameters/omfile-flushontxend
    ../../reference/parameters/omfile-iobuffersize
@@ -145,6 +146,10 @@ Module Parameters
         :end-before: .. summary-end
    * - :ref:`param-omfile-filegroupnum`
      - .. include:: ../../reference/parameters/omfile-filegroupnum.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omfile-followsymlinks`
+     - .. include:: ../../reference/parameters/omfile-followsymlinks.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
    * - :ref:`param-omfile-dirowner`
@@ -284,6 +289,10 @@ selects whether a static or dynamic file (name) shall be written to.
         :end-before: .. summary-end
    * - :ref:`param-omfile-filecreatemode`
      - .. include:: ../../reference/parameters/omfile-filecreatemode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omfile-followsymlinks`
+     - .. include:: ../../reference/parameters/omfile-followsymlinks.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
    * - :ref:`param-omfile-dircreatemode`

--- a/doc/source/reference/parameters/omfile-followsymlinks.rst
+++ b/doc/source/reference/parameters/omfile-followsymlinks.rst
@@ -1,0 +1,66 @@
+.. _param-omfile-followsymlinks:
+.. _omfile.parameter.module.followsymlinks:
+
+followSymlinks
+==============
+
+.. index::
+   single: omfile; followSymlinks
+   single: followSymlinks
+
+.. summary-start
+
+Controls whether omfile follows a symbolic link in the final output path
+component.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omfile`.
+
+:Name: followSymlinks
+:Scope: module, action
+:Type: boolean
+:Default: depends on ``global(compatibility.defaults.secure=...)``
+:Required?: no
+:Introduced: 8.2608.0
+
+Description
+-----------
+
+When set to ``on``, omfile keeps the historic behavior and follows a symbolic
+link if the final component of the configured output path is a symlink. When
+set to ``off``, omfile opens the final path component with ``O_NOFOLLOW`` where
+the platform supports it, so a symlinked output file is rejected instead of
+being followed.
+
+If the parameter is not configured explicitly, the default follows
+``global(compatibility.defaults.secure=...)``:
+
+- ``strict``: do not follow the final output path component.
+- ``warn``: follow the symlink and emit a warning when the final output path
+  component is a symlink.
+- ``backward-compatible``: follow the symlink without a warning.
+
+This setting only applies to the final path component. Symlinks in parent
+directories are not rejected by this parameter.
+
+Action usage
+------------
+
+.. _param-omfile-action-followsymlinks:
+.. _omfile.parameter.action.followsymlinks:
+.. code-block:: rsyslog
+
+   action(type="omfile" file="/var/log/app.log" followSymlinks="off")
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="builtin:omfile" followSymlinks="off")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omfile`.

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -1884,6 +1884,7 @@ static rsRetVal qqueueLoadPersStrmInfoFixup(strm_t *pStrm, qqueue_t __attribute_
     ISOBJ_TYPE_assert(pThis, qqueue);
     CHKiRet(strm.SetDir(pStrm, pThis->pszSpoolDir, pThis->lenSpoolDir));
     CHKiRet(strm.SetbSync(pStrm, pThis->bSyncQueueFiles));
+    CHKiRet(strm.SetbNoFollowFinal(pStrm, 1));
 finalize_it:
     RETiRet;
 }
@@ -1916,6 +1917,7 @@ static rsRetVal qqueueTryLoadPersistedInfo(qqueue_t *pThis) {
     CHKiRet(strm.Construct(&psQIF));
     CHKiRet(strm.SettOperationsMode(psQIF, STREAMMODE_READ));
     CHKiRet(strm.SetsType(psQIF, STREAMTYPE_FILE_SINGLE));
+    CHKiRet(strm.SetbNoFollowFinal(psQIF, 1));
     CHKiRet(strm.SetFName(psQIF, pThis->pszQIFNam, pThis->lenQIFNam));
     CHKiRet(strm.ConstructFinalize(psQIF));
 
@@ -2012,6 +2014,7 @@ static rsRetVal qConstructDisk(qqueue_t *pThis) {
         CHKiRet(strm.SetiMaxFiles(pThis->tVars.disk.pWrite, MAX_DISK_QUEUE_FILES));
         CHKiRet(strm.SettOperationsMode(pThis->tVars.disk.pWrite, STREAMMODE_WRITE));
         CHKiRet(strm.SetsType(pThis->tVars.disk.pWrite, STREAMTYPE_FILE_CIRCULAR));
+        CHKiRet(strm.SetbNoFollowFinal(pThis->tVars.disk.pWrite, 1));
         if (pThis->useCryprov) {
             CHKiRet(strm.Setcryprov(pThis->tVars.disk.pWrite, &pThis->cryprov));
             CHKiRet(strm.SetcryprovData(pThis->tVars.disk.pWrite, pThis->cryprovData));
@@ -2024,6 +2027,7 @@ static rsRetVal qConstructDisk(qqueue_t *pThis) {
         CHKiRet(strm.SetiMaxFiles(pThis->tVars.disk.pReadDeq, MAX_DISK_QUEUE_FILES));
         CHKiRet(strm.SettOperationsMode(pThis->tVars.disk.pReadDeq, STREAMMODE_READ));
         CHKiRet(strm.SetsType(pThis->tVars.disk.pReadDeq, STREAMTYPE_FILE_CIRCULAR));
+        CHKiRet(strm.SetbNoFollowFinal(pThis->tVars.disk.pReadDeq, 1));
         if (pThis->useCryprov) {
             CHKiRet(strm.Setcryprov(pThis->tVars.disk.pReadDeq, &pThis->cryprov));
             CHKiRet(strm.SetcryprovData(pThis->tVars.disk.pReadDeq, pThis->cryprovData));
@@ -2037,6 +2041,7 @@ static rsRetVal qConstructDisk(qqueue_t *pThis) {
         CHKiRet(strm.SetiMaxFiles(pThis->tVars.disk.pReadDel, MAX_DISK_QUEUE_FILES));
         CHKiRet(strm.SettOperationsMode(pThis->tVars.disk.pReadDel, STREAMMODE_READ));
         CHKiRet(strm.SetsType(pThis->tVars.disk.pReadDel, STREAMTYPE_FILE_CIRCULAR));
+        CHKiRet(strm.SetbNoFollowFinal(pThis->tVars.disk.pReadDel, 1));
         if (pThis->useCryprov) {
             CHKiRet(strm.Setcryprov(pThis->tVars.disk.pReadDel, &pThis->cryprov));
             CHKiRet(strm.SetcryprovData(pThis->tVars.disk.pReadDel, pThis->cryprovData));
@@ -4147,6 +4152,7 @@ static rsRetVal qqueuePersist(qqueue_t *pThis, int bIsCheckpoint) {
     CHKiRet(strm.SettOperationsMode(psQIF, STREAMMODE_WRITE_TRUNC));
     CHKiRet(strm.SetbSync(psQIF, pThis->bSyncQueueFiles));
     CHKiRet(strm.SetsType(psQIF, STREAMTYPE_FILE_SINGLE));
+    CHKiRet(strm.SetbNoFollowFinal(psQIF, 1));
     CHKiRet(strm.SetFName(psQIF, (uchar *)tmpQIFName, lentmpQIFName));
     CHKiRet(strm.ConstructFinalize(psQIF));
 

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -279,6 +279,11 @@ static rsRetVal doPhysOpen(strm_t *pThis) {
         DBGPRINTF("Note: stream '%s' is a named pipe, open with O_NONBLOCK\n", pThis->pszCurrFName);
         iFlags |= O_NONBLOCK;
     }
+#ifdef O_NOFOLLOW
+    if (pThis->bNoFollowFinal) {
+        iFlags |= O_NOFOLLOW;
+    }
+#endif
 
     /* Keep lock held through open + init to avoid async close/open races. */
     if (bDoLock) d_pthread_mutex_lock(&pThis->mut);
@@ -2026,13 +2031,15 @@ finalize_it:
 /* simple ones first */
 DEFpropSetMeth(strm, iMaxFileSize, int64) DEFpropSetMeth(strm, iFileNumDigits, int)
     DEFpropSetMeth(strm, tOperationsMode, int) DEFpropSetMeth(strm, tOpenMode, mode_t)
-        DEFpropSetMeth(strm, compressionDriver, strm_compressionDriver_t) DEFpropSetMeth(strm, sType, strmType_t)
-            DEFpropSetMeth(strm, iZipLevel, int) DEFpropSetMeth(strm, bVeryReliableZip, int)
-                DEFpropSetMeth(strm, bSync, int) DEFpropSetMeth(strm, bReopenOnTruncate, int)
-                    DEFpropSetMeth(strm, sIOBufSize, size_t) DEFpropSetMeth(strm, iSizeLimit, off_t)
-                        DEFpropSetMeth(strm, iFlushInterval, int) DEFpropSetMeth(strm, pszSizeLimitCmd, uchar *)
-                            DEFpropSetMeth(strm, bSizeLimitCmdPassFileName, int)
-                                DEFpropSetMeth(strm, cryprov, cryprov_if_t *) DEFpropSetMeth(strm, cryprovData, void *)
+        DEFpropSetMeth(strm, bNoFollowFinal, int) DEFpropSetMeth(strm, compressionDriver, strm_compressionDriver_t)
+            DEFpropSetMeth(strm, sType, strmType_t) DEFpropSetMeth(strm, iZipLevel, int)
+                DEFpropSetMeth(strm, bVeryReliableZip, int) DEFpropSetMeth(strm, bSync, int)
+                    DEFpropSetMeth(strm, bReopenOnTruncate, int) DEFpropSetMeth(strm, sIOBufSize, size_t)
+                        DEFpropSetMeth(strm, iSizeLimit, off_t) DEFpropSetMeth(strm, iFlushInterval, int)
+                            DEFpropSetMeth(strm, pszSizeLimitCmd, uchar *)
+                                DEFpropSetMeth(strm, bSizeLimitCmdPassFileName, int)
+                                    DEFpropSetMeth(strm, cryprov, cryprov_if_t *)
+                                        DEFpropSetMeth(strm, cryprovData, void *)
 
     /* sets timeout in seconds */
     void ATTR_NONNULL() strmSetReadTimeout(strm_t *const __restrict__ pThis, const int val) {
@@ -2239,6 +2246,7 @@ static rsRetVal strmDup(strm_t *const pThis, strm_t **ppNew) {
     pNew->lenDir = pThis->lenDir;
     pNew->tOperationsMode = pThis->tOperationsMode;
     pNew->tOpenMode = pThis->tOpenMode;
+    pNew->bNoFollowFinal = pThis->bNoFollowFinal;
     pNew->compressionDriver = pThis->compressionDriver;
     pNew->iMaxFileSize = pThis->iMaxFileSize;
     pNew->iMaxFiles = pThis->iMaxFiles;
@@ -2410,6 +2418,7 @@ BEGINobjQueryInterface(strm)
     pIf->SetiFileNumDigits = strmSetiFileNumDigits;
     pIf->SettOperationsMode = strmSettOperationsMode;
     pIf->SettOpenMode = strmSettOpenMode;
+    pIf->SetbNoFollowFinal = strmSetbNoFollowFinal;
     pIf->SetcompressionDriver = strmSetcompressionDriver;
     pIf->SetsType = strmSetsType;
     pIf->SetiZipLevel = strmSetiZipLevel;

--- a/runtime/stream.h
+++ b/runtime/stream.h
@@ -174,6 +174,7 @@ struct strm_s {
         int64 strtOffs; /* start offset in file for current line/msg */
         int fileNotFoundError; /* boolean; if set, report file not found errors, else silently ignore */
         int noRepeatedErrorOutput; /* if a file is missing the Error is only given once */
+        sbool bNoFollowFinal; /* if set, do not follow final path component on open */
         int ignoringMsg;
         strm_compressionDriver_t compressionDriver;
 };
@@ -209,6 +210,7 @@ BEGINinterface(strm) /* name must also be changed in ENDinterface macro! */
     INTERFACEpropSetMeth(strm, iFileNumDigits, int);
     INTERFACEpropSetMeth(strm, tOperationsMode, int);
     INTERFACEpropSetMeth(strm, tOpenMode, mode_t);
+    INTERFACEpropSetMeth(strm, bNoFollowFinal, int);
     INTERFACEpropSetMeth(strm, compressionDriver, strm_compressionDriver_t);
     INTERFACEpropSetMeth(strm, sType, strmType_t);
     INTERFACEpropSetMeth(strm, iZipLevel, int);
@@ -230,7 +232,7 @@ BEGINinterface(strm) /* name must also be changed in ENDinterface macro! */
     INTERFACEpropSetMeth(strm, cryprov, cryprov_if_t *);
     INTERFACEpropSetMeth(strm, cryprovData, void *);
 ENDinterface(strm)
-#define strmCURR_IF_VERSION 16 /* increment whenever you change the interface structure! */
+#define strmCURR_IF_VERSION 17 /* increment whenever you change the interface structure! */
     /* V10, 2013-09-10: added new parameter bEscapeLF, changed mode to uint8_t (rgerhards) */
     /* V11, 2015-12-03: added new parameter bReopenOnTruncate */
     /* V12, 2015-12-11: added new parameter trimLineOverBytes, changed mode to uint32_t */
@@ -238,6 +240,7 @@ ENDinterface(strm)
     /* V14, 2019-11-13: added new parameter bEscapeLFString (rgerhards) */
     /* V15, ?? - description missing */
     /* V16, 2026-01-28: added new parameter bSizeLimitCmdPassFileName (rgerhards) */
+    /* V17, 2026-06-23: added bNoFollowFinal stream property setter */
 
 #define strmGetCurrFileNum(pStrm) ((pStrm)->iCurrFNum)
 
@@ -250,6 +253,7 @@ PROTOTYPEpropSetMeth(strm, iMaxFileSize, int64);
 PROTOTYPEpropSetMeth(strm, iFileNumDigits, int);
 PROTOTYPEpropSetMeth(strm, tOperationsMode, int);
 PROTOTYPEpropSetMeth(strm, tOpenMode, mode_t);
+PROTOTYPEpropSetMeth(strm, bNoFollowFinal, int);
 PROTOTYPEpropSetMeth(strm, compressionDriver, strm_compressionDriver_t);
 PROTOTYPEpropSetMeth(strm, sType, strmType_t);
 PROTOTYPEpropSetMeth(strm, iZipLevel, int);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -264,6 +264,7 @@ TESTS_DEFAULT = \
 	omfile-dynafilecachesize-invalid.sh \
 	omfile-dynafile-mmnormalize-property.sh \
 	omfile-read-only-errmsg.sh \
+	omfile-followsymlinks.sh \
 	omfile-null-filename.sh \
 	omfile-whitespace-filename.sh \
 	omfile-read-only.sh \
@@ -751,6 +752,7 @@ TESTS_LIBYAML = \
 	action-ratelimit-reload.sh \
 	action-ratelimit-validation.sh \
 	ratelimit-many-named-configs.sh \
+	yaml-omfile-followsymlinks.sh \
 	ratelimit_hup.sh \
 	yaml-basic.sh \
 	yaml-basic-yamlonly.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -366,6 +366,7 @@ TESTS_DEFAULT = \
 	daqueue-truncated-segment-startup.sh \
 	diskq-rfc5424.sh \
 	diskqueue-truncated-segment-startup.sh \
+	diskqueue-final-symlink.sh \
 	diskqueue.sh \
 	diskqueue-fsync.sh \
 	diskqueue-full.sh \

--- a/tests/diskqueue-final-symlink.sh
+++ b/tests/diskqueue-final-symlink.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Verify that a persistent disk queue rejects a symlinked segment file. The
+# first phase saves a real segmented queue; the second replaces its newest
+# final-path-component segment with a link to a copy. A legacy queue would
+# resume through the link and append the new message to that copied segment.
+# The oracle is the target checksum after shutdown, so a daemon diagnostic or
+# timing-dependent failure cannot make the test pass. The 20ms action delay
+# makes the 100-message setup batch remain on disk long enough to preserve
+# multiple 16KiB segments before the deliberately immediate shutdown.
+# added 2026-07-24 by Codex, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+
+SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
+TARGET_FILE="${RSYSLOG_DYNNAME}.queue-target"
+TARGET_SUM="${RSYSLOG_DYNNAME}.queue-target.sum"
+
+write_conf() {
+	generate_conf
+	add_conf '
+module(load="../plugins/omtesting/.libs/omtesting")
+global(workDirectory="'"$SPOOL_DIR"'")
+
+main_queue(
+	queue.type="disk"
+	queue.filename="mainq"
+	queue.maxFileSize="16k"
+	queue.saveOnShutdown="on"
+	queue.timeoutShutdown="1"
+)
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\\n")
+:omtesting:sleep 0 20000
+if ($msg contains "msgnum:") then {
+	action(type="omfile" template="outfmt" file="'"$RSYSLOG_OUT_LOG"'")
+}
+'
+}
+
+rm -rf "$SPOOL_DIR"
+rm -f "$TARGET_FILE" "$TARGET_SUM"
+
+write_conf
+startup
+injectmsg 0 100
+shutdown_immediate
+wait_shutdown
+
+SEGMENT_FILE=$(find "$SPOOL_DIR" -maxdepth 1 -type f -name 'mainq.[0-9]*' | sort | tail -n 1)
+if [ -z "$SEGMENT_FILE" ]; then
+	echo "FAIL: first phase did not preserve a disk queue segment"
+	ls -l "$SPOOL_DIR"
+	error_exit 1
+fi
+
+cp "$SEGMENT_FILE" "$TARGET_FILE" || error_exit 1
+cksum "$TARGET_FILE" > "$TARGET_SUM" || error_exit 1
+rm -f "$SEGMENT_FILE"
+ln -s "../$TARGET_FILE" "$SEGMENT_FILE" || error_exit 1
+
+write_conf
+startup
+injectmsg 100 1
+shutdown_immediate
+wait_shutdown
+
+if ! cksum "$TARGET_FILE" | cmp -s - "$TARGET_SUM"; then
+	echo "FAIL: disk queue followed final-component segment symlink"
+	error_exit 1
+fi
+
+exit_test

--- a/tests/omfile-followsymlinks.sh
+++ b/tests/omfile-followsymlinks.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Validate omfile final-component symlink policy. The test covers the default
+# strict/warn compatibility modes plus an explicit action override. The oracle
+# is the symlink target content after synchronized shutdown, with warning text
+# asserted through the configured omfile output rather than rsyslogd stderr.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+
+run_case() {
+	local name="$1"
+	local mode="$2"
+	local action_extra="$3"
+	local expect_target="$4"
+	local expect_warning="$5"
+	local link="${RSYSLOG_DYNNAME}.${name}.link"
+	local target="${RSYSLOG_DYNNAME}.${name}.target"
+	local normal="${RSYSLOG_DYNNAME}.${name}.normal"
+
+	rm -f "$link" "$target" "$normal"
+	: >"$target"
+	ln -s "$target" "$link" || skip_test
+
+	generate_conf
+	add_conf '
+global(compatibility.defaults.secure="'${mode}'")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'${RSYSLOG_DYNNAME}'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+if $msg contains "msgnum:" then {
+	action(type="omfile" template="outfmt" file="'${link}'" '${action_extra}')
+}
+action(type="omfile" file="'${normal}'" template="outfmt")
+'
+	startup
+	injectmsg 0 1
+	shutdown_when_empty
+	wait_shutdown
+
+	if [ "$expect_target" = "yes" ]; then
+		content_check "00000000" "$target"
+	else
+		if [ -s "$target" ]; then
+			echo "FAIL: ${name} wrote through symlink target unexpectedly"
+			cat "$target"
+			error_exit 1
+		fi
+	fi
+
+	if [ "$expect_warning" = "yes" ]; then
+		content_check "following symbolic link output file" "$normal"
+	else
+		check_not_present "following symbolic link output file" "$normal"
+	fi
+}
+
+run_case strict strict '' no no
+run_case warn warn '' yes yes
+run_case explicit_on warn 'followSymlinks="on"' yes no
+run_case explicit_off backward-compatible 'followSymlinks="off"' no no
+
+exit_test

--- a/tests/yaml-omfile-followsymlinks.sh
+++ b/tests/yaml-omfile-followsymlinks.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Validate YAML frontend parity for omfile followSymlinks. The config uses
+# backward-compatible global defaults but sets followSymlinks false on the
+# action, so the symlink target must remain empty after synchronized shutdown.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+
+link="${RSYSLOG_DYNNAME}.yaml.link"
+target="${RSYSLOG_DYNNAME}.yaml.target"
+normal="${RSYSLOG_DYNNAME}.yaml.normal"
+
+rm -f "$link" "$target" "$normal"
+: >"$target"
+ln -s "$target" "$link" || skip_test
+
+cat >"${RSYSLOG_DYNNAME}.omfile-follow.yaml" <<YAML_EOF
+version: 2
+templates:
+  - name: outfmt
+    type: string
+    string: "%msg:F,58:2%\\n"
+rulesets:
+  - name: main
+    statements:
+      - if: '\$msg contains "msgnum:"'
+        then:
+          - type: omfile
+            file: "${link}"
+            template: outfmt
+            followSymlinks: "off"
+          - type: omfile
+            file: "${normal}"
+            template: outfmt
+YAML_EOF
+
+generate_conf
+add_conf '
+global(compatibility.defaults.secure="backward-compatible")
+include(file="'${RSYSLOG_DYNNAME}'.omfile-follow.yaml")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'${RSYSLOG_DYNNAME}'.tcpflood_port"
+      ruleset="main")
+'
+
+startup
+tcpflood -m1
+shutdown_when_empty
+wait_shutdown
+
+if [ -s "$target" ]; then
+	echo "FAIL: YAML followSymlinks=false wrote through symlink target"
+	cat "$target"
+	error_exit 1
+fi
+content_check "00000000" "$normal"
+
+exit_test

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -47,6 +47,7 @@
 #include <libgen.h>
 #include <unistd.h>
 #include <sys/file.h>
+#include <sys/stat.h>
 #include <fcntl.h>
 #ifdef HAVE_ATOMIC_BUILTINS
     #include <pthread.h>
@@ -201,6 +202,8 @@ typedef struct _instanceData {
     sbool bUseAsyncWriter; /**< use async stream writer? */
     sbool bVeryRobustZip;
     sbool bAddLF; /**< append LF to records that are missing it? */
+    int bFollowSymlinks; /**< allow final output path component to be a symlink? */
+    sbool bFollowSymlinksExplicit; /**< was symlink policy configured explicitly? */
     statsobj_t *stats; /**< dynafile, primarily cache stats */
     STATSCOUNTER_DEF(ctrRequests, mutCtrRequests);
     STATSCOUNTER_DEF(ctrLevel0, mutCtrLevel0);
@@ -262,6 +265,8 @@ struct modConfData_s {
     gid_t fileGID;
     gid_t dirGID;
     int bDynafileDoNotSuspend;
+    int bFollowSymlinks;
+    sbool bFollowSymlinksExplicit;
     strm_compressionDriver_t compressionDriver;
     int compressionDriver_workers;
     sbool bAddLF; /**< default setting for addLF action parameter */
@@ -287,6 +292,7 @@ static struct cnfparamdescr modpdescr[] = {
     {"fileownernum", eCmdHdlrInt, 0},
     {"filegroup", eCmdHdlrGID, 0},
     {"dynafile.donotsuspend", eCmdHdlrBinary, 0},
+    {"followsymlinks", eCmdHdlrBinary, 0},
     {"filegroupnum", eCmdHdlrInt, 0},
 };
 static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / sizeof(struct cnfparamdescr), modpdescr};
@@ -314,6 +320,7 @@ static struct cnfparamdescr actpdescr[] = {{"dynafilecachesize", eCmdHdlrInt, 0}
                                            {"sync", eCmdHdlrBinary, 0}, /* legacy: actionfileenablesync */
                                            {"file", eCmdHdlrString, 0}, /* either "file" or ... */
                                            {"dynafile", eCmdHdlrString, 0}, /* "dynafile" MUST be present */
+                                           {"followsymlinks", eCmdHdlrBinary, 0},
                                            {"sig.provider", eCmdHdlrGetWord, 0},
                                            {"cry.provider", eCmdHdlrGetWord, 0},
                                            {"closetimeout", eCmdHdlrPositiveInt, 0},
@@ -629,6 +636,27 @@ static rsRetVal sigprovPrepare(instanceData *__restrict__ const pData, uchar *__
     RETiRet;
 }
 
+static int getCompatDefaultFollowSymlinks(const rsconf_t *const cnf) {
+    return cnf == NULL || cnf->globals.compatDefaultsSecure != COMPAT_DEFAULTS_SECURE_STRICT;
+}
+
+static void warnIfFollowingSymlink(const instanceData *__restrict__ const pData,
+                                   const uchar *__restrict__ const fileName) {
+    struct stat st;
+
+    if (!pData->bFollowSymlinks || pData->bFollowSymlinksExplicit || runModConf == NULL || runModConf->pConf == NULL ||
+        runModConf->pConf->globals.compatDefaultsSecure != COMPAT_DEFAULTS_SECURE_WARN) {
+        return;
+    }
+    if (lstat((const char *)fileName, &st) == 0 && S_ISLNK(st.st_mode)) {
+        LogMsg(0, RS_RET_OK, LOG_WARNING,
+               "omfile: following symbolic link output file '%s'; "
+               "set action(type=\"omfile\" followSymlinks=\"off\") or "
+               "global(compatibility.defaults.secure=\"strict\") to reject final-component symlinks",
+               fileName);
+    }
+}
+
 /**
  * @brief Prepares file access for a given file name.
  *
@@ -671,7 +699,13 @@ static rsRetVal prepareFile(instanceData *__restrict__ const pData,
         /* no matter if we needed to create directories or not, we now try to create
          * the file. -- rgerhards, 2008-12-18 (based on patch from William Tisater)
          */
-        fd = open((char *)newFileName, O_WRONLY | O_APPEND | O_CREAT | O_NOCTTY | O_CLOEXEC, pData->fCreateMode);
+        int openFlags = O_WRONLY | O_APPEND | O_CREAT | O_NOCTTY | O_CLOEXEC;
+#ifdef O_NOFOLLOW
+        if (!pData->bFollowSymlinks) {
+            openFlags |= O_NOFOLLOW;
+        }
+#endif
+        fd = open((char *)newFileName, openFlags, pData->fCreateMode);
         if (fd != -1) {
             /* check and set uid/gid */
             if (pData->fileUID != (uid_t)-1 || pData->fileGID != (gid_t)-1) {
@@ -696,6 +730,7 @@ static rsRetVal prepareFile(instanceData *__restrict__ const pData,
             ABORT_FINALIZE((openErrno == ENOENT) ? RS_RET_FILE_NOT_FOUND : RS_RET_FILE_OPEN_ERROR);
         }
     }
+    warnIfFollowingSymlink(pData, newFileName);
 
     /* the copies below are clumpsy, but there is no way around given the
      * anomalies in dirname() and basename() [they MODIFY the provided buffer...]
@@ -720,6 +755,7 @@ static rsRetVal prepareFile(instanceData *__restrict__ const pData,
     CHKiRet(strm.SetsIOBufSize(pData->pStrm, (size_t)pData->iIOBufSize));
     CHKiRet(strm.SettOperationsMode(pData->pStrm, STREAMMODE_WRITE_APPEND));
     CHKiRet(strm.SettOpenMode(pData->pStrm, cs.fCreateMode));
+    CHKiRet(strm.SetbNoFollowFinal(pData->pStrm, !pData->bFollowSymlinks));
     CHKiRet(strm.SetcompressionDriver(pData->pStrm, runModConf->compressionDriver));
     CHKiRet(strm.SetCompressionWorkers(pData->pStrm, runModConf->compressionDriver_workers));
     CHKiRet(strm.SetbSync(pData->pStrm, pData->bSyncFile));
@@ -1029,6 +1065,8 @@ BEGINbeginCnfLoad
     pModConf->dirGID = -1;
     pModConf->bDynafileDoNotSuspend = 1;
     pModConf->bAddLF = 1;
+    pModConf->bFollowSymlinks = -1;
+    pModConf->bFollowSymlinksExplicit = 0;
 ENDbeginCnfLoad
 
 BEGINsetModCnf
@@ -1098,6 +1136,9 @@ BEGINsetModCnf
             loadModConf->fileGID = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "dynafile.donotsuspend")) {
             loadModConf->bDynafileDoNotSuspend = (int)pvals[i].val.d.n;
+        } else if (!strcmp(modpblk.descr[i].name, "followsymlinks")) {
+            loadModConf->bFollowSymlinks = (int)pvals[i].val.d.n;
+            loadModConf->bFollowSymlinksExplicit = 1;
         } else {
             dbgprintf(
                 "omfile: program error, non-handled "
@@ -1316,6 +1357,11 @@ static void setInstParamDefaults(instanceData *__restrict__ const pData) {
     pData->iFlushInterval = FLUSH_INTRVL_DFLT;
     pData->bUseAsyncWriter = USE_ASYNCWRITER_DFLT;
     pData->bAddLF = loadModConf->bAddLF;
+    pData->bFollowSymlinks = loadModConf->bFollowSymlinks;
+    pData->bFollowSymlinksExplicit = loadModConf->bFollowSymlinksExplicit;
+    if (pData->bFollowSymlinks == -1) {
+        pData->bFollowSymlinks = getCompatDefaultFollowSymlinks(loadConf);
+    }
     pData->sigprovName = NULL;
     pData->cryprovName = NULL;
     pData->useSigprov = 0;
@@ -1561,6 +1607,9 @@ BEGINnewActInst
             CHKmalloc(pData->fname = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             CODE_STD_STRING_REQUESTnewActInst(2);
             pData->bDynamicName = 1;
+        } else if (!strcmp(actpblk.descr[i].name, "followsymlinks")) {
+            pData->bFollowSymlinks = (int)pvals[i].val.d.n;
+            pData->bFollowSymlinksExplicit = 1;
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
             CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "sig.provider")) {


### PR DESCRIPTION
## Summary
- add stream-level final-component no-follow support and enable it for disk queue stream/.qi files
- add omfile `followSymlinks` module/action parameter integrated with `compatibility.defaults.secure`
- document the final-component-only behavior and add RainerScript/YAML regressions

## Reporter credit

Thanks to [@0xseiryuu](https://github.com/0xseiryuu) for the clear report, concrete affected call sites, and the analysis of both the omfile and disk-queue stream exposure. That analysis made the compatibility-preserving final-component policy and focused regression coverage possible.

Closes: https://github.com/rsyslog/rsyslog/issues/6718

## Validation

Final post-rebase validation against `main` at `ab5e800f5`:

- `RSYSLOG_LOCAL_CHECK_JOBS=10 RSYSLOG_LOCAL_BUILD_JOBS=10 devtools/local-validation-plan.sh --run`
  - mock distribution check: passed
  - Ubuntu 26.04: 1,538 total, 1,509 passed, 29 expected skips, 0 failed
  - `omfile-followsymlinks.sh`, `yaml-omfile-followsymlinks.sh`, and `diskqueue-final-symlink.sh`: passed
  - full segmented disk/DA queue family: passed
  - static analyzer: no bugs found
  - final local Cubic: no issues found
  - image: `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`)
- `devtools/format-code.sh --git-changed --check --check-if-available`: passed
- test antipattern scans: no matches
- `git diff --check upstream/main...HEAD`: passed

The testbench-plumbing classification conservatively kept all service families enabled.

## Review follow-up

- addressed local Cubic feedback by bumping the stream interface version
- addressed local Cubic feedback by suppressing warn-mode symlink notices when `followSymlinks="on"` is explicit
- addressed hosted repo policy feedback by adding the new parameter page to `doc/Makefile.am`
- addressed hosted Cubic feedback by applying `bNoFollowFinal` to named-pipe stream opens as well
