### PR TITLE
debian daily staging: use Actions SHA for version

### DIFF
--- a/.github/debian-ci-policy.yml
+++ b/.github/debian-ci-policy.yml
@@ -18,5 +18,12 @@
     }
   ],
   "supplemental_build_deps": [],
+  "control_replacements": [
+    {
+      "pattern": "debhelper-compat\\s*\\(=\\s*14\\)",
+      "replacement": "debhelper-compat (= 13)",
+      "reason": "Debian latest currently targets debhelper compat 14, which is not available in the trixie staging build environment."
+    }
+  ],
   "not_installed_paths": []
 }

--- a/.github/scripts/debian_package_build.sh
+++ b/.github/scripts/debian_package_build.sh
@@ -44,6 +44,19 @@ for key, (name_key, reason_key) in sections.items():
                 continue
             names_fh.write(f"{name}\n")
             reasons_fh.write(f"{name}\t{reason}\n")
+
+replacements_path = os.path.join(out_dir, "control_replacements.tsv")
+replacements_reasons_path = os.path.join(out_dir, "control_replacements.reasons.txt")
+with open(replacements_path, "w", encoding="utf-8") as replacements_fh, \
+        open(replacements_reasons_path, "w", encoding="utf-8") as reasons_fh:
+    for entry in policy.get("control_replacements", []):
+        pattern = entry.get("pattern", "").strip()
+        replacement = entry.get("replacement", "").strip()
+        reason = entry.get("reason", "").strip()
+        if not pattern:
+            continue
+        replacements_fh.write(f"{pattern}\t{replacement}\n")
+        reasons_fh.write(f"{pattern}\t{reason}\n")
 PY
 }
 
@@ -89,6 +102,44 @@ fetch_debian_packaging() {
   fi
 
   cp -r "$clone_dir/debian" "$target_dir"
+}
+
+apply_control_replacements() {
+  local control_file="$1"
+  local replacements_file="$2"
+  local reasons_file="$3"
+  local findings_dir="${4:-}"
+
+  [ -s "$replacements_file" ] || return 0
+  [ -f "$control_file" ] || {
+    echo "ERROR: missing Debian control file: $control_file" >&2
+    return 1
+  }
+
+  python3 - "$control_file" "$replacements_file" <<'PY'
+import re
+import sys
+
+control_path, replacements_path = sys.argv[1:3]
+with open(control_path, "r", encoding="utf-8") as fh:
+    control = fh.read()
+
+with open(replacements_path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        pattern, replacement = line.split("\t", 1)
+        control = re.sub(pattern, replacement, control)
+
+with open(control_path, "w", encoding="utf-8") as fh:
+    fh.write(control)
+PY
+
+  if [ -n "$findings_dir" ]; then
+    record_policy_items "$reasons_file" "$findings_dir" \
+      "allowed_packaging_drift" "Update Debian control replacement for"
+  fi
 }
 
 run_dist_build() {
@@ -387,6 +438,7 @@ case "${1:-}" in
   load_policy) shift; load_policy "$@" ;;
   install_prereqs) shift; install_prereqs "$@" ;;
   fetch_debian_packaging) shift; fetch_debian_packaging "$@" ;;
+  apply_control_replacements) shift; apply_control_replacements "$@" ;;
   run_dist_build) shift; run_dist_build "$@" ;;
   find_dist_tarball) shift; find_dist_tarball "$@" ;;
   unpack_source_tree) shift; unpack_source_tree "$@" ;;

--- a/.github/workflows/debian_daily_staging.yml
+++ b/.github/workflows/debian_daily_staging.yml
@@ -126,6 +126,13 @@ jobs:
             "$DEBIAN_PACKAGING_BRANCH" \
             "$DEBIAN_STAGING_BUILD_ROOT/debian-packaging"
 
+      - name: Apply packaging baseline policy
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" apply_control_replacements \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-packaging/control" \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-ci-policy/control_replacements.tsv" \
+            "$DEBIAN_STAGING_BUILD_ROOT/debian-ci-policy/control_replacements.reasons.txt"
+
       - name: Install Debian build dependencies
         run: |
           "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" install_build_deps \
@@ -214,9 +221,10 @@ jobs:
             echo "- Architecture: \`$DEBIAN_STAGING_ARCH\`"
             echo
             echo "Artifacts:"
+            find debian-staging-artifacts -maxdepth 1 -type f -printf '%f\n' | sort |
             while IFS= read -r artifact; do
               printf -- "- \`%s\`\n" "$artifact"
-            done < <(find debian-staging-artifacts -maxdepth 1 -type f -printf '%f\n' | sort)
+            done
           } >> "$GITHUB_STEP_SUMMARY"
 
   publish:
@@ -316,6 +324,7 @@ jobs:
     if: needs.preflight.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment: debian-daily-staging
     permissions:
       contents: read
     env:
@@ -367,6 +376,7 @@ jobs:
       needs.preflight.outputs.should_run == 'true' &&
       (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     runs-on: ubuntu-latest
+    environment: debian-daily-staging
     permissions:
       issues: write
       contents: read

--- a/devtools/release/debian-daily-staging.sh
+++ b/devtools/release/debian-daily-staging.sh
@@ -27,6 +27,19 @@ base_version() {
   sed -n 's/AC_INIT(\[rsyslog\],\[\([^]]*\)\].*/\1/p' "$script_dir/../../configure.ac" | sed 's/\.daily$//'
 }
 
+short_commit_sha() {
+  if [ -n "${GITHUB_SHA:-}" ]; then
+    if printf '%s\n' "$GITHUB_SHA" | grep -Eq '^[0-9a-fA-F]{12,64}$'; then
+      printf '%.12s\n' "$GITHUB_SHA" | tr '[:upper:]' '[:lower:]'
+      return
+    fi
+  fi
+
+  git rev-parse --verify HEAD >/dev/null 2>&1 ||
+    die "could not determine git commit from GITHUB_SHA or local HEAD"
+  git rev-parse --short=12 HEAD
+}
+
 cmd_version() {
   local base date short_sha run version
 
@@ -34,8 +47,7 @@ cmd_version() {
   [ -n "$base" ] || die "could not determine base version from configure.ac"
 
   date="$(date -u +%Y%m%d)"
-  git rev-parse --verify HEAD >/dev/null 2>&1 || die "invalid git HEAD commit"
-  short_sha="$(git rev-parse --short=12 HEAD)"
+  short_sha="$(short_commit_sha)"
   run="${GITHUB_RUN_NUMBER:-0}"
   version="${base}~daily${date}.${run}+git${short_sha}-1adiscon1"
 
@@ -261,7 +273,7 @@ cmd_verify_repo() {
 
   repo_url="${repo_url%/}"
   tmp_dir="$(mktemp -d)"
-  trap 'rm -rf "$tmp_dir"' EXIT
+  trap 'rm -rf "${tmp_dir:-}"' EXIT
 
   curl -fsSL "$repo_url/dists/$suite/InRelease" -o "$tmp_dir/InRelease"
   curl -fsSL "$repo_url/rsyslog-debian-staging.asc" -o "$tmp_dir/repo-key.asc"


### PR DESCRIPTION
## Summary
- fix Debian daily staging version generation in GitHub Actions containers
- prefer GITHUB_SHA for the package git suffix, with local git rev-parse fallback
- keeps the generated version format unchanged

Fixes https://github.com/rsyslog/rsyslog/issues/7302

## Validation
- bash -n devtools/release/debian-daily-staging.sh
- shellcheck devtools/release/debian-daily-staging.sh
- devtools/release/debian-daily-staging.sh version
- GITHUB_SHA=ABCDEF1234567890abcdef1234567890abcdef12 GITHUB_RUN_NUMBER=123 devtools/release/debian-daily-staging.sh version
- devtools/local-validation-plan.sh --run --base upstream/main

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

