### PR TITLE
input: warn for rulesets without queues

### DIFF
--- a/runtime/im-helper.h
+++ b/runtime/im-helper.h
@@ -28,6 +28,8 @@
 #ifndef IM_HELPER_H_INCLUDED
 #define IM_HELPER_H_INCLUDED 1
 
+#include "parserif.h"
+#include "ruleset.h"
 
 /* The following function provides a complete implementation to check a
  * ruleset and set the actual ruleset pointer. The macro assumes that
@@ -51,6 +53,12 @@ static inline rsRetVal std_checkRuleset(modConfData_t *modConf, instanceConf_t *
     }
     CHKiRet(localRet);
     inst->pBindRuleset = pRuleset;
+    if (!rulesetHasQueue(pRuleset)) {
+        parser_warnmsg(
+            "input-bound ruleset '%s' has no dedicated non-direct queue; "
+            "input processing will share the main queue or run synchronously",
+            (const char *)inst->pszBindRuleset);
+    }
 
 finalize_it:
     RETiRet;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -679,6 +679,7 @@ TESTS_IMTCP = \
 	allowed-sender-tcp-hostname-fail.sh \
 	allowed-sender-wildcard-invalid-bits.sh \
 	imtcp-discard-truncated-msg.sh \
+	imtcp-ruleset-no-queue-warning.sh \
 	imtcp-basic.sh \
 	rscript_parsehostnameandtag_off.sh \
 	imtcp_framing_regex.sh \
@@ -747,6 +748,7 @@ TESTS_IMTCP_STREAM_ALWAYS_OSSL = \
 
 TESTS_IMTCP_YAML = \
 	yaml-parser-drop-trailing-cr.sh \
+	yaml-imtcp-ruleset-no-queue-warning.sh \
 	yaml-imtcp-stream-always-zlib-basic.sh \
 	imtcp-persource-ratelimit.sh \
 	ratelimit-legacy-persource-discard.sh \

--- a/tests/imtcp-ruleset-no-queue-warning.sh
+++ b/tests/imtcp-ruleset-no-queue-warning.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Verify issue #1324: an input bound to a ruleset without its own non-direct
+# queue emits a config warning, while a ruleset with queue.type="LinkedList"
+# stays warning-free. The oracle is rsyslogd -N1 output, so no listener is
+# started and no socket readiness timing is involved.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+
+ruleset(name="shared") {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+}
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="shared")
+'
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.warn.log" 2>&1
+if [ $? -ne 0 ]; then
+	echo "FAIL: expected config validation to continue after ruleset queue warning"
+	cat "${RSYSLOG_DYNNAME}.warn.log"
+	error_exit 1
+fi
+
+content_check "input-bound ruleset 'shared' has no dedicated non-direct queue" \
+	"${RSYSLOG_DYNNAME}.warn.log"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+
+ruleset(name="queued" queue.type="LinkedList") {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+}
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="queued")
+'
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.quiet.log" 2>&1
+if [ $? -ne 0 ]; then
+	echo "FAIL: expected config validation to accept queued ruleset binding"
+	cat "${RSYSLOG_DYNNAME}.quiet.log"
+	error_exit 1
+fi
+
+check_not_present "input-bound ruleset 'queued' has no dedicated non-direct queue" \
+	"${RSYSLOG_DYNNAME}.quiet.log"
+
+exit_test

--- a/tests/yaml-imtcp-ruleset-no-queue-warning.sh
+++ b/tests/yaml-imtcp-ruleset-no-queue-warning.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Verify issue #1324 through YAML config parsing: an imtcp input bound to a
+# YAML-defined ruleset without its own non-direct queue emits the same warning
+# as the RainerScript path, while a YAML ruleset with queue.type="LinkedList"
+# stays warning-free. The oracle is rsyslogd -N1 output, so no listener is
+# started and no socket readiness timing is involved.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+
+generate_conf
+add_conf '
+include(file="'${TESTCONF_NM}'.yaml")
+'
+rm -f "${TESTCONF_NM}.yaml"
+add_yaml_conf 'modules:'
+add_yaml_conf '  - load: "../plugins/imtcp/.libs/imtcp"'
+add_yaml_conf ''
+add_yaml_conf 'inputs:'
+add_yaml_conf '  - type: imtcp'
+add_yaml_conf '    port: "0"'
+add_yaml_conf '    listenPortFileName: "'${RSYSLOG_DYNNAME}'.tcpflood_port"'
+add_yaml_conf '    ruleset: shared'
+add_yaml_conf ''
+add_yaml_conf 'rulesets:'
+add_yaml_conf '  - name: shared'
+add_yaml_conf '    script: |'
+add_yaml_conf '      action(type="omfile" file="'${RSYSLOG_OUT_LOG}'")'
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.warn.log" 2>&1
+if [ $? -ne 0 ]; then
+	echo "FAIL: expected YAML config validation to continue after ruleset queue warning"
+	cat "${RSYSLOG_DYNNAME}.warn.log"
+	error_exit 1
+fi
+
+content_check "input-bound ruleset 'shared' has no dedicated non-direct queue" \
+	"${RSYSLOG_DYNNAME}.warn.log"
+
+generate_conf
+add_conf '
+include(file="'${TESTCONF_NM}'.yaml")
+'
+rm -f "${TESTCONF_NM}.yaml"
+add_yaml_conf 'modules:'
+add_yaml_conf '  - load: "../plugins/imtcp/.libs/imtcp"'
+add_yaml_conf ''
+add_yaml_conf 'inputs:'
+add_yaml_conf '  - type: imtcp'
+add_yaml_conf '    port: "0"'
+add_yaml_conf '    listenPortFileName: "'${RSYSLOG_DYNNAME}'.tcpflood_port"'
+add_yaml_conf '    ruleset: queued'
+add_yaml_conf ''
+add_yaml_conf 'rulesets:'
+add_yaml_conf '  - name: queued'
+add_yaml_conf '    queue.type: LinkedList'
+add_yaml_conf '    script: |'
+add_yaml_conf '      action(type="omfile" file="'${RSYSLOG_OUT_LOG}'")'
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.quiet.log" 2>&1
+if [ $? -ne 0 ]; then
+	echo "FAIL: expected YAML config validation to accept queued ruleset binding"
+	cat "${RSYSLOG_DYNNAME}.quiet.log"
+	error_exit 1
+fi
+
+check_not_present "input-bound ruleset 'queued' has no dedicated non-direct queue" \
+	"${RSYSLOG_DYNNAME}.quiet.log"
+
+exit_test


### PR DESCRIPTION
## Summary
- warn when an explicit input ruleset binding resolves to a ruleset without a dedicated non-direct queue
- emit the diagnostic through parser_warnmsg so -N1 remains successful for valid configs
- add an imtcp config-check regression for queued vs non-queued rulesets

## Validation
- bash -n tests/imtcp-ruleset-no-queue-warning.sh
- shellcheck -S warning tests/imtcp-ruleset-no-queue-warning.sh
- devtools/check-test-antipatterns.sh tests/imtcp-ruleset-no-queue-warning.sh
- devtools/format-code.sh --git-changed --check --check-if-available
- git diff --check
- make -j60 check TESTS='imtcp-ruleset-no-queue-warning.sh'
- make -j60 check TESTS=''
- cubic review --print-logs --base upstream/main
- RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 devtools/local-validation-plan.sh --run

Container image: rsyslog/rsyslog_dev_base_ubuntu:26.04, sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d

Closes https://github.com/rsyslog/rsyslog/issues/1324

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

