### PR TITLE
impcap: bound-check ARP address lengths

### DIFF
--- a/contrib/impcap/arp_parser.c
+++ b/contrib/impcap/arp_parser.c
@@ -42,6 +42,27 @@ struct arp_header_s {
 
 typedef struct arp_header_s arp_header_t;
 
+static int arp_addr_lengths_available(const arp_header_t *arp_header, int pktSize) {
+    const size_t hdrLen = sizeof(*arp_header);
+    const size_t hwAddrLen = arp_header->hwAddrLen;
+    const size_t pAddrLen = arp_header->pAddrLen;
+    const size_t addrLen = 2 * (hwAddrLen + pAddrLen);
+
+    if (!(pktSize >= 0 && (size_t)pktSize >= hdrLen && addrLen <= (size_t)pktSize - hdrLen)) {
+        return 0;
+    }
+
+    if (ntohs(arp_header->hwType) == 1 && hwAddrLen < 6) {
+        return 0;
+    }
+
+    if (ntohs(arp_header->pType) == ETHERTYPE_IP && pAddrLen < 4) {
+        return 0;
+    }
+
+    return 1;
+}
+
 /*
  *  This function parses the bytes in the received packet to extract ARP metadata.
  *
@@ -78,6 +99,12 @@ data_ret_t *arp_parse(const uchar *packet, int pktSize, struct json_object *jpar
     json_object_object_add(jparent, "ARP_hwType", json_object_new_int(ntohs(arp_header->hwType)));
     json_object_object_add(jparent, "ARP_pType", json_object_new_int(ntohs(arp_header->pType)));
     json_object_object_add(jparent, "ARP_op", json_object_new_int(ntohs(arp_header->opCode)));
+
+    if (!arp_addr_lengths_available(arp_header, pktSize)) {
+        DBGPRINTF("ARP packet address lengths exceed captured packet size: hwAddrLen=%u pAddrLen=%u pktSize=%d\n",
+                  arp_header->hwAddrLen, arp_header->pAddrLen, pktSize);
+        RETURN_DATA_AFTER(28);
+    }
 
     if (ntohs(arp_header->hwType) == 1) { /* ethernet addresses */
         char hwAddrSrc[20], hwAddrDst[20];
@@ -140,10 +167,18 @@ data_ret_t *rarp_parse(const uchar *packet, int pktSize, struct json_object *jpa
     json_object_object_add(jparent, "RARP_pType", json_object_new_int(ntohs(rarp_header->pType)));
     json_object_object_add(jparent, "RARP_op", json_object_new_int(ntohs(rarp_header->opCode)));
 
+    if (!arp_addr_lengths_available(rarp_header, pktSize)) {
+        DBGPRINTF("RARP packet address lengths exceed captured packet size: hwAddrLen=%u pAddrLen=%u pktSize=%d\n",
+                  rarp_header->hwAddrLen, rarp_header->pAddrLen, pktSize);
+        RETURN_DATA_AFTER(28);
+    }
+
     if (ntohs(rarp_header->hwType) == 1) { /* ethernet addresses */
-        char *hwAddrSrc = ether_ntoa((struct ether_addr *)rarp_header->pAddr);
-        char *hwAddrDst =
-            ether_ntoa((struct ether_addr *)(rarp_header->pAddr + rarp_header->hwAddrLen + rarp_header->pAddrLen));
+        char hwAddrSrc[20], hwAddrDst[20];
+
+        ether_ntoa_r((struct ether_addr *)rarp_header->pAddr, hwAddrSrc);
+        ether_ntoa_r((struct ether_addr *)(rarp_header->pAddr + rarp_header->hwAddrLen + rarp_header->pAddrLen),
+                     hwAddrDst);
 
         json_object_object_add(jparent, "RARP_hwSrc", json_object_new_string((char *)hwAddrSrc));
         json_object_object_add(jparent, "RARP_hwDst", json_object_new_string((char *)hwAddrDst));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -31,6 +31,8 @@ TESTS_GSSAPI_LIBYAML = \
 	imgssapi-yaml-include-listen-port-file.sh
 EXTRA_DIST += $(TESTS_GSSAPI) $(TESTS_GSSAPI_LIBYAML) unit/gss_token_util_test.c
 
+EXTRA_DIST += unit/impcap_arp_parser_test.c
+
 TESTS_IMPTCP_TABESCAPE = \
 	tabescape_dflt.sh \
 	tabescape_dflt-udp.sh \
@@ -2315,6 +2317,18 @@ runtime_unit_msg_replace_SOURCES = \
 
 runtime_unit_ommongodb_date_SOURCES = \
 	unit/ommongodb_date_test.c
+
+if ENABLE_IMPCAP
+check_PROGRAMS += runtime_unit_impcap_arp_parser
+TESTS += runtime_unit_impcap_arp_parser
+
+runtime_unit_impcap_arp_parser_SOURCES = \
+	unit/impcap_arp_parser_test.c
+
+runtime_unit_impcap_arp_parser_CPPFLAGS = \
+	$(runtime_unit_linkedlist_CPPFLAGS)
+runtime_unit_impcap_arp_parser_LDADD = $(LIBFASTJSON_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
+endif
 
 if ENABLE_GSSAPI
 check_PROGRAMS += runtime_unit_gss_token_util

--- a/tests/unit/impcap_arp_parser_test.c
+++ b/tests/unit/impcap_arp_parser_test.c
@@ -1,0 +1,248 @@
+/* Regression test for contrib/impcap ARP/RARP address-length handling.
+ *
+ * impcap is optional and only exposes this path when configured to process
+ * captured L2 traffic. Malformed ARP/RARP frames can still be attacker-provided
+ * on such interfaces, so the parser must not trust packet-controlled
+ * hwAddrLen/pAddrLen fields to form offsets beyond the captured packet.
+ *
+ * The malformed cases below use minimal captured ARP/RARP payloads with either
+ * oversized address lengths or Ethernet/IPv4 lengths that are too short for the
+ * fixed-width address converters. Before the fix, guard-page mode made the real
+ * parser crash while converting the destination Ethernet address. The oracle
+ * here is that malformed packets return without address metadata, while a
+ * normal Ethernet/IPv4 ARP and RARP packet still produces the expected parsed
+ * fields. The demonstrated impact is crash/DoS; this test does not claim code
+ * execution or information disclosure.
+ */
+
+#define _GNU_SOURCE
+#include "config.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "contrib/impcap/parsers.h"
+
+#define CHECK(cond)                                                                  \
+    do {                                                                             \
+        if (!(cond)) {                                                               \
+            fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__, #cond); \
+            exit(1);                                                                 \
+        }                                                                            \
+    } while (0)
+
+int Debug = 0;
+void r_dbgprintf(const char *srcname, const char *fmt, ...) {
+    (void)srcname;
+    (void)fmt;
+}
+
+static void set_u16(unsigned char *packet, size_t off, unsigned value) {
+    packet[off] = (unsigned char)(value >> 8);
+    packet[off + 1] = (unsigned char)value;
+}
+
+static void fill_arp_header(unsigned char *packet, unsigned opCode) {
+    memset(packet, 0, 28);
+    set_u16(packet, 0, 1); /* hardware type: Ethernet */
+    set_u16(packet, 2, ETHERTYPE_IP); /* protocol type: IPv4 */
+    packet[4] = 6; /* Ethernet address length */
+    packet[5] = 4; /* IPv4 address length */
+    set_u16(packet, 6, opCode);
+}
+
+static void fill_valid_arp(unsigned char *packet, unsigned opCode) {
+    fill_arp_header(packet, opCode);
+
+    const unsigned char hwSrc[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
+    const unsigned char pSrc[4] = {192, 0, 2, 1};
+    const unsigned char hwDst[6] = {0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+    const unsigned char pDst[4] = {198, 51, 100, 2};
+
+    memcpy(packet + 8, hwSrc, sizeof(hwSrc));
+    memcpy(packet + 14, pSrc, sizeof(pSrc));
+    memcpy(packet + 18, hwDst, sizeof(hwDst));
+    memcpy(packet + 24, pDst, sizeof(pDst));
+}
+
+static void fill_malformed_arp(unsigned char *packet) {
+    fill_arp_header(packet, 1);
+    packet[4] = 250; /* attacker-controlled length exceeds captured packet */
+}
+
+static long guarded_page_size(void) {
+    const long page = sysconf(_SC_PAGESIZE);
+    CHECK(page > 28);
+    return page;
+}
+
+static unsigned char *make_guarded_malformed_packet(void) {
+    const long page = guarded_page_size();
+
+    unsigned char *map = mmap(NULL, (size_t)page * 2, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK(map != MAP_FAILED);
+    CHECK(mprotect(map + page, (size_t)page, PROT_NONE) == 0);
+
+    unsigned char *packet = map + page - 28;
+    fill_malformed_arp(packet);
+    return packet;
+}
+
+static void free_guarded_packet(unsigned char *packet) {
+    const long page = guarded_page_size();
+    unsigned char *map = packet + 28 - page;
+    CHECK(munmap(map, (size_t)page * 2) == 0);
+}
+
+static int object_has_key(struct json_object *obj, const char *key) {
+    struct json_object *tmp = NULL;
+    return json_object_object_get_ex(obj, key, &tmp);
+}
+
+static void check_json_string(struct json_object *obj, const char *key, const char *expected) {
+    struct json_object *value = NULL;
+    CHECK(json_object_object_get_ex(obj, key, &value));
+    const char *actual = json_object_get_string(value);
+    if (strcmp(actual, expected) != 0) {
+        fprintf(stderr, "%s: expected '%s', got '%s'\n", key, expected, actual);
+        exit(1);
+    }
+}
+
+static void check_no_address_fields(struct json_object *obj, const char *prefix) {
+    char key[32];
+
+    snprintf(key, sizeof(key), "%s_hwSrc", prefix);
+    CHECK(!object_has_key(obj, key));
+    snprintf(key, sizeof(key), "%s_hwDst", prefix);
+    CHECK(!object_has_key(obj, key));
+    snprintf(key, sizeof(key), "%s_pSrc", prefix);
+    CHECK(!object_has_key(obj, key));
+    snprintf(key, sizeof(key), "%s_pDst", prefix);
+    CHECK(!object_has_key(obj, key));
+}
+
+typedef data_ret_t *(*arp_test_parser_t)(const uchar *, int, struct json_object *);
+
+static void run_short_fixed_width_length_case(
+    arp_test_parser_t parse, const char *prefix, unsigned opCode, unsigned hwAddrLen, unsigned pAddrLen) {
+    unsigned char packet[28];
+    struct json_object *j = json_object_new_object();
+    CHECK(j != NULL);
+
+    fill_valid_arp(packet, opCode);
+    packet[4] = (unsigned char)hwAddrLen;
+    packet[5] = (unsigned char)pAddrLen;
+
+    data_ret_t *ret = parse(packet, sizeof(packet), j);
+    CHECK(ret != NULL);
+    CHECK(ret->size == 0);
+    free(ret);
+
+    check_no_address_fields(j, prefix);
+    json_object_put(j);
+}
+
+static void test_malformed_lengths_do_not_parse_addresses(void) {
+    unsigned char *packet = make_guarded_malformed_packet();
+    struct json_object *j = json_object_new_object();
+    CHECK(j != NULL);
+
+    data_ret_t *ret = arp_parse(packet, 28, j);
+    CHECK(ret != NULL);
+    CHECK(ret->size == 0);
+    free(ret);
+
+    CHECK(object_has_key(j, "ARP_hwType"));
+    CHECK(object_has_key(j, "ARP_pType"));
+    CHECK(object_has_key(j, "ARP_op"));
+    CHECK(!object_has_key(j, "ARP_hwSrc"));
+    CHECK(!object_has_key(j, "ARP_hwDst"));
+    CHECK(!object_has_key(j, "ARP_pSrc"));
+    CHECK(!object_has_key(j, "ARP_pDst"));
+
+    json_object_put(j);
+    free_guarded_packet(packet);
+}
+
+static void test_malformed_rarp_lengths_do_not_parse_addresses(void) {
+    unsigned char *packet = make_guarded_malformed_packet();
+    struct json_object *j = json_object_new_object();
+    CHECK(j != NULL);
+
+    data_ret_t *ret = rarp_parse(packet, 28, j);
+    CHECK(ret != NULL);
+    CHECK(ret->size == 0);
+    free(ret);
+
+    CHECK(object_has_key(j, "RARP_hwType"));
+    CHECK(object_has_key(j, "RARP_pType"));
+    CHECK(object_has_key(j, "RARP_op"));
+    CHECK(!object_has_key(j, "RARP_hwSrc"));
+    CHECK(!object_has_key(j, "RARP_hwDst"));
+    CHECK(!object_has_key(j, "RARP_pSrc"));
+    CHECK(!object_has_key(j, "RARP_pDst"));
+
+    json_object_put(j);
+    free_guarded_packet(packet);
+}
+
+static void test_short_fixed_width_lengths_do_not_parse_addresses(void) {
+    run_short_fixed_width_length_case(arp_parse, "ARP", 1, 5, 4);
+    run_short_fixed_width_length_case(arp_parse, "ARP", 1, 6, 3);
+    run_short_fixed_width_length_case(rarp_parse, "RARP", 3, 5, 4);
+    run_short_fixed_width_length_case(rarp_parse, "RARP", 3, 6, 3);
+}
+
+static void test_valid_arp_still_parses_addresses(void) {
+    unsigned char packet[28];
+    struct json_object *j = json_object_new_object();
+    CHECK(j != NULL);
+    fill_valid_arp(packet, 1);
+
+    data_ret_t *ret = arp_parse(packet, sizeof(packet), j);
+    CHECK(ret != NULL);
+    CHECK(ret->size == 0);
+    free(ret);
+
+    check_json_string(j, "ARP_hwSrc", "0:11:22:33:44:55");
+    check_json_string(j, "ARP_hwDst", "aa:bb:cc:dd:ee:ff");
+    check_json_string(j, "ARP_pSrc", "192.0.2.1");
+    check_json_string(j, "ARP_pDst", "198.51.100.2");
+
+    json_object_put(j);
+}
+
+static void test_valid_rarp_still_parses_addresses(void) {
+    unsigned char packet[28];
+    struct json_object *j = json_object_new_object();
+    CHECK(j != NULL);
+    fill_valid_arp(packet, 3);
+
+    data_ret_t *ret = rarp_parse(packet, sizeof(packet), j);
+    CHECK(ret != NULL);
+    CHECK(ret->size == 0);
+    free(ret);
+
+    check_json_string(j, "RARP_hwSrc", "0:11:22:33:44:55");
+    check_json_string(j, "RARP_hwDst", "aa:bb:cc:dd:ee:ff");
+    check_json_string(j, "RARP_pSrc", "192.0.2.1");
+    check_json_string(j, "RARP_pDst", "198.51.100.2");
+
+    json_object_put(j);
+}
+
+#include "../../contrib/impcap/arp_parser.c"
+
+int main(void) {
+    test_malformed_lengths_do_not_parse_addresses();
+    test_malformed_rarp_lengths_do_not_parse_addresses();
+    test_short_fixed_width_lengths_do_not_parse_addresses();
+    test_valid_arp_still_parses_addresses();
+    test_valid_rarp_still_parses_addresses();
+    return 0;
+}


### PR DESCRIPTION
## Summary

This hardens the optional `impcap` ARP/RARP parser against malformed captured packets whose packet-controlled hardware or protocol address lengths do not fit in the captured buffer.

The parser still emits fixed ARP/RARP metadata for such malformed packets, but it now stops before converting address fields whose offsets would extend beyond the captured packet. Normal Ethernet/IPv4 ARP and RARP parsing is preserved.

## Scope and impact wording

This is intentionally framed as hardening for an optional contrib module. The affected path is exposed when `impcap` is configured to process captured L2 traffic on an interface that can see malformed attacker-provided ARP/RARP frames.

The demonstrated impact is a crash/DoS from an out-of-bounds read in the parser path. This PR does not claim code execution or information disclosure.

## Reproducer

The new unit test uses a guard-page packet to make the original out-of-bounds read deterministic. It verifies that malformed ARP/RARP frames return without address metadata and that valid ARP/RARP packets still produce the expected parsed fields.

## Validation

- Pre-fix guard-page reproducer: crashed with `rc=139`, confirming the issue.
- `./autogen.sh --enable-impcap --enable-testbench --disable-generate-man-pages`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `make -C tests check TESTS=runtime_unit_impcap_arp_parser`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j"${RSYSLOG_LOCAL_BUILD_JOBS:-10}"`
- `devtools/local-validation-plan.sh --base upstream/main --run` passed on rerun. The first scoped run hit unrelated `omprog` fd-count failures; the new impcap unit test passed in that run as well.