### PR TITLE
packaging: update troubleshooting documentation links

### DIFF
--- a/packaging/docker/base/centos7/rsyslog.conf
+++ b/packaging/docker/base/centos7/rsyslog.conf
@@ -1,7 +1,7 @@
 # rsyslog configuration file
 
 # For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
-# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+# If you experience problems, see https://docs.rsyslog.com/doc/troubleshooting/index.html
 
 #### MODULES ####
 

--- a/packaging/docker/rsyslog/minimal/rsyslog.conf
+++ b/packaging/docker/rsyslog/minimal/rsyslog.conf
@@ -1,7 +1,7 @@
 # rsyslog configuration file
 
 # For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
-# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+# If you experience problems, see https://docs.rsyslog.com/doc/troubleshooting/index.html
 
 #### MODULES ####
 

--- a/packaging/rpm/rpmbuild/SOURCES/rsyslog.conf
+++ b/packaging/rpm/rpmbuild/SOURCES/rsyslog.conf
@@ -1,7 +1,7 @@
 # rsyslog configuration file
 
 # For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
-# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+# If you experience problems, see https://docs.rsyslog.com/doc/troubleshooting/index.html
 
 #### MODULES ####
 

--- a/platform/redhat/centos/rsyslog.conf
+++ b/platform/redhat/centos/rsyslog.conf
@@ -1,7 +1,7 @@
 # rsyslog configuration file
 
 # For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
-# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+# If you experience problems, see https://docs.rsyslog.com/doc/troubleshooting/index.html
 
 #### MODULES ####
 


### PR DESCRIPTION
packaging: update troubleshooting documentation links

The old http://www.rsyslog.com/doc/troubleshoot.html URL now
returns 404. This updates it to the current location in all
shipped default configuration files.

This improves the out-of-box experience for users of Docker
images, RPM packages, and CentOS/Red Hat platform configs.

BEFORE: help link in rsyslog.conf pointed to a broken page.
AFTER:  help link points to the maintained troubleshooting
        documentation.

Impact: purely documentation; no runtime or functional change.

Refs: https://github.com/rsyslog/rsyslog