### PR TITLE
omprog/omstdout: guard empty template LF checks

### DIFF
--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -966,7 +966,10 @@ BEGINdoAction
     const uchar *const szMsg = ppString[0];
     const size_t len = strlen((char *)szMsg);
     CHKiRet(sendMessage(pWrkrData->pData, pWrkrData->pChildCtx, szMsg));
-    if (szMsg[len - 1] != '\n') {
+    /* Template rendering may produce an empty message. It still needs the same
+     * child-input newline terminator, but szMsg[-1] must not be inspected.
+     */
+    if (len == 0 || szMsg[len - 1] != '\n') {
         const time_t tt = time(NULL);
         if (tt > pWrkrData->pData->block_if_err) {
             LogMsg(0, NO_ERRCODE, LOG_WARNING,

--- a/plugins/omstdout/omstdout.c
+++ b/plugins/omstdout/omstdout.c
@@ -203,10 +203,13 @@ BEGINdoAction
      * needs to be more solid. -- rgerhards, 2012-11-28
      */
     dbgprintf("omstdout: len: %d, toWrite: %s\n", (int)len, toWrite);
-    if ((r = write(1, toWrite, len)) != (int)len) { /* 1 is stdout! */
+    if (len > 0 && (r = write(1, toWrite, len)) != (int)len) { /* 1 is stdout! */
         DBGPRINTF("omstdout: error %d writing to stdout[%zd]: %s\n", r, len, toWrite);
     }
-    if (pWrkrData->pData->bEnsureLFEnding && toWrite[len - 1] != '\n') {
+    /* A rendered template may legitimately be empty. Treat that like any other
+     * non-LF-terminated message; do not inspect toWrite[-1].
+     */
+    if (pWrkrData->pData->bEnsureLFEnding && (len == 0 || toWrite[len - 1] != '\n')) {
         if ((r = write(1, "\n", 1)) != 1) { /* write missing LF */
             DBGPRINTF("omstdout: error %d writing \\n to stdout\n", r);
         }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1009,6 +1009,7 @@ TESTS_OMPROG = \
 	omprog-single-instance.sh \
 	omprog-single-instance-outfile.sh \
 	omprog-invalid-args.sh \
+	omprog-empty-template.sh \
 	omprog-transactions.sh \
 	omprog-if-error.sh \
 	omprog-transactions-failed-messages.sh \
@@ -1459,7 +1460,8 @@ TESTS_PMNULL = \
 	pmnull-withparams.sh
 
 TESTS_OMSTDOUT = \
-	omstdout-basic.sh
+	omstdout-basic.sh \
+	omstdout-empty-template.sh
 
 TESTS_LIBYAML_IMTCP = \
 	config-translate-rs-roundtrip.sh \

--- a/tests/omprog-empty-template.sh
+++ b/tests/omprog-empty-template.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Regression coverage for empty rendered templates reaching omprog. The
+# stimulus is a real action invocation whose configured string template renders
+# to the empty C string. The oracle is rsyslogd's proper-termination marker:
+# before the guard in omprog, ASan reports a one-byte under-read in the
+# trailing-LF check and rsyslogd aborts before writing this marker.
+. ${srcdir:=.}/diag.sh init
+
+set_proper_termination_file
+generate_conf
+add_conf '
+module(load="../plugins/omprog/.libs/omprog")
+template(name="empty" type="string" string="")
+
+if $rawmsg contains "trigger-empty-template" then {
+	action(type="omprog" binary="/bin/cat" template="empty")
+}
+'
+
+startup
+injectmsg_literal 'trigger-empty-template'
+shutdown_when_empty
+wait_shutdown
+check_proper_termination
+
+exit_test

--- a/tests/omstdout-empty-template.sh
+++ b/tests/omstdout-empty-template.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Regression coverage for empty rendered templates reaching omstdout with
+# ensureLFEnding enabled. The stimulus is a real action invocation whose
+# configured string template renders to the empty C string. The oracle is
+# rsyslogd's proper-termination marker: before the guard in omstdout, ASan
+# reports a one-byte under-read in the trailing-LF check and rsyslogd aborts
+# before writing this marker.
+. ${srcdir:=.}/diag.sh init
+
+set_proper_termination_file
+generate_conf
+add_conf '
+module(load="../plugins/omstdout/.libs/omstdout")
+template(name="empty" type="string" string="")
+
+if $rawmsg contains "trigger-empty-template" then {
+	action(type="omstdout" template="empty" ensurelfending="on")
+}
+'
+
+startup
+injectmsg_literal 'trigger-empty-template'
+shutdown_when_empty
+wait_shutdown
+check_proper_termination
+
+exit_test


### PR DESCRIPTION
## Summary

This hardens `omprog` and `omstdout` for the case where a configured template renders to an empty string.

Both modules used the rendered length to inspect the last byte before appending a trailing newline. For an empty rendered template, that check indexed one byte before the template buffer. Empty template output is valid input to an action, so the modules should treat it like other non-newline-terminated output without reading before the buffer.

## Changes

- Guard `omprog` and `omstdout` trailing-newline checks with `len == 0`.
- Preserve the existing behavior of appending a newline when needed.
- Add regression tests for empty rendered templates reaching each module.
- Use `set_proper_termination_file` / `check_proper_termination` so sanitizer builds catch the original abort and normal CI seals clean shutdown.

## Validation

Initial reproducer before the fix:

- `omstdout`: ASan reported a one-byte heap-buffer-under-read in `plugins/omstdout/omstdout.c` at the trailing-LF check.
- `omprog`: ASan reported the same pattern in `plugins/omprog/omprog.c` at the trailing-LF check.

Local validation after the fix:

- `devtools/format-code.sh --git-changed --check --check-if-available`
- `devtools/check-test-antipatterns.sh tests/omstdout-empty-template.sh tests/omprog-empty-template.sh`
- `shellcheck -S warning tests/omstdout-empty-template.sh tests/omprog-empty-template.sh`
- `./devtools/local-validation-plan.sh --base upstream/main --run`
  - Ubuntu 26.04 dev container: `rsyslog/rsyslog_dev_base_ubuntu:26.04`, digest `sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`
  - full container test summary observed: `TOTAL: 1247`, `PASS: 1214`, `SKIP: 33`, `FAIL: 0`
  - local Cubic review: no issues found
- Post-rebase focused ASan validation:
  - `make -C tests check TESTS="omstdout-empty-template.sh omprog-empty-template.sh"`
  - `TOTAL: 2`, `PASS: 2`, `FAIL: 0`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

