### PR TITLE
tests: cover net.enableDNS local hostname path

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -86,6 +86,7 @@ TESTS_ELASTICSEARCH_VALGRIND = \
 TESTS_DEFAULT = \
 	backtick-cat-procfs.sh \
 	preservefqdn-localhostname-internal.sh \
+	net-enabledns-off-localhostname.sh \
 	immark.sh \
 	immark-inputname.sh \
 	immark-ruleset.sh \

--- a/tests/net-enabledns-off-localhostname.sh
+++ b/tests/net-enabledns-off-localhostname.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Regression test for https://github.com/rsyslog/rsyslog/issues/4486.
+# With net.enableDNS="off", config processing must not call getaddrinfo() to
+# canonicalize a non-FQDN local host name.  The preload helpers return a
+# non-FQDN from gethostname() and write a marker if that synthetic name is ever
+# passed to getaddrinfo(); a clean -N1 run with no marker proves DNS was avoided.
+. ${srcdir:=.}/diag.sh init
+skip_ASAN "LD_PRELOAD conflicts with ASan runtime load order"
+
+export RSYSLOG_PRELOAD=".libs/liboverride_gethostname_nonfqdn.so:.libs/liboverride_getaddrinfo.so"
+export RSYSLOG_GETADDRINFO_MARKER="$RSYSLOG_DYNNAME.getaddrinfo.marker"
+
+generate_conf
+add_conf '
+global(net.enableDNS="off")
+'
+if ! rsyslogd_config_check; then
+	printf 'rsyslogd -N1 failed unexpectedly\n'
+	error_exit 1
+fi
+if [ -e "$RSYSLOG_GETADDRINFO_MARKER" ]; then
+	printf 'getaddrinfo() was called for the synthetic local hostname:\n'
+	cat "$RSYSLOG_GETADDRINFO_MARKER"
+	error_exit 1
+fi
+
+exit_test

--- a/tests/override_getaddrinfo.c
+++ b/tests/override_getaddrinfo.c
@@ -1,25 +1,70 @@
-// we need this for dlsym(): #include <dlfcn.h>
 #include "config.h"
-#include <stdio.h>
-#include <errno.h>
-#include <sys/types.h>
-#include <sys/socket.h>
+#include <fcntl.h>
 #include <netdb.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-int getaddrinfo(const char *node __attribute__((unused)),
-                const char *service __attribute__((unused)),
-                const struct addrinfo *hints __attribute__((unused)),
-                struct addrinfo **res __attribute__((unused))) {
-    return EAI_MEMORY;
+static int make_passive_ipv4(const char *service, struct addrinfo **res) {
+    struct addrinfo *ai = NULL;
+    struct sockaddr_in *sa = NULL;
+    char *endptr = NULL;
+    const long port = (service == NULL) ? 0 : strtol(service, &endptr, 10);
+
+    if (res == NULL || (service != NULL && (*service == '\0' || *endptr != '\0' || port < 0 || port > 65535))) {
+        return EAI_NONAME;
+    }
+
+    ai = calloc(1, sizeof(*ai));
+    sa = calloc(1, sizeof(*sa));
+    if (ai == NULL || sa == NULL) {
+        free(ai);
+        free(sa);
+        return EAI_MEMORY;
+    }
+
+    sa->sin_family = AF_INET;
+    sa->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    sa->sin_port = htons((uint16_t)port);
+
+    ai->ai_family = AF_INET;
+    ai->ai_socktype = SOCK_STREAM;
+    ai->ai_protocol = IPPROTO_TCP;
+    ai->ai_addrlen = sizeof(*sa);
+    ai->ai_addr = (struct sockaddr *)sa;
+    *res = ai;
+    return 0;
 }
 
-static void __attribute__((constructor)) my_init(void) {
-    /* we currently do not need this entry point, but keep it as
-     * a "template". It can be used, e.g. to emit some diagnostic
-     * information:
-    printf("loaded\n");
-     * or - more importantly - obtain a pointer to the overriden
-     * API:
-    orig_etry = dlsym(RTLD_NEXT, "original_entry_point");
-    */
+int getaddrinfo(const char *node,
+                const char *service,
+                const struct addrinfo *hints __attribute__((unused)),
+                struct addrinfo **res) {
+    if (node == NULL || strcmp(node, "**UNSPECIFIED**") == 0) {
+        return make_passive_ipv4(service, res);
+    }
+    if (node != NULL && strcmp(node, "nonfqdn") == 0) {
+        const char *marker = getenv("RSYSLOG_GETADDRINFO_MARKER");
+        if (marker != NULL && marker[0] != '\0') {
+            const int fd = open(marker, O_CREAT | O_WRONLY | O_APPEND, 0600);
+            if (fd >= 0) {
+                const ssize_t written = write(fd, "nonfqdn\n", sizeof("nonfqdn\n") - 1);
+                (void)written;
+                (void)close(fd);
+            }
+        }
+        if (res != NULL) {
+            *res = NULL;
+        }
+        return EAI_MEMORY;
+    }
+    if (res != NULL) {
+        *res = NULL;
+    }
+    return EAI_NONAME;
 }


### PR DESCRIPTION
## Summary
- adds a regression test for `global(net.enableDNS="off")` during local hostname discovery
- extends the existing `override_getaddrinfo` preload helper so it can both satisfy passive testbench lookups and mark unexpected DNS canonicalization of the synthetic non-FQDN host
- documents that current runtime code already avoids `getaddrinfo()` in this path

## Issue
Closes https://github.com/rsyslog/rsyslog/issues/4486

## Validation
- `make -j60 check TESTS=""`
- `./tests/net-enabledns-off-localhostname.sh`
- `make -j60 check TESTS='net-enabledns-off-localhostname.sh'`
- `devtools/format-code.sh --git-changed`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `bash -n tests/net-enabledns-off-localhostname.sh`
- `shellcheck -S warning tests/net-enabledns-off-localhostname.sh`
- `devtools/check-test-antipatterns.sh tests/net-enabledns-off-localhostname.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j60`
- `cubic review -j --base upstream/main --prompt 'Review this rsyslog testbench-only change for correctness, portability, resource lifetime, and whether the getaddrinfo override can affect unrelated tests.'`
- `RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 CI_MAKE_OPT=-j60 CI_MAKE_CHECK_OPT=-j60 devtools/local-validation-plan.sh --run`

Local container image: `rsyslog/rsyslog_dev_base_ubuntu:26.04`, image id `sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`.

Lane relaxations: none beyond the helper's change-gated testbench-plumbing plan.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

