### PR TITLE
omhttp: continue after permanent data failures

### DIFF
--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -1925,6 +1925,20 @@ finalize_it:
     RETiRet;
 }
 
+static rsRetVal submitBatchDatafailOk(wrkrInstanceData_t *pWrkrData, uchar **tpls) {
+    DEFiRet;
+    const size_t nmemb = pWrkrData->batch.nmemb;
+    const rsRetVal submitRet = submitBatch(pWrkrData, tpls);
+    if (submitRet == RS_RET_DATAFAIL) {
+        DBGPRINTF("omhttp: permanent data failure for batch of %zu message(s), continuing transaction\n", nmemb);
+        FINALIZE;
+    }
+    CHKiRet(submitRet);
+
+finalize_it:
+    RETiRet;
+}
+
 BEGINbeginTransaction
     CODESTARTbeginTransaction;
     if (!pWrkrData->pData->batchMode) {
@@ -1963,7 +1977,7 @@ BEGINcommitTransaction
                 } else if (strcmp((char *)serverData->restPATH, (char *)restPath) != 0) {
                     /* restPath changed -> flush current batch if it contains data */
                     if (pWrkrData->batch.nmemb > 0) {
-                        CHKiRet(submitBatch(pWrkrData, NULL));
+                        CHKiRet(submitBatchDatafailOk(pWrkrData, NULL));
                         serverData = pWrkrData->listServerDataWkr[pWrkrData->serverIndex];
                     }
                     initializeBatch(pWrkrData);
@@ -1976,7 +1990,8 @@ BEGINcommitTransaction
             if (pData->maxBatchSize == 1) {
                 initializeBatch(pWrkrData);
                 CHKiRet(buildBatch(pWrkrData, payload));
-                CHKiRet(submitBatch(pWrkrData, tpls));
+                CHKiRet(submitBatchDatafailOk(pWrkrData, tpls));
+                initializeBatch(pWrkrData);
                 continue;
             }
 
@@ -1998,7 +2013,7 @@ BEGINcommitTransaction
 
             if (submit) {
                 /* flush current batch, then start a new one. keep dyn restPath consistent */
-                CHKiRet(submitBatch(pWrkrData, NULL));
+                CHKiRet(submitBatchDatafailOk(pWrkrData, NULL));
                 initializeBatch(pWrkrData);
                 if (pData->dynRestPath) {
                     uchar *restPath = actParam(pParams, iNumTpls, i, 1).param;
@@ -2012,14 +2027,19 @@ BEGINcommitTransaction
             CHKiRet(buildBatch(pWrkrData, payload));
         } else {
             /* non-batch mode: send immediately */
-            CHKiRet(curlPost(pWrkrData, payload, strlen((char *)payload), tpls, 1));
+            const rsRetVal postRet = curlPost(pWrkrData, payload, strlen((char *)payload), tpls, 1);
+            if (postRet == RS_RET_DATAFAIL) {
+                DBGPRINTF("omhttp: permanent data failure for single message, continuing transaction\n");
+                continue;
+            }
+            CHKiRet(postRet);
         }
     }
 
     /* finalize any remaining batch data */
     if (pData->batchMode) {
         if (pWrkrData->batch.nmemb > 0) {
-            CHKiRet(submitBatch(pWrkrData, NULL));
+            CHKiRet(submitBatchDatafailOk(pWrkrData, NULL));
         } else {
             dbgprintf("omhttp: commitTransaction, pWrkrData->batch.nmemb = 0, nothing to send. \n");
         }

--- a/doc/source/configuration/modules/omhttp.rst
+++ b/doc/source/configuration/modules/omhttp.rst
@@ -320,6 +320,30 @@ The token is necessary when you use the profile "hec:splunk:event" or "hec:splun
 This value is ignored if you use other profile.
 
 
+HTTP Status Handling
+====================
+
+omhttp separates transport failures from HTTP response statuses. Connection
+failures, HTTP 429, and HTTP 5xx responses are retried through the normal
+action suspend/resume path unless a more specific retry ruleset is configured.
+Ordinary HTTP 3xx and 4xx responses are treated as permanent data failures:
+omhttp records the failed request and response in :ref:`param-omhttp-errorfile`
+when configured, does not retry the same payload indefinitely, and continues
+with later HTTP request payloads. In batch mode the failed HTTP request payload
+is the batch, so all events in that batch are treated as failed together.
+
+Some HTTP targets use 4xx responses for temporary authorization states or for
+data that the target will never accept. Use :ref:`param-omhttp-httpretrycodes`
+when a specific 4xx response should be retried, for example a temporary
+authorization failure. Use :ref:`param-omhttp-httpignorablecodes` only when it
+is acceptable to mark that response as handled without writing the failed
+payload to :ref:`param-omhttp-errorfile`. For Splunk HEC, HTTP 400 commonly
+means the event body was rejected; operators should usually inspect the
+configured :ref:`param-omhttp-errorfile` entry first, fix the template or source
+payload when needed, and only then decide whether a status-specific retry or
+ignore policy is appropriate.
+
+
 Statistic Counter
 =================
 

--- a/doc/source/reference/parameters/omhttp-httpignorablecodes.rst
+++ b/doc/source/reference/parameters/omhttp-httpignorablecodes.rst
@@ -25,7 +25,14 @@ This parameter applies to :doc:`../../configuration/modules/omhttp`.
 
 Description
 -----------
-An array of strings that defines a list of one or more HTTP status codes that are not retriable by the omhttp plugin.
+An array of strings that defines one or more HTTP status codes that omhttp
+treats as successfully handled after the HTTP response is received. Use this
+only when dropping the affected message is acceptable for the target system.
+For example, a Splunk HEC deployment may choose to ignore a known permanent
+HTTP 400 response after capturing the failed request in :ref:`param-omhttp-errorfile`.
+
+Codes listed here override the normal failure result. They do not make the
+remote service accept the data, and they do not replay the message later.
 
 Input usage
 -----------

--- a/doc/source/reference/parameters/omhttp-httpretrycodes.rst
+++ b/doc/source/reference/parameters/omhttp-httpretrycodes.rst
@@ -19,13 +19,18 @@ This parameter applies to :doc:`../../configuration/modules/omhttp`.
 :Name: httpretrycodes
 :Scope: input
 :Type: array
-:Default: input=2xx status codes
+:Default: input=none
 :Required?: no
 :Introduced: Not specified
 
 Description
 -----------
-An array of strings that defines a list of one or more HTTP status codes that are retriable by the omhttp plugin. By default non-2xx HTTP status codes are considered retriable.
+An array of strings that defines one or more HTTP status codes that are
+retriable by the omhttp plugin in addition to its built-in retry behavior.
+By default, transport failures, HTTP 429, and HTTP 5xx responses are retried;
+ordinary HTTP 3xx and 4xx responses are treated as permanent data failures.
+Use this parameter when a deployment wants a specific response, such as a
+temporary HTTP 403 from an authorization workflow, to follow the retry path.
 
 Input usage
 -----------

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1036,6 +1036,9 @@ TESTS_OMHTTP = \
 	omhttp-auth.sh \
 	omhttp-basic.sh \
 	omhttp-basic-ignorecodes.sh \
+	omhttp-datafail-continues.sh \
+	omhttp-datafail-continues-batch.sh \
+	omhttp-datafail-continues-batch-single.sh \
 	omhttp-batch-fail-with-400.sh \
 	omhttp-batch-jsonarray-compress.sh \
 	omhttp-batch-jsonarray-retry.sh \

--- a/tests/omhttp-datafail-continues-batch-single.sh
+++ b/tests/omhttp-datafail-continues-batch-single.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+#
+# Regression test for rsyslog/rsyslog#4348 in omhttp batch mode with
+# batch.maxsize="1". A single HTTP 400 is still a permanent data failure for
+# only that HTTP request payload; it must not leave the action in DATAFAIL state
+# and block later good events. The mock server rejects message 00000002 and the
+# oracle is that messages after it still arrive, with only message 2 missing.
+
+# shellcheck disable=SC2034,SC2154
+
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=10
+
+omhttp_start_server 0 --fail-msgnum-400 00000002
+
+generate_conf
+add_conf '
+module(load="../contrib/omhttp/.libs/omhttp")
+
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+if $msg contains "msgnum:" then
+	action(
+		name="action_omhttp"
+		type="omhttp"
+		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+		template="tpl"
+
+		server="localhost"
+		serverport="'$omhttp_server_lstnport'"
+		restpath="my/endpoint"
+		batch="on"
+		batch.format="jsonarray"
+		batch.maxsize="1"
+
+		usehttps="off"
+	)
+'
+
+startup
+injectmsg 0 $NUMMESSAGES
+shutdown_when_empty
+wait_shutdown
+omhttp_get_data $omhttp_server_lstnport my/endpoint jsonarray
+omhttp_stop_server
+EXPECTED='00000000
+00000001
+00000003
+00000004
+00000005
+00000006
+00000007
+00000008
+00000009'
+cmp_exact
+exit_test

--- a/tests/omhttp-datafail-continues-batch.sh
+++ b/tests/omhttp-datafail-continues-batch.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+#
+# Regression test for rsyslog/rsyslog#4348 in omhttp batch mode. A permanent
+# HTTP 400 rejects the whole HTTP request payload; for a multi-message batch,
+# that means all events in that batch are failed together. The mock server
+# rejects the batch containing message 00000002. The neighboring message in
+# that failed HTTP payload can vary with transaction boundaries, so the oracle
+# checks the stable behavior: message 2 is absent, later batches are still sent,
+# and messages known to be outside the rejected payload are not duplicated.
+
+# shellcheck disable=SC2034,SC2154
+
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=10
+
+omhttp_start_server 0 --fail-msgnum-400 00000002
+
+generate_conf
+add_conf '
+module(load="../contrib/omhttp/.libs/omhttp")
+
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+main_queue(queue.dequeueBatchSize="10")
+
+if $msg contains "msgnum:" then
+	action(
+		name="action_omhttp"
+		type="omhttp"
+		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+		template="tpl"
+
+		server="localhost"
+		serverport="'$omhttp_server_lstnport'"
+		restpath="my/endpoint"
+		batch="on"
+		batch.format="jsonarray"
+		batch.maxsize="2"
+
+		usehttps="off"
+	)
+'
+
+startup
+injectmsg 0 $NUMMESSAGES
+shutdown_when_empty
+wait_shutdown
+omhttp_get_data $omhttp_server_lstnport my/endpoint jsonarray
+omhttp_stop_server
+content_count_check "00000000" 1
+check_not_present "00000002"
+content_count_check "00000004" 1
+content_count_check "00000005" 1
+content_count_check "00000006" 1
+content_count_check "00000007" 1
+content_count_check "00000008" 1
+content_count_check "00000009" 1
+exit_test

--- a/tests/omhttp-datafail-continues.sh
+++ b/tests/omhttp-datafail-continues.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+#
+# Regression test for rsyslog/rsyslog#4348: a permanent omhttp data
+# failure such as HTTP 400 must drop only the rejected event and must not
+# leave the action in DATAFAIL state so later good events stop flowing.
+# The mock server rejects message 00000002 with HTTP 400 and accepts all
+# other payloads. The oracle is that messages after the rejected payload
+# still arrive, with only message 2 missing from the accepted sequence.
+
+# shellcheck disable=SC2034,SC2154
+
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=10
+
+omhttp_start_server 0 --fail-msgnum-400 00000002
+
+generate_conf
+add_conf '
+module(load="../contrib/omhttp/.libs/omhttp")
+
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+if $msg contains "msgnum:" then
+	action(
+		name="action_omhttp"
+		type="omhttp"
+		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+		template="tpl"
+
+		server="localhost"
+		serverport="'$omhttp_server_lstnport'"
+		restpath="my/endpoint"
+		batch="off"
+
+		usehttps="off"
+	)
+'
+
+startup
+injectmsg 0 $NUMMESSAGES
+shutdown_when_empty
+wait_shutdown
+omhttp_get_data $omhttp_server_lstnport my/endpoint
+omhttp_stop_server
+EXPECTED='00000000
+00000001
+00000003
+00000004
+00000005
+00000006
+00000007
+00000008
+00000009'
+cmp_exact
+exit_test

--- a/tests/omhttp_server.py
+++ b/tests/omhttp_server.py
@@ -108,6 +108,12 @@ class MyHandler(BaseHTTPRequestHandler):
         else:
             post_data = raw_data
 
+        if metadata['fail_msgnum_400'] and metadata['fail_msgnum_400'].encode('utf-8') in post_data:
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(b'BAD REQUEST')
+            return
+
         if self.path not in data:
             data[self.path] = []
         data[self.path].append(post_data.decode('utf-8'))
@@ -151,6 +157,8 @@ if __name__ == '__main__':
                         default=-1, help='fail with 400 after n posts')
     parser.add_argument('--fail-with-401-or-403-after', action='store', type=int,
                         default=-1, help='fail with 401 or 403 after n posts')
+    parser.add_argument('--fail-msgnum-400', action='store', default='',
+                        help='fail with 400 when the raw post body contains this message number')
     parser.add_argument('--fail-with-delay-secs', action='store', type=int, default=0, help='fail with n secs of delay')
     parser.add_argument('--fail-interval-start', action='store', type=int,
                         default=-1, help='start failing after n seconds from the first POST')
@@ -164,6 +172,7 @@ if __name__ == '__main__':
     metadata['fail_with'] = args.fail_with
     metadata['fail_with_400_after'] = args.fail_with_400_after
     metadata['fail_with_401_or_403_after'] = args.fail_with_401_or_403_after
+    metadata['fail_msgnum_400'] = args.fail_msgnum_400
     metadata['fail_with_delay_secs'] = args.fail_with_delay_secs
     metadata['fail_interval_start'] = args.fail_interval_start
     metadata['fail_interval_stop'] = args.fail_interval_stop


### PR DESCRIPTION
## Summary

Fixes `omhttp` handling for permanent HTTP data failures:

- consumes `RS_RET_DATAFAIL` after the failed HTTP request payload has been logged/recorded
- continues with later HTTP request payloads instead of letting the action core retry/split the same permanent failure
- preserves retry behavior for transport failures, HTTP 429/5xx, and statuses configured through `httpRetryCodes`
- documents the request-payload semantics, including the batch-mode case where one failed HTTP request means the whole batch failed

This changes the PR from documentation-only into the code fix for https://github.com/rsyslog/rsyslog/issues/4348.

## Reproducer / Tests

Added mock-server support for rejecting a selected message number with HTTP 400 and three regressions:

- `omhttp-datafail-continues.sh`
- `omhttp-datafail-continues-batch-single.sh`
- `omhttp-datafail-continues-batch.sh`

The tests cover non-batch sends, `batch.maxsize="1"`, and multi-message batches. The multi-message batch test intentionally expects the whole rejected HTTP request payload to be absent.

## Validation

- `./autogen.sh --enable-debug --enable-testbench --enable-omhttp --enable-imdiag --enable-omstdout --disable-generate-man-pages` passed
- `make -j60 check TESTS=""` passed
- focused omhttp regressions and nearby omhttp tests passed:
  - `./tests/omhttp-datafail-continues.sh`
  - `./tests/omhttp-datafail-continues-batch-single.sh`
  - `./tests/omhttp-datafail-continues-batch.sh`
  - `./tests/omhttp-basic-ignorecodes.sh`
  - `./tests/omhttp-batch-fail-with-400.sh`
  - `./tests/omhttp-batch-jsonarray.sh`
  - `./tests/omhttp-batch-jsonarray-retry.sh`
- `shellcheck -S warning` on the three new tests passed
- `devtools/check-test-antipatterns.sh` on the three new tests passed
- `devtools/format-python.sh --check-if-available tests/omhttp_server.py` passed
- `bash devtools/format-code.sh --git-changed --check --check-if-available` passed
- `git diff --check` passed
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j60` passed
- rendered docs build passed:
  - `RSYSLOG_LOCAL_DOC_JOBS=60 ./doc/tools/build-doc-linux.sh --clean --format html --jobs 60`
- local Cubic review found a valid first issue in the `batch.maxsize=1` path; fixed, rerun clean: `No issues found.`
- local clang static analyzer container passed:
  - image `rsyslog/rsyslog_dev_base_ubuntu:26.04`
  - image id `sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`
  - command used the skill's Ubuntu 26.04 `run-static-analyzer.sh` lane with Kafka/Elasticsearch/MySQL service families disabled as unrelated to `omhttp`
  - result: `scan-build: No bugs found. static analyzer result: 0`
- change-gated Ubuntu 26.04 container check was run with `-j60`; it failed only in unrelated `diag-core-classification.sh` due the container's external `systemd-coredump` `kernel.core_pattern`
  - summary: `TOTAL: 1263 PASS:1229 SKIP:33 FAIL:1`
  - focused container rerun of `diag-core-classification.sh` passed
  - omhttp tests in the broad container run passed

Because of the unrelated full-container diagnostic-core failure, this has strong targeted and container evidence but not a perfectly clean local full container check. Hosted CI should provide the final broad gate.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->