### PR TITLE
Make proper termination markers default in testbench

### DIFF
--- a/contrib/imkmsg/imkmsg.c
+++ b/contrib/imkmsg/imkmsg.c
@@ -161,7 +161,7 @@ BEGINrunInput
      * signalled to do so. This, however, is handled by the framework,
      * right into the sleep below.
      */
-    while (!pThrd->bShallStop) {
+    while (!thrdGetShallStop(pThrd)) {
         /* klogLogKMsg() waits for the next kernel message, obtains it
          * and then submits it to the rsyslog main queue.
          * rgerhards, 2008-04-09

--- a/doc/source/development/dev_testbench.rst
+++ b/doc/source/development/dev_testbench.rst
@@ -95,12 +95,21 @@ Proper termination detection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Daemonized tests cannot rely on shell ``wait`` to observe the real rsyslogd
-exit status because the original child exits after forking the daemon. For
-shutdown or crash-sensitive daemonized tests, call
-``set_proper_termination_file`` before ``generate_conf`` and
-``check_proper_termination`` after ``wait_shutdown``. The helper configures
-imdiag's ``properTerminationFile`` parameter, which stores the path in rsyslog
-core and writes the marker as the final action before returning from ``main``.
+exit status because the original child exits after forking the daemon. Regular
+``generate_conf`` tests configure imdiag's ``properTerminationFile`` parameter
+automatically from the per-test ``RSYSLOG_DYNNAME`` basename and instance
+suffix. The path is stored in rsyslog core and written as the final action
+before returning from ``main``. ``wait_shutdown`` validates the marker when one
+is configured and the shutdown was initiated through harness helpers that saved
+the rsyslogd pid, so regular shutdown or crash-sensitive tests should use the
+standard ``shutdown_when_empty`` or ``shutdown_immediate`` path instead of
+adding test-local shutdown observers. Use ``set_proper_termination_file`` only
+for special manual-startup or non-generated-config cases, and call
+``check_proper_termination`` directly only when that special path cannot use
+``wait_shutdown``.
+Tests that intentionally kill rsyslogd to create dirty on-disk state must use
+the testbench kill helper so the next ``wait_shutdown`` knows that no clean
+main-return marker is expected for that phase.
 A timeoutGuard abort writes the same file before aborting with
 ``status=error`` and ``reason=timeoutGuard``. The harness prints marker content
 before failing so diagnostics such as ``queue.overall.size`` survive in the test

--- a/plugins/im3195/im3195.c
+++ b/plugins/im3195/im3195.c
@@ -196,7 +196,7 @@ BEGINrunInput
      * signalled to do so. This, however, is handled by the framework,
      * right into the sleep below.
      */
-    while (!pThrd->bShallStop) {
+    while (!thrdGetShallStop(pThrd)) {
         /* now move the listener to running state. Control will only
          * return after SIGUSR1.
          */

--- a/plugins/imdtls/imdtls.c
+++ b/plugins/imdtls/imdtls.c
@@ -1173,7 +1173,9 @@ BEGINrunInput
     for (inst = runModConf->root; inst != NULL; inst = inst->next) {
         if (inst->bEnableLstn) {
             pthread_kill(inst->tid, SIGTTIN);
-            DTLSCloseSocket(inst);
+            if (inst->sockfd >= 0) {
+                shutdown(inst->sockfd, SHUT_RDWR);
+            }
         }
     }
 
@@ -1181,6 +1183,7 @@ BEGINrunInput
     for (inst = runModConf->root; inst != NULL; inst = inst->next) {
         if (inst->bEnableLstn) {
             pthread_join(inst->tid, NULL);
+            DTLSCloseSocket(inst);
         }
     }
 

--- a/plugins/imklog/imklog.c
+++ b/plugins/imklog/imklog.c
@@ -293,7 +293,7 @@ BEGINrunInput
      * signalled to do so. This, however, is handled by the framework,
      * right into the sleep below.
      */
-    while (!pThrd->bShallStop) {
+    while (!thrdGetShallStop(pThrd)) {
         /* klogLogKMsg() waits for the next kernel message, obtains it
          * and then submits it to the rsyslog main queue.
          * rgerhards, 2008-04-09

--- a/plugins/imsolaris/imsolaris.c
+++ b/plugins/imsolaris/imsolaris.c
@@ -248,12 +248,12 @@ static rsRetVal getMsgs(thrdInfo_t *pThrd, int timeout) {
         CHKmalloc(pRcv = (uchar *)malloc(iMaxLine + 1));
     }
 
-    while (pThrd->bShallStop != RSTRUE) {
+    while (thrdGetShallStop(pThrd) != RSTRUE) {
         DBGPRINTF("imsolaris: waiting for next message (timeout %d)...\n", timeout);
         if (timeout == 0) {
             nfds = poll(&sun_Pfd, 1, timeout); /* wait without timeout */
 
-            if (pThrd->bShallStop == RSTRUE) {
+            if (thrdGetShallStop(pThrd) == RSTRUE) {
                 break;
             }
 
@@ -344,7 +344,7 @@ BEGINrunInput
     DBGPRINTF("imsolaris: starting regular poll loop\n");
     iRet = getMsgs(pThrd, -1); /* this is the primary poll loop, infinite timeout */
 
-    DBGPRINTF("imsolaris: terminating (bShallStop=%d)\n", pThrd->bShallStop);
+    DBGPRINTF("imsolaris: terminating (bShallStop=%d)\n", thrdGetShallStop(pThrd));
 finalize_it:
     RETiRet;
 ENDrunInput

--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -614,7 +614,7 @@ static rsRetVal processSocket(struct wrkrInfo_s *pWrkr,
     multiSub.nElem = 0;
     iNbrTimeUsed = 0;
     while (1) { /* loop is terminated if we have a "bad" receive, done below in the body */
-        if (pWrkr->pThrd->bShallStop == RSTRUE) ABORT_FINALIZE(RS_RET_FORCE_TERM);
+        if (thrdGetShallStop(pWrkr->pThrd) == RSTRUE) ABORT_FINALIZE(RS_RET_FORCE_TERM);
         memset(pWrkr->recvmsg_iov, 0, runModConf->batchSize * sizeof(struct iovec));
         memset(pWrkr->recvmsg_mmh, 0, runModConf->batchSize * sizeof(struct mmsghdr));
         memset(pWrkr->frominet, 0, runModConf->batchSize * sizeof(struct sockaddr_storage));
@@ -701,7 +701,7 @@ static rsRetVal processSocket(struct wrkrInfo_s *pWrkr,
     multiSub.nElem = 0;
     iNbrTimeUsed = 0;
     while (1) { /* loop is terminated if we have a bad receive, done below in the body */
-        if (pWrkr->pThrd->bShallStop == RSTRUE) ABORT_FINALIZE(RS_RET_FORCE_TERM);
+        if (thrdGetShallStop(pWrkr->pThrd) == RSTRUE) ABORT_FINALIZE(RS_RET_FORCE_TERM);
         memset(&frominet, 0, sizeof(frominet));
         memset(iov, 0, sizeof(iov));
         iov[0].iov_base = pWrkr->pRcvBuf;
@@ -920,12 +920,12 @@ static rsRetVal rcvMainLoop(struct wrkrInfo_s *const __restrict__ pWrkr) {
         nfds = epoll_wait(efd, currEvt, NUM_EPOLL_EVENTS, -1);
         DBGPRINTF("imudp: epoll_wait() returned with %d fds\n", nfds);
 
-        if (pWrkr->pThrd->bShallStop == RSTRUE) break; /* terminate input! */
+        if (thrdGetShallStop(pWrkr->pThrd) == RSTRUE) break; /* terminate input! */
 
         for (i = 0; i < nfds; ++i) {
             processSocket(pWrkr, currEvt[i].data.ptr, &frominetPrev, &bIsPermitted);
         }
-        if (pWrkr->pThrd->bShallStop == RSTRUE) break; /* terminate input! */
+        if (thrdGetShallStop(pWrkr->pThrd) == RSTRUE) break; /* terminate input! */
     }
 
 finalize_it:

--- a/plugins/omsendertrack/omsendertrack.c
+++ b/plugins/omsendertrack/omsendertrack.c
@@ -33,6 +33,7 @@
  */
 #include "config.h"
 #include "rsyslog.h"
+#include "atomic.h"
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdarg.h>
@@ -94,6 +95,7 @@ typedef struct _instanceData {
     pthread_rwlock_t mutSenders; /**< protects the sender hash table */
     struct hashtable *stats_senders; /**< hash table of sender_stats_t */
     int bShutdownBackgroundWriter; /**< tells bgwriter to terminate */
+    DEF_ATOMIC_HELPER_MUT(mutShutdownBackgroundWriter);
     pthread_t bgw_tid; /**< thread ID of background writer */
     int bgw_initialized; /**< indicates thread started */
 } instanceData;
@@ -552,9 +554,9 @@ static void *bgWriter(void *arg) {
     }
 #endif
 
-    while (pData->bShutdownBackgroundWriter == 0) {
+    while (ATOMIC_FETCH_32BIT(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter) == 0) {
         srSleep(pData->interval, 0);
-        if (pData->bShutdownBackgroundWriter == 1) {
+        if (ATOMIC_FETCH_32BIT(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter) == 1) {
             break;
         }
         dbgprintf("bgwriter writing report file\n");
@@ -666,7 +668,7 @@ BEGINfreeInstance
     CODESTARTfreeInstance;
     /* stop bgWriter */
     if (pData->bgw_initialized) {
-        pData->bShutdownBackgroundWriter = 1;
+        ATOMIC_STORE_1_TO_INT(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter);
         pthread_kill(pData->bgw_tid, SIGTTIN);
 
         /* wait until stopped */
@@ -683,6 +685,7 @@ BEGINfreeInstance
     free((void *)pData->statefile);
     if (pData->statefile_tmp) free((void *)pData->statefile_tmp);
     pthread_rwlock_destroy(&pData->mutSenders);
+    DESTROY_ATOMIC_HELPER_MUT(pData->mutShutdownBackgroundWriter);
     hashtable_destroy(pData->stats_senders, 1); /* 1 => free all values automatically */
 ENDfreeInstance
 
@@ -749,6 +752,7 @@ BEGINnewActInst
     }
 
     CHKiRet(createInstance(&pData));
+    INIT_ATOMIC_HELPER_MUT(pData->mutShutdownBackgroundWriter);
     CHKiRet(setInstParamDefaults(pData));
 
     for (i = 0; i < actpblk.nParams; ++i) {
@@ -801,6 +805,7 @@ BEGINparseSelectorAct
     /* ok, if we reach this point, we have something for us */
     p += sizeof(":omsendertrack:") - 1; /* eat indicator sequence  (-1 because of '\0'!) */
     CHKiRet(createInstance(&pData));
+    INIT_ATOMIC_HELPER_MUT(pData->mutShutdownBackgroundWriter);
 
     /* check if a non-standard template is to be applied */
     if (*(p - 1) == ';') --p;

--- a/runtime/action.c
+++ b/runtime/action.c
@@ -794,6 +794,24 @@ static void ATTR_NONNULL() actionRetry(action_t *const pThis, wti_t *const pWti)
     incActionResumeInRow(pWti, pThis);
 }
 
+static time_t actionGetResumeRetryTime(const action_t *const pThis) {
+#ifdef HAVE_ATOMIC_BUILTINS64
+    return __atomic_load_n(&pThis->ttResumeRtry, __ATOMIC_RELAXED);
+#else
+    return pThis->ttResumeRtry;
+#endif
+}
+
+
+static void actionSetResumeRetryTime(action_t *const pThis, const time_t ttResumeRtry) {
+#ifdef HAVE_ATOMIC_BUILTINS64
+    __atomic_store_n(&pThis->ttResumeRtry, ttResumeRtry, __ATOMIC_RELAXED);
+#else
+    pThis->ttResumeRtry = ttResumeRtry;
+#endif
+}
+
+
 /* Suspend action, this involves changing the action state as well
  * as setting the next retry time.
  * if we have more than 10 retries, we prolong the
@@ -804,6 +822,7 @@ static void ATTR_NONNULL() actionRetry(action_t *const pThis, wti_t *const pWti)
  */
 static void ATTR_NONNULL() actionSuspend(action_t *const pThis, wti_t *const pWti) {
     time_t ttNow;
+    time_t ttResumeRtry;
     int suspendDuration;
     char timebuf[32];
 
@@ -818,15 +837,16 @@ static void ATTR_NONNULL() actionSuspend(action_t *const pThis, wti_t *const pWt
     if (pThis->iResumeIntervalMax > 0 && suspendDuration > pThis->iResumeIntervalMax) {
         suspendDuration = pThis->iResumeIntervalMax;
     }
-    pThis->ttResumeRtry = ttNow + suspendDuration;
+    ttResumeRtry = ttNow + suspendDuration;
+    actionSetResumeRetryTime(pThis, ttResumeRtry);
     actionSetState(pThis, __func__, pWti, ACT_STATE_SUSP);
-    pThis->ctrSuspendDuration += suspendDuration;
+    STATSCOUNTER_ADD(pThis->ctrSuspendDuration, pThis->mutCtrSuspendDuration, suspendDuration);
     if (getActionNbrResRtry(pWti, pThis) == 0) {
         STATSCOUNTER_INC(pThis->ctrSuspend, pThis->mutCtrSuspend);
     }
 
     if (pThis->bReportSuspensionCont || (pThis->bReportSuspension && getActionNbrResRtry(pWti, pThis) == 0)) {
-        ctime_r(&pThis->ttResumeRtry, timebuf);
+        ctime_r(&ttResumeRtry, timebuf);
         timebuf[strlen(timebuf) - 1] = '\0'; /* strip LF */
         LogMsg(0, RS_RET_SUSPENDED, LOG_WARNING,
                "action '%s' suspended (module '%s'), next retry is %s, retry nbr %d. "
@@ -836,8 +856,7 @@ static void ATTR_NONNULL() actionSuspend(action_t *const pThis, wti_t *const pWt
     DBGPRINTF(
         "action '%s' suspended, earliest retry=%lld (now %lld), iNbrResRtry %d, "
         "duration %d\n",
-        pThis->pszName, (long long)pThis->ttResumeRtry, (long long)ttNow, getActionNbrResRtry(pWti, pThis),
-        suspendDuration);
+        pThis->pszName, (long long)ttResumeRtry, (long long)ttNow, getActionNbrResRtry(pWti, pThis), suspendDuration);
 }
 
 
@@ -905,8 +924,8 @@ static rsRetVal ATTR_NONNULL() actionDoRetry(action_t *const pThis, wti_t *const
                 DBGPRINTF(
                     "actionDoRetry: %s, controlled by resumeInterval, may miss the next try."
                     "Will sleep %d seconds. ResumeRtry=%lld (now %lld), iRetries %d\n",
-                    pThis->pszName, pThis->iResumeInterval, (long long)pThis->ttResumeRtry, (long long)ttTemp,
-                    iRetries);
+                    pThis->pszName, pThis->iResumeInterval, (long long)actionGetResumeRetryTime(pThis),
+                    (long long)ttTemp, iRetries);
                 srSleep(pThis->iResumeInterval, 0);
                 if (*pWti->pbShutdownImmediate) {
                     ABORT_FINALIZE(RS_RET_FORCE_TERM);
@@ -1085,7 +1104,7 @@ static rsRetVal actionTryResume(action_t *const pThis, wti_t *const pWti) {
          * here. -- rgerhards, 2009-03-18
          */
         datetime.GetTime(&ttNow); /* cache "now" */
-        if (ttNow >= pThis->ttResumeRtry) {
+        if (ttNow >= actionGetResumeRetryTime(pThis)) {
             actionSetState(pThis, __func__, pWti, ACT_STATE_RTRY); /* back to retries */
         }
     }
@@ -1099,7 +1118,7 @@ static rsRetVal actionTryResume(action_t *const pThis, wti_t *const pWti) {
         if (ttNow == NO_TIME_PROVIDED) /* use cached result if we have it */
             datetime.GetTime(&ttNow);
         dbgprintf("actionTryResume: action[%s] state: %s, next retry (if applicable): %u [now %u]\n", pThis->pszName,
-                  getActStateName(pThis, pWti), (unsigned)pThis->ttResumeRtry, (unsigned)ttNow);
+                  getActStateName(pThis, pWti), (unsigned)actionGetResumeRetryTime(pThis), (unsigned)ttNow);
     }
 
 finalize_it:

--- a/runtime/srutils.c
+++ b/runtime/srutils.c
@@ -816,7 +816,7 @@ rsRetVal ATTR_NONNULL() split_binary_parameters(uchar **const szBinary,
     DBGPRINTF("iParams %d (+1 for NULL terminator)\n", *iParams);
 
     /* create argv[] */
-    CHKmalloc(*aParams = malloc((*iParams + 1) * sizeof(char *)));
+    CHKmalloc(*aParams = calloc(*iParams + 1, sizeof(char *)));
     iPrm = 0;
     bInQuotes = FALSE;
     /* Set first parameter to binary */

--- a/runtime/statsobj.c
+++ b/runtime/statsobj.c
@@ -308,14 +308,50 @@ static void destructCounter(statsobj_t *pThis, ctr_t *pCtr) {
     destructUnlinkedCounter(pCtr);
 }
 
+static intctr_t getIntCtrValue(const intctr_t *const ctr) {
+#ifdef HAVE_ATOMIC_BUILTINS64
+    return __atomic_load_n(ctr, __ATOMIC_RELAXED);
+#else
+    return *ctr;
+#endif
+}
+
+
+static void resetIntCtrValue(intctr_t *const ctr) {
+#ifdef HAVE_ATOMIC_BUILTINS64
+    __atomic_store_n(ctr, 0, __ATOMIC_RELAXED);
+#else
+    *ctr = 0;
+#endif
+}
+
+
+static int getIntValue(const int *const ctr) {
+#ifdef HAVE_ATOMIC_BUILTINS
+    return __atomic_load_n(ctr, __ATOMIC_RELAXED);
+#else
+    return *ctr;
+#endif
+}
+
+
+static void resetIntValue(int *const ctr) {
+#ifdef HAVE_ATOMIC_BUILTINS
+    __atomic_store_n(ctr, 0, __ATOMIC_RELAXED);
+#else
+    *ctr = 0;
+#endif
+}
+
+
 static void resetResettableCtr(ctr_t *pCtr, int8_t bResetCtrs) {
     if ((bResetCtrs && (pCtr->flags & CTR_FLAG_RESETTABLE)) || (pCtr->flags & CTR_FLAG_MUST_RESET)) {
         switch (pCtr->ctrType) {
             case ctrType_IntCtr:
-                *(pCtr->val.pIntCtr) = 0;
+                resetIntCtrValue(pCtr->val.pIntCtr);
                 break;
             case ctrType_Int:
-                *(pCtr->val.pInt) = 0;
+                resetIntValue(pCtr->val.pInt);
                 break;
             default:
                 // No action needed for other cases
@@ -355,9 +391,9 @@ finalize_it:
 static intctr_t accumulatedValue(ctr_t *pCtr) {
     switch (pCtr->ctrType) {
         case ctrType_IntCtr:
-            return *(pCtr->val.pIntCtr);
+            return getIntCtrValue(pCtr->val.pIntCtr);
         case ctrType_Int:
-            return *(pCtr->val.pInt);
+            return (intctr_t)getIntValue(pCtr->val.pInt);
         default:
             // No action needed for other cases
             break;
@@ -469,10 +505,10 @@ static rsRetVal getStatsLine(statsobj_t *pThis, cstr_t **ppcstr, int8_t bResetCt
         cstrAppendChar(pcstr, '=');
         switch (pCtr->ctrType) {
             case ctrType_IntCtr:
-                rsCStrAppendInt(pcstr, *(pCtr->val.pIntCtr));  // TODO: OK?????
+                rsCStrAppendInt(pcstr, getIntCtrValue(pCtr->val.pIntCtr));
                 break;
             case ctrType_Int:
-                rsCStrAppendInt(pcstr, *(pCtr->val.pInt));
+                rsCStrAppendInt(pcstr, getIntValue(pCtr->val.pInt));
                 break;
             default:
                 // No action needed for other cases
@@ -563,10 +599,10 @@ static ATTR_NO_SANITIZE_THREAD rsRetVal emitPrometheusForObject(statsobj_t *o,
         /* 1) Read the current accumulated value.  Might be IntCtr or Int. */
         switch (pCtr->ctrType) {
             case ctrType_IntCtr:
-                value = *(pCtr->val.pIntCtr);
+                value = getIntCtrValue(pCtr->val.pIntCtr);
                 break;
             case ctrType_Int:
-                value = (uint64_t)(*(pCtr->val.pInt));
+                value = (uint64_t)getIntValue(pCtr->val.pInt);
                 break;
             default:
                 value = 0;
@@ -577,10 +613,10 @@ static ATTR_NO_SANITIZE_THREAD rsRetVal emitPrometheusForObject(statsobj_t *o,
         if ((bResetCtrs && (pCtr->flags & CTR_FLAG_RESETTABLE)) || (pCtr->flags & CTR_FLAG_MUST_RESET)) {
             switch (pCtr->ctrType) {
                 case ctrType_IntCtr:
-                    *(pCtr->val.pIntCtr) = 0;
+                    resetIntCtrValue(pCtr->val.pIntCtr);
                     break;
                 case ctrType_Int:
-                    *(pCtr->val.pInt) = 0;
+                    resetIntValue(pCtr->val.pInt);
                     break;
                 default:
                     break;
@@ -732,8 +768,7 @@ static rsRetVal getAllCounters(statsobj_counter_cb_t cb, void *ctx) {
             /* Read counter value based on type */
             switch (ctr->ctrType) {
                 case ctrType_IntCtr:
-                    /* Atomic uint64 - safe to read directly */
-                    value = *(ctr->val.pIntCtr);
+                    value = getIntCtrValue(ctr->val.pIntCtr);
                     break;
 
                 case ctrType_Int:
@@ -741,7 +776,7 @@ static rsRetVal getAllCounters(statsobj_counter_cb_t cb, void *ctx) {
                      * behavior. Value may be stale but acceptable for monitoring.
                      * Most ctrType_Int counters are gauges (queue size, open files)
                      * protected by application-level mutexes. */
-                    value = (uint64_t)(*(ctr->val.pInt));
+                    value = (uint64_t)getIntValue(ctr->val.pInt);
                     break;
 
                 default:

--- a/runtime/threads.c
+++ b/runtime/threads.c
@@ -61,6 +61,7 @@ static rsRetVal thrdConstruct(thrdInfo_t **ppThis) {
     CHKmalloc(pThis = calloc(1, sizeof(thrdInfo_t)));
     pthread_mutex_init(&pThis->mutThrd, NULL);
     pthread_cond_init(&pThis->condThrdTerm, NULL);
+    INIT_ATOMIC_HELPER_MUT(pThis->mutShallStop);
     *ppThis = pThis;
 
 finalize_it:
@@ -90,6 +91,7 @@ static rsRetVal thrdDestruct(thrdInfo_t *pThis) {
 
     pthread_mutex_destroy(&pThis->mutThrd);
     pthread_cond_destroy(&pThis->condThrdTerm);
+    DESTROY_ATOMIC_HELPER_MUT(pThis->mutShallStop);
     free(pThis->name);
     free(pThis);
 
@@ -110,7 +112,7 @@ static rsRetVal thrdTerminateNonCancel(thrdInfo_t *pThis) {
 
     DBGPRINTF("request term via SIGTTIN for input thread '%s' %p\n", pThis->name, (void *)pThis->thrdID);
 
-    pThis->bShallStop = RSTRUE;
+    thrdSetShallStop(pThis);
     d_pthread_mutex_lock(&pThis->mutThrd);
     timeoutComp(&tTimeout, runConf->globals.inputTimeoutShutdown);
     was_active = pThis->bIsActive;

--- a/runtime/threads.h
+++ b/runtime/threads.h
@@ -22,18 +22,29 @@
 #ifndef THREADS_H_INCLUDED
 #define THREADS_H_INCLUDED
 
+#include "atomic.h"
+
 /* the thread object */
 struct thrdInfo {
     pthread_mutex_t mutThrd; /* mutex for handling long-running operations and shutdown */
     pthread_cond_t condThrdTerm; /* condition: thread terminates (used just for shutdown loop) */
     int bIsActive; /* Is thread running? */
     int bShallStop; /* set to 1 if the thread should be stopped ? */
+    DEF_ATOMIC_HELPER_MUT(mutShallStop);
     rsRetVal (*pUsrThrdMain)(struct thrdInfo *); /* user thread main to be called in new thread */
     rsRetVal (*pAfterRun)(struct thrdInfo *); /* cleanup function */
     pthread_t thrdID;
     sbool bNeedsCancel; /* must input be terminated by pthread_cancel()? */
     uchar *name; /* a thread name, mainly for user interaction */
 };
+
+static inline int thrdGetShallStop(thrdInfo_t *pThis) {
+    return ATOMIC_FETCH_32BIT(&pThis->bShallStop, &pThis->mutShallStop);
+}
+
+static inline void thrdSetShallStop(thrdInfo_t *pThis) {
+    ATOMIC_STORE_1_TO_INT(&pThis->bShallStop, &pThis->mutShallStop);
+}
 
 /* prototypes */
 rsRetVal thrdExit(void);

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -58,11 +58,19 @@ minimal containers. Findings are review prompts, not automatic blockers.
   testbench helpers; if custom plumbing is required, make ownership and cleanup
   explicit.
 - **Daemonized shutdown tests without a final rsyslogd oracle**: shell ``wait``
-  cannot observe the real daemon process exit status after rsyslogd forks. For
-  daemonized tests that care about crashes or clean shutdown, use
-  ``set_proper_termination_file`` before ``generate_conf`` and
-  ``check_proper_termination`` after ``wait_shutdown``. Do not use helper
-  cleanup or observer processes as the clean-shutdown oracle. ``timeoutGuard``
+  cannot observe the real daemon process exit status after rsyslogd forks.
+  Regular ``generate_conf`` tests get a proper termination file automatically
+  from ``RSYSLOG_DYNNAME`` plus the instance suffix, and ``wait_shutdown``
+  validates it when shutdown was initiated through harness helpers that saved
+  the rsyslogd pid. Use the standard ``shutdown_when_empty`` or
+  ``shutdown_immediate`` path for shutdown or crash-sensitive tests. Use
+  ``set_proper_termination_file`` only for special manual-startup or
+  non-generated-config cases, and use ``check_proper_termination`` only when
+  such a special path cannot use ``wait_shutdown``. Do not use helper cleanup
+  or observer processes as the clean-shutdown oracle. Tests that intentionally
+  kill rsyslogd to create dirty state must use the harness kill helper so
+  ``wait_shutdown`` does not expect a clean main-return marker for that phase.
+  ``timeoutGuard``
   remains mandatory hang protection and must not be removed, disabled, or
   weakened to make such tests pass; if timeoutGuard aborts rsyslogd, it must
   preserve the termination marker with ``status=error`` and useful diagnostics.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -310,6 +310,7 @@ TESTS_DEFAULT = \
 	asynwr_deadlock4.sh \
 	asynwr_dynfile_flushtxend-off.sh \
 	imdiag-modern-module-config.sh \
+	imdiag-proper-termination-core-ignore.sh \
 	imdiag-proper-termination-timeoutguard.sh \
 	global-maxopenfiles-rainerscript.sh \
 	compat-configformat-rainerscript.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -441,6 +441,7 @@ generate_conf() {
 		export RSYSLOG_PIDBASE="${RSYSLOG_DYNNAME}:" # also used by instance 2!
 		mkdir -p $RSYSLOG_DYNNAME.spool
 	fi
+	set_proper_termination_file "$1"
 	local proper_termination_file_var="RSTB_PROPER_TERMINATION_FILE$1"
 	local proper_termination_file="${!proper_termination_file_var:-}"
 	if [ "$yaml_only" = "1" ]; then
@@ -538,15 +539,20 @@ set_proper_termination_file() {
 	fi
 	local proper_termination_file="$PWD/$RSYSLOG_DYNNAME.proper-termination$suffix"
 	export "${proper_termination_file_var}=$proper_termination_file"
+	rm -f "$proper_termination_file"
 }
 
 proper_termination_file_is_valid() {
-	local file
+	local file expected_pid
 	file="$(get_proper_termination_file "$1")"
+	expected_pid="${2:-}"
 	[ -n "$file" ] || return 1
 	[ -f "$file" ] || return 1
 	grep -qx 'status=ok' "$file" || return 1
 	grep -qx 'phase=main-return' "$file" || return 1
+	if [ -n "$expected_pid" ]; then
+		grep -qx "pid=$expected_pid" "$file" || return 1
+	fi
 	return 0
 }
 
@@ -566,7 +572,7 @@ print_proper_termination_file() {
 check_proper_termination() {
 	local file
 	file="$(get_proper_termination_file "$1")"
-	if proper_termination_file_is_valid "$1"; then
+	if proper_termination_file_is_valid "$1" "$2"; then
 		return
 	fi
 	printf 'FAIL: proper termination file missing or invalid: %s\n' "${file:-<not configured>}"
@@ -640,6 +646,7 @@ cmp_exact_file() {
 # code common to all startup...() functions
 startup_common() {
 	instance=
+	local proper_termination_file
 	if [ "$RSYSLOG_YAML_ONLY" = "1" ]; then
 		if [ "$1" == "2" ]; then
 		    CONF_FILE="${TESTCONF_NM}2.yaml"
@@ -667,6 +674,10 @@ startup_common() {
 	# starts rsyslog multiple times does not pick up the old port number.
 	rm -f "$RSYSLOG_PIDBASE$instance.pid"
 	rm -f $RSYSLOG_DYNNAME.imdiag$instance.port
+	proper_termination_file="$(get_proper_termination_file "$instance")"
+	if [ -n "$proper_termination_file" ]; then
+		rm -f "$proper_termination_file"
+	fi
 	if [ ! -f $CONF_FILE ]; then
 	    echo "ERROR: config file '$CONF_FILE' not found!"
 	    error_exit 1
@@ -1983,13 +1994,20 @@ shutdown_immediate() {
 # $1 is the instance
 # $2 optional timeout in seconds (defaults to remaining TB_TEST_MAX_RUNTIME window)
 wait_shutdown() {
-	local shutdown_deadline now timeout_override
+	local shutdown_deadline now timeout_override pid_save observed_shutdown expect_no_marker_var
 	timeout_override="${2:-}"
 	if [ "$USE_VALGRIND" == "YES" ] || [ "$USE_VALGRIND" == "YES-NOLEAK" ]; then
 		wait_shutdown_vg "$1"
 		return
 	fi
-	out_pid=$(cat $RSYSLOG_PIDBASE$1.pid.save)
+	pid_save="$RSYSLOG_PIDBASE$1.pid.save"
+	observed_shutdown=0
+	if [ -s "$pid_save" ]; then
+		out_pid=$(cat "$pid_save")
+		observed_shutdown=1
+	else
+		out_pid=""
+	fi
 	if [ -n "$timeout_override" ]; then
 		shutdown_deadline=$(( $(date +%s) + timeout_override ))
 	else
@@ -2025,7 +2043,13 @@ quit"
 		fi
 	done
 	unset terminated
-	unset out_pid
+	expect_no_marker_var="RSTB_EXPECT_NO_PROPER_TERMINATION${1:-}"
+	if [ "$observed_shutdown" -eq 1 ] && [ -n "$(get_proper_termination_file "$1")" ] &&
+		[ "${!expect_no_marker_var:-}" != "YES" ]; then
+		check_proper_termination "$1" "$out_pid"
+	fi
+	unset "$expect_no_marker_var"
+	unset observed_shutdown
 	# Check for test-specific core files first (prevents Issue #6268 race condition)
 	core_found=0
 	if [ -n "$RSYSLOG_DYNNAME" ]; then
@@ -2038,7 +2062,7 @@ quit"
 		core_found=1
 	fi
 	if [ $core_found -eq 1 ]; then
-		if proper_termination_file_is_valid "$1"; then
+		if proper_termination_file_is_valid "$1" "$out_pid"; then
 			printf 'INFO: core file exists, but proper termination file proves rsyslogd reached main return; ignoring as stale/foreign core\n'
 		else
 			printf 'ABORT! core file exists (maybe from a parallel run!)\n'
@@ -2048,6 +2072,7 @@ quit"
 			error_exit  1
 		fi
 	fi
+	unset out_pid
 }
 
 
@@ -2275,7 +2300,9 @@ issue_HUP() {
 
 # actually, we wait for rsyslog.pid to be deleted. $1 is the instance
 wait_shutdown_vg() {
-	wait $(cat $RSYSLOG_PIDBASE$1.pid)
+	local out_pid expect_no_marker_var
+	out_pid="$(cat $RSYSLOG_PIDBASE$1.pid)"
+	wait "$out_pid"
 	export RSYSLOGD_EXIT=$?
 	echo rsyslogd run exited with $RSYSLOGD_EXIT
 
@@ -2287,6 +2314,11 @@ wait_shutdown_vg() {
 	if [ "$USE_VALGRIND" == "YES" ] || [ "$USE_VALGRIND" == "YES-NOLEAK" ]; then
 		check_exit_vg
 	fi
+	expect_no_marker_var="RSTB_EXPECT_NO_PROPER_TERMINATION${1:-}"
+	if [ -n "$(get_proper_termination_file "$1")" ] && [ "${!expect_no_marker_var:-}" != "YES" ]; then
+		check_proper_termination "$1" "$out_pid"
+	fi
+	unset "$expect_no_marker_var"
 }
 
 check_file_exists() {
@@ -5443,6 +5475,7 @@ make -j$(getconf _NPROCESSORS_ONLN) check TESTS="" || error_exit 100
 		fi
 		;;
    'kill-immediate') # kill rsyslog unconditionally
+		export RSTB_EXPECT_NO_PROPER_TERMINATION=YES
 		kill -9 $(cat $RSYSLOG_PIDBASE.pid)
 		# note: we do not wait for the actual termination!
 		;;

--- a/tests/imdiag-proper-termination-core-ignore.sh
+++ b/tests/imdiag-proper-termination-core-ignore.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Verify regular diag.sh-generated rsyslog tests get a proper termination
+# marker automatically. A clean shutdown with that marker must not fail because
+# a generic core.* file from another parallel test is present in the test dir.
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=1
+
+test_error_exit_handler() {
+	rm -f core.foreign-from-other-test
+}
+
+generate_conf
+add_conf 'action(type="omfile" file="'$RSYSLOG_OUT_LOG'")'
+startup
+injectmsg 0 "$NUMMESSAGES"
+touch core.foreign-from-other-test
+shutdown_when_empty
+wait_shutdown
+
+rm -f core.foreign-from-other-test
+
+exit_test

--- a/tests/imdiag-proper-termination-timeoutguard.sh
+++ b/tests/imdiag-proper-termination-timeoutguard.sh
@@ -12,7 +12,6 @@ fi
 # aborts rsyslogd, so disable core files after init to avoid polluting CI hosts.
 ulimit -c 0 || true
 
-set_proper_termination_file
 generate_conf
 export RS_REDIR=">$RSYSLOG_DYNNAME.rsyslog.log 2>&1"
 startup_common "" ""

--- a/tests/omkafka-unreachable-shutdown.sh
+++ b/tests/omkafka-unreachable-shutdown.sh
@@ -2,9 +2,6 @@
 # Regression coverage for GitHub issue #4452. An unreachable Kafka broker can
 # trigger delivery callbacks during shutdown. This test runs rsyslogd in daemon
 # mode because the regression path is shutdown of the backgrounded process.
-# The proper termination file is written as rsyslogd's final main-return action;
-# its absence catches daemon crashes whose core dump may be captured outside the
-# test directory, where local core-file checks alone would miss the failure.
 . ${srcdir:=.}/diag.sh init
 require_plugin omkafka
 skip_TSAN "daemonized shutdown with imdiag injection forks while rsyslog threads are active"
@@ -13,7 +10,6 @@ export RSTB_DAEMONIZE="YES"
 export RSTB_GLOBAL_INPUT_SHUTDOWN_TIMEOUT=10000
 export NUMMESSAGES=2
 
-set_proper_termination_file
 generate_conf
 add_conf '
 module(load="../plugins/omkafka/.libs/omkafka")
@@ -50,7 +46,6 @@ wait_shutdown
 if [ -f "$RSYSLOG_OUT_LOG" ]; then
     check_not_present "Segmentation fault" "$RSYSLOG_OUT_LOG"
 fi
-check_proper_termination
 check_file_exists "$RSYSLOG_DYNNAME.failedmsg"
 
 exit_test


### PR DESCRIPTION
## Summary

- configure `imdiag` proper termination markers automatically for regular `generate_conf` testbench instances
- keep explicit marker helpers for special manual-startup or non-generated-config cases
- add focused coverage that a generic `core.*` from another parallel test is ignored after a clean, marked shutdown
- update the testbench docs and existing omkafka/timeoutGuard tests to use the new default behavior
- keep the affected tests enabled under TSAN and fix the sanitizer-visible shutdown/data-access races exposed by the stricter oracle

## Rationale

The proper termination marker introduced for daemonized shutdown tests is the right first-class oracle for clean rsyslogd termination. Leaving it opt-in still allows the older #6268-style generic core-file contamination class for regular tests. With this change, generated test configs get the marker by default, so `wait_shutdown` can distinguish a clean rsyslogd main-return from stale or foreign generic core files.

This also addresses the clean-shutdown detection gap from #7285: daemonized tests no longer need to infer rsyslogd success from shell `wait` or generic core-file scans alone. The stricter oracle made several existing TSAN-visible races observable, so this update fixes those instead of skipping the tests.

## TSAN Fixes

- read input-thread `bShallStop` through the existing atomic helper pattern
- make `omsendertrack` background-writer shutdown polling atomic
- read/reset stats counters with atomic builtins where available
- access action resume retry timestamps atomically
- close the `imdtls` listener socket only after the handler thread has joined
- initialize `split_binary_parameters` argv storage so ASAN cleanup cannot free an uninitialized poisoned pointer

## Validation

- `git diff --check`
- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --enable-omkafka --enable-kafka-tests`
- `make -j$(nproc) check TESTS=""`
- `bash -n tests/diag.sh tests/imdiag-proper-termination-core-ignore.sh tests/imdiag-proper-termination-timeoutguard.sh tests/omkafka-unreachable-shutdown.sh`
- `devtools/check-test-antipatterns.sh tests/imdiag-proper-termination-core-ignore.sh tests/imdiag-proper-termination-timeoutguard.sh tests/omkafka-unreachable-shutdown.sh`
- `make -j$(nproc) check TESTS="imdiag-proper-termination-core-ignore.sh imdiag-proper-termination-timeoutguard.sh omkafka-unreachable-shutdown.sh"`
- direct focused runs of `imdiag-proper-termination-core-ignore.sh`, `imdiag-proper-termination-timeoutguard.sh`, and `omkafka-unreachable-shutdown.sh`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"`
- TSAN focused regression set including the imudp/parser/omsendertrack/ratelimit cases, `omrelp-shutdown-partial-session.sh`, and `imdtls-basic-timeout.sh`
- TSAN full test phase in `rsyslog/rsyslog_dev_base_ubuntu:26.04`: `make -C tests -j10 VERBOSE=1 check` with `-fsanitize=thread`, result `1104 PASS`, `31 SKIP`, `0 FAIL`
- clean broader local container CI in `rsyslog/rsyslog_dev_base_ubuntu:26.04` after removing stale TSAN objects: `devtools/run-ci.sh`, result `1363 PASS`, `29 SKIP`, `0 FAIL`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->