### PR TITLE
add Debian daily staging workflow

### DIFF
--- a/.github/workflows/debian_daily_staging.yml
+++ b/.github/workflows/debian_daily_staging.yml
@@ -1,0 +1,434 @@
+# Copyright 2026 Rainer Gerhards and Others
+#
+# https://github.com/rsyslog/rsyslog
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: debian daily staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_to_pages:
+        description: Publish the generated APT repository to the staging Pages repository
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    - cron: '23 3 * * *'
+
+concurrency:
+  group: debian-daily-staging
+  cancel-in-progress: false
+
+env:
+  DEBIAN_CI_POLICY_FILE: .github/debian-ci-policy.yml
+  DEBIAN_CI_HELPER: .github/scripts/debian_package_build.sh
+  DEBIAN_STAGING_HELPER: devtools/release/debian-daily-staging.sh
+  DEBIAN_PACKAGING_REPO: https://salsa.debian.org/debian/rsyslog.git
+  DEBIAN_PACKAGING_BRANCH: debian/latest
+  DEBIAN_STAGING_BUILD_ROOT: /tmp/rsyslog-debian-daily-staging-build
+  DEBIAN_STAGING_SUITE: trixie
+  DEBIAN_STAGING_COMPONENT: main
+  DEBIAN_STAGING_ARCH: amd64
+
+jobs:
+  preflight:
+    name: preflight
+    runs-on: ubuntu-latest
+    if: github.repository == 'rsyslog/rsyslog'
+    permissions:
+      contents: read
+    outputs:
+      should_run: ${{ steps.decision.outputs.should_run }}
+      should_publish: ${{ steps.decision.outputs.should_publish }}
+    steps:
+      - name: Decide whether this run is active
+        id: decision
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE_ENABLED: ${{ vars.DEBIAN_DAILY_STAGING_ENABLED }}
+          MANUAL_PUBLISH: ${{ github.event.inputs.publish_to_pages }}
+        run: |
+          set -euo pipefail
+          should_run=false
+          should_publish=false
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            should_run=true
+            if [ "${MANUAL_PUBLISH:-false}" = "true" ]; then
+              should_publish=true
+            fi
+          elif [ "${SCHEDULE_ENABLED:-false}" = "true" ]; then
+            should_run=true
+            should_publish=true
+          fi
+
+          {
+            echo "should_run=$should_run"
+            echo "should_publish=$should_publish"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: build Debian staging packages
+    needs: preflight
+    if: needs.preflight.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    container:
+      image: debian:trixie
+      options: --user root
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      upstream_version: ${{ steps.version.outputs.upstream_version }}
+      base_version: ${{ steps.version.outputs.base_version }}
+    steps:
+      - name: Checkout rsyslog source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install prerequisites
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" install_prereqs
+          apt-get install -y --no-install-recommends curl xz-utils
+
+      - name: Generate staging version
+        id: version
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_STAGING_HELPER" version
+
+      - name: Load Debian CI policy
+        run: |
+          mkdir -p "$DEBIAN_STAGING_BUILD_ROOT"
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" load_policy \
+            "$GITHUB_WORKSPACE/$DEBIAN_CI_POLICY_FILE" \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-ci-policy"
+
+      - name: Fetch Debian packaging baseline
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" fetch_debian_packaging \
+            "$DEBIAN_PACKAGING_REPO" \
+            "$DEBIAN_PACKAGING_BRANCH" \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-packaging"
+
+      - name: Install Debian build dependencies
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" install_build_deps \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-packaging/control" \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-ci-policy/supplemental_build_deps.txt"
+
+      - name: Generate rsyslog dist tarball
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" run_dist_build \
+            "$GITHUB_WORKSPACE"
+
+      - name: Locate rsyslog dist tarball
+        run: |
+          dist_tarball="$(
+            "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" find_dist_tarball \
+              "$GITHUB_WORKSPACE"
+          )"
+          echo "DIST_TARBALL=$dist_tarball" >> "$GITHUB_ENV"
+
+      - name: Unpack tarball and inject Debian packaging
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" unpack_source_tree \
+            "$GITHUB_WORKSPACE" \
+            "$DIST_TARBALL" \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-packaging" \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-src"
+
+      - name: Stamp staging changelog
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_STAGING_HELPER" stamp-changelog \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-src" \
+            "$VERSION"
+
+      - name: Apply Debian CI policy
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" apply_not_installed_policy \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-src" \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-ci-policy/not_installed_paths.txt" \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-ci-policy/not_installed_paths.reasons.txt"
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" resolve_patch_policy \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-src" \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-ci-policy/allowed_patch_skips.txt" \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-ci-policy/allowed_patch_skips.reasons.txt" \
+            strict
+
+      - name: Build source and binary packages
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_STAGING_HELPER" build-package \
+            "$GITHUB_WORKSPACE" \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-src" \
+            "$DIST_TARBALL" \
+            "$GITHUB_WORKSPACE/debian-staging-artifacts" \
+            "$VERSION" \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-daily-staging-build.log"
+
+      - name: Generate artifact manifest
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_STAGING_HELPER" manifest \
+            "$GITHUB_WORKSPACE/debian-staging-artifacts" \
+            "$VERSION" \
+            "$DEBIAN_STAGING_SUITE" \
+            "$DEBIAN_STAGING_ARCH"
+
+      - name: Upload Debian staging artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: debian-staging-${{ steps.version.outputs.version }}
+          path: debian-staging-artifacts/
+          if-no-files-found: error
+
+      - name: Summarize build
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "### Debian daily staging build"
+            echo
+            echo "- Version: \`$VERSION\`"
+            echo "- Suite: \`$DEBIAN_STAGING_SUITE\`"
+            echo "- Architecture: \`$DEBIAN_STAGING_ARCH\`"
+            echo
+            echo "Artifacts:"
+            while IFS= read -r artifact; do
+              printf -- "- \`%s\`\n" "$artifact"
+            done < <(find debian-staging-artifacts -maxdepth 1 -type f -printf '%f\n' | sort)
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: publish GitHub Pages APT repo
+    needs:
+      - preflight
+      - build
+    if: needs.preflight.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: debian-daily-staging
+    permissions:
+      contents: read
+    env:
+      STAGING_REPO_OWNER: ${{ vars.DEBIAN_STAGING_REPO_OWNER }}
+      STAGING_REPO_NAME: ${{ vars.DEBIAN_STAGING_REPO_NAME }}
+      STAGING_PAGES_TOKEN: ${{ secrets.DEBIAN_STAGING_PAGES_TOKEN }}
+      DEBIAN_STAGING_GPG_PRIVATE_KEY: ${{ secrets.DEBIAN_STAGING_GPG_PRIVATE_KEY }}
+      DEBIAN_STAGING_GPG_PASSPHRASE: ${{ secrets.DEBIAN_STAGING_GPG_PASSPHRASE }}
+    steps:
+      - name: Checkout rsyslog source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install repository generation tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends apt-utils gnupg xz-utils
+
+      - name: Download Debian staging artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: debian-staging-${{ needs.build.outputs.version }}
+          path: debian-staging-artifacts
+
+      - name: Verify artifact checksums
+        run: |
+          cd debian-staging-artifacts
+          sha256sum -c SHA256SUMS
+
+      - name: Import staging signing key
+        run: |
+          set -euo pipefail
+          install -m 700 -d "$HOME/.gnupg"
+          printf '%s\n' "$DEBIAN_STAGING_GPG_PRIVATE_KEY" | gpg --batch --import
+          gpg --batch --list-secret-keys
+
+      - name: Checkout staging Pages repository
+        run: |
+          set -euo pipefail
+          [ -n "$STAGING_REPO_OWNER" ] || { echo "DEBIAN_STAGING_REPO_OWNER is empty" >&2; exit 1; }
+          [ -n "$STAGING_REPO_NAME" ] || { echo "DEBIAN_STAGING_REPO_NAME is empty" >&2; exit 1; }
+          [ -n "$STAGING_PAGES_TOKEN" ] || { echo "DEBIAN_STAGING_PAGES_TOKEN is empty" >&2; exit 1; }
+
+          repo_url="https://x-access-token:${STAGING_PAGES_TOKEN}@github.com/${STAGING_REPO_OWNER}/${STAGING_REPO_NAME}.git"
+          if git ls-remote --exit-code --heads "$repo_url" gh-pages >/dev/null; then
+            git clone --depth=1 --branch gh-pages "$repo_url" staging-pages
+          else
+            git ls-remote "$repo_url" >/dev/null
+            mkdir staging-pages
+            git -C staging-pages init
+            git -C staging-pages checkout -b gh-pages
+            git -C staging-pages remote add origin "$repo_url"
+          fi
+
+      - name: Generate signed APT repository
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_STAGING_HELPER" generate-repo \
+            "$GITHUB_WORKSPACE/debian-staging-artifacts" \
+            "$GITHUB_WORKSPACE/staging-pages" \
+            "$DEBIAN_STAGING_SUITE" \
+            "$DEBIAN_STAGING_COMPONENT"
+
+      - name: Commit and push staging repository
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd staging-pages
+          git config user.name "rsyslog release bot"
+          git config user.email "release-bot@adiscon.com"
+          git add .
+          if git diff --cached --quiet; then
+            echo "No staging repository changes to publish."
+            exit 0
+          fi
+          git commit -m "publish rsyslog Debian staging $VERSION"
+          git push origin HEAD:gh-pages
+
+  verify:
+    name: verify Pages repository
+    needs:
+      - preflight
+      - build
+      - publish
+    if: needs.preflight.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      DEBIAN_STAGING_REPO_URL: ${{ vars.DEBIAN_STAGING_REPO_URL }}
+      DEBIAN_STAGING_GPG_FINGERPRINT: ${{ vars.DEBIAN_STAGING_GPG_FINGERPRINT }}
+    steps:
+      - name: Checkout rsyslog source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install verification tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends curl gnupg xz-utils
+
+      - name: Wait for Pages and verify package metadata
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          [ -n "$DEBIAN_STAGING_REPO_URL" ] || { echo "DEBIAN_STAGING_REPO_URL is empty" >&2; exit 1; }
+          [ -n "$DEBIAN_STAGING_GPG_FINGERPRINT" ] || { echo "DEBIAN_STAGING_GPG_FINGERPRINT is empty" >&2; exit 1; }
+          for attempt in $(seq 1 20); do
+            if "$GITHUB_WORKSPACE/$DEBIAN_STAGING_HELPER" verify-repo \
+              "$DEBIAN_STAGING_REPO_URL" \
+              "$DEBIAN_STAGING_SUITE" \
+              "$VERSION" \
+              "$DEBIAN_STAGING_GPG_FINGERPRINT"; then
+              exit 0
+            fi
+            echo "Repository not ready yet, retrying ($attempt/20)..."
+            if [ "$attempt" -lt 20 ]; then
+              sleep 30
+            fi
+          done
+          echo "Repository verification did not succeed before timeout." >&2
+          exit 1
+
+  report_failure:
+    name: report failure
+    needs:
+      - preflight
+      - build
+      - publish
+      - verify
+    if: >-
+      always() &&
+      needs.preflight.outputs.should_run == 'true' &&
+      (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Create or update failure issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+          REPO_URL: ${{ vars.DEBIAN_STAGING_REPO_URL }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+        with:
+          script: |
+            const version = process.env.VERSION || `run-${context.runId}`;
+            const title = `[debian-daily-staging] rsyslog ${version} failed`;
+            const body = [
+              `Automated Debian daily staging failed for \`${version}\`.`,
+              '',
+              `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `Commit: ${context.sha}`,
+              `Repository URL: ${process.env.REPO_URL || '(not configured)'}`,
+              '',
+              'Job results:',
+              `- build: ${process.env.BUILD_RESULT}`,
+              `- publish: ${process.env.PUBLISH_RESULT}`,
+              `- verify: ${process.env.VERIFY_RESULT}`,
+              '',
+              'Inspect the workflow artifacts and logs, then rerun the workflow manually after fixing the cause.'
+            ].join('\n');
+
+            const {owner, repo} = context.repo;
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100
+            });
+            const issue = existing.find(item => item.title === title && !item.pull_request);
+            if (issue) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body
+              });
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body
+            });
+            try {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: created.data.number,
+                labels: ['release', 'packaging', 'debian', 'daily-stable', 'automated']
+              });
+            } catch (error) {
+              core.warning(`Could not add labels: ${error.message}`);
+            }

--- a/devtools/release/debian-daily-staging.sh
+++ b/devtools/release/debian-daily-staging.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: debian-daily-staging.sh <command> [args...]
+
+Commands:
+  version
+  stamp-changelog <source-dir> <version>
+  build-package <workspace> <source-dir> <dist-tarball> <artifact-dir> <version> <build-log>
+  manifest <artifact-dir> <version> <suite> <arch>
+  generate-repo <artifact-dir> <repo-dir> <suite> <component>
+  verify-repo <repo-url> <suite> <version> <expected-key-fingerprint>
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+base_version() {
+  local script_dir
+
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  sed -n 's/AC_INIT(\[rsyslog\],\[\([^]]*\)\].*/\1/p' "$script_dir/../../configure.ac" | sed 's/\.daily$//'
+}
+
+cmd_version() {
+  local base date short_sha run version
+
+  base="$(base_version)"
+  [ -n "$base" ] || die "could not determine base version from configure.ac"
+
+  date="$(date -u +%Y%m%d)"
+  git rev-parse --verify HEAD >/dev/null 2>&1 || die "invalid git HEAD commit"
+  short_sha="$(git rev-parse --short=12 HEAD)"
+  run="${GITHUB_RUN_NUMBER:-0}"
+  version="${base}~daily${date}.${run}+git${short_sha}-1adiscon1"
+
+  printf '%s\n' "$version"
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      printf 'version=%s\n' "$version"
+      printf 'upstream_version=%s\n' "${version%%-*}"
+      printf 'base_version=%s\n' "$base"
+    } >> "$GITHUB_OUTPUT"
+  fi
+}
+
+cmd_stamp_changelog() {
+  local source_dir="$1"
+  local version="$2"
+
+  [ -d "$source_dir/debian" ] || die "missing debian directory: $source_dir/debian"
+
+  cd "$source_dir"
+  export DEBEMAIL="${DEBEMAIL:-release-bot@adiscon.com}"
+  export DEBFULLNAME="${DEBFULLNAME:-Adiscon package maintainers}"
+  dch --force-distribution --distribution trixie --newversion "$version" \
+    "Automated rsyslog Debian daily staging build."
+}
+
+cmd_build_package() {
+  local workspace="$1"
+  local source_dir="$2"
+  local dist_tarball="$3"
+  local artifact_dir="$4"
+  local version="$5"
+  local build_log="$6"
+  local upstream_version parent parent_real workspace_real rc
+
+  upstream_version="${version%%-*}"
+  parent="$(dirname "$source_dir")"
+  parent_real="$(readlink -f "$parent")"
+  workspace_real="$(readlink -f "$workspace")"
+
+  [ -f "$workspace/$dist_tarball" ] || die "missing dist tarball: $workspace/$dist_tarball"
+  [ -d "$source_dir/debian" ] || die "missing Debian source tree: $source_dir"
+  case "$parent_real" in
+    /|/tmp|"$workspace_real")
+      die "refusing to collect package artifacts from unsafe build parent: $parent_real"
+      ;;
+  esac
+
+  rm -rf "$artifact_dir"
+  mkdir -p "$artifact_dir"
+  find "$parent" -maxdepth 1 -type f \
+    \( -name '*.deb' -o -name '*.dsc' -o -name '*.changes' -o -name '*.buildinfo' \
+       -o -name '*.orig.tar.*' -o -name '*.debian.tar.*' \) \
+    -delete
+
+  cp "$workspace/$dist_tarball" "$parent/rsyslog_${upstream_version}.orig.tar.gz"
+
+  cd "$source_dir"
+  export DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS:-nocheck}"
+
+  set +e
+  dpkg-buildpackage -us -uc -j"$(nproc)" 2>&1 | tee "$build_log"
+  rc=${PIPESTATUS[0]}
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    return "$rc"
+  fi
+
+  if grep -Eq '(^|/)(doc/source|source)/[^:]+:[0-9]+: (CRITICAL|ERROR):|^Sphinx error:' "$build_log"; then
+    die "Debian docs build emitted fatal Sphinx/docutils diagnostics"
+  fi
+
+  cp "$build_log" "$artifact_dir/build.log"
+  find "$parent" -maxdepth 1 -type f \
+    \( -name "*_${version}_*.deb" -o -name "*_${version}.dsc" \
+       -o -name "*_${version}_*.changes" -o -name "*_${version}_*.buildinfo" \
+       -o -name "rsyslog_${upstream_version}.orig.tar.*" \
+       -o -name "rsyslog_${version}.debian.tar.*" \) \
+    -exec cp -a {} "$artifact_dir/" \;
+
+  find "$artifact_dir" -maxdepth 1 -type f -name '*.deb' | grep -q . || die "no .deb artifacts collected"
+  find "$artifact_dir" -maxdepth 1 -type f -name '*.dsc' | grep -q . || die "no .dsc artifact collected"
+  find "$artifact_dir" -maxdepth 1 -type f -name '*.changes' | grep -q . || die "no .changes artifact collected"
+}
+
+cmd_manifest() {
+  local artifact_dir="$1"
+  local version="$2"
+  local suite="$3"
+  local arch="$4"
+
+  [ -d "$artifact_dir" ] || die "missing artifact directory: $artifact_dir"
+
+  (
+    cd "$artifact_dir"
+    find . -maxdepth 1 -type f \
+      \( -name '*.deb' -o -name '*.dsc' -o -name '*.changes' -o -name '*.buildinfo' \
+         -o -name '*.orig.tar.*' -o -name '*.debian.tar.*' \) \
+      -printf '%P\0' | sort -z | xargs -0 -r sha256sum > SHA256SUMS
+  )
+
+  python3 - "$artifact_dir" "$version" "$suite" "$arch" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+artifact_dir, version, suite, arch = sys.argv[1:5]
+files = []
+for name in sorted(os.listdir(artifact_dir)):
+    path = os.path.join(artifact_dir, name)
+    if not os.path.isfile(path):
+        continue
+    release_suffixes = (
+        ".deb",
+        ".dsc",
+        ".changes",
+        ".buildinfo",
+        ".orig.tar.gz",
+        ".orig.tar.xz",
+        ".orig.tar.bz2",
+        ".debian.tar.gz",
+        ".debian.tar.xz",
+        ".debian.tar.bz2",
+    )
+    if not name.endswith(release_suffixes):
+        continue
+    with open(path, "rb") as fh:
+        h = hashlib.sha256()
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+        digest = h.hexdigest()
+    files.append({"name": name, "sha256": digest, "size": os.path.getsize(path)})
+
+manifest = {
+    "package": "rsyslog",
+    "version": version,
+    "suite": suite,
+    "architecture": arch,
+    "git_sha": os.environ.get("GITHUB_SHA", ""),
+    "github_run_id": os.environ.get("GITHUB_RUN_ID", ""),
+    "github_run_number": os.environ.get("GITHUB_RUN_NUMBER", ""),
+    "files": files,
+}
+with open(os.path.join(artifact_dir, "manifest.json"), "w", encoding="utf-8") as fh:
+    json.dump(manifest, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+PY
+}
+
+secret_key_fingerprint() {
+  gpg --batch --list-secret-keys --with-colons | awk -F: '$1 == "fpr" {print $10; exit}'
+}
+
+gpg_sign_args() {
+  if [ -n "${DEBIAN_STAGING_GPG_PASSPHRASE:-}" ]; then
+    printf '%s\0' --pinentry-mode loopback --passphrase "$DEBIAN_STAGING_GPG_PASSPHRASE"
+  fi
+}
+
+cmd_generate_repo() {
+  local artifact_dir="$1"
+  local repo_dir="$2"
+  local suite="$3"
+  local component="$4"
+  local arch="amd64"
+  local key_fpr dist_dir packages_file
+
+  [ -d "$artifact_dir" ] || die "missing artifact directory: $artifact_dir"
+  find "$artifact_dir" -maxdepth 1 -type f -name '*.deb' | grep -q . || die "no .deb artifacts in $artifact_dir"
+  command -v apt-ftparchive >/dev/null 2>&1 || die "apt-ftparchive not found; install apt-utils"
+
+  mkdir -p "$repo_dir/pool/main/r/rsyslog"
+  cp -a "$artifact_dir"/*.deb "$repo_dir/pool/main/r/rsyslog/"
+  cp -a "$artifact_dir"/manifest.json "$artifact_dir"/SHA256SUMS "$repo_dir/pool/main/r/rsyslog/"
+
+  key_fpr="$(secret_key_fingerprint)"
+  [ -n "$key_fpr" ] || die "no GPG secret key available for repository signing"
+  gpg --batch --armor --export "$key_fpr" > "$repo_dir/rsyslog-debian-staging.asc"
+
+  dist_dir="$repo_dir/dists/$suite"
+  packages_file="$dist_dir/$component/binary-$arch/Packages"
+  mkdir -p "$(dirname "$packages_file")"
+
+  (
+    cd "$repo_dir"
+    apt-ftparchive packages "pool/main/r/rsyslog" > "dists/$suite/$component/binary-$arch/Packages"
+    xz -9 -k -f "dists/$suite/$component/binary-$arch/Packages"
+    apt-ftparchive \
+      -o "APT::FTPArchive::Release::Origin=Adiscon" \
+      -o "APT::FTPArchive::Release::Label=rsyslog Debian daily staging" \
+      -o "APT::FTPArchive::Release::Suite=$suite" \
+      -o "APT::FTPArchive::Release::Codename=$suite" \
+      -o "APT::FTPArchive::Release::Architectures=$arch" \
+      -o "APT::FTPArchive::Release::Components=$component" \
+      -o "APT::FTPArchive::Release::Description=rsyslog Debian daily staging packages" \
+      release "dists/$suite" > "dists/$suite/Release"
+  )
+
+  mapfile -d '' -t extra_gpg_args < <(gpg_sign_args)
+  gpg --batch --yes "${extra_gpg_args[@]}" --local-user "$key_fpr" --clearsign \
+    --output "$dist_dir/InRelease" "$dist_dir/Release"
+  gpg --batch --yes "${extra_gpg_args[@]}" --local-user "$key_fpr" --detach-sign --armor \
+    --output "$dist_dir/Release.gpg" "$dist_dir/Release"
+}
+
+cmd_verify_repo() {
+  local repo_url="$1"
+  local suite="$2"
+  local version="$3"
+  local expected_key_fpr="$4"
+  local tmp_dir
+  local packages_url_path="dists/$suite/main/binary-amd64/Packages.xz"
+  local packages_release_path="main/binary-amd64/Packages.xz"
+  local packages_hash packages_size actual_key_fpr
+
+  command -v curl >/dev/null 2>&1 || die "curl not found"
+  command -v gpg >/dev/null 2>&1 || die "gpg not found"
+  command -v gpgv >/dev/null 2>&1 || die "gpgv not found"
+  command -v xz >/dev/null 2>&1 || die "xz not found"
+  [ -n "$expected_key_fpr" ] || die "missing expected signing key fingerprint"
+
+  repo_url="${repo_url%/}"
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' EXIT
+
+  curl -fsSL "$repo_url/dists/$suite/InRelease" -o "$tmp_dir/InRelease"
+  curl -fsSL "$repo_url/rsyslog-debian-staging.asc" -o "$tmp_dir/repo-key.asc"
+  gpg --batch --dearmor -o "$tmp_dir/repo-key.gpg" "$tmp_dir/repo-key.asc"
+  actual_key_fpr="$(gpg --batch --show-keys --with-colons "$tmp_dir/repo-key.asc" |
+    awk -F: '$1 == "fpr" {print $10; exit}')"
+  [ "${actual_key_fpr^^}" = "${expected_key_fpr^^}" ] ||
+    die "published signing key fingerprint $actual_key_fpr does not match expected $expected_key_fpr"
+  gpgv --keyring "$tmp_dir/repo-key.gpg" "$tmp_dir/InRelease"
+
+  curl -fsSL "$repo_url/$packages_url_path" -o "$tmp_dir/Packages.xz"
+  packages_hash="$(sha256sum "$tmp_dir/Packages.xz" | awk '{print $1}')"
+  packages_size="$(wc -c < "$tmp_dir/Packages.xz" | tr -d ' ')"
+  awk -v hash="$packages_hash" -v size="$packages_size" -v path="$packages_release_path" \
+    '$1 == hash && $2 == size && $3 == path { found = 1 } END { exit !found }' \
+    "$tmp_dir/InRelease" || die "Packages.xz checksum is not present in signed InRelease"
+  xz -dc "$tmp_dir/Packages.xz" > "$tmp_dir/Packages"
+
+  grep -Fxq "Package: rsyslog" "$tmp_dir/Packages" || die "rsyslog package not found in Packages"
+  grep -Fxq "Version: $version" "$tmp_dir/Packages" || die "version $version not found in Packages"
+}
+
+command="${1:-}"
+case "$command" in
+  version) shift; cmd_version "$@" ;;
+  stamp-changelog) shift; cmd_stamp_changelog "$@" ;;
+  build-package) shift; cmd_build_package "$@" ;;
+  manifest) shift; cmd_manifest "$@" ;;
+  generate-repo) shift; cmd_generate_repo "$@" ;;
+  verify-repo) shift; cmd_verify_repo "$@" ;;
+  *) usage; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

Add a GitHub-first prototype for Debian daily staging packages.

This introduces a scheduled/manual workflow that builds Debian trixie amd64 staging packages from the existing Debian CI packaging path, uploads build evidence artifacts, optionally publishes a signed APT repository to a separate GitHub Pages repository, verifies the published metadata, and creates/updates a failure issue when the pipeline fails.

The publisher intentionally targets a separate Pages repository so the existing rsyslog documentation Pages deployment is not touched.

## Notes

The workflow expects the `debian-daily-staging` GitHub Environment to provide the staging GPG key, Pages publishing token, staging repo settings, repository URL, and expected signing-key fingerprint. Scheduled runs remain disabled until `DEBIAN_DAILY_STAGING_ENABLED=true`.

## Validation

- `bash -n devtools/release/debian-daily-staging.sh`
- `shellcheck devtools/release/debian-daily-staging.sh`
- `actionlint .github/workflows/debian_daily_staging.yml`
- `zizmor --strict-collection .github/workflows/debian_daily_staging.yml`
- `devtools/local-validation-plan.sh --run --base upstream/main`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

