### PR TITLE
build: avoid empty usertools install dirs

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,8 +1,7 @@
 sbin_PROGRAMS =
-bin_PROGRAMS =
 CLEANFILES =
-man1_MANS =
-man_MANS = rsyslogd.8 rsyslog.conf.5
+man5_MANS = rsyslog.conf.5
+man8_MANS = rsyslogd.8
 
 sbin_PROGRAMS += rsyslogd
 rsyslogd_SOURCES = \
@@ -78,7 +77,7 @@ endif # if OS_AIX
 endif # if OS_APPLE
 endif # if OS_LINUX
 
-EXTRA_DIST = $(man_MANS) \
+EXTRA_DIST = $(man5_MANS) $(man8_MANS) \
 	rscryutil.rst \
 	recover_qi.pl
 
@@ -95,6 +94,7 @@ msggen_SOURCES = msggen.c
 endif
 
 if ENABLE_USERTOOLS
+bin_PROGRAMS =
 if ENABLE_OMMONGODB
 bin_PROGRAMS += logctl
 logctl_SOURCES = logctl.c
@@ -122,6 +122,7 @@ rscryutil_LDFLAGS = \
 -Wl,--whole-archive,--no-whole-archive
 
 if ENABLE_GENERATE_MAN_PAGES
+man1_MANS =
 RSTMANFILE = rscryutil.rst
 rscryutil.1: $(RSTMANFILE)
 	$(AM_V_GEN) $(RST2MAN) $(RSTMANFILE) $@


### PR DESCRIPTION
## Summary
- scope bin_PROGRAMS to ENABLE_USERTOOLS so disabled usertools no longer create an empty bin directory
- scope man1_MANS to generated usertool manpages while keeping rsyslogd.8 and rsyslog.conf.5 in section-specific man variables
- preserve enabled usertools/manpage installs for rscryutil

Closes https://github.com/rsyslog/rsyslog/issues/4802

## Validation
- Reproduced before fix with --disable-usertools --disable-generate-man-pages: install created empty /usr/local/bin and /usr/local/share/man/man1
- After fix disabled path: ./autogen.sh --disable-usertools --disable-generate-man-pages --enable-testbench; make -j60; make install DESTDIR=/tmp/rsyslog-i4802-install-after2; verified no /usr/local/bin or /usr/local/share/man/man1 and daemon man5/man8 remain installed
- Enabled path: ./autogen.sh --enable-usertools --enable-generate-man-pages --enable-openssl --enable-libgcrypt --enable-testbench; make -j60; make install DESTDIR=/tmp/rsyslog-i4802-install-enabled; verified rscryutil, man1/rscryutil.1, man5, and man8 install
- devtools/format-code.sh --git-changed --check --check-if-available
- git diff --check
- cubic review: no issues found
- RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 devtools/local-validation-plan.sh --run
  - Ubuntu 26.04 dev-container image: rsyslog/rsyslog_dev_base_ubuntu:26.04
  - image id/digest: sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d
  - container suite: 1375 total / 1348 pass / 0 fail
  - Ubuntu 26.04 static analyzer result: 0
  - local Cubic: no issues found


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

