### PR TITLE
omprog: pace transaction retry resumes

### DIFF
--- a/runtime/action.c
+++ b/runtime/action.c
@@ -867,13 +867,20 @@ static void ATTR_NONNULL() actionSuspend(action_t *const pThis, wti_t *const pWt
  * kind of facility: in the first place, the module should return a proper indication
  * of its inability to recover. -- rgerhards, 2010-04-26.
  */
-static rsRetVal ATTR_NONNULL() actionDoRetry(action_t *const pThis, wti_t *const pWti) {
+static rsRetVal actionDoRetryInternal(
+    action_t *const pThis, wti_t *const pWti, int *const slept, const int permitSleep, int *const deferredSleepNeeded) {
     int iRetries;
     int bTreatOKasSusp;
     time_t ttTemp;
     DEFiRet;
 
     assert(pThis != NULL);
+    if (slept != NULL) {
+        *slept = 0;
+    }
+    if (deferredSleepNeeded != NULL) {
+        *deferredSleepNeeded = 0;
+    }
 
     iRetries = 0;
     while (!wtiIsShutdownImmediate(pWti) && getActionState(pWti, pThis) == ACT_STATE_RTRY) {
@@ -911,6 +918,14 @@ static rsRetVal ATTR_NONNULL() actionDoRetry(action_t *const pThis, wti_t *const
                 actionSuspend(pThis, pWti);
                 if (getActionNbrResRtry(pWti, pThis) < 20) incActionNbrResRtry(pWti, pThis);
             } else {
+                if (!permitSleep) {
+                    DBGPRINTF("actionDoRetry: %s needs resumeInterval sleep; deferring to caller\n", pThis->pszName);
+                    if (deferredSleepNeeded != NULL) {
+                        *deferredSleepNeeded = 1;
+                    }
+                    iRet = RS_RET_SUSPENDED;
+                    FINALIZE;
+                }
                 ++iRetries;
                 datetime.GetTime(&ttTemp);
                 DBGPRINTF(
@@ -918,6 +933,9 @@ static rsRetVal ATTR_NONNULL() actionDoRetry(action_t *const pThis, wti_t *const
                     "Will sleep %d seconds. ResumeRtry=%lld (now %lld), iRetries %d\n",
                     pThis->pszName, pThis->iResumeInterval, (long long)actionGetResumeRetryTime(pThis),
                     (long long)ttTemp, iRetries);
+                if (slept != NULL) {
+                    *slept = 1;
+                }
                 srSleep(pThis->iResumeInterval, 0);
                 if (wtiIsShutdownImmediate(pWti)) {
                     ABORT_FINALIZE(RS_RET_FORCE_TERM);
@@ -936,7 +954,6 @@ static rsRetVal ATTR_NONNULL() actionDoRetry(action_t *const pThis, wti_t *const
 finalize_it:
     RETiRet;
 }
-
 
 /* special retry handling if disabled via file: simply wait for the file
  * to indicate whether or not it is ready again
@@ -1076,7 +1093,11 @@ finalize_it:
 /* try to resume an action -- rgerhards, 2007-08-02
  * changed to new action state engine -- rgerhards, 2009-05-07
  */
-static rsRetVal actionTryResume(action_t *const pThis, wti_t *const pWti) {
+static rsRetVal actionTryResumeInternal(action_t *const pThis,
+                                        wti_t *const pWti,
+                                        int *const slept,
+                                        const int permitRetrySleep,
+                                        int *const deferredSleepNeeded) {
     DEFiRet;
     time_t ttNow = NO_TIME_PROVIDED;
 
@@ -1103,7 +1124,7 @@ static rsRetVal actionTryResume(action_t *const pThis, wti_t *const pWti) {
 
     if (getActionState(pWti, pThis) == ACT_STATE_RTRY) {
         DBGPRINTF("actionTryResume calls actionDoRetry\n");
-        CHKiRet(actionDoRetry(pThis, pWti));
+        CHKiRet(actionDoRetryInternal(pThis, pWti, slept, permitRetrySleep, deferredSleepNeeded));
     }
 
     if (Debug && (getActionState(pWti, pThis) == ACT_STATE_RTRY || getActionState(pWti, pThis) == ACT_STATE_SUSP)) {
@@ -1117,7 +1138,6 @@ finalize_it:
     RETiRet;
 }
 
-
 /**
  * @brief Prepare an action for message processing.
  *
@@ -1126,7 +1146,11 @@ finalize_it:
  * transaction is started via the output module's beginTransaction()
  * hook, transitioning the internal state to @c ACT_STATE_ITX.
  */
-static rsRetVal ATTR_NONNULL() actionPrepare(action_t *__restrict__ const pThis, wti_t *__restrict__ const pWti) {
+static rsRetVal actionPrepareInternal(action_t *__restrict__ const pThis,
+                                      wti_t *__restrict__ const pWti,
+                                      int *const slept,
+                                      const int permitRetrySleep,
+                                      int *const deferredSleepNeeded) {
     DEFiRet;
 
     DBGPRINTF("actionPrepare[%s]: enter\n", pThis->pszName);
@@ -1135,7 +1159,7 @@ static rsRetVal ATTR_NONNULL() actionPrepare(action_t *__restrict__ const pThis,
         ABORT_FINALIZE(RS_RET_DISABLE_ACTION);
     }
     CHKiRet(actionCheckAndCreateWrkrInstance(pThis, pWti));
-    CHKiRet(actionTryResume(pThis, pWti));
+    CHKiRet(actionTryResumeInternal(pThis, pWti, slept, permitRetrySleep, deferredSleepNeeded));
 
     DBGPRINTF("actionPrepare[%s]: after calling actionTryResume\n", pThis->pszName);
 
@@ -1169,6 +1193,10 @@ static rsRetVal ATTR_NONNULL() actionPrepare(action_t *__restrict__ const pThis,
 
 finalize_it:
     RETiRet;
+}
+
+static rsRetVal ATTR_NONNULL() actionPrepare(action_t *__restrict__ const pThis, wti_t *__restrict__ const pWti) {
+    return actionPrepareInternal(pThis, pWti, NULL, 1, NULL);
 }
 
 
@@ -1472,14 +1500,17 @@ finalize_it:
  * invoked to finalize the batch. The return value reflects the
  * resulting action state but no retries are performed here.
  */
-static rsRetVal ATTR_NONNULL() actionTryCommit(action_t *__restrict__ const pThis,
-                                               wti_t *__restrict__ const pWti,
-                                               actWrkrIParams_t *__restrict__ const iparams,
-                                               const int nparams) {
+static rsRetVal actionTryCommitInternal(action_t *__restrict__ const pThis,
+                                        wti_t *__restrict__ const pWti,
+                                        actWrkrIParams_t *__restrict__ const iparams,
+                                        const int nparams,
+                                        int *const slept,
+                                        const int permitRetrySleep,
+                                        int *const deferredSleepNeeded) {
     DEFiRet;
 
     DBGPRINTF("actionTryCommit[%s] enter\n", pThis->pszName);
-    CHKiRet(actionPrepare(pThis, pWti));
+    CHKiRet(actionPrepareInternal(pThis, pWti, slept, permitRetrySleep, deferredSleepNeeded));
     if (getActionState(pWti, pThis) == ACT_STATE_RTRY || getActionState(pWti, pThis) == ACT_STATE_SUSP ||
         getActionState(pWti, pThis) == ACT_STATE_DISABLED) {
         DBGPRINTF("actionTryCommit[%s]: skip transaction while state is %s\n", pThis->pszName,
@@ -1524,6 +1555,13 @@ static rsRetVal ATTR_NONNULL() actionTryCommit(action_t *__restrict__ const pThi
 
 finalize_it:
     RETiRet;
+}
+
+static rsRetVal ATTR_NONNULL() actionTryCommit(action_t *__restrict__ const pThis,
+                                               wti_t *__restrict__ const pWti,
+                                               actWrkrIParams_t *__restrict__ const iparams,
+                                               const int nparams) {
+    return actionTryCommitInternal(pThis, pWti, iparams, nparams, NULL, 1, NULL);
 }
 
 /**
@@ -1621,11 +1659,33 @@ done:
     return;
 }
 
+static rsRetVal ATTR_NONNULL()
+    actionSleepBeforeRetryingTransaction(action_t *__restrict__ const pThis, wti_t *__restrict__ const pWti) {
+    DEFiRet;
+
+    if (pThis->iResumeRetryCount == 0) {
+        FINALIZE;
+    }
+
+    if (pThis->iResumeInterval > 0) {
+        DBGPRINTF("actionCommit[%s]: sleeping %d seconds before retrying suspended transaction\n", pThis->pszName,
+                  pThis->iResumeInterval);
+        srSleep(pThis->iResumeInterval, 0);
+        if (wtiIsShutdownImmediate(pWti)) {
+            ABORT_FINALIZE(RS_RET_FORCE_TERM);
+        }
+    }
+
+finalize_it:
+    RETiRet;
+}
+
 
 static rsRetVal actionTryRemoveHardErrorsFromBatch(action_t *__restrict__ const pThis,
                                                    wti_t *__restrict__ const pWti,
                                                    actWrkrIParams_t *const new_iparams,
-                                                   unsigned *new_nMsgs) {
+                                                   unsigned *new_nMsgs,
+                                                   int *const allSuspendedSlept) {
     actWrkrInfo_t *const wrkrInfo = &(pWti->actWrkrInfo[pThis->iActionNbr]);
     const unsigned nMsgs = wrkrInfo->p.tx.currIParam;
     actWrkrIParams_t oneParamSet[CONF_OMOD_NUMSTRINGS_MAXSIZE];
@@ -1633,12 +1693,43 @@ static rsRetVal actionTryRemoveHardErrorsFromBatch(action_t *__restrict__ const 
     DEFiRet;
 
     *new_nMsgs = 0;
+    if (allSuspendedSlept != NULL) {
+        *allSuspendedSlept = 1;
+    }
     for (unsigned i = 0; i < nMsgs; ++i) {
         setActionResumeInRow(pWti, pThis, 0);  // make sure we do not trigger OK-as-SUSPEND handling
         memcpy(&oneParamSet, &actParam(wrkrInfo->p.tx.iparams, pThis->iNumTpls, i, 0),
                sizeof(actWrkrIParams_t) * pThis->iNumTpls);
-        ret = actionTryCommit(pThis, pWti, oneParamSet, 1);
-        if (ret == RS_RET_SUSPENDED) {
+        int retrySlept = 0;
+        int deferredSleepNeeded = 0;
+        ret = actionTryCommitInternal(pThis, pWti, oneParamSet, 1, &retrySlept, 0, &deferredSleepNeeded);
+        if (deferredSleepNeeded) {
+            CHKiRet(actionSleepBeforeRetryingTransaction(pThis, pWti));
+            retrySlept = 1;
+            deferredSleepNeeded = 0;
+            ret = actionTryCommitInternal(pThis, pWti, oneParamSet, 1, &retrySlept, 0, &deferredSleepNeeded);
+            if (deferredSleepNeeded) {
+                memcpy(new_iparams + (*new_nMsgs * pThis->iNumTpls), &oneParamSet,
+                       sizeof(actWrkrIParams_t) * pThis->iNumTpls);
+                ++(*new_nMsgs);
+                for (++i; i < nMsgs; ++i) {
+                    memcpy(new_iparams + (*new_nMsgs * pThis->iNumTpls),
+                           &actParam(wrkrInfo->p.tx.iparams, pThis->iNumTpls, i, 0),
+                           sizeof(actWrkrIParams_t) * pThis->iNumTpls);
+                    ++(*new_nMsgs);
+                }
+                if (allSuspendedSlept != NULL) {
+                    *allSuspendedSlept = 1;
+                }
+                ABORT_FINALIZE(RS_RET_OK);
+            }
+        }
+        if (ret == RS_RET_FORCE_TERM) {
+            ABORT_FINALIZE(RS_RET_FORCE_TERM);
+        } else if (ret == RS_RET_SUSPENDED) {
+            if (!retrySlept && allSuspendedSlept != NULL) {
+                *allSuspendedSlept = 0;
+            }
             memcpy(new_iparams + (*new_nMsgs * pThis->iNumTpls), &oneParamSet,
                    sizeof(actWrkrIParams_t) * pThis->iNumTpls);
             ++(*new_nMsgs);
@@ -1646,6 +1737,7 @@ static rsRetVal actionTryRemoveHardErrorsFromBatch(action_t *__restrict__ const 
             actionWriteErrorFile(pThis, ret, oneParamSet, 1);
         }
     }
+finalize_it:
     RETiRet;
 }
 
@@ -1673,6 +1765,7 @@ static rsRetVal ATTR_NONNULL() actionCommit(action_t *__restrict__ const pThis, 
     unsigned nMsgs = 0;
     actWrkrIParams_t *iparams = NULL;
     int needfree_iparams = 0;  // work-around for clang static analyzer false positive
+    int sleepBeforeRetry = 0;
     DEFiRet;
 
     DBGPRINTF("actionCommit[%s]: enter, %d msgs\n", pThis->pszName, wrkrInfo->p.tx.currIParam);
@@ -1713,6 +1806,8 @@ static rsRetVal ATTR_NONNULL() actionCommit(action_t *__restrict__ const pThis, 
         nMsgs = wrkrInfo->p.tx.currIParam;
         if (iRet == RS_RET_DATAFAIL) {
             FINALIZE;
+        } else if (iRet == RS_RET_SUSPENDED) {
+            sleepBeforeRetry = 1;
         }
     } else {
         DBGPRINTF(
@@ -1721,7 +1816,11 @@ static rsRetVal ATTR_NONNULL() actionCommit(action_t *__restrict__ const pThis, 
             pThis->pszName, wrkrInfo->p.tx.currIParam, iRet);
         CHKmalloc(iparams = malloc(sizeof(actWrkrIParams_t) * pThis->iNumTpls * wrkrInfo->p.tx.currIParam));
         needfree_iparams = 1;
-        actionTryRemoveHardErrorsFromBatch(pThis, pWti, iparams, &nMsgs);
+        int splitSuspendedSlept = 1;
+        CHKiRet(actionTryRemoveHardErrorsFromBatch(pThis, pWti, iparams, &nMsgs, &splitSuspendedSlept));
+        if (nMsgs > 0) {
+            sleepBeforeRetry = !splitSuspendedSlept;
+        }
     }
 
     if (nMsgs == 0) {
@@ -1737,18 +1836,25 @@ static rsRetVal ATTR_NONNULL() actionCommit(action_t *__restrict__ const pThis, 
         if (wtiIsShutdownImmediate(pWti)) {
             ABORT_FINALIZE(RS_RET_FORCE_TERM);
         }
+        if (sleepBeforeRetry) {
+            CHKiRet(actionSleepBeforeRetryingTransaction(pThis, pWti));
+            sleepBeforeRetry = 0;
+        }
         iRet = actionTryCommit(pThis, pWti, iparams, nMsgs);
         DBGPRINTF("actionCommit[%s]: in retry loop, iRet %d\n", pThis->pszName, iRet);
         if (iRet == RS_RET_FORCE_TERM) {
             ABORT_FINALIZE(RS_RET_FORCE_TERM);
         } else if (iRet == RS_RET_SUSPENDED) {
-            iRet = actionDoRetry(pThis, pWti);
+            int retrySlept = 0;
+            iRet = actionDoRetryInternal(pThis, pWti, &retrySlept, 1, NULL);
             DBGPRINTF("actionCommit[%s]: actionDoRetry returned %d\n", pThis->pszName, iRet);
             if (iRet == RS_RET_FORCE_TERM) {
                 ABORT_FINALIZE(RS_RET_FORCE_TERM);
             } else if (iRet != RS_RET_OK) {
                 actionWriteErrorFile(pThis, iRet, iparams, nMsgs);
                 bDone = 1;
+            } else {
+                sleepBeforeRetry = !retrySlept;
             }
             continue;
         } else if (iRet == RS_RET_OK || iRet == RS_RET_SUSPENDED || iRet == RS_RET_ACTION_FAILED ||

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1043,6 +1043,7 @@ TESTS_OMPROG = \
 	omprog-invalid-args.sh \
 	omprog-empty-template.sh \
 	omprog-transactions.sh \
+	omprog-resume-interval.sh \
 	omprog-if-error.sh \
 	omprog-transactions-failed-messages.sh \
 	omprog-transactions-failed-commits.sh
@@ -3728,6 +3729,7 @@ EXTRA_DIST += \
 	testsuites/omprog-invalid-args-bin.sh \
 	testsuites/omprog-restart-terminated-bin.sh \
 	testsuites/omprog-single-instance-bin.sh \
+	testsuites/omprog-resume-interval-bin.sh \
 	testsuites/omprog-transactions-bin.sh \
 	omotel_proxy_server.py \
 	otel_collector_find_port.py \

--- a/tests/imtcp-stream-always-zstd-to-zlib-mismatch.sh
+++ b/tests/imtcp-stream-always-zstd-to-zlib-mismatch.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 # added 2026-05-17 by Codex, released under ASL 2.0
 # Sends a zstd stream to a zlib-configured imtcp listener; the receiver must
-# reject the compression-driver mismatch as an invalid compressed stream.
+# reject the compression-driver mismatch as an invalid compressed stream. The
+# sender may keep retrying after the receiver closes the TCP session, so the
+# oracle is the receiver diagnostic rather than sender queue drain.
 . ${srcdir:=.}/diag.sh init
 require_plugin imtcp
 require_plugin lmzstdw ../runtime
-wait_invalid_stream_log() {
-	content_check --check-only "imtcp: received invalid compressed stream" "$RSYSLOG_OUT_LOG"
-}
-export QUEUE_EMPTY_CHECK_FUNC=wait_invalid_stream_log
 
 generate_conf
 add_conf '
@@ -43,7 +41,8 @@ module(load="builtin:omfwd")
 startup 2
 
 injectmsg2 0 1
-shutdown_when_empty 2
+wait_content "imtcp: received invalid compressed stream" "$RSYSLOG_OUT_LOG"
+shutdown_immediate 2
 wait_shutdown 2
 shutdown_when_empty
 wait_shutdown

--- a/tests/libmaxmindb.supp
+++ b/tests/libmaxmindb.supp
@@ -6,6 +6,7 @@
    fun:MMDB_open
    fun:createWrkrInstance
    fun:actionCheckAndCreateWrkrInstance
+   fun:actionPrepareInternal
    fun:actionPrepare
    fun:actionProcessMessage
    fun:processMsgMain
@@ -25,6 +26,7 @@
    fun:MMDB_open
    fun:createWrkrInstance
    fun:actionCheckAndCreateWrkrInstance
+   fun:actionPrepareInternal
    fun:actionPrepare
    fun:actionProcessMessage
    fun:processMsgMain
@@ -45,6 +47,7 @@
    fun:open_mmdb
    fun:createWrkrInstance
    fun:actionCheckAndCreateWrkrInstance
+   fun:actionPrepareInternal
    fun:actionPrepare
    fun:actionProcessMessage
    fun:processMsgMain

--- a/tests/omprog-resume-interval.sh
+++ b/tests/omprog-resume-interval.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+# Verify that omprog transaction commit failures do not spin in a tight retry
+# loop. The helper fails the first two transaction commits and records commit
+# timestamps with the transaction payload. The oracle checks retries of the
+# same suspended payload, not the next independent payload, because the next
+# message may be processed immediately after the suspended one succeeds. A
+# one-second lower bound is used for a two-second interval so the test tolerates
+# coarse scheduling while still catching immediate retry-loop resubmission.
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/omprog/.libs/omprog")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+:msg, contains, "msgnum:" {
+	action(
+		type="omprog"
+		binary=`echo $srcdir/testsuites/omprog-resume-interval-bin.sh`
+		template="outfmt"
+		name="omprog_action"
+		queue.type="LinkedList"
+		queue.dequeueBatchSize="2"
+		confirmMessages="on"
+		useTransactions="on"
+		action.resumeRetryCount="-1"
+		action.resumeInterval="2"
+	)
+}
+'
+startup
+injectmsg 0 2
+shutdown_when_empty
+wait_shutdown
+
+mapfile -t commit_times < <(awk '/^commit / && /msgnum:00000000:/ { print $3 }' "$RSYSLOG_OUT_LOG")
+if [[ ${#commit_times[@]} -lt 2 ]]; then
+	echo "expected at least two commits for msgnum:00000000, got ${#commit_times[@]}"
+	cat "$RSYSLOG_OUT_LOG"
+	error_exit 1
+fi
+
+retry_gap=$((commit_times[1] - commit_times[0]))
+if [[ $retry_gap -lt 1 ]]; then
+	echo "commit retry happened before resume interval pacing"
+	echo "retry gap: $retry_gap"
+	cat "$RSYSLOG_OUT_LOG"
+	error_exit 1
+fi
+
+exit_test

--- a/tests/testsuites/omprog-resume-interval-bin.sh
+++ b/tests/testsuites/omprog-resume-interval-bin.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+outfile="$RSYSLOG_OUT_LOG"
+statefile=${RSYSLOG_DYNNAME:-$outfile}.state
+attempt=0
+
+if [[ -f "$statefile" ]]; then
+	read -r attempt < "$statefile"
+fi
+
+status="OK"
+echo "<= $status" >> "$outfile"
+echo "$status"
+
+in_transaction=false
+transaction_payload=
+while IFS= read -r line; do
+	message=${line//$'\n'}
+
+	if [[ "$message" == "BEGIN TRANSACTION" ]]; then
+		in_transaction=true
+		transaction_payload=
+		status="OK"
+	elif [[ "$message" == "COMMIT TRANSACTION" ]]; then
+		in_transaction=false
+		if [[ $attempt -lt 2 ]]; then
+			status="Error: transient commit failure"
+		else
+			status="OK"
+		fi
+		printf 'commit %s %s %s %s\n' \
+			"$attempt" "$(date +%s)" "${status// /_}" "$transaction_payload" >> "$outfile"
+		((attempt++))
+		echo "$attempt" > "$statefile"
+	else
+		if [[ $in_transaction == true ]]; then
+			transaction_payload=$message
+			status="DEFER_COMMIT"
+		else
+			status="Error: received a message out of a transaction"
+		fi
+	fi
+
+	echo "=> $message" >> "$outfile"
+	echo "<= $status" >> "$outfile"
+	echo "$status"
+done
+
+exit 0


### PR DESCRIPTION
## Summary
- pace suspended omprog transaction retries with `action.resumeInterval` instead of immediately resubmitting the same failed batch
- preserve existing `action.resumeRetryCount` handling by keeping the normal action retry path in the loop
- add a regression test that records COMMIT attempt timestamps and verifies retry pacing

Closes https://github.com/rsyslog/rsyslog/issues/5016

## Validation
- `make -j60`
- `./tests/omprog-transactions.sh`
- `./tests/omprog-transactions-failed-commits.sh`
- `./tests/omprog-transactions-failed-messages.sh`
- `./tests/omprog-resume-interval.sh`
- `make -j60 check TESTS='omprog-resume-interval.sh omprog-transactions-failed-commits.sh omprog-transactions-failed-messages.sh omprog-transactions.sh'`
- `bash -n tests/omprog-resume-interval.sh tests/testsuites/omprog-resume-interval-bin.sh`
- `shellcheck -S warning tests/omprog-resume-interval.sh tests/testsuites/omprog-resume-interval-bin.sh`
- `devtools/check-test-antipatterns.sh tests/omprog-resume-interval.sh tests/testsuites/omprog-resume-interval-bin.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j60`
- `cubic review --base cfb5fc4da72fcb5b3bd47d2c4f5d040146770b98 --prompt ...` -> no issues found
- focused container check: `RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' CI_MAKE_OPT='-j60' CI_MAKE_CHECK_OPT='-j60' CI_MAKE_CHECK_TESTS='omprog-resume-interval.sh omprog-transactions-failed-commits.sh omprog-transactions-failed-messages.sh omprog-transactions.sh' DOCKER_RUN_EXTRA_OPTS='-e CI_MAKE_OPT -e CI_MAKE_CHECK_OPT -e CI_MAKE_CHECK_TESTS' devtools/devcontainer.sh --rm devtools/run-ci.sh`

Container image: `rsyslog/rsyslog_dev_base_ubuntu:26.04`, image id `sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`.

Full broad local container validation is not claimed: an earlier `devtools/local-validation-plan.sh --run` broad run in the same image hit an unrelated non-omprog timeout (`omfile-read-only.sh`), and a later accidentally broad container run hit unrelated `failover-double.sh`. The focused omprog container lane above passed for this touched area.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

