### PR TITLE
Fix imdiag timeoutGuard daemon shutdown oracle

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -501,6 +501,7 @@ EXTRA_DIST = \
     source/reference/parameters/imdiag-inputshutdowntimeout.rst \
     source/reference/parameters/imdiag-listenportfilename.rst \
     source/reference/parameters/imdiag-listenportfilename-module.rst \
+    source/reference/parameters/imdiag-properterminationfile.rst \
     source/reference/parameters/imdiag-mainmsgqueuetimeoutenqueue.rst \
     source/reference/parameters/imdiag-mainmsgqueuetimeoutshutdown.rst \
     source/reference/parameters/imdiag-maxsessions.rst \

--- a/doc/source/configuration/modules/imdiag.rst
+++ b/doc/source/configuration/modules/imdiag.rst
@@ -44,6 +44,10 @@ Module Parameters
      - .. include:: ../../reference/parameters/imdiag-aborttimeout.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-imdiag-properterminationfile`
+     - .. include:: ../../reference/parameters/imdiag-properterminationfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-imdiag-mainmsgqueuetimeoutshutdown`
      - .. include:: ../../reference/parameters/imdiag-mainmsgqueuetimeoutshutdown.rst
         :start-after: .. summary-start
@@ -131,6 +135,7 @@ that it does not conflict with the test's own ``modules:`` section.
        listenportfilename: "test.imdiag.port"
        serverrun: "0"
        aborttimeout: "580"
+       properterminationfile: "./rstb.example.proper-termination"
        mainmsgqueuetimeoutshutdown: "10000"
        mainmsgqueuetimeoutenqueue: "30000"
        inputshutdowntimeout: "60000"
@@ -148,6 +153,7 @@ that it does not conflict with the test's own ``modules:`` section.
    :hidden:
 
    ../../reference/parameters/imdiag-aborttimeout
+   ../../reference/parameters/imdiag-properterminationfile
    ../../reference/parameters/imdiag-listenportfilename-module
    ../../reference/parameters/imdiag-mainmsgqueuetimeoutshutdown
    ../../reference/parameters/imdiag-mainmsgqueuetimeoutenqueue

--- a/doc/source/development/dev_testbench.rst
+++ b/doc/source/development/dev_testbench.rst
@@ -91,6 +91,26 @@ Both RainerScript and yaml-only modes use the imdiag port file
 ``wait_startup`` polls for this file and fast-fails if rsyslogd exits before
 it appears. No ``.started`` marker file is used.
 
+Proper termination detection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Daemonized tests cannot rely on shell ``wait`` to observe the real rsyslogd
+exit status because the original child exits after forking the daemon. For
+shutdown or crash-sensitive daemonized tests, call
+``set_proper_termination_file`` before ``generate_conf`` and
+``check_proper_termination`` after ``wait_shutdown``. The helper configures
+imdiag's ``properTerminationFile`` parameter, which stores the path in rsyslog
+core and writes the marker as the final action before returning from ``main``.
+A timeoutGuard abort writes the same file before aborting with
+``status=error`` and ``reason=timeoutGuard``. The harness prints marker content
+before failing so diagnostics such as ``queue.overall.size`` survive in the test
+log.
+
+Do not add helper cleanup or observer processes to prove daemon shutdown. They
+have historically caused their own races. ``timeoutGuard`` remains mandatory
+hang protection and must preserve this diagnostic marker behavior when it
+terminates rsyslogd.
+
 Queue and Input Timeouts
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/reference/parameters/imdiag-properterminationfile.rst
+++ b/doc/source/reference/parameters/imdiag-properterminationfile.rst
@@ -1,0 +1,63 @@
+.. _param-imdiag-properterminationfile:
+.. _imdiag.parameter.module.properterminationfile:
+
+ProperTerminationFile
+=====================
+
+.. index::
+   single: imdiag; ProperTerminationFile
+
+.. summary-start
+
+Configures the testbench-only file that rsyslogd writes as its final normal
+process-exit action.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdiag`.
+
+:Name: ProperTerminationFile
+:Scope: module
+:Type: string
+:Default: unset
+:Required?: no
+
+Description
+-----------
+
+``ProperTerminationFile`` is intended for daemonized rsyslog testbench
+scenarios where the shell cannot use ``wait`` to observe the real daemon
+process exit status. When set, imdiag passes the path to rsyslog core-owned
+storage. If rsyslog reaches the final normal ``main`` return path, the core
+writes the file as the last action before returning to the operating system.
+
+The marker file is opened with ``O_NOFOLLOW`` and mode ``0600``. If the file
+cannot be opened, written, or closed, rsyslog writes a concise diagnostic to
+stderr and exits with a non-zero status. No rsyslog internal warning or error
+message is emitted for marker write failures.
+
+A valid clean-shutdown file contains line-oriented fields such as
+``status=ok`` and ``phase=main-return``. TimeoutGuard writes the same file
+before aborting with ``status=error``, ``reason=timeoutGuard``, and
+``phase=timeoutguard-abort``. Marker content also includes
+``queue.overall.size`` so failing tests retain basic queue backlog context.
+Absence of the file means the daemon did not prove a proper final shutdown and
+testbench code should treat that as crash or abort evidence.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imdiag" properTerminationFile="./rstb.example.proper-termination")
+
+YAML usage
+----------
+
+.. code-block:: yaml
+
+   testbench_modules:
+     - load: "../plugins/imdiag/.libs/imdiag"
+       properterminationfile: "./rstb.example.proper-termination"
+
+See also :doc:`../../configuration/modules/imdiag`.

--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -104,6 +104,11 @@ pthread_cond_t statsReporterWatch;
 int statsReported = 0;
 static int abortTimeout = -1; /* for timeoutGuard - if set, abort rsyslogd after that many seconds */
 static pthread_t timeoutGuard_thrd; /* thread ID for timeoutGuard thread (if active) */
+static pthread_mutex_t timeoutGuardMut = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t timeoutGuardCond = PTHREAD_COND_INITIALIZER;
+static int timeoutGuardStop = 0;
+static int timeoutGuardActive = 0;
+static pid_t timeoutGuardPid = 0;
 
 /* config settings */
 struct modConfData_s {
@@ -113,6 +118,7 @@ struct modConfData_s {
     uchar *pszInjectDelayMode;
     uchar *pszStrmDrvrAuthMode;
     uchar *pszInputName;
+    uchar *pszProperTerminationFile;
     permittedPeers_t *pPermPeersRoot;
     int abortTimeout; /* abort timeout in seconds, -1 = disabled */
     int iTCPSessMax;
@@ -126,6 +132,7 @@ static modConfData_t *loadModConf = NULL; /* modConf ptr for current load proces
 static struct cnfparamdescr modpdescr[] = {
     {"listenportfilename", eCmdHdlrString, 0},
     {"aborttimeout", eCmdHdlrInt, 0},
+    {"properterminationfile", eCmdHdlrString, 0},
     {"serverrun", eCmdHdlrString, 0},
     {"injectdelaymode", eCmdHdlrString, 0},
     {"maxsessions", eCmdHdlrInt, 0},
@@ -813,18 +820,17 @@ static void *timeoutGuard(ATTR_UNUSED void *arg) {
     time(&strtTO);
     endTO = strtTO + abortTimeout;
 
-    while (1) {
-        int to = endTO - time(NULL);
-        dbgprintf("timeoutGuard: sleep timeout %d seconds\n", to);
-        if (to > 0) {
-            srSleep(to, 0);
-        }
-        if (time(NULL) < endTO) {
-            dbgprintf("timeoutGuard: spurios wakeup, going back to sleep, time: %lld\n", (long long)time(NULL));
-        } else {
-            break;
-        }
+    pthread_mutex_lock(&timeoutGuardMut);
+    while (!timeoutGuardStop && time(NULL) < endTO) {
+        struct timespec timeout = {.tv_sec = endTO, .tv_nsec = 0};
+        pthread_cond_timedwait(&timeoutGuardCond, &timeoutGuardMut, &timeout);
     }
+    if (timeoutGuardStop) {
+        pthread_mutex_unlock(&timeoutGuardMut);
+        return NULL;
+    }
+    pthread_mutex_unlock(&timeoutGuardMut);
+
     dbgprintf("timeoutGuard: sleep expired, aborting\n");
     /* note: we use fprintf to stderr intentionally! */
 
@@ -834,7 +840,17 @@ static void *timeoutGuard(ATTR_UNUSED void *arg) {
             (long long)strtTO, (long long)endTO, (long long)time(NULL), (long long)(time(NULL) - strtTO),
             (int)glblGetOurPid());
     fflush(stderr);
+    (void)rsyslogdWriteTerminationMarker("error", "timeoutGuard", "timeoutguard-abort");
     abort();
+}
+
+
+static void stopTimeoutGuard(void) {
+    pthread_mutex_lock(&timeoutGuardMut);
+    timeoutGuardStop = 1;
+    abortTimeout = -1;
+    pthread_cond_signal(&timeoutGuardCond);
+    pthread_mutex_unlock(&timeoutGuardMut);
 }
 
 
@@ -854,8 +870,23 @@ static rsRetVal setAbortTimeout(void __attribute__((unused)) * pVal, int timeout
         ABORT_FINALIZE(RS_RET_ERR);
     }
     abortTimeout = timeout;
+    pthread_mutex_lock(&timeoutGuardMut);
+    timeoutGuardStop = 0;
+    pthread_mutex_unlock(&timeoutGuardMut);
+
     const int iState = pthread_create(&timeoutGuard_thrd, NULL, timeoutGuard, NULL);
-    if (iState != 0) {
+    if (iState == 0) {
+        pthread_mutex_lock(&timeoutGuardMut);
+        timeoutGuardActive = 1;
+        timeoutGuardPid = getpid();
+        pthread_mutex_unlock(&timeoutGuardMut);
+    } else {
+        pthread_mutex_lock(&timeoutGuardMut);
+        timeoutGuardStop = 0;
+        timeoutGuardActive = 0;
+        timeoutGuardPid = 0;
+        pthread_mutex_unlock(&timeoutGuardMut);
+        abortTimeout = -1;
         LogError(iState, NO_ERRCODE,
                  "imdiag: error enabling timeoutGuard thread -"
                  "not guarding against system hang");
@@ -896,6 +927,7 @@ BEGINbeginCnfLoad
     pModConf->pszInjectDelayMode = NULL;
     pModConf->pszStrmDrvrAuthMode = NULL;
     pModConf->pszInputName = NULL;
+    pModConf->pszProperTerminationFile = NULL;
     pModConf->pPermPeersRoot = NULL;
     pModConf->abortTimeout = -1;
     pModConf->iTCPSessMax = -1;
@@ -924,6 +956,8 @@ BEGINsetModCnf
             CHKmalloc(loadModConf->pszLstnPortFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "aborttimeout")) {
             loadModConf->abortTimeout = (int)pvals[i].val.d.n;
+        } else if (!strcmp(modpblk.descr[i].name, "properterminationfile")) {
+            CHKmalloc(loadModConf->pszProperTerminationFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "serverrun")) {
             CHKmalloc(loadModConf->pszServerRun = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "injectdelaymode")) {
@@ -989,6 +1023,9 @@ BEGINendCnfLoad
         pszInputName = loadModConf->pszInputName;
         loadModConf->pszInputName = NULL; /* ownership transferred to global */
     }
+    if (loadModConf->pszProperTerminationFile != NULL) {
+        CHKiRet(rsyslogdSetProperTerminationFile(loadModConf->pszProperTerminationFile));
+    }
     if (loadModConf->pPermPeersRoot != NULL && pPermPeersRoot == NULL) {
         pPermPeersRoot = loadModConf->pPermPeersRoot;
         loadModConf->pPermPeersRoot = NULL; /* ownership transferred to global */
@@ -1022,6 +1059,7 @@ BEGINfreeCnf
     free(pModConf->pszInjectDelayMode);
     free(pModConf->pszStrmDrvrAuthMode);
     free(pModConf->pszInputName);
+    free(pModConf->pszProperTerminationFile);
     if (pModConf->pPermPeersRoot != NULL) {
         net.DestructPermittedPeers(&pModConf->pPermPeersRoot);
     }
@@ -1107,6 +1145,19 @@ ENDafterRun
 
 BEGINmodExit
     CODESTARTmodExit;
+    /* Ask the guard thread to stop and join it before imdiag can be unloaded. */
+    stopTimeoutGuard();
+    pthread_mutex_lock(&timeoutGuardMut);
+    const int joinTimeoutGuard = timeoutGuardActive && timeoutGuardPid == getpid();
+    pthread_mutex_unlock(&timeoutGuardMut);
+    if (joinTimeoutGuard) {
+        void *dummy;
+        pthread_join(timeoutGuard_thrd, &dummy);
+    }
+    pthread_mutex_lock(&timeoutGuardMut);
+    timeoutGuardActive = 0;
+    timeoutGuardPid = 0;
+    pthread_mutex_unlock(&timeoutGuardMut);
     if (pOurTcpsrv != NULL) iRet = tcpsrv.Destruct(&pOurTcpsrv);
 
     if (pPermPeersRoot != NULL) {
@@ -1133,16 +1184,6 @@ BEGINmodExit
     objRelease(datetime, CORE_COMPONENT);
     objRelease(prop, CORE_COMPONENT);
     objRelease(statsobj, CORE_COMPONENT);
-
-    /* clean up timeoutGuard if active */
-    if (abortTimeout != -1) {
-        int r = pthread_cancel(timeoutGuard_thrd);
-        if (r == 0) {
-            void *dummy;
-            pthread_join(timeoutGuard_thrd, &dummy);
-        }
-        abortTimeout = -1; /* mark cleaned up so resetConfigVariables won't double-cancel */
-    }
 ENDmodExit
 
 
@@ -1155,7 +1196,6 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) * pp, void __
     free(pszInputName);
     free(pszLstnPortFileName);
     pszLstnPortFileName = NULL;
-    abortTimeout = -1;
     if (pszStrmDrvrAuthMode != NULL) {
         free(pszStrmDrvrAuthMode);
         pszStrmDrvrAuthMode = NULL;

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -953,6 +953,22 @@ void rsrtSetErrLogger(void (*errLogger)(const int, const int, const uchar *));
 void dfltErrLogger(const int, const int, const uchar *errMsg);
 /** Determine the local host name and store it in the configuration. */
 rsRetVal queryLocalHostname(rsconf_t *const);
+/** Configure the testbench-only termination marker file.
+ *
+ * This hook is used by imdiag so daemonized tests can prove how rsyslogd
+ * terminated even when the shell cannot wait for the daemon child. The core
+ * duplicates @p path because the normal marker is written after loadable
+ * modules have already been unloaded.
+ */
+rsRetVal rsyslogdSetProperTerminationFile(const uchar *path);
+/** Write the configured testbench termination marker.
+ *
+ * @param status Short status string such as "ok" or "error".
+ * @param reason Termination reason such as "normal" or "timeoutGuard".
+ * @param phase Lifecycle phase that writes the marker.
+ * @return 0 on success or if no marker is configured; non-zero on write error.
+ */
+int rsyslogdWriteTerminationMarker(const char *status, const char *reason, const char *phase);
 
 
 /* this define below is intended to be used to implement empty

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -57,6 +57,15 @@ minimal containers. Findings are review prompts, not automatic blockers.
   clients, or probes need deterministic readiness and cleanup. Prefer existing
   testbench helpers; if custom plumbing is required, make ownership and cleanup
   explicit.
+- **Daemonized shutdown tests without a final rsyslogd oracle**: shell ``wait``
+  cannot observe the real daemon process exit status after rsyslogd forks. For
+  daemonized tests that care about crashes or clean shutdown, use
+  ``set_proper_termination_file`` before ``generate_conf`` and
+  ``check_proper_termination`` after ``wait_shutdown``. Do not use helper
+  cleanup or observer processes as the clean-shutdown oracle. ``timeoutGuard``
+  remains mandatory hang protection and must not be removed, disabled, or
+  weakened to make such tests pass; if timeoutGuard aborts rsyslogd, it must
+  preserve the termination marker with ``status=error`` and useful diagnostics.
 - **Queue tests assuming immediate drain or shutdown ordering**: use
   queue-specific synchronization where possible. Do not assume that input
   completion, shutdown start, or a fixed delay means all queued messages reached

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -308,6 +308,7 @@ TESTS_DEFAULT = \
 	asynwr_deadlock4.sh \
 	asynwr_dynfile_flushtxend-off.sh \
 	imdiag-modern-module-config.sh \
+	imdiag-proper-termination-timeoutguard.sh \
 	global-maxopenfiles-rainerscript.sh \
 	compat-configformat-rainerscript.sh \
 	compat-defaults-secure-dynafile-rainerscript.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -441,6 +441,8 @@ generate_conf() {
 		export RSYSLOG_PIDBASE="${RSYSLOG_DYNNAME}:" # also used by instance 2!
 		mkdir -p $RSYSLOG_DYNNAME.spool
 	fi
+	local proper_termination_file_var="RSTB_PROPER_TERMINATION_FILE$1"
+	local proper_termination_file="${!proper_termination_file_var:-}"
 	if [ "$yaml_only" = "1" ]; then
 		export RSYSLOG_YAML_ONLY=1
 		export TESTCONF_EXT="yaml"
@@ -464,6 +466,8 @@ generate_conf() {
 			[ -n "$RSTB_IMDIAG_INJECT_DELAY_MODE" ] &&
 				printf '    injectdelaymode: "%s"\n' "$RSTB_IMDIAG_INJECT_DELAY_MODE"
 			printf '    aborttimeout: "%s"\n' "$TB_TEST_MAX_RUNTIME"
+			[ -n "$proper_termination_file" ] &&
+				printf '    properterminationfile: "%s"\n' "$proper_termination_file"
 			printf '    mainmsgqueuetimeoutshutdown: "%s"\n' "$RSTB_GLOBAL_QUEUE_SHUTDOWN_TIMEOUT"
 			printf '    mainmsgqueuetimeoutenqueue: "%s"\n' "$RSTB_MAIN_Q_TO_ENQUEUE"
 			printf '    inputshutdowntimeout: "%s"\n' "$RSTB_GLOBAL_INPUT_SHUTDOWN_TIMEOUT"
@@ -483,6 +487,8 @@ generate_conf() {
 			[ -n "$RSTB_IMDIAG_INJECT_DELAY_MODE" ] &&
 				printf '    injectdelaymode="%s"\n' "$RSTB_IMDIAG_INJECT_DELAY_MODE"
 			printf '    aborttimeout="%s"\n' "$TB_TEST_MAX_RUNTIME"
+			[ -n "$proper_termination_file" ] &&
+				printf '    properterminationfile="%s"\n' "$proper_termination_file"
 			printf '    mainmsgqueuetimeoutshutdown="%s"\n' "$RSTB_GLOBAL_QUEUE_SHUTDOWN_TIMEOUT"
 			printf '    mainmsgqueuetimeoutenqueue="%s"\n' "$RSTB_MAIN_Q_TO_ENQUEUE"
 			printf '    inputshutdowntimeout="%s"\n' "$RSTB_GLOBAL_INPUT_SHUTDOWN_TIMEOUT"
@@ -513,6 +519,57 @@ generate_conf() {
 # $1 is config fragment, $2 the instance id, if given
 add_conf() {
 	printf '%s' "$1" >> ${TESTCONF_NM}$2.conf
+}
+
+get_proper_termination_file() {
+	local instance="${1:-}"
+	local proper_termination_file_var="RSTB_PROPER_TERMINATION_FILE${instance}"
+	printf '%s' "${!proper_termination_file_var:-}"
+}
+
+set_proper_termination_file() {
+	local instance="${1:-}"
+	local proper_termination_file_var="RSTB_PROPER_TERMINATION_FILE${instance}"
+	local suffix=""
+	if [ -n "$instance" ]; then
+		suffix=".$instance"
+	fi
+	local proper_termination_file="$PWD/$RSYSLOG_DYNNAME.proper-termination$suffix"
+	export "${proper_termination_file_var}=$proper_termination_file"
+}
+
+proper_termination_file_is_valid() {
+	local file
+	file="$(get_proper_termination_file "$1")"
+	[ -n "$file" ] || return 1
+	[ -f "$file" ] || return 1
+	grep -qx 'status=ok' "$file" || return 1
+	grep -qx 'phase=main-return' "$file" || return 1
+	return 0
+}
+
+print_proper_termination_file() {
+	local file
+	file="$(get_proper_termination_file "$1")"
+	[ -n "$file" ] || return
+	printf '%s\n' "--- proper termination file: $file ---"
+	if [ -f "$file" ]; then
+		cat "$file"
+	else
+		ls -l "$file" 2>/dev/null || true
+	fi
+	printf '%s\n' '--- end proper termination file ---'
+}
+
+check_proper_termination() {
+	local file
+	file="$(get_proper_termination_file "$1")"
+	if proper_termination_file_is_valid "$1"; then
+		return
+	fi
+	printf 'FAIL: proper termination file missing or invalid: %s\n' "${file:-<not configured>}"
+	print_proper_termination_file "$1"
+	error_exit 1
 }
 
 # add YAML content to the yaml config file (yaml-only mode)
@@ -1979,10 +2036,15 @@ quit"
 		core_found=1
 	fi
 	if [ $core_found -eq 1 ]; then
-	   printf 'ABORT! core file exists (maybe from a parallel run!)\n'
-	   pwd
-	   ls -l core.* ${RSYSLOG_DYNNAME}.core core.${RSYSLOG_DYNNAME}.* 2>/dev/null
-	   error_exit  1
+		if proper_termination_file_is_valid "$1"; then
+			printf 'INFO: core file exists, but proper termination file proves rsyslogd reached main return; ignoring as stale/foreign core\n'
+		else
+			printf 'ABORT! core file exists (maybe from a parallel run!)\n'
+			print_proper_termination_file "$1"
+			pwd
+			ls -l core.* ${RSYSLOG_DYNNAME}.core core.${RSYSLOG_DYNNAME}.* 2>/dev/null
+			error_exit  1
+		fi
 	fi
 }
 

--- a/tests/imdiag-proper-termination-timeoutguard.sh
+++ b/tests/imdiag-proper-termination-timeoutguard.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Verify timeoutGuard writes the imdiag proper termination marker before aborting.
+export TEST_MAX_RUNTIME=2
+. ${srcdir:=.}/diag.sh init
+
+if [ -n "$USE_VALGRIND" ]; then
+	printf 'timeoutGuard validation intentionally aborts rsyslogd; skipping valgrind mode\n'
+	skip_test
+fi
+
+# diag.sh raises the core limit for crash diagnostics. This test intentionally
+# aborts rsyslogd, so disable core files after init to avoid polluting CI hosts.
+ulimit -c 0 || true
+
+set_proper_termination_file
+generate_conf
+export RS_REDIR=">$RSYSLOG_DYNNAME.rsyslog.log 2>&1"
+startup_common "" ""
+bash -c "LD_PRELOAD=$RSYSLOG_PRELOAD ../tools/rsyslogd -C -n -i$RSYSLOG_PIDBASE$instance.pid -M\"$RSYSLOG_MODDIR\" -f$CONF_FILE $RS_REDIR" >/dev/null 2>&1 &
+rsyslog_job_pid=$!
+wait_startup "$instance"
+reassign_ports
+
+marker=$(get_proper_termination_file)
+wait_file_exists "$marker"
+wait "$rsyslog_job_pid" >/dev/null 2>&1
+
+print_proper_termination_file
+if proper_termination_file_is_valid; then
+	printf 'timeoutGuard validation: abort marker unexpectedly passed clean-shutdown validation\n'
+	error_exit 1
+fi
+
+grep -qx 'status=error' "$marker" || error_exit 1
+grep -qx 'reason=timeoutGuard' "$marker" || error_exit 1
+grep -qx 'phase=timeoutguard-abort' "$marker" || error_exit 1
+grep -Eq '^queue\.overall\.size=[0-9]+$' "$marker" || error_exit 1
+
+exit_test

--- a/tests/omkafka-unreachable-shutdown.sh
+++ b/tests/omkafka-unreachable-shutdown.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # Regression coverage for GitHub issue #4452. An unreachable Kafka broker can
-# trigger delivery callbacks during shutdown; the oracle is that rsyslog exits
-# cleanly without crashing while omkafka reports the failed delivery path.
+# trigger delivery callbacks during shutdown. This test runs rsyslogd in daemon
+# mode because the regression path is shutdown of the backgrounded process.
+# The proper termination file is written as rsyslogd's final main-return action;
+# its absence catches daemon crashes whose core dump may be captured outside the
+# test directory, where local core-file checks alone would miss the failure.
 . ${srcdir:=.}/diag.sh init
 require_plugin omkafka
 skip_TSAN "daemonized shutdown with imdiag injection forks while rsyslog threads are active"
@@ -10,6 +13,7 @@ export RSTB_DAEMONIZE="YES"
 export RSTB_GLOBAL_INPUT_SHUTDOWN_TIMEOUT=10000
 export NUMMESSAGES=2
 
+set_proper_termination_file
 generate_conf
 add_conf '
 module(load="../plugins/omkafka/.libs/omkafka")
@@ -46,5 +50,7 @@ wait_shutdown
 if [ -f "$RSYSLOG_OUT_LOG" ]; then
     check_not_present "Segmentation fault" "$RSYSLOG_OUT_LOG"
 fi
+check_proper_termination
+check_file_exists "$RSYSLOG_DYNNAME.failedmsg"
 
 exit_test

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -51,6 +51,7 @@
 #include "rsyslog.h"
 #include "wti.h"
 #include "ratelimit.h"
+#include "queue.h"
 #include "parser.h"
 #include "linkedlist.h"
 #include "ruleset.h"
@@ -239,6 +240,7 @@ int bHaveMainQueue = 0; /* set to 1 if the main queue - in queueing mode - is av
 prop_t *pInternalInputName = NULL; /* there is only one global inputName for all internally-generated messages */
 ratelimit_t *internalMsg_ratelimiter = NULL; /* ratelimiter for rsyslog-own messages */
 int send_to_all = 0; /* send message to all IPv4/IPv6 addresses */
+static uchar *properTerminationFile = NULL; /* testbench-only final shutdown marker path */
 
 static struct queuefilenames_s {
     struct queuefilenames_s *next;
@@ -2454,6 +2456,91 @@ static void mainloop(void) {
 
 /* Finalize and destruct all actions.
  */
+rsRetVal rsyslogdSetProperTerminationFile(const uchar *path) {
+    uchar *newPath = NULL;
+
+    if (path != NULL && path[0] != '\0') {
+        const size_t lenPath = strlen((const char *)path) + 1;
+        newPath = malloc(lenPath);
+        if (newPath == NULL) return RS_RET_OUT_OF_MEMORY;
+        memcpy(newPath, path, lenPath);
+    }
+
+    free(properTerminationFile);
+    properTerminationFile = newPath;
+    return RS_RET_OK;
+}
+
+
+int rsyslogdWriteTerminationMarker(const char *status, const char *reason, const char *phase) {
+    if (properTerminationFile == NULL || properTerminationFile[0] == '\0') return 0;
+
+    if (status == NULL) status = "unknown";
+    if (reason == NULL) reason = "unknown";
+    if (phase == NULL) phase = "unknown";
+
+#ifndef O_NOFOLLOW
+    fprintf(stderr,
+            "rsyslogd: proper termination file '%s' cannot be safely opened: "
+            "O_NOFOLLOW is unavailable on this platform\n",
+            (const char *)properTerminationFile);
+    return 1;
+#else
+    int fd = open((const char *)properTerminationFile, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC, 0600);
+    if (fd < 0) {
+        fprintf(stderr, "rsyslogd: error opening proper termination file '%s': %s\n",
+                (const char *)properTerminationFile, strerror(errno));
+        return 1;
+    }
+
+    #ifdef ENABLE_IMDIAG
+    const unsigned overallQueueSize = PREFER_FETCH_32BIT(iOverallQueueSize);
+    #else
+    const unsigned overallQueueSize = 0;
+    #endif
+    char buf[512];
+    const int len = snprintf(buf, sizeof(buf),
+                             "status=%s\nreason=%s\npid=%d\nsignal=%d\nversion=%s\nphase=%s\n"
+                             "queue.overall.size=%u\n",
+                             status, reason, (int)getpid(), bFinished, VERSION, phase, overallQueueSize);
+    if (len < 0 || (size_t)len >= sizeof(buf)) {
+        fprintf(stderr, "rsyslogd: error formatting proper termination file '%s'\n",
+                (const char *)properTerminationFile);
+        close(fd);
+        return 1;
+    }
+
+    const char *cursor = buf;
+    size_t remaining = (size_t)len;
+    while (remaining > 0) {
+        const ssize_t written = write(fd, cursor, remaining);
+        if (written < 0) {
+            if (errno == EINTR) continue;
+            fprintf(stderr, "rsyslogd: error writing proper termination file '%s': %s\n",
+                    (const char *)properTerminationFile, strerror(errno));
+            close(fd);
+            return 1;
+        }
+        if (written == 0) {
+            fprintf(stderr, "rsyslogd: short write to proper termination file '%s'\n",
+                    (const char *)properTerminationFile);
+            close(fd);
+            return 1;
+        }
+        cursor += written;
+        remaining -= (size_t)written;
+    }
+
+    if (close(fd) != 0) {
+        fprintf(stderr, "rsyslogd: error closing proper termination file '%s': %s\n",
+                (const char *)properTerminationFile, strerror(errno));
+        return 1;
+    }
+    return 0;
+#endif
+}
+
+
 static void rsyslogd_destructAllActions(void) {
     ruleset.DestructAllActions(runConf);
     PREFER_STORE_0_TO_INT(&bHaveMainQueue); /* flag that internal messages need to be temporarily stored */
@@ -2630,5 +2717,5 @@ int main(int argc, char **argv) {
     osf_close();
     pthread_mutex_destroy(&mutChildDied);
     pthread_mutex_destroy(&mutHadHUP);
-    return 0;
+    return rsyslogdWriteTerminationMarker("ok", "normal", "main-return");
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/rsyslog/rsyslog/issues/7285.

This fixes a general `imdiag` timeoutGuard shutdown bug that was exposed by `omkafka-unreachable-shutdown.sh`. The Debian report's important stack trace points at `pthread_cancel()` inside `imdiag modExit` while modules are being unloaded, not at omkafka message processing.

`imdiag` now stops timeoutGuard cooperatively with a condition variable and joins it before module unload in the process that created the thread. Daemon children skip cleanup of copied `pthread_t` values after fork.

The PR also addresses the report's second point: a daemonized test could sometimes report success even though rsyslogd had segfaulted, because the old harness only observed that the pid disappeared. `imdiag` now provides a testbench-only proper termination oracle. `properTerminationFile` is copied into core-owned storage, and rsyslogd writes that file as the final action before returning from `main`. A missing or invalid marker proves that the daemon did not reach normal final shutdown and fails the test.

The marker is opened with `O_NOFOLLOW` and mode `0600`; open/write/close failures emit a concise stderr message and return a non-zero process status without recording an rsyslog internal warning/error.

`timeoutGuard` writes the same marker before aborting, with `status=error`, `reason=timeoutGuard`, `phase=timeoutguard-abort`, and `queue.overall.size` so timeout diagnostics survive in the test log.

`omkafka-unreachable-shutdown.sh` now uses this oracle after `wait_shutdown`, so a daemon crash during late shutdown can no longer look like a successful test merely because the pid disappeared.

## Notes

- This is not an omkafka data-path fix; omkafka is the reproducer from #7285.
- `timeoutGuard` remains mandatory and must preserve this diagnostic marker behavior.
- Helper cleanup/observer processes are intentionally avoided.
- Clean shutdown marker content includes `status=ok`, `reason=normal`, `pid`, `signal`, `version`, `phase=main-return`, and `queue.overall.size`.
- TimeoutGuard marker content includes `status=error`, `reason=timeoutGuard`, `phase=timeoutguard-abort`, and `queue.overall.size`.
- The testbench prints marker content before failing invalid-marker/core-detected paths, and ignores stale/foreign local core files only when the clean marker is valid.

## Validation

- `bash -n tests/diag.sh`
- `bash -n tests/omkafka-unreachable-shutdown.sh`
- `bash -n tests/imdiag-proper-termination-timeoutguard.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `make -j$(nproc) check TESTS=""`
- `./tests/imdiag-proper-termination-timeoutguard.sh`
- `./tests/omkafka-unreachable-shutdown.sh`
- `devtools/check-test-antipatterns.sh tests/omkafka-unreachable-shutdown.sh`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`
- local negative check: symlink `properTerminationFile` exits non-zero and does not write the symlink target
- local negative check: SIGABRT exits non-zero and does not create the marker
- local regression experiment: reintroducing the old `pthread_cancel()` `imdiag modExit` path made `omkafka-unreachable-shutdown.sh` fail immediately with a missing proper termination marker; restoring cooperative stop made it pass again.