### PR TITLE
gtls: guard early debug-level lookup

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -219,7 +219,14 @@ int glblGetMaxLine(rsconf_t *cnf) {
 
 
 int GetGnuTLSLoglevel(rsconf_t *cnf) {
-    return (cnf->globals.iGnuTLSLoglevel);
+    /*
+     * Loadable netstream drivers can be initialized while a configuration is
+     * still being parsed, before runConf points at an active configuration.
+     */
+    if (cnf == NULL) {
+        cnf = loadConf;
+    }
+    return ((cnf != NULL) ? cnf->globals.iGnuTLSLoglevel : 0);
 }
 
 /* define a macro for the simple properties' set and get functions

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1574,6 +1574,7 @@ TESTS_MMDBLOOKUP_VALGRIND = \
     mmdb-multilevel-vg.sh
 
 TESTS_GNUTLS = \
+	gtls-absolute-module-path.sh \
 	imtcp-tls-basic.sh \
 	imtcp-tls-input-basic.sh \
 	imtcp-tls-input-2certs.sh \

--- a/tests/gtls-absolute-module-path.sh
+++ b/tests/gtls-absolute-module-path.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Regression test for loading the GnuTLS netstream driver by absolute path.
+# The issue report used module(load="/custom/path/lmnsd_gtls.so"), which caused
+# early driver initialization to dereference runConf before a config was active.
+# Oracle: rsyslogd -C -N1 must accept the config without crashing.
+# added 2026-06-23 by Codex
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+
+gtls_module="$(cd .. && pwd)/runtime/.libs/lmnsd_gtls.so"
+if [ ! -f "$gtls_module" ]; then
+	echo "lmnsd_gtls module not built - skipping test"
+	exit 77
+fi
+
+generate_conf
+add_conf '
+global(
+	workDirectory="'$RSYSLOG_DYNNAME'.spool"
+	debug.gnutls="1"
+	defaultNetstreamDriver="gtls"
+)
+module(load="'$gtls_module'")
+'
+
+../tools/rsyslogd -C -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -ne 0 ]; then
+	cat "${RSYSLOG_DYNNAME}.log"
+	error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
## Summary

Fixes a config/startup segfault when the GnuTLS netstream driver is loaded via an absolute module path such as `module(load="/custom/path/lmnsd_gtls.so")`.

`lmnsd_gtls` can be initialized while the configuration is still being parsed, before `runConf` points to an active config. `GetGnuTLSLoglevel(runConf)` therefore needs the same early-config fallback pattern used by other global getters.

Closes https://github.com/rsyslog/rsyslog/issues/5239

## Validation

- Manual reproducer: `rsyslogd -C -N1` with an absolute build-tree `lmnsd_gtls.so` path now exits 0.
- `make -j60 check TESTS='gtls-absolute-module-path.sh'`
- `make -j60 check TESTS=""`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j60`
- Local Cubic review: no issues found.
- Local container image: `rsyslog/rsyslog_dev_base_ubuntu:26.04`, image ID/digest `sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`.
- Ubuntu 26.04 static analyzer container: no bugs found.
- Ubuntu 26.04 change-gated container check: `1376 total / 1349 pass / 27 skip / 0 fail`.
- Ubuntu 26.04 sanitizer container check: `1180 total / 1152 pass / 28 skip / 0 fail`.

## Notes

No service lane relaxation beyond the workflow-defined sanitizer/test relevance configuration. TSAN was not run because this change does not touch threading, queueing, locks, or shared mutable lifecycle paths.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

