### PR TITLE
imuxsock: clarify missing Socket diagnostics

### DIFF
--- a/doc/source/configuration/modules/imuxsock.rst
+++ b/doc/source/configuration/modules/imuxsock.rst
@@ -445,6 +445,11 @@ messages from applications running on the local system.
 
 This only needs to be done once.
 
+Do not add a bare ``input(type="imuxsock")`` for the system log socket.
+Additional ``imuxsock`` input objects are only for extra Unix sockets and must
+set the :ref:`param-imuxsock-socket` parameter. Configure the system log socket
+with module-level ``SysSock.*`` parameters instead.
+
 
 Enable flow control
 -------------------
@@ -572,4 +577,3 @@ system log socket.
    ../../reference/parameters/imuxsock-unlink
    ../../reference/parameters/imuxsock-usespecialparser
    ../../reference/parameters/imuxsock-parsehostname
-

--- a/doc/source/reference/parameters/imuxsock-socket.rst
+++ b/doc/source/reference/parameters/imuxsock-socket.rst
@@ -20,12 +20,15 @@ This parameter applies to :doc:`../../configuration/modules/imuxsock`.
 :Scope: input
 :Type: string
 :Default: input=none
-:Required?: no
+:Required?: yes
 :Introduced: at least 7.0.0, possibly earlier
 
 Description
 -----------
-Adds additional unix socket. Formerly specified with the ``-a`` option.
+Adds an additional unix socket. Formerly specified with the ``-a`` option.
+This parameter is required for every ``input(type="imuxsock" ...)`` object,
+because input objects configure additional sockets only. The system log socket
+is configured on the module object with ``SysSock.*`` parameters.
 
 Input usage
 -----------

--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -285,23 +285,15 @@ static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / si
 
 /* input instance parameters */
 static struct cnfparamdescr inppdescr[] = {
-    {"socket", eCmdHdlrString, CNFPARAM_REQUIRED}, /* legacy: addunixlistensocket */
-    {"unlink", eCmdHdlrBinary, 0},
-    {"createpath", eCmdHdlrBinary, 0},
-    {"parsetrusted", eCmdHdlrBinary, 0},
-    {"ignoreownmessages", eCmdHdlrBinary, 0},
-    {"hostname", eCmdHdlrString, 0},
-    {"ignoretimestamp", eCmdHdlrBinary, 0},
-    {"flowcontrol", eCmdHdlrBinary, 0},
-    {"usesystimestamp", eCmdHdlrBinary, 0},
-    {"annotate", eCmdHdlrBinary, 0},
-    {"usespecialparser", eCmdHdlrBinary, 0},
-    {"parsehostname", eCmdHdlrBinary, 0},
-    {"usepidfromsystem", eCmdHdlrBinary, 0},
-    {"ruleset", eCmdHdlrString, 0},
-    {"ratelimit.interval", eCmdHdlrInt, 0},
-    {"ratelimit.burst", eCmdHdlrInt, 0},
-    {"ratelimit.severity", eCmdHdlrInt, 0},
+    {"socket", eCmdHdlrString, 0}, /* legacy: addunixlistensocket */
+    {"unlink", eCmdHdlrBinary, 0},        {"createpath", eCmdHdlrBinary, 0},
+    {"parsetrusted", eCmdHdlrBinary, 0},  {"ignoreownmessages", eCmdHdlrBinary, 0},
+    {"hostname", eCmdHdlrString, 0},      {"ignoretimestamp", eCmdHdlrBinary, 0},
+    {"flowcontrol", eCmdHdlrBinary, 0},   {"usesystimestamp", eCmdHdlrBinary, 0},
+    {"annotate", eCmdHdlrBinary, 0},      {"usespecialparser", eCmdHdlrBinary, 0},
+    {"parsehostname", eCmdHdlrBinary, 0}, {"usepidfromsystem", eCmdHdlrBinary, 0},
+    {"ruleset", eCmdHdlrString, 0},       {"ratelimit.interval", eCmdHdlrInt, 0},
+    {"ratelimit.burst", eCmdHdlrInt, 0},  {"ratelimit.severity", eCmdHdlrInt, 0},
     {"ratelimit.name", eCmdHdlrString, 0}};
 static struct cnfparamblk inppblk = {CNFPARAMBLK_VERSION, sizeof(inppdescr) / sizeof(struct cnfparamdescr), inppdescr};
 
@@ -1486,6 +1478,7 @@ ENDsetModCnf
 BEGINnewInpInst
     struct cnfparamvals *pvals;
     instanceConf_t *inst;
+    int haveSocketParam;
     int i;
     CODESTARTnewInpInst;
     DBGPRINTF("newInpInst (imuxsock)\n");
@@ -1499,6 +1492,21 @@ BEGINnewInpInst
     if (Debug) {
         dbgprintf("input param blk in imuxsock:\n");
         cnfparamsPrint(&inppblk, pvals);
+    }
+
+    haveSocketParam = 0;
+    for (i = 0; i < inppblk.nParams; ++i) {
+        if (!strcmp(inppblk.descr[i].name, "socket") && pvals[i].bUsed) {
+            haveSocketParam = 1;
+            break;
+        }
+    }
+    if (!haveSocketParam) {
+        LogError(0, RS_RET_MISSING_CNFPARAMS,
+                 "imuxsock: input(type=\"imuxsock\") defines an additional UNIX socket; "
+                 "set Socket=\"...\" for that input, or configure the system log socket "
+                 "with module-level SysSock.* parameters");
+        ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
     }
 
     CHKiRet(createInstance(&inst));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -344,6 +344,7 @@ TESTS_DEFAULT = \
 	dircreate_dflt.sh \
 	dircreate_off.sh \
 	imuxsock_legacy.sh \
+	imuxsock_missing_socket.sh \
 	imuxsock_logger.sh \
 	imuxsock_unlink_off_stale_socket.sh \
 	imuxsock_logger_ratelimit.sh \

--- a/tests/imuxsock_missing_socket.sh
+++ b/tests/imuxsock_missing_socket.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Verify that a bare imuxsock input reports how to configure the intended
+# socket. The oracle is rsyslogd -N1 failing with the imuxsock-specific
+# diagnostic: additional imuxsock inputs require Socket, while the system log
+# socket is configured through module-level SysSock.* parameters.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/imuxsock/.libs/imuxsock")
+input(type="imuxsock")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+
+log="$RSYSLOG_DYNNAME.config-check.log"
+if ../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"$log" 2>&1; then
+	echo "FAIL: rsyslogd accepted imuxsock input without Socket"
+	error_exit 1
+fi
+
+content_check 'imuxsock: input(type="imuxsock") defines an additional UNIX socket' "$log"
+content_check 'set Socket="..." for that input' "$log"
+content_check 'module-level SysSock.* parameters' "$log"
+
+exit_test


### PR DESCRIPTION
## Summary
- add an imuxsock-specific config error when input(type="imuxsock") omits Socket
- clarify that input objects are for additional Unix sockets and SysSock.* configures the system socket
- add a focused regression test using diag.sh content_check

Closes https://github.com/rsyslog/rsyslog/issues/4295

## Validation
- devtools/format-code.sh --git-changed --check --check-if-available
- git diff --check
- bash -n tests/imuxsock_missing_socket.sh
- devtools/check-test-antipatterns.sh tests/imuxsock_missing_socket.sh
- make -j60 check TESTS='imuxsock_missing_socket.sh'
- RSYSLOG_LOCAL_BUILD_JOBS=60 RSYSLOG_LOCAL_CHECK_JOBS=60 CI_MAKE_OPT=-j60 CI_MAKE_CHECK_OPT=-j60 devtools/local-validation-plan.sh --run
- Local Cubic review: no issues found

Container validation used Docker image rsyslog/rsyslog_dev_base_ubuntu:26.04 with image id sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d. No manual lane relaxations beyond the helper relevance selection.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

