### PR TITLE
tests: avoid bytes formatting in zlib stream test

### DIFF
--- a/tests/imtcp-stream-always-zlib-fragmented-ratio.sh
+++ b/tests/imtcp-stream-always-zlib-fragmented-ratio.sh
@@ -31,10 +31,10 @@ import time
 import zlib
 
 port = int(sys.argv[1])
-payload = b"".join(
-    b"<129>Mar 10 01:00:00 172.20.245.8 tag: msgnum:%08d AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n" % i
+payload = "".join(
+    "<129>Mar 10 01:00:00 172.20.245.8 tag: msgnum:%08d AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n" % i
     for i in range(0, 2000)
-)
+).encode("ascii")
 compressed = zlib.compress(payload, level=1)
 sock = socket.create_connection(("127.0.0.1", port))
 sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)


### PR DESCRIPTION
## Summary
- fix `imtcp-stream-always-zlib-fragmented-ratio.sh` for older Python 3 runtimes used by Solaris CI
- format the payload as text first, then encode to ASCII bytes before zlib compression
- preserve the existing fragmented stream compression scenario and oracle

## Evidence
Buildbot Solaris failures #7289, #7280, and #7275 all failed in the same test with:

```text
TypeError: unsupported operand type(s) for %: 'bytes' and 'int'
wait_file_lines failed, expected 2000 got 0
```

## Validation
- `bash -n tests/imtcp-stream-always-zlib-fragmented-ratio.sh`
- `shellcheck -S warning tests/imtcp-stream-always-zlib-fragmented-ratio.sh`
- `devtools/check-test-antipatterns.sh tests/imtcp-stream-always-zlib-fragmented-ratio.sh`
- Python payload expression smoke check
- `./autogen.sh`
- `./configure --enable-testbench --enable-imdiag --disable-generate-man-pages`
- `make -j60 check TESTS=""`
- `./tests/imtcp-stream-always-zlib-fragmented-ratio.sh`
- `make -j60 check TESTS='imtcp-stream-always-zlib-fragmented-ratio.sh'`
- `devtools/local-validation-plan.sh --base upstream/main --run`
- `cubic review --print-logs`

Container validation used `rsyslog/rsyslog_dev_base_ubuntu:26.04`, image id `sha256:17e57e817596410451a48b11dd4388a6e69ae9affd2a45cfb38f6cf87c48fc2d`. The helper classified this as `test-shell-only`; the focused container lane is the intended reduced lane because the patch changes only Python payload formatting, not timing, ports, lifecycle, or shared harness behavior.


closes: https://github.com/rsyslog/rsyslog/issues/7289 
closes: https://github.com/rsyslog/rsyslog/issues/7280
closes: https://github.com/rsyslog/rsyslog/issues/7275

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

