### PR TITLE
ommongodb: preserve ISODate fractional seconds

### DIFF
--- a/plugins/ommongodb/Makefile.am
+++ b/plugins/ommongodb/Makefile.am
@@ -1,5 +1,5 @@
 pkglib_LTLIBRARIES = ommongodb.la
-ommongodb_la_SOURCES = ommongodb.c
+ommongodb_la_SOURCES = ommongodb.c ommongodb_date.c ommongodb_date.h
 ommongodb_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS) $(LIBMONGOC_CFLAGS)
 ommongodb_la_LDFLAGS = -module -avoid-version
 ommongodb_la_LIBADD = $(LIBMONGOC_LIBS)

--- a/plugins/ommongodb/ommongodb.c
+++ b/plugins/ommongodb/ommongodb.c
@@ -63,6 +63,7 @@ PRAGMA_DIAGNOSTIC_POP;
 #include "cfsysline.h"
 #include "parserif.h"
 #include "unicode-helper.h"
+#include "ommongodb_date.h"
 
 MODULE_TYPE_OUTPUT;
 MODULE_TYPE_NOKEEP;
@@ -406,16 +407,9 @@ static int BSONAppendJSONObject(bson_t *doc, const char *name, struct json_objec
         case json_type_string: {
             /* Convert text to ISODATE when needed */
             if (strncmp(name, "date", 5) == 0 || strncmp(name, "time", 5) == 0) {
-                struct tm tm;
                 const char *datestr = json_object_get_string(json);
-                if (strptime(datestr, "%Y-%m-%dT%H:%M:%S:%Z", &tm) != NULL ||
-                    strptime(datestr, "%Y-%m-%dT%H:%M:%S%Z", &tm) != NULL ||
-                    strptime(datestr, "%Y-%m-%dT%H:%M:%SZ", &tm) != NULL) {
-                    tm.tm_isdst = -1;
-                    time_t epoch;
-                    int64 ts;
-                    epoch = mktime(&tm);
-                    ts = 1000 * (int64)epoch;
+                int64_t ts;
+                if (ommongodbParseIsoDateMs(datestr, &ts)) {
                     return BSON_APPEND_DATE_TIME(doc, name, ts);
                 } else {
                     DBGPRINTF("Unknown date format of field '%s' : '%s' \n", name, datestr);
@@ -443,16 +437,14 @@ static int BSONAppendExtendedJSON(bson_t *doc, const char *name, struct json_obj
     if (!json_object_iter_equal(&it, &itEnd)) {
         const char *const key = json_object_iter_peek_name(&it);
         if (strcmp(key, "$date") == 0) {
-            struct tm tm;
-            int64 ts;
+            int64_t ts;
             struct json_object *val;
 
             val = json_object_iter_peek_value(&it);
             DBGPRINTF("ommongodb: extended json date detected %s", json_object_get_string(val));
-            tm.tm_isdst = -1;
-            strptime(json_object_get_string(val), "%Y-%m-%dT%H:%M:%S%z", &tm);
-            ts = 1000 * (int64)mktime(&tm);
-            return BSON_APPEND_DATE_TIME(doc, name, ts);
+            if (ommongodbParseIsoDateMs(json_object_get_string(val), &ts)) {
+                return BSON_APPEND_DATE_TIME(doc, name, ts);
+            }
         }
     }
     return FALSE;

--- a/plugins/ommongodb/ommongodb_date.c
+++ b/plugins/ommongodb/ommongodb_date.c
@@ -1,0 +1,169 @@
+#include "config.h"
+
+#include "ommongodb_date.h"
+
+#include <limits.h>
+#include <stddef.h>
+#include <string.h>
+
+static int parseNDigits(const char **pos, int digits, int min, int max, int *out) {
+    int val;
+    int i;
+
+    val = 0;
+    for (i = 0; i < digits; ++i) {
+        const char ch = **pos;
+        if (ch < '0' || ch > '9') {
+            return 0;
+        }
+        val = val * 10 + ch - '0';
+        ++*pos;
+    }
+    if (val < min || val > max) {
+        return 0;
+    }
+    *out = val;
+    return 1;
+}
+
+static int consumeChar(const char **pos, char ch) {
+    if (**pos != ch) {
+        return 0;
+    }
+    ++*pos;
+    return 1;
+}
+
+static int isLeapYear(int year) {
+    return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+}
+
+static int daysInMonth(int year, int month) {
+    static const int monthDays[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+    if (month == 2 && isLeapYear(year)) {
+        return 29;
+    }
+    return monthDays[month - 1];
+}
+
+static int64_t daysFromCivil(int year, int month, int day) {
+    const int adjustedYear = year - (month <= 2);
+    const int era = (adjustedYear >= 0 ? adjustedYear : adjustedYear - 399) / 400;
+    const unsigned yoe = (unsigned)(adjustedYear - era * 400);
+    const unsigned monthPrime = (unsigned)(month + (month > 2 ? -3 : 9));
+    const unsigned doy = (153 * monthPrime + 2) / 5 + (unsigned)day - 1;
+    const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+
+    return (int64_t)era * 146097 + (int64_t)doe - 719468;
+}
+
+static int parseFractionMs(const char **pos, int *milliseconds) {
+    int ms;
+    int digits;
+
+    *milliseconds = 0;
+    if (**pos != '.') {
+        return 1;
+    }
+    ++*pos;
+
+    ms = 0;
+    digits = 0;
+    while (**pos >= '0' && **pos <= '9') {
+        if (digits < 3) {
+            ms = ms * 10 + **pos - '0';
+        }
+        ++digits;
+        ++*pos;
+    }
+    if (digits == 0) {
+        return 0;
+    }
+    while (digits < 3) {
+        ms *= 10;
+        ++digits;
+    }
+
+    *milliseconds = ms;
+    return 1;
+}
+
+static int parseTimezoneOffsetMinutes(const char **pos, int *offsetMinutes) {
+    int sign;
+    int hours;
+    int minutes;
+
+    if (**pos == 'Z') {
+        ++*pos;
+        *offsetMinutes = 0;
+        return 1;
+    }
+    if (strncmp(*pos, "UTC", 3) == 0) {
+        *pos += 3;
+        *offsetMinutes = 0;
+        return 1;
+    }
+    if (strncmp(*pos, ":UTC", 4) == 0) {
+        *pos += 4;
+        *offsetMinutes = 0;
+        return 1;
+    }
+    if (**pos != '+' && **pos != '-') {
+        return 0;
+    }
+
+    sign = (**pos == '-') ? -1 : 1;
+    ++*pos;
+    if (!parseNDigits(pos, 2, 0, 23, &hours)) {
+        return 0;
+    }
+    if (**pos == ':') {
+        ++*pos;
+    }
+    if (!parseNDigits(pos, 2, 0, 59, &minutes)) {
+        return 0;
+    }
+
+    *offsetMinutes = sign * (hours * 60 + minutes);
+    return 1;
+}
+
+int ommongodbParseIsoDateMs(const char *date, int64_t *timestampMs) {
+    const char *pos;
+    int year;
+    int month;
+    int day;
+    int hour;
+    int minute;
+    int second;
+    int milliseconds;
+    int offsetMinutes;
+    int64_t seconds;
+
+    if (date == NULL || timestampMs == NULL) {
+        return 0;
+    }
+
+    pos = date;
+    if (!parseNDigits(&pos, 4, 0, 9999, &year) || !consumeChar(&pos, '-') || !parseNDigits(&pos, 2, 1, 12, &month) ||
+        !consumeChar(&pos, '-') || !parseNDigits(&pos, 2, 1, 31, &day) || !consumeChar(&pos, 'T') ||
+        !parseNDigits(&pos, 2, 0, 23, &hour) || !consumeChar(&pos, ':') || !parseNDigits(&pos, 2, 0, 59, &minute) ||
+        !consumeChar(&pos, ':') || !parseNDigits(&pos, 2, 0, 59, &second) || !parseFractionMs(&pos, &milliseconds) ||
+        !parseTimezoneOffsetMinutes(&pos, &offsetMinutes) || *pos != '\0') {
+        return 0;
+    }
+
+    if (day > daysInMonth(year, month)) {
+        return 0;
+    }
+
+    seconds = daysFromCivil(year, month, day) * 86400 + (int64_t)hour * 3600 + (int64_t)minute * 60 + second;
+    seconds -= (int64_t)offsetMinutes * 60;
+    if (seconds > (INT64_MAX - milliseconds) / 1000 || seconds < (INT64_MIN + milliseconds) / 1000) {
+        return 0;
+    }
+
+    *timestampMs = seconds * 1000 + milliseconds;
+    return 1;
+}

--- a/plugins/ommongodb/ommongodb_date.h
+++ b/plugins/ommongodb/ommongodb_date.h
@@ -1,0 +1,8 @@
+#ifndef OMMONGODB_DATE_H
+#define OMMONGODB_DATE_H
+
+#include <stdint.h>
+
+int ommongodbParseIsoDateMs(const char *date, int64_t *timestampMs);
+
+#endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2286,8 +2286,10 @@ pkglib_LTLIBRARIES =
 check_DATA =
 
 # TODO: reenable TESTRUNS = rt_init rscript
-check_PROGRAMS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace
-TESTS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace
+check_PROGRAMS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace \
+	runtime_unit_ommongodb_date
+TESTS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace \
+	runtime_unit_ommongodb_date
 
 runtime_unit_linkedlist_SOURCES = \
 	unit/linkedlist_test.c
@@ -2300,6 +2302,9 @@ runtime_unit_parser_pri_SOURCES = \
 
 runtime_unit_msg_replace_SOURCES = \
 	unit/msg_replace_test.c
+
+runtime_unit_ommongodb_date_SOURCES = \
+	unit/ommongodb_date_test.c
 
 if ENABLE_GSSAPI
 check_PROGRAMS += runtime_unit_gss_token_util
@@ -2334,11 +2339,15 @@ runtime_unit_parser_pri_CPPFLAGS = \
 	$(runtime_unit_linkedlist_CPPFLAGS)
 runtime_unit_msg_replace_CPPFLAGS = \
 	$(runtime_unit_linkedlist_CPPFLAGS)
+runtime_unit_ommongodb_date_CPPFLAGS = \
+	$(runtime_unit_linkedlist_CPPFLAGS) \
+	-I$(top_srcdir)/plugins/ommongodb
 
 runtime_unit_linkedlist_LDADD = $(RSRT_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
 runtime_unit_stringbuf_LDADD = $(LIBESTR_LIBS) $(LIBFASTJSON_LIBS) $(LIBSYSTEMD_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
 runtime_unit_parser_pri_LDADD = $(LIBESTR_LIBS) $(LIBFASTJSON_LIBS) $(LIBSYSTEMD_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
 runtime_unit_msg_replace_LDADD = $(runtime_unit_linkedlist_LDADD)
+runtime_unit_ommongodb_date_LDADD = $(runtime_unit_linkedlist_LDADD)
 
 if ENABLE_LIBLOGGING_STDLOG
 runtime_unit_linkedlist_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)

--- a/tests/unit/ommongodb_date_test.c
+++ b/tests/unit/ommongodb_date_test.c
@@ -1,0 +1,59 @@
+#include "config.h"
+
+/* Verify ommongodb's ISODate parser preserves BSON millisecond precision.
+ * The oracle is direct epoch-millisecond comparison for UTC, numeric-offset,
+ * fractional-second, legacy :UTC, and invalid-input cases.
+ */
+#include <stdint.h>
+#include <stdio.h>
+
+#include "ommongodb_date.h"
+
+/*
+ * Pull the implementation into this test translation unit so Automake does not
+ * need to manage dependency files for sources outside tests/ during distcheck.
+ */
+#include "../../plugins/ommongodb/ommongodb_date.c"
+
+#define CHECK(cond)                                                                  \
+    do {                                                                             \
+        if (!(cond)) {                                                               \
+            fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__, #cond); \
+            return 1;                                                                \
+        }                                                                            \
+    } while (0)
+
+static int expect_date(const char *date, int64_t expected) {
+    int64_t actual;
+
+    actual = -1;
+    CHECK(ommongodbParseIsoDateMs(date, &actual) == 1);
+    CHECK(actual == expected);
+    return 0;
+}
+
+static int expect_invalid(const char *date) {
+    int64_t actual;
+
+    actual = -1;
+    CHECK(ommongodbParseIsoDateMs(date, &actual) == 0);
+    CHECK(actual == -1);
+    return 0;
+}
+
+int main(void) {
+    CHECK(expect_date("2019-10-20T12:00:19Z", 1571572819000LL) == 0);
+    CHECK(expect_date("2019-10-20T12:00:19.1Z", 1571572819100LL) == 0);
+    CHECK(expect_date("2019-10-20T12:00:19.123Z", 1571572819123LL) == 0);
+    CHECK(expect_date("2019-10-20T12:00:19.123456Z", 1571572819123LL) == 0);
+    CHECK(expect_date("2019-10-20T12:00:19.123+02:00", 1571565619123LL) == 0);
+    CHECK(expect_date("2019-10-20T12:00:19.123+0200", 1571565619123LL) == 0);
+    CHECK(expect_date("2019-10-20T12:00:19:UTC", 1571572819000LL) == 0);
+
+    CHECK(expect_invalid("2019-10-20T12:00:19.Z") == 0);
+    CHECK(expect_invalid("2019-02-29T12:00:19Z") == 0);
+    CHECK(expect_invalid("2019-10-20T12:00:19") == 0);
+    CHECK(expect_invalid("2019") == 0);
+    CHECK(expect_invalid("2019-10-20T12:00:19U") == 0);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a deterministic ISO/RFC3339-style date parser for ommongodb
- preserve BSON millisecond precision for date/time field auto-conversion and extended JSON `$date`
- add focused unit coverage for fractional seconds, offsets, legacy `:UTC`, and invalid dates

Closes https://github.com/rsyslog/rsyslog/issues/3923

## Validation
- devtools/format-code.sh --git-changed --check --check-if-available
- git diff --check
- CC=gcc ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-ommongodb --disable-generate-man-pages
- make -j60 check TESTS='runtime_unit_ommongodb_date'
- RSYSLOG_LOCAL_BUILD_JOBS=60 RSYSLOG_LOCAL_CHECK_JOBS=60 CI_MAKE_OPT=-j60 CI_MAKE_CHECK_OPT=-j60 devtools/local-validation-plan.sh --run
- Local Cubic review: no issues found

Container validation used Docker image rsyslog/rsyslog_dev_base_ubuntu:26.04 with image id sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d. No manual lane relaxations beyond the helper relevance selection.

## Hosted follow-up
The first hosted run failed older/dist-style lanes because Automake generated a dependency target under `../plugins/ommongodb/.deps/` for the unit-test source. The amended head keeps the unit test in one translation unit instead, and the focused unit test plus full local validation helper passed again.