### PR TITLE
config: keep empty include globs silent

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -265,10 +265,12 @@ These will not be mentioned individually, check commit log for details.
   configuration-check failure.
   Closes https://github.com/rsyslog/rsyslog/issues/728
   Closes https://github.com/rsyslog/rsyslog/issues/2752
-- 2026-05-22: config: warn for unmatched include globs
-  Non-optional IncludeConfig wildcards that match no files now emit a parser
-  warning while preserving the historical non-fatal startup behavior.
+- 2026-05-22: config: keep unmatched include globs silent
+  Non-optional IncludeConfig wildcards that match no files remain accepted
+  without an error or warning, preserving the historical non-fatal startup
+  behavior and avoiding noise for optional-by-design include directories.
   Closes https://github.com/rsyslog/rsyslog/issues/4415
+  Closes https://github.com/rsyslog/rsyslog/issues/7286
 - 2026-05-20: imptcp: harden concurrency, boundaries, and memory handling
   imptcp received additional defense-in-depth work around listener statistics
   synchronization, receive buffer boundaries, zero-initialized session and

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -6147,9 +6147,6 @@ int ATTR_NONNULL() cnfDoInclude(const char *const name, const int optional) {
     result = glob(finalName, GLOB_MARK, NULL, &cfgFiles);
     if (result == GLOB_NOMATCH && containsGlobWildcard((char *)finalName)) {
 #endif /* HAVE_GLOB_NOMAGIC */
-        if (optional == 0) {
-            parser_warnmsg("IncludeConfig pattern '%s' did not match any files", finalName);
-        }
         goto done;
     }
 

--- a/tests/incltest_dir_empty_wildcard.sh
+++ b/tests/incltest_dir_empty_wildcard.sh
@@ -1,23 +1,27 @@
 #!/bin/bash
-# Verify that a non-optional $IncludeConfig wildcard that matches no files logs
-# a parser warning but does not prevent rsyslog from starting and processing
-# messages. The warning is checked during config validation because include
-# parsing happens before normal daemon action output is fully configured.
+# Verify that a non-optional $IncludeConfig wildcard that matches no files is
+# accepted silently. The oracle is successful config validation and runtime
+# message processing, with no include no-match, warning, or error diagnostic in
+# the captured rsyslogd output.
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf "\$IncludeConfig ${srcdir}/testsuites/incltest.d/*.conf-not-there
 "
-add_conf '$template outfmt,"%msg:F,58:2%\n"
+add_conf 'global(compatibility.defaults.secure="strict")
+$template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")'
-export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
+DIAG_LOG="${RSYSLOG_DYNNAME}.rsyslog.log"
+: > "$DIAG_LOG"
+export RS_REDIR=">>\"$DIAG_LOG\" 2>&1"
 rsyslogd_config_check
-unset RS_REDIR
-content_check "IncludeConfig pattern '${srcdir}/testsuites/incltest.d/*.conf-not-there' did not match any files" \
-	"${RSYSLOG_DYNNAME}.rsyslog.log"
 startup
+unset RS_REDIR
 # 100 messages are enough - the question is if the include is read ;)
 injectmsg 0 100
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
+check_not_present "IncludeConfig pattern" "$DIAG_LOG"
+check_not_present "[Ww][Aa][Rr][Nn]" "$DIAG_LOG"
+check_not_present "[Ee][Rr][Rr][Oo][Rr]" "$DIAG_LOG"
 seq_check 0 99
 exit_test


### PR DESCRIPTION
## Summary

This v8-stable follow-up keeps `$IncludeConfig` wildcard includes silent when the pattern matches no files. Empty include directories are a normal deployment state, so rsyslog should not emit an error, warning, or other diagnostic just because there is currently nothing to include.

## Root Cause

The include handling path recently emitted a parser warning for non-optional wildcard patterns that returned `GLOB_NOMATCH`. That made normal empty include directories noisy during startup.

## Changes

- Remove the parser warning for unmatched wildcard include patterns.
- Update the existing empty wildcard include regression test to assert no include no-match, warning, or error diagnostics are emitted during config validation or startup.
- Keep message processing coverage in the test so the silent no-match path still starts and runs normally.
- Update the `ChangeLog` entry to describe the preserved silent behavior.

## Validation

Targeted at `rsyslog/rsyslog:v8-stable`.

- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout`
- `devtools/local-validation-plan.sh --base upstream/v8-stable --run`

The local validation helper completed successfully, including the change-gated Ubuntu 26.04 container run, static analyzer lane, mock distcheck, and local Cubic review.

Container image: `rsyslog/rsyslog_dev_base_ubuntu:26.04`
Image ID/digest: `sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`

Closes https://github.com/rsyslog/rsyslog/issues/7286

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

