### PR TITLE
statsobj: handle lock control failures

### DIFF
--- a/runtime/dynstats.c
+++ b/runtime/dynstats.c
@@ -1024,9 +1024,14 @@ static rsRetVal dynstats_addNewCtr(dynstats_bucket_t *b,
                                    const uchar *metric,
                                    uint8_t doInitialIncrement,
                                    uint64_t doInitialOffset) {
-    dynstats_ctr_t *ctr;
+    dynstats_ctr_t *ctr = NULL;
     dynstats_ctr_t *found_ctr, *survivor_ctr, *effective_ctr = NULL;
-    int created;
+    int created = 0;
+    int bucketLockHeld = 0;
+    int bucketMutationCommitted = 0;
+    int destroyCreatedCtrOnFailure = 0;
+    int survivorUnlinked = 0;
+    int tableInserted = 0;
     uchar *copy_of_key = NULL;
     DEFiRet;
 
@@ -1039,7 +1044,8 @@ static rsRetVal dynstats_addNewCtr(dynstats_bucket_t *b,
 
     CHKiRet(dynstats_createCtr(b, metric, &ctr));
 
-    pthread_rwlock_wrlock(&b->lock);
+    CHKiConcCtrl(pthread_rwlock_wrlock(&b->lock));
+    bucketLockHeld = 1;
     found_ctr = (dynstats_ctr_t *)hashtable_search(b->table, ctr->metric);
     if (found_ctr != NULL) {
         if (doInitialIncrement) {
@@ -1062,9 +1068,11 @@ static rsRetVal dynstats_addNewCtr(dynstats_bucket_t *b,
                 if (survivor_ctr == b->survivor_ctrs) {
                     b->survivor_ctrs = survivor_ctr->next;
                 }
+                survivorUnlinked = 1;
             }
             if ((created = hashtable_insert(b->table, copy_of_key, effective_ctr))) {
-                statsobj.AddPreCreatedCtr(b->stats, effective_ctr->pCtr);
+                tableInserted = 1;
+                CHKiRet(statsobj.AddPreCreatedCtr(b->stats, effective_ctr->pCtr));
             }
         }
         if (created) {
@@ -1083,7 +1091,13 @@ static rsRetVal dynstats_addNewCtr(dynstats_bucket_t *b,
             }
         }
     }
-    pthread_rwlock_unlock(&b->lock);
+    bucketMutationCommitted = 1;
+    const int ret = pthread_rwlock_unlock(&b->lock);
+    if (ret != 0) {
+        LogError(ret, RS_RET_CONC_CTRL_ERR, "dynstats: error unlocking bucket mutex");
+        abort();
+    }
+    bucketLockHeld = 0;
 
     if (found_ctr != NULL) {
         // ignore
@@ -1098,7 +1112,33 @@ static rsRetVal dynstats_addNewCtr(dynstats_bucket_t *b,
     }
 
 finalize_it:
-    if (((!created) || (effective_ctr != ctr)) && (ctr != NULL)) {
+    if (bucketLockHeld) {
+        if (iRet != RS_RET_OK && !bucketMutationCommitted && tableInserted) {
+            if (effective_ctr == ctr) {
+                destroyCreatedCtrOnFailure = 1;
+            }
+            hashtable_remove(b->table, copy_of_key);
+            copy_of_key = NULL;
+            created = 0;
+        }
+        if (iRet != RS_RET_OK && !bucketMutationCommitted && survivorUnlinked) {
+            if (effective_ctr->prev != NULL) {
+                effective_ctr->prev->next = effective_ctr;
+            }
+            if (effective_ctr->next != NULL) {
+                effective_ctr->next->prev = effective_ctr;
+            }
+            if (b->survivor_ctrs == effective_ctr->next) {
+                b->survivor_ctrs = effective_ctr;
+            }
+        }
+        const int cleanupRet = pthread_rwlock_unlock(&b->lock);
+        if (cleanupRet != 0) {
+            LogError(cleanupRet, RS_RET_CONC_CTRL_ERR, "dynstats: error unlocking bucket mutex during error cleanup");
+            abort();
+        }
+    }
+    if ((destroyCreatedCtrOnFailure || (!created) || (effective_ctr != ctr)) && (ctr != NULL)) {
         dynstats_destroyCtr(ctr);
     }
     RETiRet;

--- a/runtime/statsobj.c
+++ b/runtime/statsobj.c
@@ -82,9 +82,27 @@ static struct hashtable *stats_senders = NULL;
 
 /* ------------------------------ statsobj linked list maintenance  ------------------------------ */
 
-static void addToObjList(statsobj_t *pThis) {
-    pthread_mutex_lock(&mutStats);
-    if (pThis->flags && STATSOBJ_FLAG_DO_PREPEND) {
+static rsRetVal statsobjLock(pthread_mutex_t *mutex, const char *lockName) {
+    const int ret = pthread_mutex_lock(mutex);
+    if (ret != 0) {
+        LogError(ret, RS_RET_CONC_CTRL_ERR, "statsobj: error locking %s mutex", lockName);
+        return RS_RET_CONC_CTRL_ERR;
+    }
+    return RS_RET_OK;
+}
+
+static void statsobjUnlock(pthread_mutex_t *mutex, const char *lockName) {
+    const int ret = pthread_mutex_unlock(mutex);
+    if (ret != 0) {
+        LogError(ret, RS_RET_CONC_CTRL_ERR, "statsobj: error unlocking %s mutex", lockName);
+        abort();
+    }
+}
+
+static rsRetVal addToObjList(statsobj_t *pThis) {
+    DEFiRet;
+    CHKiRet(statsobjLock(&mutStats, "stats object list"));
+    if (pThis->flags & STATSOBJ_FLAG_DO_PREPEND) {
         pThis->next = objRoot;
         if (objRoot != NULL) {
             objRoot->prev = pThis;
@@ -97,27 +115,39 @@ static void addToObjList(statsobj_t *pThis) {
         objLast = pThis;
         if (objRoot == NULL) objRoot = pThis;
     }
-    pthread_mutex_unlock(&mutStats);
+    /* Unlock failures happen after shared state was already updated.  Log them,
+     * but do not make callers roll back objects that are now visible.
+     */
+    statsobjUnlock(&mutStats, "stats object list");
+finalize_it:
+    RETiRet;
 }
 
 
-static void removeFromObjList(statsobj_t *pThis) {
-    pthread_mutex_lock(&mutStats);
+static rsRetVal removeFromObjList(statsobj_t *pThis) {
+    DEFiRet;
+    CHKiRet(statsobjLock(&mutStats, "stats object list"));
     if (pThis->prev != NULL) pThis->prev->next = pThis->next;
     if (pThis->next != NULL) pThis->next->prev = pThis->prev;
     if (objLast == pThis) objLast = pThis->prev;
     if (objRoot == pThis) objRoot = pThis->next;
-    pthread_mutex_unlock(&mutStats);
+    statsobjUnlock(&mutStats, "stats object list");
+finalize_it:
+    RETiRet;
 }
 
 
-static void addCtrToList(statsobj_t *pThis, ctr_t *pCtr) {
-    pthread_mutex_lock(&pThis->mutCtr);
+static rsRetVal addCtrToList(statsobj_t *pThis, ctr_t *pCtr) {
+    DEFiRet;
+    CHKiRet(statsobjLock(&pThis->mutCtr, "counter list"));
     pCtr->prev = pThis->ctrLast;
     if (pThis->ctrLast != NULL) pThis->ctrLast->next = pCtr;
     pThis->ctrLast = pCtr;
     if (pThis->ctrRoot == NULL) pThis->ctrRoot = pCtr;
-    pthread_mutex_unlock(&pThis->mutCtr);
+    /* See addToObjList(): rollback after successful list mutation is unsafe. */
+    statsobjUnlock(&pThis->mutCtr, "counter list");
+finalize_it:
+    RETiRet;
 }
 
 /* ------------------------------ methods ------------------------------ */
@@ -126,11 +156,12 @@ static void addCtrToList(statsobj_t *pThis, ctr_t *pCtr) {
 /* Standard-Constructor
  */
 BEGINobjConstruct(statsobj) /* be sure to specify the object type also in END macro! */
-    pthread_mutex_init(&pThis->mutCtr, NULL);
+    CHKiConcCtrl(pthread_mutex_init(&pThis->mutCtr, NULL));
     pThis->ctrLast = NULL;
     pThis->ctrRoot = NULL;
     pThis->read_notifier = NULL;
     pThis->flags = 0;
+finalize_it:
 ENDobjConstruct(statsobj)
 
 
@@ -139,7 +170,8 @@ ENDobjConstruct(statsobj)
 static rsRetVal statsobjConstructFinalize(statsobj_t *pThis) {
     DEFiRet;
     ISOBJ_TYPE_assert(pThis, statsobj);
-    addToObjList(pThis);
+    CHKiRet(addToObjList(pThis));
+finalize_it:
     RETiRet;
 }
 
@@ -226,7 +258,7 @@ static rsRetVal addManagedCounter(statsobj_t *pThis,
             break;
     }
     if (linked) {
-        addCtrToList(pThis, ctr);
+        CHKiRet(addCtrToList(pThis, ctr));
     }
     *entryRef = ctr;
 
@@ -240,10 +272,10 @@ finalize_it:
     RETiRet;
 }
 
-static void addPreCreatedCounter(statsobj_t *pThis, ctr_t *pCtr) {
+static rsRetVal addPreCreatedCounter(statsobj_t *pThis, ctr_t *pCtr) {
     pCtr->next = NULL;
     pCtr->prev = NULL;
-    addCtrToList(pThis, pCtr);
+    return addCtrToList(pThis, pCtr);
 }
 
 static rsRetVal addCounter(statsobj_t *pThis, const uchar *ctrName, statsCtrType_t ctrType, int8_t flags, void *pCtr) {
@@ -850,7 +882,12 @@ void checkGoneAwaySenders(const time_t tCurr) {
 /* destructor for the statsobj object */
 BEGINobjDestruct(statsobj) /* be sure to specify the object type also in END and CODESTART macros! */
     CODESTARTobjDestruct(statsobj);
-    removeFromObjList(pThis);
+    iRet = removeFromObjList(pThis);
+    /* Do not enter ENDobjDestruct on unlink failure: that macro frees pThis
+     * and would leave objRoot/objLast pointing at released memory. There is no
+     * safe recovery path once we cannot lock the global list for destruction.
+     */
+    if (iRet != RS_RET_OK) abort();
 
     /* destruct counters */
     destructUnlinkedCounters(unlinkAllCounters(pThis));
@@ -915,8 +952,8 @@ BEGINAbstractObjClassInit(statsobj, 1, OBJ_IS_CORE_MODULE) /* class, version */
     OBJSetMethodHandler(objMethod_CONSTRUCTION_FINALIZER, statsobjConstructFinalize);
 
     /* init other data items */
-    pthread_mutex_init(&mutStats, NULL);
-    pthread_mutex_init(&mutSenders, NULL);
+    CHKiConcCtrl(pthread_mutex_init(&mutStats, NULL));
+    CHKiConcCtrl(pthread_mutex_init(&mutSenders, NULL));
 
     if ((stats_senders = create_hashtable(100, hash_from_string, key_equals_string, NULL)) == NULL) {
         LogError(0, RS_RET_INTERNAL_ERROR,

--- a/runtime/statsobj.h
+++ b/runtime/statsobj.h
@@ -212,13 +212,13 @@ BEGINinterface(statsobj) /* name must also be changed in ENDinterface macro! */
      */
     rsRetVal (*AddManagedCounter)(statsobj_t *pThis, const uchar *ctrName, statsCtrType_t ctrType, int8_t flags,
                                   void *pCtr, ctr_t **ref, int8_t linked);
-    void (*AddPreCreatedCtr)(statsobj_t *pThis, ctr_t *ctr);
+    rsRetVal (*AddPreCreatedCtr)(statsobj_t *pThis, ctr_t *ctr);
     void (*DestructCounter)(statsobj_t *pThis, ctr_t *ref);
     void (*DestructUnlinkedCounter)(ctr_t *ctr);
     ctr_t *(*UnlinkAllCounters)(statsobj_t *pThis);
     rsRetVal (*EnableStats)(void);
 ENDinterface(statsobj)
-#define statsobjCURR_IF_VERSION 14 /* increment whenever you change the interface structure! */
+#define statsobjCURR_IF_VERSION 15 /* increment whenever you change the interface structure! */
 /* Changes
  * v2-v9 rserved for future use in "older" version branches
  * v10, 2012-04-01: GetAllStatsLines got fmt parameter
@@ -226,6 +226,7 @@ ENDinterface(statsobj)
  *                  - GetAllStatsLines got parameter telling if ctrs shall be reset
  * v13, 2016-05-19: GetAllStatsLines cb data type changed (char* instead of cstr)
  * v14, 2026-02-01: Add GetAllCounters() native counter iteration API
+ * v15, 2026-06-23: AddPreCreatedCtr returns rsRetVal for lock failure propagation
  */
 
 


### PR DESCRIPTION
## Summary
- check statsobj mutex init/acquire failures and propagate them as concurrency-control errors
- make unrecoverable unlock/destructor sync failures log and fail-stop instead of corrupting shared stats lists
- propagate AddPreCreatedCtr failures into dynstats and roll back pre-commit bucket state

Closes https://github.com/rsyslog/rsyslog/issues/4752

## Validation
- devtools/format-code.sh --git-changed --check --check-if-available
- git diff --check
- CC=gcc CFLAGS="-g" ./configure --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --disable-generate-man-pages
- make -j60 check TESTS=""
- cubic review: no issues found
- RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 devtools/local-validation-plan.sh --run
  - Ubuntu 26.04 dev-container image: rsyslog/rsyslog_dev_base_ubuntu:26.04
  - image id/digest: sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d
  - container suite: 1375 total / 1348 pass / 0 fail
  - Ubuntu 26.04 static analyzer result: 0
  - local Cubic: no issues found


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

