### PR TITLE
doc: clarify omprog transaction mode status

### DIFF
--- a/doc/source/configuration/modules/omprog.rst
+++ b/doc/source/configuration/modules/omprog.rst
@@ -145,6 +145,21 @@ Action Parameters
         :start-after: .. summary-start
         :end-before: .. summary-end
 
+Transaction Mode Status
+=======================
+
+The :ref:`param-omprog-usetransactions` option is still implemented by the
+existing ``omprog`` module and remains experimental. It uses the legacy output
+transaction callbacks because the setting is action-specific: deployments can
+enable transaction markers for one external program while leaving another
+``omprog`` action in per-message mode.
+
+The newer output transaction interface does not currently model this kind of
+per-action switch. Treating ``useTransactions`` as a simple implementation
+conversion would either change existing behavior or require a broader core or
+module design. New configurations should enable it only when the external
+program explicitly implements the ``omprog`` transaction marker protocol.
+
 Examples
 ========
 
@@ -202,5 +217,3 @@ rsyslog will kill and restart it.
 
 Note that the ``useTransactions`` flag is not used in this example. The
 program stores and confirms each log individually.
-
-

--- a/doc/source/reference/parameters/omprog-usetransactions.rst
+++ b/doc/source/reference/parameters/omprog-usetransactions.rst
@@ -51,6 +51,20 @@ returning ``DEFER_COMMIT`` (instead of ``OK``). Refer to the link below for deta
    <https://github.com/rsyslog/rsyslog/issues/2420>`_ with the use of
    transactions together with ``confirmMessages=on``.
 
+Implementation status
+---------------------
+
+``omprog`` currently implements this option through rsyslog's legacy output
+transaction callbacks. That is intentional for the existing module: the option
+is action-specific, so one ``omprog`` action can run in transaction mode while
+another action can keep the normal per-message processing path.
+
+The newer output transaction interface expects a module to be transactional as
+a module capability instead of switching that behavior per action. Moving this
+option to that interface would therefore need either a compatible core design
+change, a separate transactional module, or an incompatible change to this
+parameter. It is not a drop-in implementation detail.
+
 Action usage
 ------------
 .. _param-omprog-action-usetransactions:


### PR DESCRIPTION
## Summary
- document that `omprog` keeps `useTransactions` on the legacy transaction callbacks because the option is action-specific
- explain why the newer output transaction interface is not a drop-in conversion for this behavior
- point new deployments at the explicit omprog transaction marker protocol when enabling the experimental option

## Issue handling
Closes rsyslog/rsyslog#3058 as a documentation/design-status resolution. I did not change runtime behavior: preserving the current per-action switch would require a broader core/module design change or an incompatible option change.

## Validation
- `devtools/local-validation-plan.sh`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 60`
- `git diff --check`

Docs-only change; no runtime container or local Cubic gate required by the repository instructions for rendered documentation edits.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

