### PR TITLE
mmkubernetes: add kubernetesurl failover

### DIFF
--- a/contrib/mmkubernetes/mmkubernetes.c
+++ b/contrib/mmkubernetes/mmkubernetes.c
@@ -136,6 +136,8 @@ typedef struct {
 struct modConfData_s {
     rsconf_t *pConf; /* our overall config object */
     uchar *kubernetesUrl; /* scheme, host, port, and optional path prefix for Kubernetes API lookups */
+    uchar **kubernetesUrls; /* ordered failover list; kubernetesUrl is the primary */
+    int nKubernetesUrls;
     uchar *srcMetadataPath; /* where to get data for kubernetes queries */
     uchar *dstMetadataPath; /* where to put metadata obtained from kubernetes */
     uchar *caCertFile; /* File holding the CA cert (+optional chain) of CA that issued the Kubernetes server cert */
@@ -162,6 +164,8 @@ struct modConfData_s {
 /* action (instance) configuration data */
 typedef struct _instanceData {
     uchar *kubernetesUrl; /* scheme, host, port, and optional path prefix for Kubernetes API lookups */
+    uchar **kubernetesUrls; /* ordered failover list; kubernetesUrl is the primary */
+    int nKubernetesUrls;
     msgPropDescr_t *srcMetadataDescr; /* where to get data for kubernetes queries */
     uchar *dstMetadataPath; /* where to put metadata obtained from kubernetes */
     uchar *caCertFile; /* File holding the CA cert (+optional chain) of CA that issued the Kubernetes server cert */
@@ -216,7 +220,7 @@ typedef struct wrkrInstanceData {
 } wrkrInstanceData_t;
 
 /* module parameters (v6 config format) */
-static struct cnfparamdescr modpdescr[] = {{"kubernetesurl", eCmdHdlrString, 0},
+static struct cnfparamdescr modpdescr[] = {{"kubernetesurl", eCmdHdlrArray, 0},
                                            {"srcmetadatapath", eCmdHdlrString, 0},
                                            {"dstmetadatapath", eCmdHdlrString, 0},
                                            {"tls.cacert", eCmdHdlrString, 0},
@@ -244,7 +248,7 @@ static struct cnfparamdescr modpdescr[] = {{"kubernetesurl", eCmdHdlrString, 0},
 static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / sizeof(struct cnfparamdescr), modpdescr};
 
 /* action (instance) parameters (v6 config format) */
-static struct cnfparamdescr actpdescr[] = {{"kubernetesurl", eCmdHdlrString, 0},
+static struct cnfparamdescr actpdescr[] = {{"kubernetesurl", eCmdHdlrArray, 0},
                                            {"srcmetadatapath", eCmdHdlrString, 0},
                                            {"dstmetadatapath", eCmdHdlrString, 0},
                                            {"tls.cacert", eCmdHdlrString, 0},
@@ -286,6 +290,90 @@ static void free_annotationmatch(annotation_match_t *match) {
         match->regexps = NULL;
         match->nmemb = 0;
     }
+}
+
+static void freeKubernetesUrlList(uchar ***urls, int *const nUrls, uchar **const primaryUrl) {
+    int i;
+
+    if (urls == NULL || nUrls == NULL || primaryUrl == NULL) return;
+    free(*primaryUrl);
+    *primaryUrl = NULL;
+    if (*urls != NULL) {
+        for (i = 0; i < *nUrls; ++i) free((*urls)[i]);
+        free(*urls);
+        *urls = NULL;
+    }
+    *nUrls = 0;
+}
+
+static void freeInstanceKubernetesUrls(instanceData *pData) {
+    if (pData == NULL) return;
+    freeKubernetesUrlList(&pData->kubernetesUrls, &pData->nKubernetesUrls, &pData->kubernetesUrl);
+}
+
+static rsRetVal setKubernetesUrls(uchar ***dstUrls,
+                                  int *const dstNUrls,
+                                  uchar **const dstPrimaryUrl,
+                                  uchar *const *const srcUrls,
+                                  const int srcNUrls) {
+    DEFiRet;
+    uchar **newUrls = NULL;
+    uchar *newPrimary = NULL;
+    int i;
+
+    if (dstUrls == NULL || dstNUrls == NULL || dstPrimaryUrl == NULL || srcUrls == NULL || srcNUrls <= 0) {
+        LogError(0, RS_RET_CONFIG_ERROR, "mmkubernetes: kubernetesurl must not be empty");
+        ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+    }
+
+    CHKmalloc(newUrls = calloc((size_t)srcNUrls, sizeof(uchar *)));
+    for (i = 0; i < srcNUrls; ++i) {
+        if (srcUrls[i] == NULL || srcUrls[i][0] == '\0') {
+            LogError(0, RS_RET_CONFIG_ERROR, "mmkubernetes: empty kubernetesurl entry");
+            ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+        }
+        CHKmalloc(newUrls[i] = (uchar *)strdup((const char *)srcUrls[i]));
+    }
+    CHKmalloc(newPrimary = (uchar *)strdup((const char *)newUrls[0]));
+
+    freeKubernetesUrlList(dstUrls, dstNUrls, dstPrimaryUrl);
+    *dstPrimaryUrl = newPrimary;
+    *dstUrls = newUrls;
+    *dstNUrls = srcNUrls;
+    newPrimary = NULL;
+    newUrls = NULL;
+
+finalize_it:
+    free(newPrimary);
+    if (newUrls != NULL) {
+        for (i = 0; i < srcNUrls; ++i) free(newUrls[i]);
+        free(newUrls);
+    }
+    RETiRet;
+}
+
+static rsRetVal setKubernetesUrlsFromArray(uchar ***dstUrls,
+                                           int *const dstNUrls,
+                                           uchar **const dstPrimaryUrl,
+                                           struct cnfarray *const ar) {
+    DEFiRet;
+    uchar **urls = NULL;
+    int i;
+
+    if (ar == NULL || ar->nmemb <= 0) {
+        LogError(0, RS_RET_CONFIG_ERROR, "mmkubernetes: kubernetesurl must not be empty");
+        ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+    }
+    CHKmalloc(urls = calloc((size_t)ar->nmemb, sizeof(uchar *)));
+    for (i = 0; i < ar->nmemb; ++i) CHKmalloc(urls[i] = (uchar *)es_str2cstr(ar->arr[i], NULL));
+    CHKiRet(setKubernetesUrls(dstUrls, dstNUrls, dstPrimaryUrl, urls, ar->nmemb));
+
+finalize_it:
+    if (urls != NULL) {
+        for (i = 0; i < (ar == NULL ? 0 : ar->nmemb); ++i) free(urls[i]);
+        free(urls);
+    }
+    RETiRet;
 }
 
 static int init_annotationmatch(annotation_match_t *match, struct cnfarray *ar) {
@@ -561,8 +649,8 @@ BEGINsetModCnf
         if (!pvals[i].bUsed) {
             continue;
         } else if (!strcmp(modpblk.descr[i].name, "kubernetesurl")) {
-            free(loadModConf->kubernetesUrl);
-            CHKmalloc(loadModConf->kubernetesUrl = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+            CHKiRet(setKubernetesUrlsFromArray(&loadModConf->kubernetesUrls, &loadModConf->nKubernetesUrls,
+                                               &loadModConf->kubernetesUrl, pvals[i].val.d.ar));
         } else if (!strcmp(modpblk.descr[i].name, "srcmetadatapath")) {
             free(loadModConf->srcMetadataPath);
             CHKmalloc(loadModConf->srcMetadataPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
@@ -748,7 +836,7 @@ ENDcreateInstance
 
 BEGINfreeInstance
     CODESTARTfreeInstance;
-    free(pData->kubernetesUrl);
+    freeInstanceKubernetesUrls(pData);
     msgPropDescrDestruct(pData->srcMetadataDescr);
     free(pData->srcMetadataDescr);
     free(pData->dstMetadataPath);
@@ -1204,8 +1292,8 @@ BEGINnewActInst
         if (!pvals[i].bUsed) {
             continue;
         } else if (!strcmp(actpblk.descr[i].name, "kubernetesurl")) {
-            free(pData->kubernetesUrl);
-            CHKmalloc(pData->kubernetesUrl = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+            CHKiRet(setKubernetesUrlsFromArray(&pData->kubernetesUrls, &pData->nKubernetesUrls, &pData->kubernetesUrl,
+                                               pvals[i].val.d.ar));
         } else if (!strcmp(actpblk.descr[i].name, "srcmetadatapath")) {
             msgPropDescrDestruct(pData->srcMetadataDescr);
             free(pData->srcMetadataDescr);
@@ -1366,11 +1454,14 @@ BEGINnewActInst
         }
     }
 
-    if (pData->kubernetesUrl == NULL) {
-        if (loadModConf->kubernetesUrl == NULL) {
-            CHKmalloc(pData->kubernetesUrl = (uchar *)strdup(DFLT_KUBERNETES_URL));
+    if (pData->nKubernetesUrls == 0) {
+        if (loadModConf->nKubernetesUrls == 0) {
+            uchar *const defaultUrl = UCHAR_CONSTANT(DFLT_KUBERNETES_URL);
+            CHKiRet(setKubernetesUrls(&pData->kubernetesUrls, &pData->nKubernetesUrls, &pData->kubernetesUrl,
+                                      &defaultUrl, 1));
         } else {
-            CHKmalloc(pData->kubernetesUrl = (uchar *)strdup((char *)loadModConf->kubernetesUrl));
+            CHKiRet(setKubernetesUrls(&pData->kubernetesUrls, &pData->nKubernetesUrls, &pData->kubernetesUrl,
+                                      loadModConf->kubernetesUrls, loadModConf->nKubernetesUrls));
         }
     }
     if (pData->srcMetadataDescr == NULL) {
@@ -1455,7 +1546,7 @@ BEGINfreeCnf
     CODESTARTfreeCnf;
     int i;
 
-    free(pModConf->kubernetesUrl);
+    freeKubernetesUrlList(&pModConf->kubernetesUrls, &pModConf->nKubernetesUrls, &pModConf->kubernetesUrl);
     free(pModConf->srcMetadataPath);
     free(pModConf->dstMetadataPath);
     free(pModConf->caCertFile);
@@ -1689,6 +1780,33 @@ finalize_it:
     RETiRet;
 }
 
+static rsRetVal queryKBWithFailover(wrkrInstanceData_t *pWrkrData,
+                                    const char *apiPath,
+                                    time_t now,
+                                    struct json_object **rply) {
+    DEFiRet;
+    char *url = NULL;
+    int i;
+
+    for (i = 0; i < pWrkrData->pData->nKubernetesUrls; ++i) {
+        if ((-1 == asprintf(&url, "%s%s", (char *)pWrkrData->pData->kubernetesUrls[i], apiPath)) || (!url)) {
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+        iRet = queryKB(pWrkrData, url, now, rply);
+        if (iRet != RS_RET_SUSPENDED || i == pWrkrData->pData->nKubernetesUrls - 1) {
+            FINALIZE;
+        }
+        LogMsg(0, RS_RET_SUSPENDED, LOG_WARNING,
+               "mmkubernetes: failed to connect to [%s], trying next configured kubernetesurl", url);
+        free(url);
+        url = NULL;
+    }
+
+finalize_it:
+    free(url);
+    RETiRet;
+}
+
 
 /* versions < 8.16.0 don't support BEGINdoAction_NoStrings */
 #if defined(BEGINdoAction_NoStrings)
@@ -1701,6 +1819,7 @@ BEGINdoAction
 #endif
     const char *podName = NULL, *ns = NULL, *containerName = NULL, *containerID = NULL;
     char *mdKey = NULL;
+    char *apiPath = NULL;
     struct json_object *jMetadata = NULL, *jMetadataCopy = NULL, *jMsgMeta = NULL, *jo = NULL;
     int add_pod_metadata = 1;
     time_t now;
@@ -1735,7 +1854,6 @@ BEGINdoAction
     jMetadata = cache_entry_get_md(pWrkrData, mdKey, now);
 
     if (jMetadata == NULL) {
-        char *url = NULL;
         struct json_object *jReply = NULL, *jo2 = NULL, *jNsMeta = NULL, *jPodData = NULL;
 
         /* check cache for namespace metadata */
@@ -1743,14 +1861,13 @@ BEGINdoAction
 
         if (jNsMeta == NULL) {
             /* query kubernetes for namespace info */
-            /* todo: move url definitions elsewhere */
-            if ((-1 == asprintf(&url, "%s/api/v1/namespaces/%s", (char *)pWrkrData->pData->kubernetesUrl, ns)) ||
-                (!url)) {
+            if ((-1 == asprintf(&apiPath, "/api/v1/namespaces/%s", ns)) || (!apiPath)) {
                 pthread_mutex_unlock(pWrkrData->pData->cache->cacheMtx);
                 ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
             }
-            iRet = queryKB(pWrkrData, url, now, &jReply);
-            free(url);
+            iRet = queryKBWithFailover(pWrkrData, apiPath, now, &jReply);
+            free(apiPath);
+            apiPath = NULL;
             if (iRet == RS_RET_NOT_FOUND) {
                 /* negative cache namespace - make a dummy empty namespace metadata object */
                 jNsMeta = json_object_new_object();
@@ -1797,14 +1914,13 @@ BEGINdoAction
             jReply = NULL;
         }
 
-        if ((-1 ==
-             asprintf(&url, "%s/api/v1/namespaces/%s/pods/%s", (char *)pWrkrData->pData->kubernetesUrl, ns, podName)) ||
-            (!url)) {
+        if ((-1 == asprintf(&apiPath, "/api/v1/namespaces/%s/pods/%s", ns, podName)) || (!apiPath)) {
             pthread_mutex_unlock(pWrkrData->pData->cache->cacheMtx);
             ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
         }
-        iRet = queryKB(pWrkrData, url, now, &jReply);
-        free(url);
+        iRet = queryKBWithFailover(pWrkrData, apiPath, now, &jReply);
+        free(apiPath);
+        apiPath = NULL;
         if (iRet == RS_RET_NOT_FOUND) {
             /* negative cache pod - make a dummy empty pod metadata object */
             iRet = RS_RET_OK;
@@ -1898,6 +2014,7 @@ BEGINdoAction
 finalize_it:
     json_object_put(jMsgMeta);
     free(mdKey);
+    free(apiPath);
 ENDdoAction
 
 

--- a/doc/source/reference/parameters/mmkubernetes-kubernetesurl.rst
+++ b/doc/source/reference/parameters/mmkubernetes-kubernetesurl.rst
@@ -18,7 +18,7 @@ This parameter applies to :doc:`../../configuration/modules/mmkubernetes`.
 
 :Name: KubernetesURL
 :Scope: action
-:Type: word
+:Type: array[string]
 :Default: https://kubernetes.default.svc.cluster.local:443
 :Required?: no
 :Introduced: at least 8.x, possibly earlier
@@ -26,6 +26,15 @@ This parameter applies to :doc:`../../configuration/modules/mmkubernetes`.
 Description
 -----------
 The URL of the Kubernetes API server. Example: `https://localhost:8443`.
+
+You can specify multiple API server URLs with standard rsyslog array syntax.
+mmkubernetes uses the first URL as the primary server, cache identity, statistic
+name, and ``master_url`` metadata value. If a transport connection to that URL
+fails, mmkubernetes tries the next configured URL for the same metadata lookup.
+Kubernetes API responses such as ``404 Not Found`` or ``429 Busy`` are handled
+with the normal module semantics and do not by themselves advance to the next
+URL. Existing single-URL configurations remain valid because a scalar value is
+treated as a one-element array.
 
 Action usage
 ------------
@@ -35,6 +44,9 @@ Action usage
 .. code-block:: rsyslog
 
    action(type="mmkubernetes" kubernetesUrl="https://localhost:8443")
+
+   action(type="mmkubernetes"
+          kubernetesUrl=["https://k8s-a.example:6443", "https://k8s-b.example:6443"])
 
 See also
 --------

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2044,7 +2044,8 @@ TESTS_MMTAGHOSTNAME = \
 
 TESTS_MMKUBERNETES = \
 	mmkubernetes-basic.sh \
-	mmkubernetes-cache-expire.sh
+	mmkubernetes-cache-expire.sh \
+	mmkubernetes-url-failover.sh
 
 TESTS_MMKUBERNETES_VALGRIND = \
 	mmkubernetes-basic-vg.sh \

--- a/tests/mmkubernetes-url-failover.sh
+++ b/tests/mmkubernetes-url-failover.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Verify that mmkubernetes can try multiple kubernetesurl values configured as
+# a standard rsyslog array. The first URL is an unreachable localhost endpoint;
+# the oracle is that metadata enrichment still succeeds through the second,
+# live test server.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+check_command_available timeout
+pwd=$( pwd )
+k8s_srv_port_file="${RSYSLOG_DYNNAME}mmk8s-test-server.port"
+generate_conf
+testsrv=mmk8s-test-server
+
+echo starting kubernetes \"emulator\"
+timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server.py 0 \
+	${RSYSLOG_DYNNAME}${testsrv}.pid \
+	${RSYSLOG_DYNNAME}${testsrv}.started \
+	${k8s_srv_port_file} > ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log 2>&1 &
+BGPROCESS=$!
+wait_file_exists "$k8s_srv_port_file"
+k8s_srv_port="$(cat "$k8s_srv_port_file")"
+wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
+echo background mmkubernetes_test_server.py process id is $BGPROCESS
+
+add_conf '
+global(workDirectory="'$RSYSLOG_DYNNAME.spool'")
+module(load="../plugins/imfile/.libs/imfile")
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+module(load="../contrib/mmkubernetes/.libs/mmkubernetes")
+
+template(name="mmk8s_template" type="list") {
+    property(name="$!all-json-plain")
+    constant(value="\n")
+}
+
+input(type="imfile" file="'$RSYSLOG_DYNNAME.spool'/pod-*.log" tag="kubernetes" addmetadata="on")
+action(type="mmjsonparse" cookie="")
+action(type="mmkubernetes" token="dummy"
+       kubernetesurl=["http://127.0.0.1:1", "http://localhost:'$k8s_srv_port'"]
+       filenamerules=["rule=:'$pwd/$RSYSLOG_DYNNAME.spool'/%pod_name:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log"]
+)
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="mmk8s_template")
+'
+
+cat > ${RSYSLOG_DYNNAME}.spool/pod-name2581_namespace-name2581_container-name2581-id2581.log <<EOF
+{"message":"a message for kubernetesurl failover","testid":2581}
+EOF
+
+startup
+wait_queueempty
+shutdown_when_empty
+wait_shutdown
+kill $BGPROCESS
+wait_pid_termination ${RSYSLOG_DYNNAME}${testsrv}.pid
+
+$PYTHON - "$RSYSLOG_OUT_LOG" <<'PY'
+import json
+import sys
+
+records = [json.loads(line) for line in open(sys.argv[1])]
+record = next((item for item in records if item.get("testid") == 2581), None)
+if record is None:
+    print("record for testid 2581 not found")
+    sys.exit(1)
+kubernetes = record.get("kubernetes", {})
+expected = {
+    "namespace_name": "namespace-name2581",
+    "pod_name": "pod-name2581",
+    "container_name": "container-name2581",
+    "namespace_id": "namespace-name2581-id",
+    "pod_id": "pod-name2581-id",
+    "master_url": "http://127.0.0.1:1",
+}
+for key, value in expected.items():
+    if kubernetes.get(key) != value:
+        print("unexpected kubernetes.{0}: {1!r} != {2!r}".format(key, kubernetes.get(key), value))
+        sys.exit(1)
+PY
+if [ $? -ne 0 ]; then
+	echo
+	echo "FAIL: expected failover-enriched record not found. $RSYSLOG_OUT_LOG is:"
+	cat ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log
+	cat $RSYSLOG_OUT_LOG
+	error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
## Summary
- adds comma-separated failover support to `mmkubernetes` `kubernetesurl`
- keeps the first URL as the primary/cache/statistics/`master_url` identity for compatibility
- retries only transport-level `RS_RET_SUSPENDED` lookup failures; Kubernetes API responses keep existing handling
- documents the new list semantics and adds a focused regression test

Fixes https://github.com/rsyslog/rsyslog/issues/2581

## Validation
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `bash -n tests/mmkubernetes-url-failover.sh`
- `devtools/check-test-antipatterns.sh tests/mmkubernetes-url-failover.sh` (advisory findings reviewed; dynamic listener port is used)
- `./autogen.sh --enable-debug --enable-testbench --enable-imfile --enable-mmjsonparse --enable-mmkubernetes --enable-impstats --disable-generate-man-pages`
- `make -j60 check TESTS='mmkubernetes-basic.sh mmkubernetes-cache-expire.sh mmkubernetes-url-failover.sh'`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j60`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 60`
- local Cubic review: `cubic review --base cfb5fc4da72fcb5b3bd47d2c4f5d040146770b98 --print-logs` (`No issues found.`)
- static analyzer container: `rsyslog/rsyslog_dev_base_ubuntu:26.04` image `sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`, `devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh` (`scan-build: No bugs found.`)
- full change-gated Ubuntu 26.04 container validation: same image, `RSYSLOG_LOCAL_BUILD_JOBS=60`, `RSYSLOG_LOCAL_CHECK_JOBS=60`, `devtools/devcontainer.sh --rm devtools/run-ci.sh` with service relevance applied (`TOTAL: 1376`, `PASS: 1281`, `SKIP: 95`, `FAIL: 0`)
- sanitizer supplement: same image, `ubuntu_26_san` ASAN/UBSAN flags, focused `CI_MAKE_CHECK_TESTS='mmkubernetes-basic.sh mmkubernetes-cache-expire.sh mmkubernetes-url-failover.sh'` (`TOTAL: 3`, `PASS: 3`)

## Lane notes
- Kafka and Elasticsearch tests were relaxed only by the standard PR service relevance/configuration where unrelated to the touched mmkubernetes path.
- TSAN was not run; the change is URL parsing/failover control flow, not shared-state or threading behavior, and TSAN must not be mixed with Valgrind.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

