### PR TITLE
imudp: store received sockaddr length

### DIFF
--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -531,9 +531,9 @@ static rsRetVal processPacket(struct lstn_s *lstn,
     /* if we reach this point, we had a good receive and can process the packet received */
     /* check if we have a different sender than before, if so, we need to query some new values */
     if (bDoACLCheck) {
-        socklen = sizeof(struct sockaddr_storage);
-        if (net.CmpHost(frominet, frominetPrev, socklen) != 0) {
-            memcpy(frominetPrev, frominet, socklen); /* update cache indicator */
+        const socklen_t cmpSocklen = sizeof(struct sockaddr_storage);
+        if (net.CmpHost(frominet, frominetPrev, cmpSocklen) != 0) {
+            memcpy(frominetPrev, frominet, cmpSocklen); /* update cache indicator */
             /* Here we check if a host is permitted to send us syslog messages. If it isn't,
              * we do not further process the message but log a warning (if we are
              * configured to do this). However, if the check would require name resolution,
@@ -572,7 +572,7 @@ static rsRetVal processPacket(struct lstn_s *lstn,
         if (runModConf->bPreserveCase) {
             pMsg->msgFlags |= PRESERVE_CASE; /* preserve case of fromhost */
         }
-        CHKiRet(msgSetFromSockinfo(pMsg, frominet));
+        CHKiRet(msgSetFromSockinfoLen(pMsg, frominet, socklen));
         CHKiRet(ratelimitAddMsg(lstn->ratelimiter, multiSub, pMsg));
         STATSCOUNTER_INC(lstn->ctrSubmit, lstn->mutCtrSubmit);
     }
@@ -617,6 +617,7 @@ static rsRetVal processSocket(struct wrkrInfo_s *pWrkr,
         if (pWrkr->pThrd->bShallStop == RSTRUE) ABORT_FINALIZE(RS_RET_FORCE_TERM);
         memset(pWrkr->recvmsg_iov, 0, runModConf->batchSize * sizeof(struct iovec));
         memset(pWrkr->recvmsg_mmh, 0, runModConf->batchSize * sizeof(struct mmsghdr));
+        memset(pWrkr->frominet, 0, runModConf->batchSize * sizeof(struct sockaddr_storage));
         for (i = 0; i < runModConf->batchSize; ++i) {
             pWrkr->recvmsg_iov[i].iov_base = pWrkr->pRcvBuf + (i * (iMaxLine + 1));
             pWrkr->recvmsg_iov[i].iov_len = iMaxLine;
@@ -701,6 +702,7 @@ static rsRetVal processSocket(struct wrkrInfo_s *pWrkr,
     iNbrTimeUsed = 0;
     while (1) { /* loop is terminated if we have a bad receive, done below in the body */
         if (pWrkr->pThrd->bShallStop == RSTRUE) ABORT_FINALIZE(RS_RET_FORCE_TERM);
+        memset(&frominet, 0, sizeof(frominet));
         memset(iov, 0, sizeof(iov));
         iov[0].iov_base = pWrkr->pRcvBuf;
         iov[0].iov_len = iMaxLine;

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2522,15 +2522,24 @@ void MsgSetDfltTZ(smsg_t *pThis, char *tz) {
  * this is always the case and without extra effort required.
  * rgerhards, 2009-11-17
  */
-rsRetVal msgSetFromSockinfo(smsg_t *pThis, struct sockaddr_storage *sa) {
+rsRetVal msgSetFromSockinfoLen(smsg_t *pThis, const struct sockaddr_storage *sa, const size_t salen) {
     DEFiRet;
+    const size_t copyLen =
+        (sa == NULL) ? 0 : ((salen < sizeof(struct sockaddr_storage)) ? salen : sizeof(struct sockaddr_storage));
     assert(pThis->rcvFrom.pRcvFrom == NULL);
 
     CHKmalloc(pThis->rcvFrom.pfrominet = malloc(sizeof(struct sockaddr_storage)));
-    memcpy(pThis->rcvFrom.pfrominet, sa, sizeof(struct sockaddr_storage));
+    memset(pThis->rcvFrom.pfrominet, 0, sizeof(struct sockaddr_storage));
+    if (copyLen > 0) {
+        memcpy(pThis->rcvFrom.pfrominet, sa, copyLen);
+    }
 
 finalize_it:
     RETiRet;
+}
+
+rsRetVal msgSetFromSockinfo(smsg_t *pThis, struct sockaddr_storage *sa) {
+    return msgSetFromSockinfoLen(pThis, sa, sizeof(struct sockaddr_storage));
 }
 
 /* rgerhards 2008-09-10: set RcvFrom name in msg object. This calls AddRef()

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -191,6 +191,7 @@ rsRetVal MsgSetStructuredData(smsg_t *const pMsg, const char *pszStrucData);
 rsRetVal MsgAddToStructuredData(smsg_t *pMsg, uchar *toadd, rs_size_t len);
 void MsgGetStructuredData(smsg_t *pM, uchar **pBuf, rs_size_t *len);
 rsRetVal msgSetFromSockinfo(smsg_t *pThis, struct sockaddr_storage *sa);
+rsRetVal msgSetFromSockinfoLen(smsg_t *pThis, const struct sockaddr_storage *sa, size_t salen);
 void MsgSetRcvFrom(smsg_t *pMsg, prop_t *);
 void MsgSetRcvFromStr(smsg_t *const pMsg, const uchar *pszRcvFrom, const int, prop_t **);
 rsRetVal MsgSetRcvFromIP(smsg_t *pMsg, prop_t *);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -487,6 +487,7 @@ TESTS_DEFAULT = \
 	lookup_sparse_array_ipv4.sh \
 	parsertest-parse1.sh \
 	parsertest-parse1-udp.sh \
+	imudp-headerless-fromhost-ip.sh \
 	parsertest-parse2.sh \
 	parsertest-parse2-udp.sh \
 	parsertest-parse_8bit_escape.sh \

--- a/tests/imudp-headerless-fromhost-ip.sh
+++ b/tests/imudp-headerless-fromhost-ip.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Regression test for lazy UDP source-address handling used by headerless
+# messages.  The fromhost-ip property resolves through the sockaddr stored at
+# receive time.  The oracle is that normal UDP loopback traffic produces stable
+# loopback source properties and never exposes the internal ?error.obtaining.ip?
+# DNS-cache sentinel reported in issue #5461.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=20
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+
+generate_conf
+add_conf '
+global(net.enableDNS="off")
+
+module(load="../plugins/imudp/.libs/imudp")
+input(type="imudp" port="'$TCPFLOOD_PORT'")
+
+template(name="outfmt" type="string" string="host=%hostname% from=%fromhost-ip% raw=%rawmsg%\n")
+
+if $rawmsg contains "headerless message" then
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+startup
+tcpflood -m "$NUMMESSAGES" -T udp -M "\"headerless message\""
+shutdown_when_empty
+wait_shutdown
+
+wait_file_lines "$RSYSLOG_OUT_LOG" "$NUMMESSAGES"
+content_check "host=headerless from=127.0.0.1 raw=headerless message" "$RSYSLOG_OUT_LOG"
+check_not_present "?error.obtaining.ip?" "$RSYSLOG_OUT_LOG"
+
+exit_test


### PR DESCRIPTION
## Summary
- store the UDP peer sockaddr using the `msg_namelen` reported by `recvmsg()`/`recvmmsg()`
- zero source-address storage before handing it to lazy fromhost/fromhost-ip resolution
- add a regression test for headerless UDP input so loopback traffic does not emit the internal `?error.obtaining.ip?` sentinel

## Issue
Closes https://github.com/rsyslog/rsyslog/issues/5461

## Validation
- `git diff --check`
- `bash -n tests/imudp-headerless-fromhost-ip.sh`
- `devtools/check-test-antipatterns.sh tests/imudp-headerless-fromhost-ip.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `make -j60 check TESTS='imudp-headerless-fromhost-ip.sh'`
- `RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 devtools/local-validation-plan.sh --run`
- local Cubic via the validation helper: no issues found
- Docker Hub image: `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`)
- static analyzer container:
  `RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' SCAN_BUILD='scan-build' SCAN_BUILD_CC='clang' SCAN_BUILD_REPORT_DIR='scan-build-report' CI_MAKE_OPT='-j20' DOCKER_RUN_EXTRA_OPTS='-e SCAN_BUILD -e SCAN_BUILD_CC -e SCAN_BUILD_REPORT_DIR' RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--disable-elasticsearch --disable-elasticsearch-tests --disable-imkafka --disable-omkafka --disable-kafka-tests --disable-mysql --disable-mysql-tests' devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh`
  - result: `scan-build: No bugs found. static analyzer result: 0`
- Ubuntu 26.04 change-gated container:
  `RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 CI_MAKE_OPT='-j60' CI_MAKE_CHECK_OPT='-j60' devtools/devcontainer.sh --rm devtools/run-ci.sh`
  - result: `# TOTAL: 1376`, `# PASS: 1349`, `# SKIP: 27`, `# FAIL: 0`, `# ERROR: 0`
- focused sanitizer supplement:
  `CI_SANITIZE_BLACKLIST='tests/asan.supp' RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' CC='clang-21' RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--disable-elasticsearch-tests --disable-libfaketime --without-valgrind-testbench --disable-valgrind --disable-kafka-tests --enable-imdiag' CFLAGS='-fstack-protector -D_FORTIFY_SOURCE=2 -fsanitize=address,undefined,nullability,unsigned-integer-overflow -fno-sanitize-recover=undefined,nullability,unsigned-integer-overflow -fno-sanitize=function -g -O3 -fno-omit-frame-pointer -fno-color-diagnostics' LSAN_OPTIONS='detect_leaks=0' UBSAN_OPTIONS='print_stacktrace=1' CI_MAKE_OPT='-j60' CI_MAKE_CHECK_OPT='-j60' CI_MAKE_CHECK_TESTS='imudp-headerless-fromhost-ip.sh parsertest-parse1-udp.sh' devtools/devcontainer.sh --rm devtools/run-ci.sh`
  - result: `# TOTAL: 2`, `# PASS: 2`, `# FAIL: 0`, `# ERROR: 0`

## Relaxations
- Kafka, Elasticsearch, and MySQL were disabled only in static-analysis/sanitizer supplement lanes because they are not touched by this imudp/runtime source-address change.
- TSAN not run: this change does not add shared mutable state, locks, queues, or thread lifecycle behavior.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

