### PR TITLE
ChangeLog: split include-glob follow-up

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,13 @@
 --------------------------------------------------------------------------------------
+Scheduled Release 8.2604.1 (aka 2026.04) 2026-06-26
+
+- 2026-06-26: config: keep unmatched include globs silent
+  IncludeConfig wildcards that match no files no longer emit a parser warning.
+  Empty include directories are again treated as a normal deployment state
+  while malformed or inaccessible include paths still report real errors.
+  Closes https://github.com/rsyslog/rsyslog/issues/7286
+
+--------------------------------------------------------------------------------------
 Scheduled Release 8.2606.0 (aka 2026.06) 2026-06-23
 
 IMPORTANT FOR MAINTAINERS
@@ -265,12 +274,10 @@ These will not be mentioned individually, check commit log for details.
   configuration-check failure.
   Closes https://github.com/rsyslog/rsyslog/issues/728
   Closes https://github.com/rsyslog/rsyslog/issues/2752
-- 2026-05-22: config: keep unmatched include globs silent
-  Non-optional IncludeConfig wildcards that match no files remain accepted
-  without an error or warning, preserving the historical non-fatal startup
-  behavior and avoiding noise for optional-by-design include directories.
+- 2026-05-22: config: warn for unmatched include globs
+  Non-optional IncludeConfig wildcards that match no files now emit a parser
+  warning while preserving the historical non-fatal startup behavior.
   Closes https://github.com/rsyslog/rsyslog/issues/4415
-  Closes https://github.com/rsyslog/rsyslog/issues/7286
 - 2026-05-20: imptcp: harden concurrency, boundaries, and memory handling
   imptcp received additional defense-in-depth work around listener statistics
   synchronization, receive buffer boundaries, zero-initialized session and


### PR DESCRIPTION
## Summary

This updates the v8-stable ChangeLog so the include-glob release note is split between the original release entry and the follow-up patch release.

## Changes

- Add a new `Scheduled Release 8.2604.1` header for the follow-up fix.
- Record that unmatched `IncludeConfig` wildcards are silent again for empty include directories.
- Restore the existing `.0` entry to the original warning behavior for issue #4415.

## Validation

- `git diff --check HEAD^ HEAD`

Text-only ChangeLog correction; no build or container validation was run.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

