### PR TITLE
omelasticsearch: escape bulk metadata values

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -1007,6 +1007,67 @@ static int ATTR_NONNULL(1) getTemplateCount(const instanceData *const pData) {
 }
 
 
+/* Bulk metadata values are JSON strings. Dynamic templates may include
+ * untrusted message content, so quote, backslash, and control bytes before
+ * inserting values into the bulk control line.
+ */
+static size_t jsonEscapedLen(const uchar *const str) {
+    size_t len = 0;
+
+    if (str == NULL) return 0;
+
+    for (const uchar *p = str; *p != '\0'; ++p) {
+        if (*p == '"' || *p == '\\') {
+            len += 2;
+        } else if (*p < 0x20) {
+            len += sizeof("\\u00ff") - 1;
+        } else {
+            ++len;
+        }
+    }
+    return len;
+}
+
+
+static int addJsonEscapedBuf(es_str_t **const buf, const uchar *const str) {
+    static const char hex[] = "0123456789abcdef";
+    const uchar *chunk = str;
+    int r = 0;
+
+    if (str == NULL) return 0;
+
+    const uchar *p;
+    for (p = str; *p != '\0'; ++p) {
+        char esc[sizeof("\\u00ff") - 1];
+        size_t escLen;
+
+        if (*p == '"' || *p == '\\') {
+            esc[0] = '\\';
+            esc[1] = (char)*p;
+            escLen = 2;
+        } else if (*p < 0x20) {
+            esc[0] = '\\';
+            esc[1] = 'u';
+            esc[2] = '0';
+            esc[3] = '0';
+            esc[4] = hex[*p >> 4];
+            esc[5] = hex[*p & 0x0f];
+            escLen = sizeof("\\u00ff") - 1;
+        } else {
+            continue;
+        }
+
+        if (p > chunk) r = es_addBuf(buf, (const char *)chunk, (size_t)(p - chunk));
+        if (r == 0) r = es_addBuf(buf, esc, escLen);
+        if (r != 0) return r;
+        chunk = p + 1;
+    }
+
+    if (p > chunk) r = es_addBuf(buf, (const char *)chunk, (size_t)(p - chunk));
+    return r;
+}
+
+
 static rsRetVal ATTR_NONNULL(1) validateActionStrings(const instanceData *const pData, uchar **const tpls) {
     DEFiRet;
 
@@ -1123,23 +1184,23 @@ static size_t computeMessageSize(const wrkrInstanceData_t *const pWrkrData,
     getIndexTypeAndParent(pWrkrData->pData, tpls, &searchIndex, &searchType, &parent, &bulkId, &pipelineName);
     r += ustrlen((char *)message);
     if (searchIndex != NULL) {
-        r += ustrlen(searchIndex);
+        r += jsonEscapedLen(searchIndex);
     }
     if (searchType != NULL) {
         if (searchType[0] == '\0') {
             r += 4;  // "_doc"
         } else {
-            r += ustrlen(searchType);
+            r += jsonEscapedLen(searchType);
         }
     }
     if (parent != NULL) {
-        r += sizeof(META_PARENT) - 1 + ustrlen(parent);
+        r += sizeof(META_PARENT) - 1 + jsonEscapedLen(parent);
     }
     if (bulkId != NULL) {
-        r += sizeof(META_ID) - 1 + ustrlen(bulkId);
+        r += sizeof(META_ID) - 1 + jsonEscapedLen(bulkId);
     }
     if (pipelineName != NULL && (!pWrkrData->pData->skipPipelineIfEmpty || pipelineName[0] != '\0')) {
-        r += sizeof(META_PIPELINE) - 1 + ustrlen(pipelineName);
+        r += sizeof(META_PIPELINE) - 1 + jsonEscapedLen(pipelineName);
     }
 
     return r;
@@ -1171,26 +1232,26 @@ static rsRetVal buildBatch(wrkrInstanceData_t *pWrkrData, uchar *message, uchar 
         endQuote = 1;
         if (pWrkrData->pData->writeOperation == ES_WRITE_CREATE)
             if (r == 0) r = es_addBuf(&pWrkrData->batch.data, META_IX, sizeof(META_IX) - 1);
-        if (r == 0) r = es_addBuf(&pWrkrData->batch.data, (char *)searchIndex, ustrlen(searchIndex));
+        if (r == 0) r = addJsonEscapedBuf(&pWrkrData->batch.data, searchIndex);
         if (searchType != NULL && searchType[0] != '\0') {
             if (r == 0) r = es_addBuf(&pWrkrData->batch.data, META_TYPE, sizeof(META_TYPE) - 1);
-            if (r == 0) r = es_addBuf(&pWrkrData->batch.data, (char *)searchType, ustrlen(searchType));
+            if (r == 0) r = addJsonEscapedBuf(&pWrkrData->batch.data, searchType);
         }
     }
     if (parent != NULL) {
         endQuote = 1;
         if (r == 0) r = es_addBuf(&pWrkrData->batch.data, META_PARENT, sizeof(META_PARENT) - 1);
-        if (r == 0) r = es_addBuf(&pWrkrData->batch.data, (char *)parent, ustrlen(parent));
+        if (r == 0) r = addJsonEscapedBuf(&pWrkrData->batch.data, parent);
     }
     if (pipelineName != NULL && (!pWrkrData->pData->skipPipelineIfEmpty || pipelineName[0] != '\0')) {
         endQuote = 1;
         if (r == 0) r = es_addBuf(&pWrkrData->batch.data, META_PIPELINE, sizeof(META_PIPELINE) - 1);
-        if (r == 0) r = es_addBuf(&pWrkrData->batch.data, (char *)pipelineName, ustrlen(pipelineName));
+        if (r == 0) r = addJsonEscapedBuf(&pWrkrData->batch.data, pipelineName);
     }
     if (bulkId != NULL) {
         endQuote = 1;
         if (r == 0) r = es_addBuf(&pWrkrData->batch.data, META_ID, sizeof(META_ID) - 1);
-        if (r == 0) r = es_addBuf(&pWrkrData->batch.data, (char *)bulkId, ustrlen(bulkId));
+        if (r == 0) r = addJsonEscapedBuf(&pWrkrData->batch.data, bulkId);
     }
     if (endQuote == 0) {
         if (r == 0) r = es_addBuf(&pWrkrData->batch.data, META_END_NOQUOTE, sizeof(META_END_NOQUOTE) - 1);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -290,6 +290,7 @@ TESTS_DEFAULT = \
 	omfwd_ratelimit_name.sh \
 	omelasticsearch_ratelimit_name.sh \
 	omelasticsearch-dynsearch-template.sh \
+	omelasticsearch-bulk-metadata-escape.sh \
 	omelasticsearch-searchtype-deprecated.sh \
 	omhttp_ratelimit_name.sh \
 	imhttp_ratelimit_name.sh \

--- a/tests/omelasticsearch-bulk-metadata-escape.sh
+++ b/tests/omelasticsearch-bulk-metadata-escape.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Regression test for omelasticsearch bulk metadata JSON escaping. Dynamic
+# metadata templates can be derived from remote message content; the oracle is
+# the captured _bulk request body from a local HTTP endpoint. The first bulk
+# metadata line must remain valid JSON and preserve attacker-shaped quotes as
+# data inside _index, _type, _parent, and _id values. The local capture
+# server writes its dynamic port before rsyslog starts and is killed by trap.
+. ${srcdir:=.}/diag.sh init
+require_plugin omelasticsearch
+
+if ! command -v python3 >/dev/null 2>&1; then
+	printf 'SKIP: python3 is required for local omelasticsearch capture server\n'
+	skip_test
+fi
+
+cat > "$RSYSLOG_DYNNAME.capture-es.py" <<'PY'
+import http.server
+import json
+import pathlib
+import socketserver
+import sys
+
+base = pathlib.Path(sys.argv[1])
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+    def do_GET(self):
+        data = json.dumps({
+            'version': {
+                'number': '8.0.0',
+                'distribution': 'elasticsearch',
+                'build_flavor': 'default',
+            },
+            'tagline': 'You Know, for Search',
+        }).encode()
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', '0'))
+        body = self.rfile.read(length)
+        (base.with_suffix('.bulk.path')).write_text(self.path)
+        (base.with_suffix('.bulk.body')).write_bytes(body)
+        data = b'{"errors":false,"items":[{"index":{"status":201}}]}'
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, fmt, *args):
+        return
+
+with socketserver.TCPServer(('127.0.0.1', 0), Handler) as httpd:
+    base.with_suffix('.capture.port').write_text(str(httpd.server_address[1]))
+    httpd.serve_forever()
+PY
+
+python3 "$RSYSLOG_DYNNAME.capture-es.py" "$RSYSLOG_DYNNAME" &
+capture_pid=$!
+cleanup_capture() {
+	kill "$capture_pid" 2>/dev/null || true
+	wait "$capture_pid" 2>/dev/null || true
+}
+trap cleanup_capture EXIT
+
+wait_file_exists "$RSYSLOG_DYNNAME.capture.port" 10
+capture_port=$(cat "$RSYSLOG_DYNNAME.capture.port")
+
+generate_conf
+add_conf '
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+template(name="msgTpl" type="string" string="{\"msg\":\"%msg:::json%\"}")
+template(name="idxTpl" type="string" string="rsyslog-%msg%")
+template(name="typeTpl" type="string" string="type-%msg%")
+template(name="parentTpl" type="string" string="parent-%msg%")
+template(name="idTpl" type="string" string="id-%msg%")
+
+if $msg contains "bad" then {
+action(type="omelasticsearch"
+       server="127.0.0.1"
+       serverport="'$capture_port'"
+       bulkmode="on"
+       dynSearchIndex="on"
+       searchIndex="idxTpl"
+       dynSearchType="on"
+       searchType="typeTpl"
+       dynParent="on"
+       parent="parentTpl"
+       dynbulkid="on"
+       bulkid="idTpl"
+       template="msgTpl"
+       esversion.major="7"
+       action.resumeRetryCount="0"
+       action.resumeInterval="1")
+}
+'
+
+startup
+injectmsg_literal '<167>1 2003-03-01T01:00:00.000Z host testprog - - - bad"quote\slash'
+shutdown_when_empty
+wait_shutdown
+wait_file_exists "$RSYSLOG_DYNNAME.bulk.body" 10
+
+python3 - "$RSYSLOG_DYNNAME.bulk.path" "$RSYSLOG_DYNNAME.bulk.body" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1]).read_text()
+body = Path(sys.argv[2]).read_text()
+lines = body.splitlines()
+if path != '/_bulk':
+    raise SystemExit('unexpected bulk path: ' + path)
+if len(lines) != 2:
+    raise SystemExit('unexpected bulk body line count: ' + repr(lines))
+metadata = json.loads(lines[0])
+document = json.loads(lines[1])
+index = metadata['index']
+expected = r'bad"quote\slash'
+expected_values = {
+    '_index': 'rsyslog-' + expected,
+    '_type': 'type-' + expected,
+    '_parent': 'parent-' + expected,
+    '_id': 'id-' + expected,
+}
+if index != expected_values:
+    raise SystemExit('unexpected escaped metadata: ' + repr(index))
+if document != {'msg': expected}:
+    raise SystemExit('unexpected escaped document: ' + repr(document))
+PY
+if [ $? -ne 0 ]; then
+	error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
## Summary

This PR escapes dynamic omelasticsearch bulk metadata values before they are written into the Elasticsearch `_bulk` control line.

Dynamic metadata templates can intentionally derive values from message properties. Before this change, attacker-shaped characters such as quotes or backslashes could be inserted into `_index`, `_type`, `_parent`, `pipeline`, or `_id` metadata as raw JSON string content. That could malformed the bulk metadata line or alter metadata semantics for affected events on the configured Elasticsearch target.

This does not allow redirecting the Elasticsearch endpoint. Server, port, credentials, and transport settings remain fixed by rsyslog configuration.

## Changes

- Add a small JSON string escaper for omelasticsearch bulk metadata values.
- Use escaped lengths when estimating bulk batch size.
- Add a local HTTP capture regression test for dynamic metadata templates using message-derived content.
- Register the new test in the default testbench set.

## Validation

- Reproduced the issue before the fix with a captured invalid `_bulk` metadata line.
- Temporarily reversed only the C fix and confirmed the new test fails with `JSONDecodeError`.
- `./autogen.sh --enable-elasticsearch --enable-testbench --disable-generate-man-pages`
- `make -j${RSYSLOG_LOCAL_BUILD_JOBS:-10} check TESTS=""`
- `cd tests && ./omelasticsearch-bulk-metadata-escape.sh`
- `cd tests && ./omelasticsearch-dynsearch-template.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `shellcheck -S warning tests/omelasticsearch-bulk-metadata-escape.sh`
- `devtools/check-test-antipatterns.sh tests/omelasticsearch-bulk-metadata-escape.sh` reported only the intentional local capture helper; the test header documents readiness and cleanup.
- Local Cubic review against `upstream/main`: no issues found.
- Ubuntu 26.04 static analyzer container: `scan-build: No bugs found`.
- Ubuntu 26.04 change-gated `run-ci.sh` container: `1259 total / 1225 pass / 34 skip / 0 fail`.

Container image: `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

