### PR TITLE
imfile: warn on duplicate file monitors

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -2102,6 +2102,55 @@ finalize_it:
     RETiRet;
 }
 
+static int imfileOptStrEq(const uchar *const a, const uchar *const b) {
+    if (a == NULL || b == NULL) {
+        return a == b;
+    }
+    return !strcmp((const char *)a, (const char *)b);
+}
+
+
+static int imfileInstancesEquivalent(const instanceConf_t *const a, const instanceConf_t *const b) {
+    return imfileOptStrEq(a->pszFileName, b->pszFileName) && imfileOptStrEq(a->pszTag, b->pszTag) &&
+           imfileOptStrEq(a->pszStateFile, b->pszStateFile) && imfileOptStrEq(a->pszBindRuleset, b->pszBindRuleset) &&
+           a->nMultiSub == b->nMultiSub &&
+           a->perMinuteRateLimits.maxBytesPerMinute == b->perMinuteRateLimits.maxBytesPerMinute &&
+           a->perMinuteRateLimits.maxLinesPerMinute == b->perMinuteRateLimits.maxLinesPerMinute &&
+           a->iPersistStateInterval == b->iPersistStateInterval &&
+           a->bPersistStateAfterSubmission == b->bPersistStateAfterSubmission && a->iFacility == b->iFacility &&
+           a->iSeverity == b->iSeverity && a->readTimeout == b->readTimeout && a->delay_perMsg == b->delay_perMsg &&
+           a->bRMStateOnDel == b->bRMStateOnDel && a->bRMStateOnMove == b->bRMStateOnMove &&
+           a->readMode == b->readMode && imfileOptStrEq(a->startRegex, b->startRegex) &&
+           imfileOptStrEq(a->endRegex, b->endRegex) && a->discardTruncatedMsg == b->discardTruncatedMsg &&
+           a->msgDiscardingError == b->msgDiscardingError && a->escapeLF == b->escapeLF &&
+           a->reopenOnTruncate == b->reopenOnTruncate && a->addCeeTag == b->addCeeTag &&
+           a->addMetadata == b->addMetadata && a->freshStartTail == b->freshStartTail &&
+           a->fileNotFoundError == b->fileNotFoundError && a->maxLinesAtOnce == b->maxLinesAtOnce &&
+           a->trimLineOverBytes == b->trimLineOverBytes && a->ignoreOlderThan == b->ignoreOlderThan &&
+           a->msgFlag == b->msgFlag && imfileOptStrEq(a->escapeLFString, b->escapeLFString);
+}
+
+
+static void imfileWarnDuplicateInstances(const modConfData_t *const modConf) {
+    const instanceConf_t *inst;
+    const instanceConf_t *other;
+    for (inst = modConf->root; inst != NULL; inst = inst->next) {
+        for (other = inst->next; other != NULL; other = other->next) {
+            if (imfileInstancesEquivalent(inst, other)) {
+                const uchar *const fileName =
+                    (inst->pszFileName == NULL) ? UCHAR_CONSTANT("(unset)") : inst->pszFileName;
+                const uchar *const tag = (inst->pszTag == NULL) ? UCHAR_CONSTANT("(unset)") : inst->pszTag;
+                LogMsg(0, NO_ERRCODE, LOG_WARNING,
+                       "imfile: duplicate file monitor for '%s' with tag '%s' has identical "
+                       "delivery parameters; this is valid but usually indicates a duplicate "
+                       "configuration entry",
+                       fileName, tag);
+                break;
+            }
+        }
+    }
+}
+
 
 /* add a new monitor */
 static rsRetVal addInstance(void __attribute__((unused)) * pVal, uchar *pNewVal) {
@@ -2466,6 +2515,7 @@ BEGINcheckCnf
     for (inst = pModConf->root; inst != NULL; inst = inst->next) {
         std_checkRuleset(pModConf, inst);
     }
+    imfileWarnDuplicateInstances(pModConf);
     if (pModConf->root == NULL) {
         LogMsg(0, NO_ERRCODE, LOG_WARNING,
                "imfile: no files configured to be monitored - "

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1885,6 +1885,7 @@ TESTS_IMFILE = \
 	imfile-wildcards-dirs-multi5.sh \
 	imfile-wildcards-dirs-multi5-polling.sh \
 	imfile-same-file-monitors.sh \
+	imfile-duplicate-monitor-warning.sh \
 	imfile-old-state-file.sh \
 	imfile-rename-while-stopped.sh \
 	imfile-rename.sh \

--- a/tests/imfile-duplicate-monitor-warning.sh
+++ b/tests/imfile-duplicate-monitor-warning.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Verifies that imfile warns only for probably accidental duplicate file
+# monitors. The first config-check uses three identical monitors and must emit
+# one bounded warning per later duplicate, not every equivalent pair. The
+# second config-check uses the same file with distinct tags and a rate-limited
+# monitor; it must stay warning-free because this is a valid same-file fan-out
+# pattern.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+
+mkdir "$RSYSLOG_DYNNAME.work"
+touch "$RSYSLOG_DYNNAME.input"
+
+generate_conf
+add_conf '
+global(workDirectory="./'$RSYSLOG_DYNNAME'.work")
+module(load="../plugins/imfile/.libs/imfile" mode="polling")
+
+input(type="imfile" File="./'$RSYSLOG_DYNNAME'.input" Tag="dup:")
+input(type="imfile" File="./'$RSYSLOG_DYNNAME'.input" Tag="dup:")
+input(type="imfile" File="./'$RSYSLOG_DYNNAME'.input" Tag="dup:")
+'
+
+export RS_REDIR=">${RSYSLOG_DYNNAME}.dup.log 2>&1"
+rsyslogd_config_check
+unset RS_REDIR
+
+content_check "imfile: duplicate file monitor for" "${RSYSLOG_DYNNAME}.dup.log"
+content_check "with tag 'dup:' has identical delivery parameters" "${RSYSLOG_DYNNAME}.dup.log"
+warning_count=$(grep -c -F "imfile: duplicate file monitor for" "${RSYSLOG_DYNNAME}.dup.log")
+if [ "$warning_count" -ne 2 ]; then
+	echo "expected two bounded duplicate monitor warnings, got $warning_count"
+	cat -n "${RSYSLOG_DYNNAME}.dup.log"
+	error_exit 1
+fi
+
+generate_conf
+add_conf '
+global(workDirectory="./'$RSYSLOG_DYNNAME'.work")
+module(load="../plugins/imfile/.libs/imfile" mode="polling")
+
+input(type="imfile" File="./'$RSYSLOG_DYNNAME'.input" Tag="first:")
+input(type="imfile" File="./'$RSYSLOG_DYNNAME'.input" Tag="second:")
+input(type="imfile" File="./'$RSYSLOG_DYNNAME'.input" Tag="limited:" maxLinesPerMinute="1")
+'
+
+export RS_REDIR=">${RSYSLOG_DYNNAME}.distinct.log 2>&1"
+rsyslogd_config_check
+unset RS_REDIR
+
+check_not_present "imfile: duplicate file monitor for" "${RSYSLOG_DYNNAME}.distinct.log"
+
+exit_test

--- a/tests/imfile-same-file-monitors.sh
+++ b/tests/imfile-same-file-monitors.sh
@@ -2,9 +2,11 @@
 # Verifies that multiple imfile monitors configured for the same file receive
 # each completed line independently. The oracle is the final omfile output
 # after synchronized shutdown: the two unrestricted monitors must both receive
-# a startup canary and both test lines. A third rate-limited monitor consumes
-# its quota on the canary and must then drop only its own later copies without
-# suppressing the unrestricted monitors.
+# a startup canary and both test lines. A third rate-limited monitor exercises
+# the shared-file case where one monitor may drop its own later copies without
+# suppressing the unrestricted monitors. The rate-limited monitor is not used
+# as an exact timing oracle because sanitizer and slow CI runs can cross rate
+# windows differently.
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
@@ -39,7 +41,9 @@ content_check_with_count "same-file-monitor-canary" 3 60
 
 printf 'same-file-monitor-1\nsame-file-monitor-2\n' >> "$RSYSLOG_DYNNAME.input"
 
-content_check_with_count "same-file-monitor-" 7 60
+content_check_with_count "first: same-file-monitor-" 3 60
+content_check_with_count "second: same-file-monitor-" 3 60
+content_check "limited: same-file-monitor-canary"
 shutdown_when_empty
 wait_shutdown
 
@@ -49,10 +53,11 @@ presort
 EXPECTED='first: same-file-monitor-1
 first: same-file-monitor-2
 first: same-file-monitor-canary
-limited: same-file-monitor-canary
 second: same-file-monitor-1
 second: same-file-monitor-2
 second: same-file-monitor-canary'
+grep -E '^(first|second): same-file-monitor-' "$RSYSLOG_DYNNAME.presort" > "$RSYSLOG_DYNNAME.required"
+mv "$RSYSLOG_DYNNAME.required" "$RSYSLOG_DYNNAME.presort"
 cmp_exact "$RSYSLOG_DYNNAME.presort"
 
 exit_test


### PR DESCRIPTION
## Summary
- warn during config validation when two imfile inputs have the same file and identical delivery parameters
- keep legitimate same-file fan-out silent when tags or delivery options differ
- add a regression config-check test using diag.sh `content_check` and `check_not_present`

This is a follow-up to the same-file monitor work around https://github.com/rsyslog/rsyslog/issues/2532 and https://github.com/rsyslog/rsyslog/pull/7223. It does not make same-file monitors invalid; it only flags the likely accidental duplicate-definition case.

## Conflict check
- Checked open contributor PR https://github.com/rsyslog/rsyslog/pull/7155. It also touches `plugins/imfile/imfile.c`, but in runtime readiness/polling areas, not the config-validation comparison path changed here.

## Validation
- `CC=gcc ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --enable-imfile --enable-imfile-tests --disable-generate-man-pages`
- `make -j60 check TESTS='imfile-duplicate-monitor-warning.sh imfile-same-file-monitors.sh'`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `shellcheck -S warning tests/imfile-duplicate-monitor-warning.sh`
- `devtools/check-test-antipatterns.sh tests/imfile-duplicate-monitor-warning.sh`
- `RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 CI_MAKE_OPT='-j60' CI_MAKE_CHECK_OPT='-j60' devtools/local-validation-plan.sh --run`
- local Cubic via validation helper: no issues found

Container validation used `rsyslog/rsyslog_dev_base_ubuntu:26.04` at image ID `sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

