### PR TITLE
rsyslogd: reject -o output over input config

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -452,6 +452,7 @@ TESTS_DEFAULT = \
 	rscript_append_json.sh \
 	msg_json_set_regression.sh \
 	config_output-o-option.sh \
+	config_output-o-option-same-file.sh \
 	rs-cbool.sh \
 	rs-cnum.sh \
 	rs-substring.sh \

--- a/tests/config_output-o-option-same-file.sh
+++ b/tests/config_output-o-option-same-file.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Verify that -o refuses to write to the same file that -f is reading.
+# The oracle is twofold: rsyslogd must reject the unsafe configuration before
+# opening the output path, and the input config must remain byte-for-byte
+# unchanged. This covers the direct same-path case and a symlink alias.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+
+cp "${TESTCONF_NM}.conf" "$RSYSLOG_DYNNAME.original.conf"
+stderr="$RSYSLOG_DYNNAME.stderr"
+
+if ../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -o"${TESTCONF_NM}.conf" \
+	-M../runtime/.libs:../.libs >"$RSYSLOG_DYNNAME.stdout" 2>"$stderr"; then
+	echo "FAIL: rsyslogd accepted -o pointing at its input config"
+	error_exit 1
+fi
+content_check "-o output path must not be the same as the input config file" "$stderr"
+
+if ! cmp -s "$RSYSLOG_DYNNAME.original.conf" "${TESTCONF_NM}.conf"; then
+	echo "FAIL: rsyslogd modified the input config in the direct same-path case"
+	echo "original:"
+	cat -n "$RSYSLOG_DYNNAME.original.conf"
+	echo "current:"
+	cat -n "${TESTCONF_NM}.conf"
+	error_exit 1
+fi
+
+ln -sf "$(basename "${TESTCONF_NM}.conf")" "$RSYSLOG_DYNNAME.same-link.conf"
+if ../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -o"$RSYSLOG_DYNNAME.same-link.conf" \
+	-M../runtime/.libs:../.libs >"$RSYSLOG_DYNNAME.link.stdout" 2>"$stderr"; then
+	echo "FAIL: rsyslogd accepted -o pointing at a symlink to its input config"
+	error_exit 1
+fi
+content_check "-o output path '$RSYSLOG_DYNNAME.same-link.conf' resolves to the same file" "$stderr"
+
+if ! cmp -s "$RSYSLOG_DYNNAME.original.conf" "${TESTCONF_NM}.conf"; then
+	echo "FAIL: rsyslogd modified the input config through a symlink output path"
+	echo "original:"
+	cat -n "$RSYSLOG_DYNNAME.original.conf"
+	echo "current:"
+	cat -n "${TESTCONF_NM}.conf"
+	error_exit 1
+fi
+
+exit_test

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -26,6 +26,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 #include <dirent.h>
 #include <unistd.h>
@@ -162,6 +163,34 @@ static void aix_close_it(int i) {
 
 /* AIXPORT : end  */
 
+
+static rsRetVal checkConfigOutputDoesNotOverwriteInput(const char *const outputPath, const char *const configPath) {
+    struct stat outputStat;
+    struct stat configStat;
+
+    if (outputPath == NULL || !strcmp(outputPath, "-") || configPath == NULL) {
+        return RS_RET_OK;
+    }
+
+    if (!strcmp(outputPath, configPath)) {
+        fprintf(stderr, "rsyslogd: -o output path must not be the same as the input config file '%s'\n", configPath);
+        return RS_RET_ERR;
+    }
+
+    if (stat(configPath, &configStat) != 0) {
+        return RS_RET_OK;
+    }
+    if (stat(outputPath, &outputStat) != 0) {
+        return RS_RET_OK;
+    }
+    if (configStat.st_dev == outputStat.st_dev && configStat.st_ino == outputStat.st_ino) {
+        fprintf(stderr, "rsyslogd: -o output path '%s' resolves to the same file as input config file '%s'\n",
+                outputPath, configPath);
+        return RS_RET_ERR;
+    }
+
+    return RS_RET_OK;
+}
 
 DEFobjCurrIf(obj) DEFobjCurrIf(prop) DEFobjCurrIf(parser) DEFobjCurrIf(ruleset) DEFobjCurrIf(net) DEFobjCurrIf(rsconf)
     DEFobjCurrIf(module) DEFobjCurrIf(datetime) DEFobjCurrIf(glbl)
@@ -1693,6 +1722,8 @@ static void initAll(int argc, char **argv) {
     }
 
     if (iRet != RS_RET_END_OF_LINKEDLIST) FINALIZE;
+
+    CHKiRet(checkConfigOutputDoesNotOverwriteInput(configOutputPath, (const char *)ConfFile));
 
     if (iTranslateFmt != RSCONF_TRANSLATE_NONE) {
         if (!iConfigVerify) {


### PR DESCRIPTION
## Summary
- Reject `-o` when it points at the same file as the master `-f` config.
- Detect both literal same-path use and existing symlink/hard-link aliases via `stat()`.
- Add a regression test proving the input config remains unchanged.

## Validation
- `bash -n tests/config_output-o-option-same-file.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `devtools/check-test-antipatterns.sh tests/config_output-o-option-same-file.sh`
- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --disable-generate-man-pages`
- `make -j60 check TESTS='config_output-o-option.sh config_output-o-option-same-file.sh'`
- `RSYSLOG_LOCAL_BUILD_JOBS=60 RSYSLOG_LOCAL_CHECK_JOBS=60 devtools/local-validation-plan.sh --run`

## Local Container And AI Review
- Fully PR-ready container-validated locally via `devtools/local-validation-plan.sh --run`.
- Classification: `testbench-plumbing`.
- Docker Hub image: `rsyslog/rsyslog_dev_base_ubuntu:26.04`.
- Image id/digest: `sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`.
- Local helper completed mock distcheck, Ubuntu 26.04 change-gated container validation, Ubuntu 26.04 static analyzer, late prompt audits, and local Cubic.
- Local Cubic result: no issues found.
- Manual service-lane relaxation: none beyond the helper's change-gated relevance selection.

Closes #4266.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

