### PR TITLE
Codify timeoutGuard testbench invariant

### DIFF
--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -797,6 +797,10 @@ finalize_it:
 }
 
 
+/* timeoutGuard is mandatory testbench hang protection. Do not remove,
+ * disable, or weaken it to make shutdown tests pass; fix lifecycle, fork,
+ * or unload bugs while preserving this inside-rsyslogd timeout oracle.
+ */
 static void *timeoutGuard(ATTR_UNUSED void *arg) {
     assert(abortTimeout != -1);
     sigset_t sigSet;

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -69,6 +69,11 @@ minimal containers. Findings are review prompts, not automatic blockers.
   behavior, race window, or invariant it was meant to exercise. If the oracle or
   setup changes, refresh the head comment and verify the original behavior is
   still covered.
+- **`imdiag` timeoutGuard is mandatory**: the timeout guard is testbench
+  safety plumbing that aborts a stuck rsyslogd from inside the process so CI can
+  retain useful failure evidence. Do not remove, disable, or weaken it to make a
+  shutdown, daemonization, or unload test pass. Fix the underlying lifecycle
+  issue or ask for maintainer guidance if preserving the guard is ambiguous.
 
 ## Writing & updating tests
 - Base new shell tests on existing ones; include `. $srcdir/diag.sh` to gain the

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -463,6 +463,7 @@ generate_conf() {
 			printf '    serverrun: "0"\n'
 			[ -n "$RSTB_IMDIAG_INJECT_DELAY_MODE" ] &&
 				printf '    injectdelaymode: "%s"\n' "$RSTB_IMDIAG_INJECT_DELAY_MODE"
+			# aborttimeout enables imdiag timeoutGuard, mandatory testbench hang protection.
 			printf '    aborttimeout: "%s"\n' "$TB_TEST_MAX_RUNTIME"
 			printf '    mainmsgqueuetimeoutshutdown: "%s"\n' "$RSTB_GLOBAL_QUEUE_SHUTDOWN_TIMEOUT"
 			printf '    mainmsgqueuetimeoutenqueue: "%s"\n' "$RSTB_MAIN_Q_TO_ENQUEUE"
@@ -482,6 +483,7 @@ generate_conf() {
 			printf '    serverrun="0"\n'
 			[ -n "$RSTB_IMDIAG_INJECT_DELAY_MODE" ] &&
 				printf '    injectdelaymode="%s"\n' "$RSTB_IMDIAG_INJECT_DELAY_MODE"
+			# aborttimeout enables imdiag timeoutGuard, mandatory testbench hang protection.
 			printf '    aborttimeout="%s"\n' "$TB_TEST_MAX_RUNTIME"
 			printf '    mainmsgqueuetimeoutshutdown="%s"\n' "$RSTB_GLOBAL_QUEUE_SHUTDOWN_TIMEOUT"
 			printf '    mainmsgqueuetimeoutenqueue="%s"\n' "$RSTB_MAIN_Q_TO_ENQUEUE"


### PR DESCRIPTION
## Summary

Codifies that `imdiag` `timeoutGuard` is mandatory testbench hang-protection plumbing and must not be removed, disabled, or weakened to make shutdown, daemonization, or unload tests pass.

This adds the invariant in:

- `plugins/imdiag/imdiag.c`, next to `timeoutGuard`
- `tests/diag.sh`, where generated test configs receive `aborttimeout`
- `tests/AGENTS.md`, for future testbench work by agents

## Rationale

`timeoutGuard` aborts a stuck rsyslogd from inside the process so CI can retain useful hang evidence. Timeout failures may indicate runtime bugs or lifecycle problems; they should be fixed at the underlying cause rather than hidden by removing the guard.

## Validation

- `bash -n tests/diag.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `devtools/local-validation-plan.sh` was run for classification; it over-reported unrelated historical files via its auto base, so the actual branch diff was reviewed directly against `upstream/main`.

No full container validation was run because this PR only adds invariant comments/guidance and changes no behavior.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

