### PR TITLE
[codex] gtls: harden DNS SAN byte handling

### DIFF
--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1160,6 +1160,7 @@ static rsRetVal gtlsChkPeerName(nsd_gtls_t *pThis, gnutls_x509_crt_t *pCert) {
     uchar lnBuf[256];
     char szAltName[1024]; /* this is sufficient for the DNSNAME and IPADDRESS... */
     int iAltName;
+    char *embeddedNul;
     size_t szAltNameLen;
     int bFoundPositiveMatch;
     int bHaveSAN = 0;
@@ -1182,6 +1183,21 @@ static rsRetVal gtlsChkPeerName(nsd_gtls_t *pThis, gnutls_x509_crt_t *pCert) {
             break;
         else if (gnuRet == GNUTLS_SAN_DNSNAME) {
             bHaveSAN = 1;
+            if (szAltNameLen == 0 || szAltNameLen >= sizeof(szAltName)) {
+                embeddedNul = NULL;
+            } else {
+                embeddedNul = memchr(szAltName, '\0', szAltNameLen);
+            }
+            if (szAltNameLen == 0 || szAltNameLen >= sizeof(szAltName) || embeddedNul != NULL) {
+                /* GnuTLS returns DNS SAN as raw bytes.  Do not let C-string
+                 * prefix semantics turn "name\\0.suffix" into authorized
+                 * peer "name".  Treat malformed DNS SAN bytes as non-matching. */
+                dbgprintf("subject alt dnsName is malformed, ignoring for name match\n");
+                CHKiRet(rsCStrAppendStr(pStr, (uchar *)"DNSname: <invalid>; "));
+                ++iAltName;
+                continue;
+            }
+            szAltName[szAltNameLen] = '\0';
             dbgprintf("subject alt dnsName: '%s'\n", szAltName);
             snprintf((char *)lnBuf, sizeof(lnBuf), "DNSname: %s; ", szAltName);
             CHKiRet(rsCStrAppendStr(pStr, lnBuf));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1607,6 +1607,7 @@ TESTS_GNUTLS = \
 	imtcp-tls-gtls-x509fingerprint-invld.sh \
 	imtcp-tls-gtls-x509fingerprint.sh \
 	imtcp-tls-gtls-x509name-invld.sh \
+	imtcp-tls-gtls-x509name-nul-san.sh \
 	imtcp-tls-gtls-x509name.sh \
 	imtcp-tls-gtls-x509name-legacy.sh \
 	omfwd-tls-gtls-no-sni.sh \

--- a/tests/imtcp-tls-gtls-x509name-nul-san.sh
+++ b/tests/imtcp-tls-gtls-x509name-nul-san.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0.
+# Defense-in-depth regression test for GnuTLS x509/name matching.
+#
+# The generated client certificate is signed by the trusted test CA but contains
+# SAN dNSName bytes "rsyslog-client\0.attacker" while its CN is deliberately
+# non-matching. A compliant CA should not issue such a malformed DNS identity,
+# and a compromised CA could simply issue the exact permitted name, so this is a
+# hardening invariant rather than a practical CA-bypass model. The oracle is
+# rejection: rsyslog must report an unauthorized peer name and must not accept
+# the test message through C-string prefix interpretation of the raw SAN bytes.
+. ${srcdir:=.}/diag.sh init
+check_command_available openssl
+check_command_available python3
+export NUMMESSAGES=1
+CERTDIR="$RSYSLOG_DYNNAME.nul-san-certs"
+mkdir -p "$CERTDIR"
+
+openssl genrsa -out "$CERTDIR/client-key.pem" 2048 >/dev/null 2>&1
+openssl req -new -key "$CERTDIR/client-key.pem" -out "$CERTDIR/client.csr" \
+	-subj "/C=US/ST=Test/O=rsyslog/CN=malicious-client" >/dev/null 2>&1
+cat > "$CERTDIR/client-ext.cnf" <<'EOF'
+[usr_cert]
+basicConstraints=CA:FALSE
+# subjectAltName = SEQUENCE { dNSName "rsyslog-client\0.attacker" }
+subjectAltName=DER:30:1a:82:18:72:73:79:73:6c:6f:67:2d:63:6c:69:65:6e:74:00:2e:61:74:74:61:63:6b:65:72
+EOF
+openssl x509 -req -in "$CERTDIR/client.csr" \
+	-CA "$srcdir/tls-certs/ca.pem" -CAkey "$srcdir/tls-certs/ca-key.pem" -set_serial 01 \
+	-out "$CERTDIR/client-cert.pem" -days 365 -sha256 \
+	-extfile "$CERTDIR/client-ext.cnf" -extensions usr_cert >/dev/null 2>&1
+
+# Sanity-check that the fixture really contains the embedded-NUL SAN bytes.
+openssl x509 -in "$CERTDIR/client-cert.pem" -outform DER -out "$CERTDIR/client-cert.der"
+python3 - "$CERTDIR/client-cert.der" <<'PY'
+from pathlib import Path
+import sys
+cert = Path(sys.argv[1]).read_bytes()
+if b"rsyslog-client\x00.attacker" not in cert:
+    raise SystemExit("embedded-NUL SAN fixture was not generated")
+PY
+
+generate_conf
+add_conf '
+global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+        defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+        defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+)
+
+module( load="../plugins/imtcp/.libs/imtcp"
+        StreamDriver.Name="gtls"
+        StreamDriver.Mode="1"
+        StreamDriver.AuthMode="x509/name"
+        PermittedPeer=["rsyslog-client"]
+)
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+tcpflood -p"$TCPFLOOD_PORT" -m"$NUMMESSAGES" -Ttls \
+	-x"$srcdir/tls-certs/ca.pem" \
+	-Z"$CERTDIR/client-cert.pem" \
+	-z"$CERTDIR/client-key.pem" || true
+shutdown_when_empty
+wait_shutdown
+content_check --regex "peer name not authorized"
+check_not_present "msgnum:00000000" "$RSYSLOG_OUT_LOG"
+exit_test


### PR DESCRIPTION
## Summary

This is a defense-in-depth hardening change for GnuTLS `x509/name` matching.

GnuTLS returns `dNSName` SAN values as byte sequences, while rsyslog's permitted-peer matcher operates on C strings. This PR makes the byte-to-string boundary explicit: malformed DNS SAN byte sequences, including embedded-NUL values such as `rsyslog-client\0.attacker`, are treated as non-matching before they reach the existing peer-name matcher.

This is intentionally not framed as a practical public- or private-CA bypass scenario. A compliant CA should not issue such a malformed DNS identity, and a compromised CA could simply issue the exact permitted name. The value is to document and preserve the invariant that raw SAN bytes must not authorize a peer through C-string prefix interpretation.

## What changed

- Validate GnuTLS DNS SAN bytes before passing them to permitted-peer matching.
- Treat empty, full-buffer, and embedded-NUL DNS SAN values as malformed non-matches.
- Leave IP SAN handling unchanged; it already uses the returned byte length via `inet_ntop()`.
- Add a focused GnuTLS `x509/name` regression/hardening test that generates a trusted test-CA client certificate containing `rsyslog-client\0.attacker` and asserts rejection.

## Validation

- Pre-fix reproducer on current upstream failed as intended: the malformed SAN was accepted as `rsyslog-client` and the expected authorization diagnostic was absent.
- `./autogen.sh --enable-gnutls --enable-gnutls-tests --enable-testbench --disable-generate-man-pages`
- `make -j${RSYSLOG_LOCAL_BUILD_JOBS:-10}`
- `make -C tests check TESTS=imtcp-tls-gtls-x509name-nul-san.sh`
- `make -C tests check TESTS='imtcp-tls-gtls-x509name.sh imtcp-tls-gtls-x509name-invld.sh'`
- `devtools/check-test-antipatterns.sh tests/imtcp-tls-gtls-x509name-nul-san.sh`
- `shellcheck -S warning tests/imtcp-tls-gtls-x509name-nul-san.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `devtools/local-validation-plan.sh --base upstream/main --run`

The local validation helper completed successfully with the Ubuntu 26.04 dev container image `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`). It included the mock distcheck, change-gated container CI, static analyzer, and local Cubic review; Cubic reported no issues.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

