### PR TITLE
omudpspoof: stop retrying failed fragments

### DIFF
--- a/plugins/omudpspoof/omudpspoof.c
+++ b/plugins/omudpspoof/omudpspoof.c
@@ -362,7 +362,6 @@ static rsRetVal UDPSend(wrkrInstanceData_t *pWrkrData, uchar *pszSourcename, cha
         len = 65528;
     }
 
-    ip = udp = 0;
     if (pWrkrData->sourcePort++ >= pData->sourcePortEnd) {
         pWrkrData->sourcePort = pData->sourcePortStart;
     }
@@ -396,6 +395,8 @@ static rsRetVal UDPSend(wrkrInstanceData_t *pWrkrData, uchar *pszSourcename, cha
         DBGPRINTF("omudpspoof: stage 1: MF:%d, msgOffs %d, hdrOffs %d, pktLen %d, udpPktLen %d, maxPktLen %d\n",
                   (hdrOffs & IP_MF) >> 13, (hdrOffs & 0x1FFF) << 3, hdrOffs, pktLen, udpPktLen, maxPktLen);
         libnet_clear_packet(pWrkrData->libnet_handle);
+        ip = LIBNET_PTAG_INITIALIZER;
+        udp = LIBNET_PTAG_INITIALIZER;
 
         /* note: libnet does need ports in host order NOT in network byte order! -- rgerhards, 2009-11-12 */
         udp = libnet_build_udp(pWrkrData->sourcePort, /* source port */
@@ -446,6 +447,9 @@ static rsRetVal UDPSend(wrkrInstanceData_t *pWrkrData, uchar *pszSourcename, cha
             bSendSuccess = RSTRUE;
         }
         msgOffs += pktLen;
+        if (bSendSuccess == RSFALSE) {
+            continue;
+        }
 
         /* We need to get rid of the UDP header to build the other fragments */
         libnet_clear_packet(pWrkrData->libnet_handle);
@@ -487,7 +491,7 @@ static rsRetVal UDPSend(wrkrInstanceData_t *pWrkrData, uchar *pszSourcename, cha
                 DBGPRINTF("omudpspoof: fragment write error len %d, sent %d: %s\n",
                           (int)(LIBNET_IPV4_H + LIBNET_UDP_H + len), lsent, libnet_geterror(pWrkrData->libnet_handle));
                 bSendSuccess = RSFALSE;
-                continue;
+                break;
             }
             msgOffs += pktLen;
         }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1803,6 +1803,9 @@ TESTS_OMUDPSPOOF = \
 	sndrcv_omudpspoof-bigmsg.sh \
 	sndrcv_omudpspoof_nonstdpt.sh
 
+TESTS_OMUDPSPOOF_IMTCP = \
+	omudpspoof-fragment-send-failure.sh
+
 TESTS_OMRULESET = \
 	omruleset.sh \
 	omruleset-queue.sh
@@ -2235,7 +2238,7 @@ EXTRA_DIST += $(TESTS_IMDTLS)
 EXTRA_DIST += $(TESTS_IMDTLS_VALGRIND)
 EXTRA_DIST += $(TESTS_IMDTLS_OMDTLS)
 EXTRA_DIST += $(TESTS_IMDTLS_OMDTLS_VALGRIND)
-EXTRA_DIST += $(TESTS_OMUDPSPOOF)
+EXTRA_DIST += $(TESTS_OMUDPSPOOF) $(TESTS_OMUDPSPOOF_IMTCP)
 EXTRA_DIST += $(TESTS_OMRULESET)
 EXTRA_DIST += $(TESTS_PMDB2DIAG)
 EXTRA_DIST += $(TESTS_PMCISCOIOS)
@@ -2349,7 +2352,7 @@ endif
 
 # Shipped even when testbench is disabled: dist tarballs are often built with
 # --disable-testbench, but downstream builds may enable testbench + imptcp.
-EXTRA_DIST += override_epoll_ctl.c
+EXTRA_DIST += override_epoll_ctl.c override_libnet_write_fail.c
 
 if ENABLE_TESTBENCH
 pkglib_LTLIBRARIES += liboverride_gethostname.la
@@ -2377,6 +2380,18 @@ liboverride_epoll_ctl.so: override_epoll_ctl.c
 		-o $@ $< $(DL_LIBS)
 
 imptcp-epoll-add-failure.log: liboverride_epoll_ctl.so
+endif
+
+if ENABLE_OMUDPSPOOF
+check_DATA += liboverride_libnet_write_fail.so
+CLEANFILES += liboverride_libnet_write_fail.so
+
+liboverride_libnet_write_fail.so: override_libnet_write_fail.c
+	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
+		$(AM_CPPFLAGS) $(CPPFLAGS) $(CFLAGS) -fPIC -shared \
+		-o $@ $<
+
+omudpspoof-fragment-send-failure.log: liboverride_libnet_write_fail.so
 endif
 
 check_PROGRAMS += $(TESTRUNS) ourtail tcpflood chkseq msleep randomgen \
@@ -3291,6 +3306,9 @@ endif # ENABLE_IMDTLS
 
 if ENABLE_OMUDPSPOOF
 TESTS += $(TESTS_OMUDPSPOOF)
+if ENABLE_IMTCP_TESTS
+TESTS += $(TESTS_OMUDPSPOOF_IMTCP)
+endif # ENABLE_IMTCP_TESTS
 endif
 
 #disabled as array-passing mode is no longer supported:	omod-if-array.sh

--- a/tests/omudpspoof-fragment-send-failure.sh
+++ b/tests/omudpspoof-fragment-send-failure.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Verifies that omudpspoof does not spin forever when libnet_write() fails
+# while sending a fragmented message. The oracle is successful shutdown after
+# injecting one oversized message while a preload shim forces every raw packet
+# write to fail. Older code retried the same fragment offset indefinitely.
+# This file is part of the rsyslog project, released under ASL 2.0.
+echo This test must be run as root [raw socket access required]
+if [ "$EUID" -ne 0 ]; then
+    exit 77
+fi
+. ${srcdir:=.}/diag.sh init
+skip_ASAN "LD_PRELOAD conflicts with ASan runtime load order"
+
+export RSYSLOG_PRELOAD=./liboverride_libnet_write_fail.so
+export TCPFLOOD_EXTRA_OPTS="-b1 -W1"
+export NUMMESSAGES=1
+export MESSAGESIZE=65000
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/omudpspoof/.libs/omudpspoof")
+
+global(maxMessageSize="64k")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
+
+template(name="spoofaddr" type="string" string="127.0.0.1")
+template(name="payload" type="string" string="%msg%\n")
+
+if $msg contains "msgnum:" then {
+	action(type="omudpspoof"
+		Target="127.0.0.1"
+		Port="514"
+		SourceTemplate="spoofaddr"
+		Template="payload"
+		mtu="1500")
+}
+'
+startup
+tcpflood -m "$NUMMESSAGES" -i1 -d "$MESSAGESIZE"
+shutdown_when_empty "" 10
+wait_shutdown
+
+exit_test

--- a/tests/override_libnet_write_fail.c
+++ b/tests/override_libnet_write_fail.c
@@ -1,0 +1,6 @@
+#include <errno.h>
+
+int libnet_write(void *handle __attribute__((unused))) {
+    errno = EMSGSIZE;
+    return -1;
+}


### PR DESCRIPTION
## Summary
- stop retrying the same omudpspoof fragment offset after `libnet_write()` fails
- skip the fragment loop when the first packet write already failed
- add a regression test that preloads a failing `libnet_write()` and proves shutdown completes

closes https://github.com/rsyslog/rsyslog/issues/4268

## Conflict check
- No open PR currently touches `plugins/omudpspoof/omudpspoof.c` or the omudpspoof test family.
- The new test is registered behind both `ENABLE_OMUDPSPOOF` and `ENABLE_IMTCP_TESTS` because it uses imtcp to inject the oversized message.

## Validation
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `bash -n tests/omudpspoof-fragment-send-failure.sh`
- `shellcheck -S warning tests/omudpspoof-fragment-send-failure.sh`
- `devtools/check-test-antipatterns.sh tests/omudpspoof-fragment-send-failure.sh`
- `CC=gcc ./autogen.sh --enable-debug --enable-testbench --enable-imptcp --enable-imtcp-tests --enable-imdiag --enable-omudpspoof --disable-generate-man-pages`
- `make -j60 check TESTS='omudpspoof-fragment-send-failure.sh'` (host build passed; test skipped because the host user is not root)
- `RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 CI_MAKE_OPT='-j60' CI_MAKE_CHECK_OPT='-j60' devtools/local-validation-plan.sh --run`
- focused root container execution: `docker run --rm --user root -v "$PWD":/rsyslog -w /rsyslog rsyslog/rsyslog_dev_base_ubuntu:26.04 bash -lc 'CC=gcc bash ./autogen.sh --enable-debug --enable-testbench --enable-imptcp --enable-imtcp-tests --enable-imdiag --enable-omudpspoof --disable-generate-man-pages >/tmp/omudpspoof-configure.log && make -j60 check TESTS="omudpspoof-fragment-send-failure.sh"'`

The focused root container run passed the new regression test. Full local validation used `rsyslog/rsyslog_dev_base_ubuntu:26.04` at image ID `sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`. Local Cubic via the validation helper reported no issues.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

