### PR TITLE
imtcp: bound zstd decoder window

### DIFF
--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -899,6 +899,29 @@ finalize_it:
     RETiRet;
 }
 
+#if defined(ENABLE_LIBZSTD) && defined(ZSTD_VERSION_NUMBER) && ZSTD_VERSION_NUMBER >= 10308
+    #define ZSTD_RSYSLOG_WINDOWLOG_MIN 10U
+    #define ZSTD_RSYSLOG_WINDOWLOG_MAX 31U
+static unsigned zstdWindowLogMaxFromBytes(uint64_t maxBytes) {
+    unsigned windowLogMax = 0;
+    uint64_t windowSize = 1;
+
+    while (windowSize < maxBytes && windowLogMax < 63) {
+        windowSize <<= 1;
+        ++windowLogMax;
+    }
+
+    /* zstd only exposes a power-of-two window-log cap. Round up so frames
+     * within the configured byte limit are not rejected unnecessarily. */
+    if (windowLogMax < ZSTD_RSYSLOG_WINDOWLOG_MIN) {
+        windowLogMax = ZSTD_RSYSLOG_WINDOWLOG_MIN;
+    } else if (windowLogMax > ZSTD_RSYSLOG_WINDOWLOG_MAX) {
+        windowLogMax = ZSTD_RSYSLOG_WINDOWLOG_MAX;
+    }
+    return windowLogMax;
+}
+#endif
+
 static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
                                        char *const pData,
                                        const size_t iLen,
@@ -919,6 +942,17 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
             logCompressedStreamFailure(pThis, "received invalid compressed stream", "zstd context allocation failed");
             ABORT_FINALIZE(RS_RET_ZLIB_ERR);
         }
+    #if defined(ZSTD_VERSION_NUMBER) && ZSTD_VERSION_NUMBER >= 10308
+        if (pThis->compressionMaxDecompressedBytesPerReceive != 0) {
+            const unsigned windowLogMax = zstdWindowLogMaxFromBytes(pThis->compressionMaxDecompressedBytesPerReceive);
+            const size_t zret =
+                ZSTD_DCtx_setParameter((ZSTD_DCtx *)pThis->zstdDctx, ZSTD_d_windowLogMax, (int)windowLogMax);
+            if (ZSTD_isError(zret)) {
+                logCompressedStreamFailure(pThis, "received invalid compressed stream", ZSTD_getErrorName(zret));
+                ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+            }
+        }
+    #endif
     }
 
     ZSTD_outBuffer output;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -730,6 +730,7 @@ TESTS_IMTCP_STREAM_ALWAYS_ZSTD = \
 	imtcp-stream-always-zstd-corrupt.sh \
 	imtcp-stream-always-zstd-truncated.sh \
 	imtcp-stream-always-zstd-empty-close.sh \
+	imtcp-stream-always-zstd-window-guard.sh \
 	imtcp-stream-always-zstd-expansion-guard.sh \
 	imtcp-stream-always-zstd-to-zlib-mismatch.sh
 
@@ -1988,7 +1989,8 @@ imtcp-stream-always-zstd-flushoff.log: imtcp-stream-always-zstd-basic.log
 imtcp-stream-always-zstd-corrupt.log: imtcp-stream-always-zstd-flushoff.log
 imtcp-stream-always-zstd-truncated.log: imtcp-stream-always-zstd-corrupt.log
 imtcp-stream-always-zstd-empty-close.log: imtcp-stream-always-zstd-truncated.log
-imtcp-stream-always-zstd-expansion-guard.log: imtcp-stream-always-zstd-empty-close.log
+imtcp-stream-always-zstd-window-guard.log: imtcp-stream-always-zstd-empty-close.log
+imtcp-stream-always-zstd-expansion-guard.log: imtcp-stream-always-zstd-window-guard.log
 imtcp-stream-always-zstd-to-zlib-mismatch.log: imtcp-stream-always-zstd-expansion-guard.log
 imtcp-impstats.log: imtcp-stream-always-zlib-truncated.log
 imtcp-stream-always-zlib-impstats.log: imtcp-impstats.log

--- a/tests/imtcp-stream-always-zstd-window-guard.sh
+++ b/tests/imtcp-stream-always-zstd-window-guard.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# added 2026-06-23 by Codex, released under ASL 2.0
+# Sends a minimal zstd frame that advertises a 128 MiB window while the imtcp
+# input allows only a 1 MiB decompressed receive burst. The oracle is that zstd
+# rejects the frame as an invalid compressed stream before any message is
+# submitted, proving the configured receive limit also bounds decoder windows.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+require_plugin lmzstdw ../runtime
+check_command_available python3
+
+wait_invalid_stream_log() {
+	content_check --check-only "received invalid compressed stream" "$RSYSLOG_OUT_LOG"
+}
+export QUEUE_EMPTY_CHECK_FUNC=wait_invalid_stream_log
+
+generate_conf
+add_conf '
+$MaxMessageSize 10k
+global(processInternalMessages="on")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	compression.mode="stream:always"
+	compression.driver="zstd"
+	compression.maxDecompressedBytesPerReceive="1048576")
+
+if $syslogtag contains "rsyslogd" then {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+	stop
+}
+action(type="omfile" file="'$RSYSLOG2_OUT_LOG'")
+'
+startup
+assign_tcpflood_port "$RSYSLOG_DYNNAME.tcpflood_port"
+
+python3 - "$TCPFLOOD_PORT" <<'PY'
+import socket
+import sys
+
+port = int(sys.argv[1])
+# Empty zstd frame with a large single-segment/window descriptor. This is the
+# compact reproducer used for the pre-output allocation path.
+payload = bytes.fromhex("28b52ffd0088010000")
+sock = socket.create_connection(("127.0.0.1", port))
+sock.sendall(payload)
+sock.close()
+PY
+
+shutdown_when_empty
+wait_shutdown
+
+content_check "received invalid compressed stream" "$RSYSLOG_OUT_LOG"
+if [ -s "$RSYSLOG2_OUT_LOG" ]; then
+	echo "FAIL: window-guarded zstd stream unexpectedly produced messages"
+	cat "$RSYSLOG2_OUT_LOG"
+	error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
### Motivation
- Prevent unbounded libzstd decoder memory allocation in the imtcp zstd streaming path by enforcing a decoder window limit derived from the configured decompression guards before any network data is fed to `ZSTD_decompressStream()`.

### Description
- Add `zstdWindowLogMaxFromBytes()` and clamp constants and derive a `windowLogMax` from `compression.maxDecompressedBytesPerReceive` to compute a safe `ZSTD_d_windowLogMax` prior to streaming decompression in `DataRcvdCompressedZstd()`.
- Apply the derived `ZSTD_d_windowLogMax` to each newly-created `ZSTD_DCtx` via `ZSTD_DCtx_setParameter()` and fail the stream if the parameter set reports an error.
- Add a focused regression test `tests/imtcp-stream-always-zstd-window-guard.sh` that sends a minimal zstd frame advertising a large window and asserts the stream is rejected before messages are produced, and register the test in `tests/Makefile.am`.
- Run repository formatting and test registration updates for the changed files and keep the per-receive guard behavior unchanged (guard still enforced after decompressed output as before).

### Testing
- Ran `./configure --enable-testbench --enable-imtcp --enable-libzstd --disable-impstats-push` which configured successfully (the default `--enable-testbench && ./autogen.sh && ./configure` attempt failed due to missing `libsnappy-dev`).
- Built and exercised host-side checks with `make -j$(nproc) check TESTS=""` which completed successfully for the targeted build scope.
- Executed the new focused test `./tests/imtcp-stream-always-zstd-window-guard.sh` which passed and confirmed the window-guard rejects oversized frames before producing messages.
- Ran style and preflight checks: `devtools/format-code.sh --git-changed --check --check-if-available` and `devtools/check-test-antipatterns.sh tests/imtcp-stream-always-zstd-window-guard.sh` which succeeded.
- Attempted `devtools/local-validation-plan.sh --run` but terminated during the long `distcheck` phase; Docker/Podman and `cubic` are not available in this environment so PR-ready local container validation and local Cubic review were not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a708c83a08332981a8618e3616d9e)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

