### PR TITLE
template: add timereceived property alias

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1235,6 +1235,7 @@ EXTRA_DIST = \
     source/reference/properties/message-syslogseverity.rst \
     source/reference/properties/message-syslogtag.rst \
     source/reference/properties/message-timegenerated.rst \
+    source/reference/properties/message-timereceived.rst \
     source/reference/properties/message-timereported.rst \
     source/reference/properties/message-timestamp.rst \
     source/reference/properties/message-uuid.rst \

--- a/doc/source/configuration/properties.rst
+++ b/doc/source/configuration/properties.rst
@@ -115,6 +115,10 @@ The following message properties exist:
      - .. include:: ../reference/properties/message-timegenerated.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`prop-message-timereceived`
+     - .. include:: ../reference/properties/message-timereceived.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`prop-message-timereported`
      - .. include:: ../reference/properties/message-timereported.rst
         :start-after: .. summary-start
@@ -169,15 +173,17 @@ Special care needs to be taken in regard to time-related system variables:
   Depending on how long the message was in the relay chain, this
   can be quite old.
 * ``timegenerated`` contains the timestamp when the message was received
-  by the local system. Here "received" actually means the point in time
+  by the local system. ``timereceived`` is an alias with the same value
+  and clearer naming. Here "received" actually means the point in time
   when the message was handed over from the OS to rsyslog's reception
   buffers, but before any actual processing takes place. This also means
   a message is "received" before it is placed into any queue. Note that
   depending on the input, some minimal processing like extraction of the
   actual message content from the receive buffer can happen. If multiple
   messages are received via the same receive buffer (a common scenario
-  for example with TCP-based syslog), they bear the same ``timegenerated``
-  stamp because they actually were received at the same time.
+  for example with TCP-based syslog), they bear the same
+  ``timegenerated`` / ``timereceived`` stamp because they actually were
+  received at the same time.
 * ``$now`` is **not** from the message. It is the system time when the
   message is being **processed**. There is always a small difference
   between ``timegenerated`` and ``$now`` because processing always
@@ -295,6 +301,7 @@ may have different time stamp. To avoid this, use *timegenerated* instead.
    ../reference/properties/message-syslogpriority
    ../reference/properties/message-syslogpriority-text
    ../reference/properties/message-timegenerated
+   ../reference/properties/message-timereceived
    ../reference/properties/message-timereported
    ../reference/properties/message-timestamp
    ../reference/properties/message-protocol-version

--- a/doc/source/reference/properties/message-timereceived.rst
+++ b/doc/source/reference/properties/message-timereceived.rst
@@ -1,0 +1,46 @@
+.. _prop-message-timereceived:
+.. _properties.message.timereceived:
+
+timereceived
+============
+
+.. index::
+   single: properties; timereceived
+   single: timereceived
+
+.. summary-start
+
+Alias for ``timegenerated`` that records when rsyslog received the message.
+
+.. summary-end
+
+This property belongs to the **Message Properties** group.
+
+:Name: timereceived
+:Category: Message Properties
+:Type: timestamp
+
+Description
+-----------
+``timereceived`` is an alias for :ref:`prop-message-timegenerated`. It returns
+the same timestamp: the point in time when the operating system hands the
+message to rsyslog's reception buffer, before queueing or ruleset processing.
+
+The alias exists because the older ``timegenerated`` name can be confused with
+the sender-side timestamp. The sender-side timestamp remains
+:ref:`prop-message-timereported`.
+
+Usage
+-----
+.. _properties.message.timereceived-usage:
+
+.. code-block:: rsyslog
+
+   template(name="example" type="list") {
+       property(name="timereceived")
+   }
+
+See also
+--------
+See :doc:`message-timegenerated` for the detailed behavior and
+:doc:`../../configuration/properties` for the category overview.

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -442,7 +442,7 @@ rsRetVal propNameToID(const uchar *const pName, propid_t *const pPropID) {
         *pPropID = PROP_SYSLOGSEVERITY;
     } else if (!strcasecmp((char *)pName, "syslogseverity-text") || !strcasecmp((char *)pName, "syslogpriority-text")) {
         *pPropID = PROP_SYSLOGSEVERITY_TEXT;
-    } else if (!strcasecmp((char *)pName, "timegenerated")) {
+    } else if (!strcasecmp((char *)pName, "timegenerated") || !strcasecmp((char *)pName, "timereceived")) {
         *pPropID = PROP_TIMEGENERATED;
     } else if (!strcasecmp((char *)pName, "programname")) {
         *pPropID = PROP_PROGRAMNAME;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -866,6 +866,7 @@ TESTS_LIBFAKETIME = \
 	timegenerated-dateordinal.sh \
 	timegenerated-dateordinal-invld.sh \
 	template-property-timegenerated.sh \
+	template-property-timereceived.sh \
 	timegenerated-utc.sh \
 	timegenerated-utc-legacy.sh \
 	timereported-utc.sh \

--- a/tests/template-property-timereceived.sh
+++ b/tests/template-property-timereceived.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# This focused template/property test proves that timereceived is accepted as a
+# message property alias for timegenerated and formats the same received-time
+# value under deterministic faketime.
+. ${srcdir:=.}/diag.sh init
+. $srcdir/faketime_common.sh
+
+export TZ=TEST+02:00
+
+generate_conf
+add_conf '
+template(name="outfmt" type="list") {
+	constant(value="generated=")
+	property(name="timegenerated" dateformat="rfc3339" date.inUTC="on")
+	constant(value="\nreceived=")
+	property(name="timereceived" dateformat="rfc3339" date.inUTC="on")
+	constant(value="\nlegacy=")
+	property(name="timegenerated" dateformat="unixtimestamp")
+	constant(value="\nalias=")
+	property(name="timereceived" dateformat="unixtimestamp")
+	constant(value="\n")
+}
+
+local4.* action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+export FAKETIME='2016-03-01 12:34:56'
+startup
+injectmsg_literal '<167>1 2003-08-24T05:14:15.000003-07:00 host app proc msgid - trigger'
+wait_file_lines --abort-on-oversize "$RSYSLOG_OUT_LOG" 4
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='generated=2016-03-01T14:34:56.000000+00:00
+received=2016-03-01T14:34:56.000000+00:00
+legacy=1456842896
+alias=1456842896'
+cmp_exact
+exit_test


### PR DESCRIPTION
## Summary
- add `timereceived` as a property-name alias for `timegenerated`
- document the alias and its relationship to sender-side `timereported`
- add a faketime regression proving both names format the same received-time value

Closes: https://github.com/rsyslog/rsyslog/issues/3920

## Validation
- `bash -n tests/template-property-timereceived.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `devtools/check-test-antipatterns.sh tests/template-property-timereceived.sh`
- `make -j60 check TESTS=''`
- `make -j60 check TESTS='template-property-timereceived.sh template-property-timegenerated.sh'`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j60`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 60`
- `RSYSLOG_LOCAL_BUILD_JOBS=60 RSYSLOG_LOCAL_CHECK_JOBS=60 devtools/local-validation-plan.sh --run`
- `cubic review --base cfb5fc4da72fcb5b3bd47d2c4f5d040146770b98 --print-logs` (`No issues found.`)

Local container validation used Docker Hub image `rsyslog/rsyslog_dev_base_ubuntu:26.04`, image id `sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`, through the repository validation helper. No service-backed lane was relaxed manually; relevance gating came from the helper for this runtime property/test/doc change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

