### PR TITLE
imhttp: enforce gzip request body limit

### DIFF
--- a/contrib/imhttp/imhttp.c
+++ b/contrib/imhttp/imhttp.c
@@ -101,8 +101,11 @@ struct route_auth_ctx_s {
 
 struct data_parse_s {
     sbool content_compressed;
+    sbool compressedDataComplete;
     sbool bzInitDone; /* did we do an init of zstrm already? */
     z_stream zstrm; /* zip stream to use for tcp compression */
+    uint64_t requestBodyBytes;
+    uint64_t decompressedBodyBytes;
     // Currently only used for octet specific parsing
     enum {
         eAtStrtFram,
@@ -156,6 +159,9 @@ struct conn_wrkr_s {
     uchar *pMsg; /* msg scratch buffer */
     size_t iMsg; /* index of next char to store in msg */
     uchar zipBuf[64 * 1024];
+    uchar *pDecompressedReqBuf;
+    size_t decompressedReqBufSize;
+    size_t decompressedReqBufLen;
     multi_submit_t multiSub;
     smsg_t *pMsgs[CONF_NUM_MULTISUB];
     char *pReadBuf;
@@ -409,6 +415,7 @@ static void exit_thread(ATTR_UNUSED const struct mg_context *ctx, ATTR_UNUSED in
             free(data->pScratchBuf);
         }
         free(data->pReadBuf);
+        free(data->pDecompressedReqBuf);
         free(data->pMsg);
         free(data);
     }
@@ -751,6 +758,65 @@ finalize_it:
     RETiRet;
 }
 
+/**
+ * Apply the imhttp request body limit to streaming byte counters.
+ *
+ * @note Content-Length only covers compressed wire bytes when gzip is used.
+ *       Keep both the wire stream and the inflated stream bounded, and parse a
+ *       gzip request only after its full inflated body stayed within the limit.
+ */
+static rsRetVal trackRequestBodyBytes(uint64_t *const counter, const size_t len, const char *const label) {
+    DEFiRet;
+
+    if (*counter > MAX_REQUEST_BODY_SIZE || (uint64_t)len > (uint64_t)MAX_REQUEST_BODY_SIZE - *counter) {
+        LogError(0, RS_RET_OVERSIZE_MSG, "imhttp: rejecting request body after %s size exceeded maximum %d bytes",
+                 label, MAX_REQUEST_BODY_SIZE);
+        ABORT_FINALIZE(RS_RET_OVERSIZE_MSG);
+    }
+    *counter += len;
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal appendDecompressedRequestBody(struct conn_wrkr_s *const connWrkr,
+                                              const uchar *const buf,
+                                              const size_t len) {
+    DEFiRet;
+    uchar *newBuf = NULL;
+
+    CHKiRet(trackRequestBodyBytes(&connWrkr->parseState.decompressedBodyBytes, len, "decompressed"));
+    if (len == 0) {
+        FINALIZE;
+    }
+
+    if (connWrkr->decompressedReqBufLen > MAX_REQUEST_BODY_SIZE ||
+        len > (size_t)MAX_REQUEST_BODY_SIZE - connWrkr->decompressedReqBufLen) {
+        ABORT_FINALIZE(RS_RET_OVERSIZE_MSG);
+    }
+
+    const size_t required = connWrkr->decompressedReqBufLen + len;
+    if (required > connWrkr->decompressedReqBufSize) {
+        size_t newSize =
+            connWrkr->decompressedReqBufSize == 0 ? INIT_SCRATCH_BUF_SIZE : connWrkr->decompressedReqBufSize;
+        while (newSize < required) {
+            if (newSize > (size_t)MAX_REQUEST_BODY_SIZE / 2) {
+                newSize = MAX_REQUEST_BODY_SIZE;
+            } else {
+                newSize *= 2;
+            }
+        }
+        CHKmalloc(newBuf = realloc(connWrkr->pDecompressedReqBuf, newSize));
+        connWrkr->pDecompressedReqBuf = newBuf;
+        connWrkr->decompressedReqBufSize = newSize;
+    }
+
+    memcpy(connWrkr->pDecompressedReqBuf + connWrkr->decompressedReqBufLen, buf, len);
+    connWrkr->decompressedReqBufLen += len;
+
+finalize_it:
+    RETiRet;
+}
+
 static rsRetVal processDataCompressed(const instanceConf_t *const inst,
                                       struct conn_wrkr_s *connWrkr,
                                       const char *buf,
@@ -773,10 +839,10 @@ static rsRetVal processDataCompressed(const instanceConf_t *const inst,
     connWrkr->parseState.zstrm.next_in = (Bytef *)buf;
     connWrkr->parseState.zstrm.avail_in = (uInt)len;
     /* run inflate() on buffer until everything has been uncompressed */
-    int outtotal = 0;
+    size_t outtotal = 0;
     do {
         int zRet = 0;
-        int outavail = 0;
+        size_t outavail = 0;
         dbgprintf("imhttp: in inflate() loop, avail_in %d, total_in %ld\n", connWrkr->parseState.zstrm.avail_in,
                   connWrkr->parseState.zstrm.total_in);
 
@@ -787,9 +853,15 @@ static rsRetVal processDataCompressed(const instanceConf_t *const inst,
         outavail = sizeof(connWrkr->zipBuf) - connWrkr->parseState.zstrm.avail_out;
         if (outavail != 0) {
             outtotal += outavail;
-            CHKiRet(processDataUncompressed(inst, connWrkr, (const char *)connWrkr->zipBuf, outavail));
+            CHKiRet(appendDecompressedRequestBody(connWrkr, connWrkr->zipBuf, outavail));
         }
         if (zRet == Z_STREAM_END) {
+            if (connWrkr->decompressedReqBufLen != 0) {
+                CHKiRet(processDataUncompressed(inst, connWrkr, (const char *)connWrkr->pDecompressedReqBuf,
+                                                connWrkr->decompressedReqBufLen));
+            }
+            connWrkr->decompressedReqBufLen = 0;
+            connWrkr->parseState.compressedDataComplete = 1;
             break;
         }
         if (zRet == Z_BUF_ERROR) {
@@ -1208,6 +1280,7 @@ static int postHandler(struct mg_connection *conn, void *cbdata) {
     }
     connWrkr->multiSub.nElem = 0;
     memset(&connWrkr->parseState, 0, sizeof(connWrkr->parseState));
+    connWrkr->decompressedReqBufLen = 0;
     connWrkr->pri = ri;
 
     if (inst->bAddMetadata && connWrkr->scratchBufSize == 0) {
@@ -1240,6 +1313,16 @@ static int postHandler(struct mg_connection *conn, void *cbdata) {
         prop.CreateOrReuseStringProp(&connWrkr->propRemoteAddr, (const uchar *)ri->remote_addr, len);
     }
 
+    if (ri->num_headers > 0) {
+        int i;
+        for (i = 0; i < ri->num_headers; i++) {
+            if (!strcasecmp(ri->http_headers[i].name, "content-encoding") &&
+                !strcasecmp(ri->http_headers[i].value, "gzip")) {
+                connWrkr->parseState.content_compressed = 1;
+            }
+        }
+    }
+
     if (ri->content_length >= 0) {
         /* We know the content length in advance */
         if ((uint64_t)ri->content_length > MAX_REQUEST_BODY_SIZE) {
@@ -1252,7 +1335,7 @@ static int postHandler(struct mg_connection *conn, void *cbdata) {
             rc = 413;
             FINALIZE;
         }
-        if ((uint64_t)ri->content_length + 1 > connWrkr->readBufSize) {
+        if (!connWrkr->parseState.content_compressed && (uint64_t)ri->content_length + 1 > connWrkr->readBufSize) {
             char *newReadBuf = realloc(connWrkr->pReadBuf, (size_t)ri->content_length + 1);
             if (newReadBuf == NULL) {
                 mg_cry(conn, "%s() - realloc failed!\n", __FUNCTION__);
@@ -1268,21 +1351,33 @@ static int postHandler(struct mg_connection *conn, void *cbdata) {
          * or connection close), indicated my mg_read returning 0 */
     }
 
-    if (ri->num_headers > 0) {
-        int i;
-        for (i = 0; i < ri->num_headers; i++) {
-            if (!strcasecmp(ri->http_headers[i].name, "content-encoding") &&
-                !strcasecmp(ri->http_headers[i].value, "gzip")) {
-                connWrkr->parseState.content_compressed = 1;
-            }
-        }
-    }
-
     while (1) {
         int count = mg_read(conn, connWrkr->pReadBuf, connWrkr->readBufSize);
         if (count > 0) {
+            localRet = trackRequestBodyBytes(&connWrkr->parseState.requestBodyBytes, (size_t)count, "wire");
+            if (localRet == RS_RET_OVERSIZE_MSG) {
+                STATSCOUNTER_INC(statsCounter.ctrFailed, statsCounter.mutCtrFailed);
+                STATSCOUNTER_INC(statsCounter.ctrDiscarded, statsCounter.mutCtrDiscarded);
+                mg_printf(conn, "HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+                rc = 413;
+                FINALIZE;
+            }
+            if (localRet != RS_RET_OK) {
+                LogError(0, localRet, "imhttp: failed tracking request payload size");
+                STATSCOUNTER_INC(statsCounter.ctrFailed, statsCounter.mutCtrFailed);
+                mg_printf(conn, "HTTP/1.1 500 Internal Server Error\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+                rc = 500;
+                FINALIZE;
+            }
             localRet = processData(inst, connWrkr, (const char *)connWrkr->pReadBuf, count);
             if (localRet != RS_RET_OK) {
+                if (localRet == RS_RET_OVERSIZE_MSG) {
+                    STATSCOUNTER_INC(statsCounter.ctrFailed, statsCounter.mutCtrFailed);
+                    STATSCOUNTER_INC(statsCounter.ctrDiscarded, statsCounter.mutCtrDiscarded);
+                    mg_printf(conn, "HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+                    rc = 413;
+                    FINALIZE;
+                }
                 LogError(0, localRet, "imhttp: failed processing request payload");
                 STATSCOUNTER_INC(statsCounter.ctrFailed, statsCounter.mutCtrFailed);
                 mg_printf(conn, "HTTP/1.1 500 Internal Server Error\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
@@ -1292,6 +1387,14 @@ static int postHandler(struct mg_connection *conn, void *cbdata) {
         } else {
             break;
         }
+    }
+
+    if (connWrkr->parseState.content_compressed && !connWrkr->parseState.compressedDataComplete) {
+        LogError(0, RS_RET_ZLIB_ERR, "imhttp: compressed request body ended before gzip stream completed");
+        STATSCOUNTER_INC(statsCounter.ctrFailed, statsCounter.mutCtrFailed);
+        mg_printf(conn, "HTTP/1.1 500 Internal Server Error\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+        rc = 500;
+        FINALIZE;
     }
 
     /* submit remainder */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1152,6 +1152,7 @@ TESTS_IMHTTP = \
 	imhttp-post-payload-multi-lf.sh \
 	imhttp-post-payload-compress.sh \
 	imhttp-post-payload-invalid-gzip.sh \
+	imhttp-post-payload-compress-size-limit.sh \
 	imhttp-post-payload-octet-oversize.sh \
 	imhttp-post-payload-basic-auth-challenge.sh \
 	imhttp-getrequest-file.sh \

--- a/tests/imhttp-post-payload-compress-size-limit.sh
+++ b/tests/imhttp-post-payload-compress-size-limit.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify that imhttp applies the request body limit after gzip decompression,
+# not only to the compressed wire body. The request uses octet-counted framing
+# so a successful rejection cannot leave a partial message behind: the oracle is
+# HTTP 413 plus an empty output file.
+
+. ${srcdir:=.}/diag.sh init
+check_command_available python3
+generate_conf
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
+add_conf '
+template(name="outfmt" type="string" string="%rawmsg%\n")
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
+input(type="imhttp" endpoint="/postrequest"
+      ruleset="ruleset"
+      supportoctetcountedframing="on")
+ruleset(name="ruleset") {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
+
+response=$(python3 - "$IMHTTP_PORT" <<'PY'
+import gzip
+import socket
+import sys
+
+MAX_REQUEST_BODY_SIZE = 16 * 1024 * 1024
+port = int(sys.argv[1])
+
+payload = b"A" * (MAX_REQUEST_BODY_SIZE + 1)
+body = str(len(payload)).encode("ascii") + b" " + payload
+compressed = gzip.compress(body, compresslevel=9)
+if len(compressed) >= MAX_REQUEST_BODY_SIZE:
+    raise SystemExit("compressed reproducer body unexpectedly exceeds the wire-size limit")
+
+request = b"".join(
+    [
+        b"POST /postrequest HTTP/1.1\r\n",
+        b"Host: localhost\r\n",
+        b"Content-Encoding: gzip\r\n",
+        b"Content-Length: " + str(len(compressed)).encode("ascii") + b"\r\n",
+        b"Connection: close\r\n",
+        b"\r\n",
+        compressed,
+    ]
+)
+
+with socket.create_connection(("127.0.0.1", port), timeout=10) as sock:
+    sock.settimeout(10)
+    sock.sendall(request)
+    response = b""
+    while True:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        response += chunk
+
+print(response.decode("latin1", "replace").splitlines()[0] if response else "")
+PY
+)
+
+echo "response: $response"
+case "$response" in
+	*" 413 "*) ;;
+	*)
+		echo "ERROR: gzip-expanded request body was not rejected with 413"
+		error_exit 1
+		;;
+esac
+
+wait_queueempty
+shutdown_when_empty
+wait_shutdown
+if [ -s "$RSYSLOG_OUT_LOG" ]; then
+	echo "ERROR: gzip-expanded oversized request produced output"
+	ls -l "$RSYSLOG_OUT_LOG"
+	error_exit 1
+fi
+exit_test


### PR DESCRIPTION
## Summary

This PR hardens `imhttp` gzip request handling so the configured request body limit is enforced on both the compressed wire body and the inflated gzip body.

The previous limit checks covered `Content-Length` and parser-level message size, but a small gzip body could inflate beyond `MAX_REQUEST_BODY_SIZE` and still be parsed. The new path tracks wire bytes while reading, tracks inflated bytes while decompressing, and only passes a gzip request to the existing uncompressed parser after `Z_STREAM_END` confirms the complete inflated body stayed within the limit.

## Approach

- Add bounded request-body counters for compressed wire bytes and inflated gzip bytes.
- Buffer inflated gzip data up to `MAX_REQUEST_BODY_SIZE` before parsing, so an oversized gzip request cannot partially submit earlier inflated chunks before the limit is detected.
- Return `413 Payload Too Large` for wire-size or inflated-size limit violations.
- Keep malformed or incomplete gzip streams on the existing error path.
- Avoid growing the wire read buffer to gzip `Content-Length`; compressed requests are streamed through the normal read buffer while only the bounded inflated body is retained for atomic parsing.
- Add a focused regression test that sends a gzip-compressed octet-counted body whose compressed size is below the limit but whose decompressed size exceeds it.

## Validation

- Reproduced the issue on clean `upstream/main` at `9ee607d6f` using the new test: response was `HTTP/1.1 200 OK` instead of `413`.
- `make -j${RSYSLOG_LOCAL_BUILD_JOBS:-10}`
- `make -C tests check TESTS=imhttp-post-payload-compress-size-limit.sh`
- `make -C tests check TESTS=imhttp-post-payload-compress.sh`
- `make -C tests check TESTS=imhttp-post-payload-content-length-limit.sh`
- `make -C tests check TESTS=imhttp-post-payload-invalid-gzip.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `devtools/check-test-antipatterns.sh tests/imhttp-post-payload-compress-size-limit.sh`
- `shellcheck -S warning tests/imhttp-post-payload-compress-size-limit.sh`

## Notes

Local Cubic review flagged the expected tradeoff: atomic gzip handling now permits one bounded inflated-body buffer, up to `MAX_REQUEST_BODY_SIZE`, per active gzip request. The patch avoids also retaining a full gzip wire buffer for compressed requests. A design that avoids the inflated buffer would need a more complex two-pass inflate path or would give up the atomic no-partial-submit property this change is meant to enforce.

Full PR-ready local container validation has not yet been run for this draft.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

