### PR TITLE
tcpflood: add GnuTLS priority string option

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1575,6 +1575,7 @@ TESTS_MMDBLOOKUP_VALGRIND = \
 
 TESTS_GNUTLS = \
 	imtcp-tls-basic.sh \
+	tcpflood-gtls-priority-invalid.sh \
 	imtcp-tls-input-basic.sh \
 	imtcp-tls-input-2certs.sh \
 	imtcp-tls-basic-verifydepth.sh \

--- a/tests/tcpflood-gtls-priority-invalid.sh
+++ b/tests/tcpflood-gtls-priority-invalid.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Regression test for tcpflood's GnuTLS priority-string option. The oracle is
+# that an invalid priority string is rejected during TLS initialization before a
+# network connection is attempted, proving the option is parsed and handed to
+# GnuTLS directly instead of being ignored.
+# This file is part of the rsyslog project, released under ASL 2.0
+unset RSYSLOG_DYNNAME RSYSLOG_OUT_LOG TESTCONF_NM
+. ${srcdir:=.}/diag.sh init
+
+./tcpflood -Ttls -g INVALID-GNUTLS-PRIORITY \
+	-z "$srcdir/tls-certs/key.pem" \
+	-Z "$srcdir/tls-certs/cert.pem" \
+	>"$RSYSLOG_OUT_LOG" 2>&1
+if [ $? -eq 0 ]; then
+	echo "FAIL: tcpflood accepted an invalid GnuTLS priority string"
+	cat "$RSYSLOG_OUT_LOG"
+	exit 1
+fi
+
+if content_check --check-only "-g requires tcpflood to use the GnuTLS TLS implementation"; then
+	echo "SKIP: tcpflood is not using the GnuTLS TLS implementation"
+	skip_test
+fi
+
+content_check "tcpflood: invalid GnuTLS priority string 'INVALID-GNUTLS-PRIORITY'"
+
+exit_test

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -71,6 +71,7 @@
  * -A	do NOT abort if an error occured during sending messages
  * -E	Permitted Peer for relp-tls
  * -L	loglevel to use for GnuTLS troubleshooting (0-off to 10-all, 0 default)
+ * -g	GnuTLS priority string for TLS mode when tcpflood is built with GnuTLS
  * -j	format message in json, parameter is JSON cookie
  * -o   number of threads to use for connection establishment (default: 25)
  * -O	Use octet-count framing
@@ -259,6 +260,7 @@ static int abortOnSendFail = 1; /* abort run if sending fails? */
 static char *tlsCAFile = NULL;
 static char *tlsCertFile = NULL;
 static char *tlsKeyFile = NULL;
+static char *tlsPriorityString = NULL;
 static char *relpAuthMode = NULL;
 static char *relpPermittedPeer = NULL;
 #if defined(HAVE_RELPENGINESETTLSLIBBYNAME)
@@ -274,6 +276,7 @@ static bool handshakeOnly = false;
 #ifdef ENABLE_GNUTLS
 static gnutls_session_t *sessArray; /* array of TLS sessions to use */
 static gnutls_certificate_credentials_t tlscred;
+static gnutls_priority_t tlsPriorityCache = NULL;
 #endif
 
 #ifdef ENABLE_OSSL
@@ -1880,7 +1883,14 @@ static void tlsLogFunction(int level, const char *msg) {
     printf("GnuTLS (level %d): %s", level, msg);
 }
 
-static void exitTLS(void) {}
+static void exitTLS(void) {
+    if (tlsPriorityCache != NULL) {
+        gnutls_priority_deinit(tlsPriorityCache);
+        tlsPriorityCache = NULL;
+    }
+    gnutls_certificate_free_credentials(tlscred);
+    gnutls_global_deinit();
+}
 
 /* global init GnuTLS
  */
@@ -1920,6 +1930,18 @@ static void initTLS(void) {
             exit(1);
         }
     }
+    if (tlsPriorityString != NULL) {
+        const char *err_pos = NULL;
+        r = gnutls_priority_init(&tlsPriorityCache, tlsPriorityString, &err_pos);
+        if (r != GNUTLS_E_SUCCESS) {
+            fprintf(stderr, "tcpflood: invalid GnuTLS priority string '%s': %s", tlsPriorityString, gnutls_strerror(r));
+            if (err_pos != NULL && *err_pos != '\0') {
+                fprintf(stderr, " near '%s'", err_pos);
+            }
+            fputc('\n', stderr);
+            exit(1);
+        }
+    }
 }
 
 
@@ -1929,8 +1951,16 @@ static void initTLSSess(const int i) {
     int r;
     gnutls_init(sessArray + i, GNUTLS_CLIENT);
 
-    /* Use default priorities */
-    gnutls_set_default_priority(sessArray[i]);
+    if (tlsPriorityCache != NULL) {
+        r = gnutls_priority_set(sessArray[i], tlsPriorityCache);
+    } else {
+        r = gnutls_set_default_priority(sessArray[i]);
+    }
+    if (r != GNUTLS_E_SUCCESS) {
+        fprintf(stderr, "Setting GnuTLS priority failed\n");
+        gnutls_perror(r);
+        exit(1);
+    }
 
     /* put our credentials to the current session */
     r = gnutls_credentials_set(sessArray[i], GNUTLS_CRD_CERTIFICATE, tlscred);
@@ -2107,7 +2137,7 @@ int main(int argc, char *argv[]) {
     setvbuf(stdout, buf, _IONBF, 48);
 
     while ((opt = getopt(argc, argv,
-                         "a:ABb:c:C:d:DeE:f:F:h:i:I:j:K:k:l:L:m:M:n:o:OP:p:rR:"
+                         "a:ABb:c:C:d:DeE:f:F:g:h:i:I:j:K:k:l:L:m:M:n:o:OP:p:rR:"
                          "sS:t:T:u:vW:w:x:XyYz:Z:H")) != -1) {
         switch (opt) {
             case 'b':
@@ -2176,6 +2206,9 @@ int main(int argc, char *argv[]) {
                 break;
             case 'f':
                 dynFileIDs = atoi(optarg);
+                break;
+            case 'g':
+                tlsPriorityString = optarg;
                 break;
             case 'F':
                 frameDelim = atoi(optarg);
@@ -2355,6 +2388,17 @@ int main(int argc, char *argv[]) {
     if (handshakeOnly && portFile != NULL) {
         fprintf(stderr, "-H cannot be combined with -w\n");
         exit(1);
+    }
+
+    if (tlsPriorityString != NULL) {
+        if (transport != TP_TLS) {
+            fprintf(stderr, "-g requires TLS transport (-Ttls)\n");
+            exit(1);
+        }
+#if !defined(ENABLE_GNUTLS) || defined(ENABLE_OSSL)
+        fprintf(stderr, "-g requires tcpflood to use the GnuTLS TLS implementation\n");
+        exit(1);
+#endif
     }
 
     if (holdOpenSeconds >= 0) {


### PR DESCRIPTION
## Summary
- add `tcpflood -g` for GnuTLS priority strings in `-Ttls` mode
- parse the priority string once with `gnutls_priority_init()` and apply it to each GnuTLS session
- reject `-g` when tcpflood is not using the GnuTLS TLS backend, and add a focused invalid-priority regression test

Closes https://github.com/rsyslog/rsyslog/issues/3516

## Validation
- `bash -n tests/tcpflood-gtls-priority-invalid.sh`
- `devtools/check-test-antipatterns.sh tests/tcpflood-gtls-priority-invalid.sh`
- `shellcheck -S warning tests/tcpflood-gtls-priority-invalid.sh`
- `devtools/format-code.sh --git-changed`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `./autogen.sh && ./configure --enable-debug --enable-testbench --enable-gnutls --enable-imtcp --disable-generate-man-pages`
- `make -j60`
- `make -j60 check TESTS='tcpflood-gtls-priority-invalid.sh'`
- `RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 devtools/local-validation-plan.sh --run`

Local full validation used `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`). In combined OpenSSL/GnuTLS builds, the new test skips because tcpflood's active TLS backend is OpenSSL.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

