### PR TITLE
omelasticsearch: add TLS version, cipher suite, and key exchange group options

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -979,8 +979,11 @@ EXTRA_DIST = \
     source/reference/parameters/omelasticsearch-template.rst \
     source/reference/parameters/omelasticsearch-timeout.rst \
     source/reference/parameters/omelasticsearch-tls-cacert.rst \
+    source/reference/parameters/omelasticsearch-tls-ciphersuites.rst \
+    source/reference/parameters/omelasticsearch-tls-keyexchangegroups.rst \
     source/reference/parameters/omelasticsearch-tls-mycert.rst \
     source/reference/parameters/omelasticsearch-tls-myprivkey.rst \
+    source/reference/parameters/omelasticsearch-tls-tlsversion.rst \
     source/reference/parameters/omelasticsearch-uid.rst \
     source/reference/parameters/omelasticsearch-usehttps.rst \
     source/reference/parameters/omelasticsearch-writeoperation.rst \

--- a/doc/source/configuration/modules/omelasticsearch.rst
+++ b/doc/source/configuration/modules/omelasticsearch.rst
@@ -173,6 +173,18 @@ Action Parameters
      - .. include:: ../../reference/parameters/omelasticsearch-tls-myprivkey.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-tls-tlsversion`
+     - .. include:: ../../reference/parameters/omelasticsearch-tls-tlsversion.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-tls-ciphersuites`
+     - .. include:: ../../reference/parameters/omelasticsearch-tls-ciphersuites.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-tls-keyexchangegroups`
+     - .. include:: ../../reference/parameters/omelasticsearch-tls-keyexchangegroups.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-omelasticsearch-allowunsignedcerts`
      - .. include:: ../../reference/parameters/omelasticsearch-allowunsignedcerts.rst
         :start-after: .. summary-start
@@ -251,6 +263,9 @@ Action Parameters
    ../../reference/parameters/omelasticsearch-tls-cacert
    ../../reference/parameters/omelasticsearch-tls-mycert
    ../../reference/parameters/omelasticsearch-tls-myprivkey
+   ../../reference/parameters/omelasticsearch-tls-tlsversion
+   ../../reference/parameters/omelasticsearch-tls-ciphersuites
+   ../../reference/parameters/omelasticsearch-tls-keyexchangegroups
    ../../reference/parameters/omelasticsearch-allowunsignedcerts
    ../../reference/parameters/omelasticsearch-skipverifyhost
    ../../reference/parameters/omelasticsearch-bulkid

--- a/doc/source/reference/parameters/omelasticsearch-tls-ciphersuites.rst
+++ b/doc/source/reference/parameters/omelasticsearch-tls-ciphersuites.rst
@@ -1,0 +1,49 @@
+.. _param-omelasticsearch-tls-ciphersuites:
+.. _omelasticsearch.parameter.module.tls-ciphersuites:
+.. _omelasticsearch.parameter.module.tls.ciphersuites:
+
+tls.ciphersuites
+================
+
+.. index::
+   single: omelasticsearch; tls.ciphersuites
+   single: tls.ciphersuites
+
+.. summary-start
+
+TLS 1.3 cipher suite selection for the Elasticsearch connection.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: tls.ciphersuites
+:Scope: action
+:Type: word
+:Default: none (libcurl/OpenSSL default)
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+Passes a colon-separated list of TLS 1.3 cipher suite names to libcurl
+(``CURLOPT_TLS13_CIPHERS``). The string is validated by OpenSSL at connection
+time; an invalid name causes the handshake to fail.
+
+Requires libcurl 7.61.0 or later. If rsyslog was built against an older
+libcurl, configuring this parameter has no effect and a warning is logged at
+startup.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-tls-ciphersuites:
+.. _omelasticsearch.parameter.action.tls-ciphersuites:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" tls.ciphersuites="TLS_AES_256_GCM_SHA384")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`,
+:ref:`param-omelasticsearch-tls-tlsversion`,
+:ref:`param-omelasticsearch-tls-keyexchangegroups`.

--- a/doc/source/reference/parameters/omelasticsearch-tls-ciphersuites.rst
+++ b/doc/source/reference/parameters/omelasticsearch-tls-ciphersuites.rst
@@ -32,7 +32,7 @@ time; an invalid name causes the handshake to fail.
 
 Requires libcurl 7.61.0 or later. If rsyslog was built against an older
 libcurl, configuring this parameter has no effect and a warning is logged at
-startup.
+configuration load.
 
 Action usage
 ------------
@@ -41,6 +41,14 @@ Action usage
 .. code-block:: rsyslog
 
    action(type="omelasticsearch" tls.ciphersuites="TLS_AES_256_GCM_SHA384")
+
+YAML usage
+----------
+.. code-block:: yaml
+
+   actions:
+     - type: omelasticsearch
+       tls.ciphersuites: "TLS_AES_256_GCM_SHA384"
 
 See also
 --------

--- a/doc/source/reference/parameters/omelasticsearch-tls-keyexchangegroups.rst
+++ b/doc/source/reference/parameters/omelasticsearch-tls-keyexchangegroups.rst
@@ -42,7 +42,7 @@ PQC key exchange requires:
 * OpenSSL 3.x with the `OQS provider <https://github.com/open-quantum-safe/oqs-provider>`_ installed
 
 If rsyslog was built against libcurl older than 7.73, configuring this
-parameter has no effect and a warning is logged at startup.
+parameter has no effect and a warning is logged at configuration load.
 
 Action usage
 ------------
@@ -55,6 +55,17 @@ Action usage
           tls.cacert="/etc/pki/tls/certs/ca-bundle.crt"
           tls.tlsversion="TLSv1.3"
           tls.keyexchangegroups="X25519MLKEM768:X25519")
+
+YAML usage
+----------
+.. code-block:: yaml
+
+   actions:
+     - type: omelasticsearch
+       usehttps: "on"
+       tls.cacert: "/etc/pki/tls/certs/ca-bundle.crt"
+       tls.tlsversion: "TLSv1.3"
+       tls.keyexchangegroups: "X25519MLKEM768:X25519"
 
 See also
 --------

--- a/doc/source/reference/parameters/omelasticsearch-tls-keyexchangegroups.rst
+++ b/doc/source/reference/parameters/omelasticsearch-tls-keyexchangegroups.rst
@@ -1,0 +1,63 @@
+.. _param-omelasticsearch-tls-keyexchangegroups:
+.. _omelasticsearch.parameter.module.tls-keyexchangegroups:
+.. _omelasticsearch.parameter.module.tls.keyexchangegroups:
+
+tls.keyexchangegroups
+=====================
+
+.. index::
+   single: omelasticsearch; tls.keyexchangegroups
+   single: tls.keyexchangegroups
+
+.. summary-start
+
+Key exchange group preference list, enabling post-quantum hybrid KEMs.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: tls.keyexchangegroups
+:Scope: action
+:Type: word
+:Default: none (libcurl/OpenSSL default)
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+Passes a colon-separated list of named key-exchange groups to libcurl
+(``CURLOPT_SSL_EC_CURVES``). Groups are advertised in order of preference
+in the TLS ClientHello.
+
+This is the primary knob for post-quantum cryptography (PQC) readiness.
+Setting it to ``X25519MLKEM768:X25519`` requests the hybrid ML-KEM / X25519
+group first, falling back to classical X25519 if the server does not support
+it. For a hard PQC-only policy, omit the ``:X25519`` suffix — connections to
+non-PQC servers will then fail.
+
+PQC key exchange requires:
+
+* libcurl 7.73.0 or later (``CURLOPT_SSL_EC_CURVES`` support)
+* OpenSSL 3.x with the `OQS provider <https://github.com/open-quantum-safe/oqs-provider>`_ installed
+
+If rsyslog was built against libcurl older than 7.73, configuring this
+parameter has no effect and a warning is logged at startup.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-tls-keyexchangegroups:
+.. _omelasticsearch.parameter.action.tls-keyexchangegroups:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch"
+          usehttps="on"
+          tls.cacert="/etc/pki/tls/certs/ca-bundle.crt"
+          tls.tlsversion="TLSv1.3"
+          tls.keyexchangegroups="X25519MLKEM768:X25519")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`,
+:ref:`param-omelasticsearch-tls-tlsversion`,
+:ref:`param-omelasticsearch-tls-ciphersuites`.

--- a/doc/source/reference/parameters/omelasticsearch-tls-tlsversion.rst
+++ b/doc/source/reference/parameters/omelasticsearch-tls-tlsversion.rst
@@ -48,6 +48,14 @@ Action usage
 
    action(type="omelasticsearch" tls.tlsversion="TLSv1.3")
 
+YAML usage
+----------
+.. code-block:: yaml
+
+   actions:
+     - type: omelasticsearch
+       tls.tlsversion: "TLSv1.3"
+
 See also
 --------
 See also :doc:`../../configuration/modules/omelasticsearch`,

--- a/doc/source/reference/parameters/omelasticsearch-tls-tlsversion.rst
+++ b/doc/source/reference/parameters/omelasticsearch-tls-tlsversion.rst
@@ -1,0 +1,55 @@
+.. _param-omelasticsearch-tls-tlsversion:
+.. _omelasticsearch.parameter.module.tls-tlsversion:
+.. _omelasticsearch.parameter.module.tls.tlsversion:
+
+tls.tlsversion
+==============
+
+.. index::
+   single: omelasticsearch; tls.tlsversion
+   single: tls.tlsversion
+
+.. summary-start
+
+Minimum TLS protocol version for the Elasticsearch connection.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: tls.tlsversion
+:Scope: action
+:Type: word
+:Default: none (libcurl default)
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+Sets the minimum (floor) TLS version accepted for the connection to
+Elasticsearch. Accepted values are ``TLSv1.2`` and ``TLSv1.3``.
+
+An unknown value is rejected at configuration load time and prevents rsyslog
+from starting.
+
+When omitted, libcurl negotiates the highest version supported by both sides,
+typically TLS 1.3 on modern systems.
+
+.. note::
+
+   Setting this to ``TLSv1.2`` downgrades the effective floor and should be
+   avoided unless the server does not support TLS 1.3.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-tls-tlsversion:
+.. _omelasticsearch.parameter.action.tls-tlsversion:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" tls.tlsversion="TLSv1.3")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`,
+:ref:`param-omelasticsearch-tls-ciphersuites`,
+:ref:`param-omelasticsearch-tls-keyexchangegroups`.

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -255,6 +255,7 @@ static struct cnfparamdescr actpdescr[] = {{"server", eCmdHdlrArray, 0},
 static struct cnfparamblk actpblk = {CNFPARAMBLK_VERSION, sizeof(actpdescr) / sizeof(struct cnfparamdescr), actpdescr};
 
 static rsRetVal ATTR_NONNULL() curlSetup(wrkrInstanceData_t *pWrkrData);
+static void ATTR_NONNULL() curlSetupTlsOptions(instanceData *const pData, CURL *const handle);
 static rsRetVal ATTR_NONNULL() detectTargetPlatformAndVersion(instanceData *const pData);
 static rsRetVal ATTR_NONNULL() applyVersionRequirements(instanceData *const pData);
 
@@ -821,8 +822,7 @@ static rsRetVal ATTR_NONNULL() detectTargetPlatformAndVersion(instanceData *cons
         curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlVersionResult);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buffer);
-        if (pData->allowUnsignedCerts) curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-        if (pData->skipVerifyHost) curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+        curlSetupTlsOptions(pData, curl);
         if (pData->authBuf != NULL) {
             curl_easy_setopt(curl, CURLOPT_USERPWD, pData->authBuf);
             curl_easy_setopt(curl, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
@@ -835,10 +835,6 @@ static rsRetVal ATTR_NONNULL() detectTargetPlatformAndVersion(instanceData *cons
             }
             curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
         }
-        if (pData->caCertFile) curl_easy_setopt(curl, CURLOPT_CAINFO, pData->caCertFile);
-        if (pData->myCertFile) curl_easy_setopt(curl, CURLOPT_SSLCERT, pData->myCertFile);
-        if (pData->myPrivKeyFile) curl_easy_setopt(curl, CURLOPT_SSLKEY, pData->myPrivKeyFile);
-
         CURLcode code = curl_easy_perform(curl);
         long status = 0;
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
@@ -2168,31 +2164,25 @@ finalize_it:
 static const struct {
     const char *name;
     long curlver;
-} tlsVersionMap[] = {{"TLSv1.2", CURL_SSLVERSION_TLSv1_2},
-#if LIBCURL_VERSION_NUM >= 0x073400
-                     {"TLSv1.3", CURL_SSLVERSION_TLSv1_3},
+} tlsVersionMap[] = {
+#if LIBCURL_VERSION_NUM >= 0x072200
+    {"TLSv1.2", CURL_SSLVERSION_TLSv1_2},
 #endif
-                     {NULL, 0}};
+#if LIBCURL_VERSION_NUM >= 0x073400
+    {"TLSv1.3", CURL_SSLVERSION_TLSv1_3},
+#endif
+    {NULL, 0}};
 
-static void ATTR_NONNULL() curlSetupCommon(wrkrInstanceData_t *const pWrkrData, CURL *const handle) {
-    PTR_ASSERT_SET_TYPE(pWrkrData, WRKR_DATA_TYPE_ES);
-    curl_easy_setopt(handle, CURLOPT_HTTPHEADER, pWrkrData->curlHeader);
-    curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1L);
-    curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlResult);
-    curl_easy_setopt(handle, CURLOPT_WRITEDATA, pWrkrData);
-    if (pWrkrData->pData->allowUnsignedCerts) curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
-    if (pWrkrData->pData->skipVerifyHost) curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
-    if (pWrkrData->pData->authBuf != NULL) {
-        curl_easy_setopt(handle, CURLOPT_USERPWD, pWrkrData->pData->authBuf);
-        curl_easy_setopt(handle, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
-    }
-    if (pWrkrData->pData->caCertFile) curl_easy_setopt(handle, CURLOPT_CAINFO, pWrkrData->pData->caCertFile);
-    if (pWrkrData->pData->myCertFile) curl_easy_setopt(handle, CURLOPT_SSLCERT, pWrkrData->pData->myCertFile);
-    if (pWrkrData->pData->myPrivKeyFile) curl_easy_setopt(handle, CURLOPT_SSLKEY, pWrkrData->pData->myPrivKeyFile);
-    if (pWrkrData->pData->tlsVersion) {
+static void ATTR_NONNULL() curlSetupTlsOptions(instanceData *const pData, CURL *const handle) {
+    if (pData->allowUnsignedCerts) curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
+    if (pData->skipVerifyHost) curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
+    if (pData->caCertFile) curl_easy_setopt(handle, CURLOPT_CAINFO, pData->caCertFile);
+    if (pData->myCertFile) curl_easy_setopt(handle, CURLOPT_SSLCERT, pData->myCertFile);
+    if (pData->myPrivKeyFile) curl_easy_setopt(handle, CURLOPT_SSLKEY, pData->myPrivKeyFile);
+    if (pData->tlsVersion) {
         long ver = CURL_SSLVERSION_DEFAULT;
         for (size_t i = 0; tlsVersionMap[i].name != NULL; i++) {
-            if (!strcmp((char *)pWrkrData->pData->tlsVersion, tlsVersionMap[i].name)) {
+            if (!strcmp((char *)pData->tlsVersion, tlsVersionMap[i].name)) {
                 ver = tlsVersionMap[i].curlver;
                 break;
             }
@@ -2200,13 +2190,25 @@ static void ATTR_NONNULL() curlSetupCommon(wrkrInstanceData_t *const pWrkrData, 
         curl_easy_setopt(handle, CURLOPT_SSLVERSION, ver);
     }
 #if LIBCURL_VERSION_NUM >= 0x073D00
-    if (pWrkrData->pData->tlsCipherSuites)
-        curl_easy_setopt(handle, CURLOPT_TLS13_CIPHERS, (char *)pWrkrData->pData->tlsCipherSuites);
+    if (pData->tlsCipherSuites) curl_easy_setopt(handle, CURLOPT_TLS13_CIPHERS, (char *)pData->tlsCipherSuites);
 #endif
 #if LIBCURL_VERSION_NUM >= 0x074900
-    if (pWrkrData->pData->tlsKeyExchangeGroups)
-        curl_easy_setopt(handle, CURLOPT_SSL_EC_CURVES, (char *)pWrkrData->pData->tlsKeyExchangeGroups);
+    if (pData->tlsKeyExchangeGroups)
+        curl_easy_setopt(handle, CURLOPT_SSL_EC_CURVES, (char *)pData->tlsKeyExchangeGroups);
 #endif
+}
+
+static void ATTR_NONNULL() curlSetupCommon(wrkrInstanceData_t *const pWrkrData, CURL *const handle) {
+    PTR_ASSERT_SET_TYPE(pWrkrData, WRKR_DATA_TYPE_ES);
+    curl_easy_setopt(handle, CURLOPT_HTTPHEADER, pWrkrData->curlHeader);
+    curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlResult);
+    curl_easy_setopt(handle, CURLOPT_WRITEDATA, pWrkrData);
+    curlSetupTlsOptions(pWrkrData->pData, handle);
+    if (pWrkrData->pData->authBuf != NULL) {
+        curl_easy_setopt(handle, CURLOPT_USERPWD, pWrkrData->pData->authBuf);
+        curl_easy_setopt(handle, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
+    }
     /* uncomment for in-dept debuggung:
     curl_easy_setopt(handle, CURLOPT_VERBOSE, TRUE); */
 }

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -164,6 +164,9 @@ typedef struct instanceConf_s {
     uchar *caCertFile;
     uchar *myCertFile;
     uchar *myPrivKeyFile;
+    uchar *tlsVersion; /* tls.tlsversion       → CURLOPT_SSLVERSION    */
+    uchar *tlsCipherSuites; /* tls.ciphersuites      → CURLOPT_TLS13_CIPHERS */
+    uchar *tlsKeyExchangeGroups; /* tls.keyexchangegroups → CURLOPT_SSL_EC_CURVES */
     es_write_ops_t writeOperation;
     sbool retryFailures;
     int ratelimitInterval;
@@ -238,6 +241,9 @@ static struct cnfparamdescr actpdescr[] = {{"server", eCmdHdlrArray, 0},
                                            {"tls.cacert", eCmdHdlrString, 0},
                                            {"tls.mycert", eCmdHdlrString, 0},
                                            {"tls.myprivkey", eCmdHdlrString, 0},
+                                           {"tls.tlsversion", eCmdHdlrString, 0},
+                                           {"tls.ciphersuites", eCmdHdlrString, 0},
+                                           {"tls.keyexchangegroups", eCmdHdlrString, 0},
                                            {"writeoperation", eCmdHdlrGetWord, 0},
                                            {"retryfailures", eCmdHdlrBinary, 0},
                                            {"ratelimit.interval", eCmdHdlrInt, 0},
@@ -351,6 +357,9 @@ BEGINfreeInstance
     free(pData->caCertFile);
     free(pData->myCertFile);
     free(pData->myPrivKeyFile);
+    free(pData->tlsVersion);
+    free(pData->tlsCipherSuites);
+    free(pData->tlsKeyExchangeGroups);
     free(pData->retryRulesetName);
     free(pData->detectedVersionString);
     if (pData->ratelimiter != NULL) ratelimitDestruct(pData->ratelimiter);
@@ -2156,6 +2165,15 @@ finalize_it:
     RETiRet;
 }
 
+static const struct {
+    const char *name;
+    long curlver;
+} tlsVersionMap[] = {{"TLSv1.2", CURL_SSLVERSION_TLSv1_2},
+#if LIBCURL_VERSION_NUM >= 0x073400
+                     {"TLSv1.3", CURL_SSLVERSION_TLSv1_3},
+#endif
+                     {NULL, 0}};
+
 static void ATTR_NONNULL() curlSetupCommon(wrkrInstanceData_t *const pWrkrData, CURL *const handle) {
     PTR_ASSERT_SET_TYPE(pWrkrData, WRKR_DATA_TYPE_ES);
     curl_easy_setopt(handle, CURLOPT_HTTPHEADER, pWrkrData->curlHeader);
@@ -2171,6 +2189,24 @@ static void ATTR_NONNULL() curlSetupCommon(wrkrInstanceData_t *const pWrkrData, 
     if (pWrkrData->pData->caCertFile) curl_easy_setopt(handle, CURLOPT_CAINFO, pWrkrData->pData->caCertFile);
     if (pWrkrData->pData->myCertFile) curl_easy_setopt(handle, CURLOPT_SSLCERT, pWrkrData->pData->myCertFile);
     if (pWrkrData->pData->myPrivKeyFile) curl_easy_setopt(handle, CURLOPT_SSLKEY, pWrkrData->pData->myPrivKeyFile);
+    if (pWrkrData->pData->tlsVersion) {
+        long ver = CURL_SSLVERSION_DEFAULT;
+        for (size_t i = 0; tlsVersionMap[i].name != NULL; i++) {
+            if (!strcmp((char *)pWrkrData->pData->tlsVersion, tlsVersionMap[i].name)) {
+                ver = tlsVersionMap[i].curlver;
+                break;
+            }
+        }
+        curl_easy_setopt(handle, CURLOPT_SSLVERSION, ver);
+    }
+#if LIBCURL_VERSION_NUM >= 0x073D00
+    if (pWrkrData->pData->tlsCipherSuites)
+        curl_easy_setopt(handle, CURLOPT_TLS13_CIPHERS, (char *)pWrkrData->pData->tlsCipherSuites);
+#endif
+#if LIBCURL_VERSION_NUM >= 0x074900
+    if (pWrkrData->pData->tlsKeyExchangeGroups)
+        curl_easy_setopt(handle, CURLOPT_SSL_EC_CURVES, (char *)pWrkrData->pData->tlsKeyExchangeGroups);
+#endif
     /* uncomment for in-dept debuggung:
     curl_easy_setopt(handle, CURLOPT_VERBOSE, TRUE); */
 }
@@ -2255,6 +2291,9 @@ static void ATTR_NONNULL() setInstParamDefaults(instanceData *const pData) {
     pData->caCertFile = NULL;
     pData->myCertFile = NULL;
     pData->myPrivKeyFile = NULL;
+    pData->tlsVersion = NULL;
+    pData->tlsCipherSuites = NULL;
+    pData->tlsKeyExchangeGroups = NULL;
     pData->writeOperation = ES_WRITE_INDEX;
     pData->retryFailures = 0;
     pData->ratelimitBurst = -1;
@@ -2376,6 +2415,38 @@ BEGINnewActInst
             } else {
                 fclose(fp);
             }
+        } else if (!strcmp(actpblk.descr[i].name, "tls.tlsversion")) {
+            char *ver;
+            int known;
+            CHKmalloc(ver = es_str2cstr(pvals[i].val.d.estr, NULL));
+            known = 0;
+            for (size_t j = 0; tlsVersionMap[j].name != NULL; j++) {
+                if (!strcmp(ver, tlsVersionMap[j].name)) {
+                    known = 1;
+                    break;
+                }
+            }
+            if (!known) {
+                LogError(0, RS_RET_PARAM_ERROR,
+                         "omelasticsearch: unknown tls.tlsversion '%s'; accepted: TLSv1.2, TLSv1.3", ver);
+                free(ver);
+                ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+            }
+            pData->tlsVersion = (uchar *)ver;
+        } else if (!strcmp(actpblk.descr[i].name, "tls.ciphersuites")) {
+            CHKmalloc(pData->tlsCipherSuites = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+#if LIBCURL_VERSION_NUM < 0x073D00
+            LogMsg(0, RS_RET_OK, LOG_WARNING,
+                   "omelasticsearch: tls.ciphersuites set but libcurl < 7.61 was used at build time; "
+                   "option will be ignored");
+#endif
+        } else if (!strcmp(actpblk.descr[i].name, "tls.keyexchangegroups")) {
+            CHKmalloc(pData->tlsKeyExchangeGroups = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+#if LIBCURL_VERSION_NUM < 0x074900
+            LogMsg(0, RS_RET_OK, LOG_WARNING,
+                   "omelasticsearch: tls.keyexchangegroups set but libcurl < 7.73 was used at build time; "
+                   "option will be ignored");
+#endif
         } else if (!strcmp(actpblk.descr[i].name, "writeoperation")) {
             char *writeop;
             CHKmalloc(writeop = es_str2cstr(pvals[i].val.d.estr, NULL));


### PR DESCRIPTION
Adds three new action parameters to omelasticsearch that expose libcurl TLS
knobs not previously reachable from RainerScript:

- `tls.tlsversion` — floor the TLS protocol version (TLSv1.2 or TLSv1.3)
- `tls.ciphersuites` — select TLS 1.3 cipher suites (libcurl >= 7.61)
- `tls.keyexchangegroups` — set key exchange group preference (libcurl >= 7.73)

The primary motivation is PQC readiness: setting
`tls.keyexchangegroups="X25519MLKEM768:X25519"` enables hybrid post-quantum
key exchange when libcurl is linked against OpenSSL 3.x with the OQS provider.

All three parameters are optional. When absent, libcurl behaviour is unchanged.

`tls.tlsversion` is validated at config load time; an unknown value aborts
startup with an error rather than being silently ignored. The two
version-gated options emit a build-time warning if the operator configures
them on a system whose libcurl predates support for them.
