### PR TITLE
imjournal: add journal namespace support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -774,6 +774,12 @@ if test "x$enable_imjournal" = "xyes" -o "x$enable_imjournal" = "xoptional"; the
                  ])
 	    ])
 	])
+	if test "x$imjournal_use_dummy" != "xyes"; then
+		save_libs=$LIBS
+		LIBS="$LIBS $LIBSYSTEMD_JOURNAL_LIBS"
+		AC_CHECK_FUNCS(sd_journal_open_namespace,,)
+		LIBS=$save_libs
+	fi
 fi
 AM_CONDITIONAL(IMJOURNAL_USE_DUMMY, test x$imjournal_use_dummy = xyes)
 AM_CONDITIONAL(ENABLE_IMJOURNAL, test x$enable_imjournal = xyes -o x$enable_imjournal = xoptional)

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -593,6 +593,7 @@ EXTRA_DIST = \
     source/reference/parameters/imjournal-ignorenonvalidstatefile.rst \
     source/reference/parameters/imjournal-ignorepreviousmessages.rst \
     source/reference/parameters/imjournal-main.rst \
+    source/reference/parameters/imjournal-namespace.rst \
     source/reference/parameters/imjournal-persiststateinterval.rst \
     source/reference/parameters/imjournal-ratelimit-burst.rst \
     source/reference/parameters/imjournal-ratelimit-interval.rst \

--- a/doc/source/configuration/modules/imjournal.rst
+++ b/doc/source/configuration/modules/imjournal.rst
@@ -122,6 +122,10 @@ Module Parameters
      - .. include:: ../../reference/parameters/imjournal-remote.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-imjournal-namespace`
+     - .. include:: ../../reference/parameters/imjournal-namespace.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-imjournal-defaulttag`
      - .. include:: ../../reference/parameters/imjournal-defaulttag.rst
         :start-after: .. summary-start
@@ -162,6 +166,7 @@ Parameters specific to the input module.
    ../../reference/parameters/imjournal-workaroundjournalbug
    ../../reference/parameters/imjournal-fsync
    ../../reference/parameters/imjournal-remote
+   ../../reference/parameters/imjournal-namespace
    ../../reference/parameters/imjournal-defaulttag
    ../../reference/parameters/imjournal-main
 

--- a/doc/source/reference/parameters/imjournal-namespace.rst
+++ b/doc/source/reference/parameters/imjournal-namespace.rst
@@ -1,0 +1,53 @@
+.. _param-imjournal-namespace:
+.. _imjournal.parameter.module.namespace:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:Namespace
+
+Namespace
+=========
+
+.. index::
+   single: imjournal; Namespace
+   single: Namespace
+
+.. summary-start
+
+Reads entries from a specific systemd journal namespace.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: Namespace
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=unset
+:Required?: no
+:Introduced: 8.2608.0
+
+Description
+-----------
+When set, ``imjournal`` opens the named systemd journal namespace instead of
+the default system journal namespace. This is useful with services that use
+systemd's ``LogNamespace=`` setting and should be processed by a dedicated
+``imjournal`` configuration.
+
+``Namespace`` uses the systemd ``sd_journal_open_namespace()`` API. If rsyslog
+is built against a libsystemd version that does not provide that API, the
+configuration fails with an explicit error.
+
+This option is mutually exclusive with :ref:`param-imjournal-remote`.
+
+Module usage
+------------
+.. _param-imjournal-module-namespace:
+.. _imjournal.parameter.module.namespace-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" Namespace="my-service")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -91,6 +91,7 @@ static int n_journal = 0;
 struct modConfData_s {
     rsconf_t *pConf;
     instanceConf_t *root, *tail;
+    char *pszNamespace;
 };
 
 static struct configSettings_s {
@@ -130,6 +131,7 @@ static struct cnfparamdescr modpdescr[] = {{"statefile", eCmdHdlrGetWord, 0},
                                            {"workaroundjournalbug", eCmdHdlrBinary, 0},
                                            {"fsync", eCmdHdlrBinary, 0},
                                            {"remote", eCmdHdlrBinary, 0},
+                                           {"namespace", eCmdHdlrString, 0},
                                            {"defaulttag", eCmdHdlrGetWord, 0}};
 static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / sizeof(struct cnfparamdescr), modpdescr};
 
@@ -295,6 +297,20 @@ finalize_it:
     RETiRet;
 }
 
+static int openJournalHandle(sd_journal **j) {
+    const int flags = cs.bRemote ? 0 : SD_JOURNAL_LOCAL_ONLY;
+    const char *const pszNamespace = runModConf == NULL ? NULL : runModConf->pszNamespace;
+
+    if (pszNamespace != NULL) {
+#ifdef HAVE_SD_JOURNAL_OPEN_NAMESPACE
+        return sd_journal_open_namespace(j, pszNamespace, flags);
+#else
+        return -ENOSYS;
+#endif
+    }
+    return sd_journal_open(j, flags);
+}
+
 static rsRetVal openJournal(struct journalContext_s *journalContext) {
     int r;
     DEFiRet;
@@ -302,8 +318,14 @@ static rsRetVal openJournal(struct journalContext_s *journalContext) {
     if (journalContext->j) {
         LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "imjournal: opening journal when already opened.\n");
     }
-    if ((r = sd_journal_open(&journalContext->j, cs.bRemote ? 0 : SD_JOURNAL_LOCAL_ONLY)) < 0) {
-        LogError(-r, RS_RET_IO_ERROR, "imjournal: sd_journal_open() failed");
+    if ((r = openJournalHandle(&journalContext->j)) < 0) {
+        const char *const pszNamespace = runModConf == NULL ? NULL : runModConf->pszNamespace;
+        if (pszNamespace != NULL) {
+            LogError(-r, RS_RET_IO_ERROR, "imjournal: sd_journal_open_namespace() failed for namespace '%s'",
+                     pszNamespace);
+        } else {
+            LogError(-r, RS_RET_IO_ERROR, "imjournal: sd_journal_open() failed");
+        }
         ABORT_FINALIZE(RS_RET_IO_ERROR);
     }
     if ((r = sd_journal_set_data_threshold(journalContext->j, glbl.GetMaxLine(runModConf->pConf))) < 0) {
@@ -926,9 +948,9 @@ static void warnIfNewestJournalEntryIsInFuture(struct journalContext_s *journalC
     }
     journalContext->nextFutureJournalProbeUsec = now_usec + FUTURE_JOURNAL_WARN_SKEW_USEC;
 
-    r = sd_journal_open(&probe, cs.bRemote ? 0 : SD_JOURNAL_LOCAL_ONLY);
+    r = openJournalHandle(&probe);
     if (r < 0) {
-        DBGPRINTF("imjournal: future-time probe sd_journal_open() failed: %d\n", r);
+        DBGPRINTF("imjournal: future-time probe journal open failed: %d\n", r);
         goto done;
     }
 
@@ -1356,6 +1378,7 @@ BEGINbeginCnfLoad
     cs.bWorkAroundJournalBug = 1;
     cs.bFsync = 0;
     cs.bRemote = 0;
+    pModConf->pszNamespace = NULL;
     cs.dfltTag = NULL;
 ENDbeginCnfLoad
 
@@ -1382,6 +1405,22 @@ BEGINcheckCnf
     for (inst = pModConf->root; inst != NULL; inst = inst->next) {
         std_checkRuleset(pModConf, inst);
     }
+    if (pModConf->pszNamespace != NULL) {
+        if (pModConf->pszNamespace[0] == '\0') {
+            LogError(0, RS_RET_INVALID_PARAMS, "imjournal: Namespace must not be empty");
+            ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
+        }
+        if (cs.bRemote) {
+            LogError(0, RS_RET_INVALID_PARAMS, "imjournal: Namespace and Remote cannot be enabled together");
+            ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
+        }
+#ifndef HAVE_SD_JOURNAL_OPEN_NAMESPACE
+        LogError(0, RS_RET_NOT_IMPLEMENTED,
+                 "imjournal: Namespace requires libsystemd support for sd_journal_open_namespace()");
+        ABORT_FINALIZE(RS_RET_NOT_IMPLEMENTED);
+#endif
+    }
+finalize_it:
 ENDcheckCnf
 
 
@@ -1501,6 +1540,7 @@ BEGINfreeCnf
     free(cs.stateFile);
     free(cs.usePid);
     free(cs.dfltTag);
+    free(pModConf->pszNamespace);
     free(cs.pszRatelimitName);
     cs.pszRatelimitName = NULL;
     statsobj.Destruct(&(statsCounter.stats));
@@ -1619,6 +1659,9 @@ BEGINsetModCnf
             cs.bFsync = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "remote")) {
             cs.bRemote = (int)pvals[i].val.d.n;
+        } else if (!strcmp(modpblk.descr[i].name, "namespace")) {
+            free(loadModConf->pszNamespace);
+            CHKmalloc(loadModConf->pszNamespace = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "defaulttag")) {
             CHKmalloc(cs.dfltTag = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -948,6 +948,7 @@ TESTS_OMHTTP_FLAKY_VALGRIND = \
 
 TESTS_IMJOURNAL = \
 	imjournal-basic.sh \
+	imjournal-namespace-remote-conflict.sh \
 	imjournal-statefile.sh \
 	imjournal-statefile-symlink.sh \
 	imjournal_ratelimit_name.sh

--- a/tests/imjournal-namespace-remote-conflict.sh
+++ b/tests/imjournal-namespace-remote-conflict.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Regression test for imjournal Namespace validation. Namespace uses the local
+# systemd journal namespace API, while Remote uses the normal journal-open path
+# for local plus remote journal files; the two settings must be rejected
+# together during config validation. The oracle is rsyslogd -N1 failing before
+# any live journal service is needed and emitting the exact conflict diagnostic.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+require_plugin imjournal
+
+generate_conf
+add_conf '
+module(load="../plugins/imjournal/.libs/imjournal"
+       Namespace="testns"
+       Remote="on")
+'
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -eq 0 ]; then
+	echo "FAIL: expected config validation failure for imjournal Namespace with Remote"
+	cat "${RSYSLOG_DYNNAME}.log"
+	error_exit 1
+fi
+
+content_check "imjournal: Namespace and Remote cannot be enabled together" "${RSYSLOG_DYNNAME}.log"
+
+exit_test


### PR DESCRIPTION
## Summary

- add an `imjournal` module-level `Namespace` parameter for systemd journal namespaces
- use `sd_journal_open_namespace()` when available, including the future-entry probe path
- reject empty `Namespace`, reject `Namespace` with `Remote`, and fail config validation clearly when libsystemd lacks namespace support
- document the parameter and add a config-only regression test for the `Namespace`/`Remote` conflict

Closes https://github.com/rsyslog/rsyslog/issues/4771

## Validation

- `bash -n tests/imjournal-namespace-remote-conflict.sh`
- `devtools/check-test-antipatterns.sh tests/imjournal-namespace-remote-conflict.sh`
- `shellcheck -S warning tests/imjournal-namespace-remote-conflict.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `./configure CC=gcc --enable-debug --enable-testbench --enable-imjournal --enable-imdiag --disable-generate-man-pages`
- `make -j60`
- `make -j60 check TESTS='imjournal-namespace-remote-conflict.sh'`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 60`
- `RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 devtools/local-validation-plan.sh --run`

Local validation image: `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`).

Journal namespace runtime reproduction was not attempted in this environment because there is no usable journal namespace service; validation is static/config-focused for the journal-specific runtime path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

