### PR TITLE
tcp: skip legacy z after stream decode

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -299,6 +299,7 @@ struct ptcpsess_s {
     DEF_ATOMIC_HELPER_MUT(mutWorkQueued);
     sbool bzInitDone; /* did we do an init of zstrm already? */
     sbool bZipStreamEnd; /* did inflate() already reach the end of the zlib stream? */
+    sbool bStreamDecompressed; /* current bytes came from stream decompression */
     z_stream zstrm; /* zip stream to use for tcp compression */
     uint8_t compressionMode;
     uint8_t compressionAutoDetectPending; /* AUTO mode: still sniffing? */
@@ -392,7 +393,6 @@ static io_q_t io_q;
 /* forward definitions */
 static rsRetVal resetConfigVariables(uchar __attribute__((unused)) * pp, void __attribute__((unused)) * pVal);
 static rsRetVal addLstn(ptcpsrv_t *pSrv, int sock, int isIPv6);
-
 
 /* function to suppress TSAN known-good case
  * We do not use a mutex an epd, but we do always access it in
@@ -989,6 +989,9 @@ static rsRetVal doSubmitMsg(ptcpsess_t *pThis, struct syslogTime *stTime, time_t
     if (pSrv->dfltTZ != NULL) MsgSetDfltTZ(pMsg, (char *)pSrv->dfltTZ);
     MsgSetFlowControlType(pMsg, pSrv->flowControl ? eFLOWCTL_LIGHT_DELAY : eFLOWCTL_NO_DELAY);
     pMsg->msgFlags = NEEDS_PARSING | PARSE_HOSTNAME;
+    if (pThis->bStreamDecompressed) {
+        pMsg->msgFlags |= NO_LEGACY_Z_DECOMPRESS;
+    }
     MsgSetRcvFrom(pMsg, pThis->peerName);
     CHKiRet(MsgSetRcvFromIP(pMsg, pThis->peerIP));
     MsgSetRuleset(pMsg, pSrv->pRuleset);
@@ -1312,6 +1315,16 @@ finalize_it:
     RETiRet;
 }
 
+static rsRetVal ATTR_NONNULL(1, 2) DataRcvdUncompressedFromStream(
+    ptcpsess_t *pThis, char *pData, const size_t iLen, struct syslogTime *stTime, time_t ttGenTime) {
+    const sbool previous = pThis->bStreamDecompressed;
+    pThis->bStreamDecompressed = RSTRUE;
+
+    const rsRetVal localRet = DataRcvdUncompressed(pThis, pData, iLen, stTime, ttGenTime);
+    pThis->bStreamDecompressed = previous;
+    return localRet;
+}
+
 static const char *zlibRetName(const int zRet) {
     switch (zRet) {
         case Z_OK:
@@ -1394,7 +1407,7 @@ static rsRetVal DataRcvdCompressed(ptcpsess_t *pThis, char *buf, size_t len) {
         if (outavail != 0) {
             outtotal += outavail;
             ATOMIC_ADD_uint64(&pThis->pLstn->rcvdDecompressed, &pThis->pLstn->mut_rcvdDecompressed, outavail);
-            CHKiRet(DataRcvdUncompressed(pThis, (char *)zipBuf, outavail, &stTime, ttGenTime));
+            CHKiRet(DataRcvdUncompressedFromStream(pThis, (char *)zipBuf, outavail, &stTime, ttGenTime));
         }
         if (pThis->bZipStreamEnd && pThis->zstrm.avail_in != 0) {
             ABORT_FINALIZE(logCompressedStreamFailure(pThis, "received trailing data after end of", Z_STREAM_END));
@@ -1759,7 +1772,7 @@ static rsRetVal doZipFinish(ptcpsess_t *pSess) {
         outavail = sizeof(zipBuf) - pSess->zstrm.avail_out;
         if (outavail != 0) {
             ATOMIC_ADD_uint64(&pSess->pLstn->rcvdDecompressed, &pSess->pLstn->mut_rcvdDecompressed, outavail);
-            CHKiRet(DataRcvdUncompressed(pSess, (char *)zipBuf, outavail, &stTime, 0));
+            CHKiRet(DataRcvdUncompressedFromStream(pSess, (char *)zipBuf, outavail, &stTime, 0));
             // TODO: query time!
         }
     } while (pSess->zstrm.avail_out == 0);

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -160,6 +160,8 @@ struct msg {
     /* rawmsg does not include a PRI (Solaris!), but PRI is already set correctly in the msg object */
     #define PRESERVE_CASE 0x200
     /* preserve case in fromhost */
+    #define NO_LEGACY_Z_DECOMPRESS 0x400
+    /* skip built-in legacy 'z' transport-frame decompression */
 
     /* (syslog) protocol types */
     #define MSG_LEGACY_PROTOCOL 0

--- a/runtime/parser.c
+++ b/runtime/parser.c
@@ -273,7 +273,8 @@ static rsRetVal uncompressMessage(smsg_t *pMsg) {
     /* we first need to check if we have a compressed record. If so,
      * we must decompress it.
      */
-    if (lenMsg > 0 && *pszMsg == 'z' && runConf->globals.bSupportCompressionExtension) { /* compressed data present? */
+    if (lenMsg > 0 && *pszMsg == 'z' && runConf->globals.bSupportCompressionExtension &&
+        !(pMsg->msgFlags & NO_LEGACY_Z_DECOMPRESS)) { /* compressed data present? */
         /* we have compressed data, so let's deflate it. We support a maximum
          * message size of iMaxLine. If it is larger, an error message is logged
          * and the message is dropped. We do NOT try to decompress larger messages

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -92,6 +92,7 @@ BEGINobjConstruct(tcps_sess) /* be sure to specify the object type also in END m
     pThis->compressionTotalBytesOut = 0;
     pThis->zipInitDone = 0;
     pThis->compressedStreamEnded = 0;
+    pThis->streamDecompressed = 0;
     pThis->zstdDctx = NULL;
     memset(&pThis->zstrm, 0, sizeof(pThis->zstrm));
     memset(pThis->tlsProbeBuf, 0, sizeof(pThis->tlsProbeBuf));
@@ -356,6 +357,9 @@ static rsRetVal defaultDoSubmitMessage(tcps_sess_t *pThis,
     if (cnf_params->dfltTZ[0] != '\0') MsgSetDfltTZ(pMsg, (char *)cnf_params->dfltTZ);
     MsgSetFlowControlType(pMsg, pThis->pSrv->bUseFlowControl ? eFLOWCTL_LIGHT_DELAY : eFLOWCTL_NO_DELAY);
     pMsg->msgFlags = NEEDS_PARSING | PARSE_HOSTNAME;
+    if (pThis->streamDecompressed) {
+        pMsg->msgFlags |= NO_LEGACY_Z_DECOMPRESS;
+    }
     MsgSetRcvFrom(pMsg, pThis->fromHost);
     CHKiRet(MsgSetRcvFromIP(pMsg, pThis->fromHostIP));
     CHKiRet(MsgSetRcvFromPort(pMsg, pThis->fromHostPort));
@@ -768,6 +772,18 @@ finalize_it:
 }
 #undef NUM_MULTISUB
 
+static rsRetVal DataRcvdUncompressedFromStream(tcps_sess_t *const pThis,
+                                               char *const pData,
+                                               const size_t iLen,
+                                               const sbool detectTls) {
+    const sbool previous = pThis->streamDecompressed;
+    pThis->streamDecompressed = RSTRUE;
+
+    const rsRetVal localRet = DataRcvdUncompressed(pThis, pData, iLen, detectTls);
+    pThis->streamDecompressed = previous;
+    return localRet;
+}
+
 static const char *compressionDriverName(const tcps_sess_t *const pThis) {
     switch (pThis->compressionDriver) {
         case TCPSRV_COMPRESS_DRIVER_ZSTD:
@@ -872,7 +888,7 @@ static rsRetVal DataRcvdCompressedZlib(tcps_sess_t *const pThis,
         if (have != 0) {
             CHKiRet(checkDecompressedBytesLimit(pThis, guard, have));
             STATSCOUNTER_ADD(pThis->pLstnInfo->ctrBytesDecompressed, pThis->pLstnInfo->mutCtrBytesDecompressed, have);
-            CHKiRet(DataRcvdUncompressed(pThis, (char *)out, have, 0));
+            CHKiRet(DataRcvdUncompressedFromStream(pThis, (char *)out, have, 0));
         }
 
         if (zret == Z_STREAM_END) {
@@ -937,7 +953,7 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
             CHKiRet(checkDecompressedBytesLimit(pThis, guard, output.pos));
             STATSCOUNTER_ADD(pThis->pLstnInfo->ctrBytesDecompressed, pThis->pLstnInfo->mutCtrBytesDecompressed,
                              output.pos);
-            CHKiRet(DataRcvdUncompressed(pThis, (char *)out, output.pos, 0));
+            CHKiRet(DataRcvdUncompressedFromStream(pThis, (char *)out, output.pos, 0));
         }
 
         if (remaining == 0) {

--- a/runtime/tcps_sess.h
+++ b/runtime/tcps_sess.h
@@ -82,6 +82,7 @@ struct tcps_sess_s {
         sbool zipInitDone;
         sbool compressedStreamEnded;
         sbool compressedStreamFailed;
+        sbool streamDecompressed;
         z_stream zstrm;
         void *zstdDctx;
 };

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -719,7 +719,8 @@ TESTS_IMTCP_STREAM_ALWAYS_ZLIB = \
 	imtcp-stream-always-zlib-corrupt.sh \
 	imtcp-stream-always-zlib-truncated.sh \
 	imtcp-stream-always-zlib-fragmented-ratio.sh \
-	imtcp-stream-always-zlib-expansion-guard.sh
+	imtcp-stream-always-zlib-expansion-guard.sh \
+	imtcp-stream-always-zlib-z-prefix.sh
 
 TESTS_IMTCP_STREAM_ALWAYS_ZLIB_IMPSTATS = \
 	imtcp-stream-always-zlib-impstats.sh
@@ -1335,8 +1336,12 @@ TESTS_IMPTCP = \
 	imptcp-basic-hup.sh \
 	imptcp-NUL.sh \
 	imptcp-NUL-rawmsg.sh \
+	imptcp-compression-none-pmnull.sh \
+	imptcp-compression-none-legacy-single.sh \
 	imptcp-stream-compression-auto.sh \
 	imptcp-stream-compression-auto-zlib-prefix-plain.sh \
+	imptcp-stream-auto-z-prefix.sh \
+	imptcp-stream-auto-legacy-single.sh \
 	rscript_random.sh \
 	rscript_hash32.sh \
 	rscript_hash64.sh \
@@ -1348,7 +1353,8 @@ TESTS_IMPTCP_STREAM_ALWAYS = \
 	imptcp-stream-always-basic.sh \
 	imptcp-stream-always-flushoff.sh \
 	imptcp-stream-always-corrupt.sh \
-	imptcp-stream-always-truncated.sh
+	imptcp-stream-always-truncated.sh \
+	imptcp-stream-always-z-prefix.sh
 
 TESTS_IMPTCP_STREAM_ALWAYS_IMPSTATS = \
 	imptcp-stream-always-impstats.sh

--- a/tests/imptcp-compression-none-legacy-single.sh
+++ b/tests/imptcp-compression-none-legacy-single.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Backward compatibility test for imptcp with compression.mode="none".
+# omfwd's legacy "@@(zN)" mode compresses each message independently and
+# prefixes the compressed payload with "z"; imptcp must still allow the
+# built-in legacy transport-frame decompression when no stream decompression is
+# active. The oracle is sequence-complete delivery of legacy-compressed messages
+# through an imptcp receiver explicitly configured for no stream decompression.
+#
+# Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1000
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+
+generate_conf
+add_conf '
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+      compression.mode="none")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+                                 file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+export RCVR_PORT=$TCPFLOOD_PORT
+
+generate_conf 2
+add_conf '
+*.* @@(z5)127.0.0.1:'$RCVR_PORT'
+' 2
+startup 2
+
+injectmsg2
+shutdown_when_empty 2
+wait_shutdown 2
+
+wait_file_lines "$RSYSLOG_OUT_LOG" "$NUMMESSAGES"
+shutdown_when_empty
+wait_shutdown
+
+seq_check
+exit_test

--- a/tests/imptcp-compression-none-pmnull.sh
+++ b/tests/imptcp-compression-none-pmnull.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Regression test for the global legacy-z decompression opt-out on imptcp input.
+# compression.mode="none" disables stream decompression only; legacy single
+# message compression is intentionally still built-in transport compatibility.
+# The oracle is that parser.supportCompressionExtension="off" delivers a plain
+# raw frame beginning with "z" unchanged and emits no legacy decompression
+# diagnostic. pmnull is used only so the test can assert the raw payload without
+# message parsing changes; it does not control the legacy-z decision.
+#
+# Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+check_command_available python3
+
+generate_conf
+add_conf '
+global(processInternalMessages="on" parser.supportCompressionExtension="off")
+
+module(load="../plugins/imptcp/.libs/imptcp")
+module(load="../plugins/pmnull/.libs/pmnull")
+
+input(type="imptcp"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+      compression.mode="none"
+      ruleset="plain_pmnull")
+
+template(name="rawline" type="string" string="%rawmsg%\n")
+
+if $syslogtag contains "rsyslogd" then {
+	action(type="omfile" file="'$RSYSLOG2_OUT_LOG'")
+	stop
+}
+
+ruleset(name="plain_pmnull" parser="rsyslog.pmnull") {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="rawline")
+}
+'
+startup
+assign_tcpflood_port "$RSYSLOG_DYNNAME.tcpflood_port"
+
+python3 - <<'PY'
+import os
+import socket
+
+port = int(os.environ["TCPFLOOD_PORT"])
+with socket.create_connection(("127.0.0.1", port), timeout=10) as sock:
+    sock.sendall(b"zis plain text, not a compressed stream\n")
+PY
+
+wait_file_lines "$RSYSLOG_OUT_LOG" 1
+shutdown_when_empty
+wait_shutdown
+
+content_check "zis plain text, not a compressed stream" "$RSYSLOG_OUT_LOG"
+check_not_present "Uncompression of a message failed" "$RSYSLOG2_OUT_LOG"
+check_not_present "imptcp: received invalid compressed stream" "$RSYSLOG2_OUT_LOG"
+exit_test

--- a/tests/imptcp-stream-always-z-prefix.sh
+++ b/tests/imptcp-stream-always-z-prefix.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Regression test for imptcp stream decompression with a decompressed payload
+# that begins with the literal byte "z". Legacy single-message compression also
+# uses a leading "z" in the built-in transport frame handling, but stream:always
+# has already selected stream decompression and must not run legacy-z handling
+# on the decoded bytes. The oracle is delivery of the raw z-prefixed message and
+# absence of the legacy decompression-error diagnostic.
+#
+# Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+check_command_available python3
+
+generate_conf
+add_conf '
+global(processInternalMessages="on")
+
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+      compression.mode="stream:always")
+
+template(name="rawline" type="string" string="%rawmsg%\n")
+
+if $syslogtag contains "rsyslogd" then {
+	action(type="omfile" file="'$RSYSLOG2_OUT_LOG'")
+	stop
+}
+
+*.* action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="rawline")
+'
+startup
+assign_tcpflood_port "$RSYSLOG_DYNNAME.tcpflood_port"
+
+python3 - <<'PY'
+import os
+import socket
+import zlib
+
+port = int(os.environ["TCPFLOOD_PORT"])
+payload = b"zstream payload starts z after imptcp inflate\n"
+compressor = zlib.compressobj()
+wire = compressor.compress(payload) + compressor.flush()
+
+with socket.create_connection(("127.0.0.1", port), timeout=10) as sock:
+    sock.sendall(wire)
+PY
+
+wait_file_lines "$RSYSLOG_OUT_LOG" 1
+shutdown_when_empty
+wait_shutdown
+
+content_check "zstream payload starts z after imptcp inflate" "$RSYSLOG_OUT_LOG"
+check_not_present "Uncompression of a message failed" "$RSYSLOG2_OUT_LOG"
+check_not_present "imptcp: received invalid compressed stream" "$RSYSLOG2_OUT_LOG"
+exit_test

--- a/tests/imptcp-stream-auto-legacy-single.sh
+++ b/tests/imptcp-stream-auto-legacy-single.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Backward compatibility test for imptcp compression.mode="stream:auto" when
+# the session is plain TCP carrying omfwd's legacy "@@(zN)" single-message
+# compression. AUTO must first check the zlib stream header; if the connection
+# is classified as plain, built-in legacy-z transport-frame decompression must
+# remain enabled. The oracle is complete, ordered delivery of legacy-compressed
+# messages.
+#
+# Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1000
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+
+generate_conf
+add_conf '
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+      compression.mode="stream:auto")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+                                 file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+export RCVR_PORT=$TCPFLOOD_PORT
+
+generate_conf 2
+add_conf '
+*.* @@(z5)127.0.0.1:'$RCVR_PORT'
+' 2
+startup 2
+
+injectmsg2
+shutdown_when_empty 2
+wait_shutdown 2
+
+wait_file_lines "$RSYSLOG_OUT_LOG" "$NUMMESSAGES"
+shutdown_when_empty
+wait_shutdown
+
+seq_check
+exit_test

--- a/tests/imptcp-stream-auto-z-prefix.sh
+++ b/tests/imptcp-stream-auto-z-prefix.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Regression test for imptcp compression.mode="stream:auto" after it classifies
+# a connection as a zlib stream. A decompressed message can legitimately begin
+# with literal "z"; once AUTO has selected the stream path via the zlib header,
+# legacy-z transport-frame handling must not run on decoded bytes. The oracle is
+# delivery of the raw z-prefixed message and no legacy decompression diagnostic.
+#
+# Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+check_command_available python3
+
+generate_conf
+add_conf '
+global(processInternalMessages="on")
+
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+      compression.mode="stream:auto")
+
+template(name="rawline" type="string" string="%rawmsg%\n")
+
+if $syslogtag contains "rsyslogd" then {
+	action(type="omfile" file="'$RSYSLOG2_OUT_LOG'")
+	stop
+}
+
+*.* action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="rawline")
+'
+startup
+assign_tcpflood_port "$RSYSLOG_DYNNAME.tcpflood_port"
+
+python3 - <<'PY'
+import os
+import socket
+import zlib
+
+port = int(os.environ["TCPFLOOD_PORT"])
+payload = b"zauto stream payload starts z after imptcp inflate\n"
+compressor = zlib.compressobj()
+wire = compressor.compress(payload) + compressor.flush()
+
+with socket.create_connection(("127.0.0.1", port), timeout=10) as sock:
+    sock.sendall(wire)
+PY
+
+wait_file_lines "$RSYSLOG_OUT_LOG" 1
+shutdown_when_empty
+wait_shutdown
+
+content_check "zauto stream payload starts z after imptcp inflate" "$RSYSLOG_OUT_LOG"
+check_not_present "Uncompression of a message failed" "$RSYSLOG2_OUT_LOG"
+check_not_present "imptcp: received invalid compressed stream" "$RSYSLOG2_OUT_LOG"
+exit_test

--- a/tests/imtcp-stream-always-zlib-z-prefix.sh
+++ b/tests/imtcp-stream-always-zlib-z-prefix.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Regression test for the generic imtcp zlib stream decompression path with a
+# decompressed payload that begins with literal "z". Legacy single-message
+# compression also uses a leading "z" in built-in transport frame handling, but
+# stream:always has already selected zlib stream decompression and must not run
+# legacy-z handling on decoded bytes. The oracle is delivery of the raw
+# z-prefixed message and absence of the legacy decompression-error diagnostic.
+#
+# Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+check_command_available python3
+
+generate_conf
+add_conf '
+global(processInternalMessages="on")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+      compression.mode="stream:always"
+      compression.driver="zlib")
+
+template(name="rawline" type="string" string="%rawmsg%\n")
+
+if $syslogtag contains "rsyslogd" then {
+	action(type="omfile" file="'$RSYSLOG2_OUT_LOG'")
+	stop
+}
+
+*.* action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="rawline")
+'
+startup
+assign_tcpflood_port "$RSYSLOG_DYNNAME.tcpflood_port"
+
+python3 - <<'PY'
+import os
+import socket
+import zlib
+
+port = int(os.environ["TCPFLOOD_PORT"])
+payload = b"zimtcp stream payload starts z after zlib inflate\n"
+compressor = zlib.compressobj()
+wire = compressor.compress(payload) + compressor.flush()
+
+with socket.create_connection(("127.0.0.1", port), timeout=10) as sock:
+    sock.sendall(wire)
+PY
+
+wait_file_lines "$RSYSLOG_OUT_LOG" 1
+shutdown_when_empty
+wait_shutdown
+
+content_check "zimtcp stream payload starts z after zlib inflate" "$RSYSLOG_OUT_LOG"
+check_not_present "Uncompression of a message failed" "$RSYSLOG2_OUT_LOG"
+check_not_present "received invalid compressed stream" "$RSYSLOG2_OUT_LOG"
+exit_test


### PR DESCRIPTION
## Summary

This fixes the compatibility boundary between TCP stream decompression and the
legacy single-message `z` transport frame.

Main has two different compression paths:

- Legacy single-message compression is the built-in transport-frame
  compatibility path. A frame beginning with literal `z` is decompressed when
  the global support flag is enabled.
- Stream compression is separate. For `compression.mode="stream:auto"`, imptcp
  first sniffs the zlib stream header (`0x78` plus RFC1950 checks) and an
  inflate probe. If that fails, the session is plain and legacy `z` handling
  remains available.

The bug is the handoff after stream decompression: decoded stream bytes were
fed back through normal uncompressed TCP framing without a marker. If the
decoded message legitimately began with literal `z`, the built-in legacy `z`
step could run again even though stream decompression had already selected the
transport path.

## Diff vs main

- `runtime/msg.h` adds `NO_LEGACY_Z_DECOMPRESS` as a message flag for bytes
  already produced by stream decompression.
- `runtime/parser.c` keeps the existing built-in literal-`z` legacy
  decompression step, but skips it when that flag is present.
- `plugins/imptcp/imptcp.c` marks messages submitted from imptcp stream inflate,
  including `stream:always` and `stream:auto` sessions classified by the zlib
  header and inflate probe.
- `runtime/tcps_sess.c/.h` mark messages submitted from the shared imtcp
  zlib/zstd stream decompression path and initialize that marker in the TCP
  session constructor.
- `stream:auto` sessions that are not classified as stream remain plain
  sessions, so legacy `z` handling stays enabled there.

## Compatibility

This is intended as a targeted error fix. It preserves existing legacy `z`
support for plain TCP, including `compression.mode="none"` and
`compression.mode="stream:auto"` sessions that are not classified as stream.

It changes only the case where bytes are known to have already been produced by
stream decompression:

- `stream:always`: decoded bytes do not run legacy `z` handling.
- `stream:auto`: if the zlib stream header/probe selected stream mode, decoded
  bytes do not run legacy `z` handling.
- `stream:auto`: if the session is plain, legacy `z` handling remains active.

Closes https://github.com/rsyslog/rsyslog/issues/2702

## Validation

- `bash -n` on the six touched test scripts
- `shellcheck -S warning` on the six touched test scripts
- `devtools/check-test-antipatterns.sh` on the six touched test scripts
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `make -C runtime -j60 CFLAGS='-g -Wno-unknown-warning-option'`
- `make -C plugins/imptcp -j60 CFLAGS='-g -Wno-unknown-warning-option'`
- `make -C plugins/imtcp -j60 CFLAGS='-g -Wno-unknown-warning-option'`
- `make -C tools -j60 CFLAGS='-g -Wno-unknown-warning-option' rsyslogd`
- `./tests/imptcp-compression-none-pmnull.sh`
- `./tests/imptcp-compression-none-legacy-single.sh`
- `./tests/imptcp-stream-auto-z-prefix.sh`
- `./tests/imptcp-stream-auto-legacy-single.sh`
- `./tests/imptcp-stream-always-z-prefix.sh`
- `./tests/imtcp-stream-always-zlib-z-prefix.sh`
- `RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 CI_MAKE_OPT=-j60 CI_MAKE_CHECK_OPT=-j60 devtools/local-validation-plan.sh --run`
- `cubic review --base cfb5fc4da72fcb5b3bd47d2c4f5d040146770b98`: no issues found

Local note: this checkout is configured as `CC=clang` with GCC-only
`-Wjump-misses-init` under `-Werror`, so focused rebuilds used clang's
`-Wno-unknown-warning-option` compatibility flag.
