### PR TITLE
testbench: detect tcpflood aborts

### DIFF
--- a/doc/source/development/dev_testbench.rst
+++ b/doc/source/development/dev_testbench.rst
@@ -115,6 +115,15 @@ A timeoutGuard abort writes the same file before aborting with
 before failing so diagnostics such as ``queue.overall.size`` survive in the test
 log.
 
+The shell ``tcpflood`` helper configures a per-invocation proper termination
+marker as well. ``tcpflood`` writes that marker as its final normal action, and
+the wrapper validates it after a zero exit status. Direct ``./tcpflood``
+invocations can opt in with ``-q <file>`` when tcpflood completion is part of
+the test oracle; the option stays single-character for portability to platforms
+without GNU-style long options.
+Tests that intentionally provoke a tcpflood send failure should use the
+``tcpflood --check-only`` wrapper form and assert the rsyslog-side oracle.
+
 Do not add helper cleanup or observer processes to prove daemon shutdown. They
 have historically caused their own races. ``timeoutGuard`` remains mandatory
 hang protection and must preserve this diagnostic marker behavior when it
@@ -142,6 +151,8 @@ marker: the process still failed to reach the expected shutdown point. In that
 case the harness reports that no owned local core was available. Helper
 processes such as ``tcpflood`` need explicit pid or exit-status checks when
 their health matters; rsyslogd core diagnostics do not prove helper health.
+Use the standard ``tcpflood`` shell helper, or pass ``-q <file>`` to direct
+``./tcpflood`` invocations, when tcpflood completion itself matters.
 Valgrind ``vgcore.*`` files are separate from generic OS core discovery: they
 belong to the supervised Valgrind run and remain a Valgrind failure signal.
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -88,6 +88,9 @@ minimal containers. Findings are review prompts, not automatic blockers.
   handling does not prove ``tcpflood`` or another helper stayed healthy. Tests
   that rely on helper correctness must track the helper pid or command status
   directly instead of expecting generic core-file scanning to catch crashes.
+  Prefer the ``tcpflood`` shell helper, which configures and validates a
+  per-invocation proper-termination marker. Direct ``./tcpflood`` calls can opt
+  in with ``-q <file>`` when tcpflood completion is part of the oracle.
 - **Queue tests assuming immediate drain or shutdown ordering**: use
   queue-specific synchronization where possible. Do not assume that input
   completion, shutdown start, or a fixed delay means all queued messages reached

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -315,6 +315,7 @@ TESTS_DEFAULT = \
 	imdiag-modern-module-config.sh \
 	imdiag-proper-termination-core-ignore.sh \
 	imdiag-proper-termination-timeoutguard.sh \
+	tcpflood-proper-termination.sh \
 	global-maxopenfiles-rainerscript.sh \
 	compat-configformat-rainerscript.sh \
 	compat-defaults-secure-dynafile-rainerscript.sh \

--- a/tests/README
+++ b/tests/README
@@ -124,3 +124,9 @@ supervised Valgrind run and remain a Valgrind failure signal.
 For local debugging you may still switch a disposable development host to a
 classic core pattern such as `core.%e.%p`, but avoid applying such changes on
 production hosts.
+
+The `tcpflood` shell helper configures and validates a per-invocation
+proper-termination marker. Direct `./tcpflood` invocations can use `-q <file>`
+for the same final-exit marker when the test needs tcpflood abort detection.
+Tests that intentionally trigger a tcpflood send failure should call
+`tcpflood --check-only` and assert the rsyslog-side result.

--- a/tests/allowed-sender-tcp-fail.sh
+++ b/tests/allowed-sender-tcp-fail.sh
@@ -18,7 +18,7 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
 assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
-tcpflood -m$NUMMESSAGES
+tcpflood --check-only -m$NUMMESSAGES
 shutdown_when_empty
 wait_shutdown
 content_check --regex "connection request from disallowed sender .* discarded"

--- a/tests/allowed-sender-tcp-hostname-fail.sh
+++ b/tests/allowed-sender-tcp-hostname-fail.sh
@@ -23,7 +23,7 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
 assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
-tcpflood -m$NUMMESSAGES
+tcpflood --check-only -m$NUMMESSAGES
 shutdown_when_empty
 wait_shutdown
 content_check --regex "connection request from disallowed sender .* discarded"

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -95,6 +95,9 @@ RSYSLOG_MODDIR=${RSYSLOG_MODDIR:-"../runtime/.libs:../.libs"}
 # TCPFLOOD_EXTRA_OPTS   enables to set extra options for tcpflood, usually
 #                       used in tests that have a common driver where it
 #                       is too hard to set these options otherwise
+# RSTB_NO_TCPFLOOD_MARKER disables the automatic tcpflood proper-termination
+#                       marker used by the tcpflood() helper. Use only when a
+#                       test intentionally bypasses normal tcpflood completion.
 # CONFIG
 export ZOOPIDFILE="$(pwd)/zookeeper.pid"
 
@@ -3300,16 +3303,130 @@ gzip_seq_check() {
 
 
 # do a tcpflood run and check if it worked params are passed to tcpflood
+tcpflood_marker_is_valid() {
+	local file="$1"
+	[ -f "$file" ] || return 1
+	grep -qx 'status=ok' "$file" &&
+		grep -qx 'phase=main-exit' "$file"
+}
+
+print_tcpflood_marker_file() {
+	local file="$1"
+	if [ -z "$file" ]; then
+		printf '%s\n' '--- tcpflood proper termination marker not configured ---'
+	elif [ -f "$file" ]; then
+		printf '%s\n' "--- tcpflood proper termination marker: $file ---"
+		cat "$file"
+		printf '%s\n' '--- end tcpflood proper termination marker ---'
+	else
+		printf '%s\n' "--- tcpflood proper termination marker missing: $file ---"
+	fi
+}
+
+tcpflood_legacy_unquote_arg() {
+	local arg="$1"
+	if [[ "$arg" == \"*\" && "$arg" == *\" ]]; then
+		arg="${arg:1:${#arg}-2}"
+		arg="${arg//\\\"/\"}"
+		arg="${arg//\\\\/\\}"
+	fi
+	printf '%s' "$arg"
+}
+
+tcpflood_legacy_unescape_arg() {
+	local arg="$1"
+	arg="${arg//\\ / }"
+	printf '%s' "$arg"
+}
+
+tcpflood_append_args() {
+	local arg
+	while [ "$#" -gt 0 ]; do
+		arg="$1"
+		shift
+		case "$arg" in
+		-M)
+			TCPFLOOD_CMD+=("$arg")
+			if [ "$#" -gt 0 ]; then
+				TCPFLOOD_CMD+=("$(tcpflood_legacy_unquote_arg "$1")")
+				shift
+			fi
+			;;
+		-M*)
+			TCPFLOOD_CMD+=("-M$(tcpflood_legacy_unquote_arg "${arg#-M}")")
+			;;
+		-j)
+			TCPFLOOD_CMD+=("$arg")
+			if [ "$#" -gt 0 ]; then
+				TCPFLOOD_CMD+=("$(tcpflood_legacy_unescape_arg "$1")")
+				shift
+			fi
+			;;
+		-j*)
+			if [[ "$arg" == "-j "* ]]; then
+				TCPFLOOD_CMD+=("-j" "$(tcpflood_legacy_unquote_arg "$(tcpflood_legacy_unescape_arg "${arg#-j }")")")
+			else
+				TCPFLOOD_CMD+=("-j$(tcpflood_legacy_unescape_arg "${arg#-j}")")
+			fi
+			;;
+		-p)
+			if [ "$#" -gt 0 ] && [ "$1" = '$TCPFLOOD_PORT' ]; then
+				shift
+			else
+				TCPFLOOD_CMD+=("$arg")
+			fi
+			;;
+		-p'$TCPFLOOD_PORT')
+			;;
+		*)
+			TCPFLOOD_CMD+=("$arg")
+			;;
+		esac
+	done
+}
+
 tcpflood() {
+	local check_only marker res use_marker
+	local -a TCPFLOOD_CMD TCPFLOOD_EXTRA_ARGS
 	if [ "$1" == "--check-only" ]; then
 		check_only="yes"
 		shift
 	else
 		check_only="no"
 	fi
-	# shellcheck disable=SC2294 # TCPFLOOD_EXTRA_OPTS is intentionally parsed as shell words.
-	eval ./tcpflood -p$TCPFLOOD_PORT "$@" $TCPFLOOD_EXTRA_OPTS
+	use_marker="yes"
+	if [ "${RSTB_NO_TCPFLOOD_MARKER:-}" = "YES" ]; then
+		use_marker="no"
+	fi
+	if [ -n "${RSYSLOG_DYNNAME:-}" ] && [ "$use_marker" = "yes" ]; then
+		TCPFLOOD_MARKER_ID=$(( ${TCPFLOOD_MARKER_ID:-0} + 1 ))
+		marker="${RSYSLOG_DYNNAME}.tcpflood.${TCPFLOOD_MARKER_ID}.proper-termination"
+		rm -f "$marker"
+	else
+		marker=""
+	fi
+	TCPFLOOD_CMD=(./tcpflood)
+	if [ -n "$marker" ]; then
+		TCPFLOOD_CMD+=(-q "$marker")
+	fi
+	TCPFLOOD_CMD+=(-p "$TCPFLOOD_PORT")
+	tcpflood_append_args "$@"
+	if [ -n "$TCPFLOOD_EXTRA_OPTS" ]; then
+		eval "TCPFLOOD_EXTRA_ARGS=( $TCPFLOOD_EXTRA_OPTS )"
+		TCPFLOOD_CMD+=("${TCPFLOOD_EXTRA_ARGS[@]}")
+	fi
+	"${TCPFLOOD_CMD[@]}"
 	res=$?
+	if [ "$res" -eq 0 ] && [ -n "$marker" ] && ! tcpflood_marker_is_valid "$marker"; then
+		echo "error during tcpflood on port ${TCPFLOOD_PORT}: proper termination marker missing or invalid"
+		print_tcpflood_marker_file "$marker"
+		error_exit 1
+	fi
+	if [ "$check_only" == "yes" ] && [ "$res" -gt 128 ]; then
+		echo "error during tcpflood on port ${TCPFLOOD_PORT}: process aborted with status $res"
+		print_tcpflood_marker_file "$marker"
+		error_exit 1
+	fi
 	if [ "$check_only" == "yes" ]; then
 		if [ "$res" -ne "0" ]; then
 			echo "error during tcpflood on port ${TCPFLOOD_PORT}! But test continues..."

--- a/tests/imtcp-bigmessage-octetcounting.sh
+++ b/tests/imtcp-bigmessage-octetcounting.sh
@@ -40,7 +40,7 @@ ruleset(name="print") {
 }
 '
 startup
-tcpflood -p'$TCPFLOOD_PORT' -m$NUMMESSAGES -d $TEST_BYTES_SENDSIZE -O
+tcpflood -m$NUMMESSAGES -d $TEST_BYTES_SENDSIZE -O
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown

--- a/tests/imtcp-bigmessage-octetstuffing.sh
+++ b/tests/imtcp-bigmessage-octetstuffing.sh
@@ -40,7 +40,7 @@ ruleset(name="print") {
 }
 '
 startup
-tcpflood -p'$TCPFLOOD_PORT' -m$NUMMESSAGES -d $TEST_BYTES_SENDSIZE
+tcpflood -m$NUMMESSAGES -d $TEST_BYTES_SENDSIZE
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown

--- a/tests/imtcp-tls-ossl-x509name.sh
+++ b/tests/imtcp-tls-ossl-x509name.sh
@@ -26,7 +26,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 					file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup
-tcpflood -p'$TCPFLOOD_PORT' -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 wait_file_lines
 shutdown_when_empty
 wait_shutdown

--- a/tests/tcpflood-proper-termination.sh
+++ b/tests/tcpflood-proper-termination.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Verify the tcpflood wrapper records a proper-termination marker for normal
+# helper completion. The oracle is the marker itself: UDP transport avoids a
+# receiver dependency, and a marker write failure must make tcpflood fail.
+. ${srcdir:=.}/diag.sh init
+
+TCPFLOOD_PORT=9 tcpflood -Tudp -m1 -s
+tcpflood_marker="${RSYSLOG_DYNNAME}.tcpflood.1.proper-termination"
+if ! tcpflood_marker_is_valid "$tcpflood_marker"; then
+	echo "FAIL: tcpflood marker missing or invalid"
+	print_tcpflood_marker_file "$tcpflood_marker"
+	error_exit 1
+fi
+content_check "pid=" "$tcpflood_marker"
+content_check "version=" "$tcpflood_marker"
+
+if ./tcpflood -q / -p9 -Tudp -m1 -s; then
+	echo "FAIL: tcpflood marker write failure was not reported"
+	error_exit 1
+fi
+
+symlink_target="${RSYSLOG_DYNNAME}.tcpflood.symlink-target"
+symlink_marker="${RSYSLOG_DYNNAME}.tcpflood.symlink-marker"
+echo "unchanged" > "$symlink_target"
+ln -s "$symlink_target" "$symlink_marker"
+if ./tcpflood -q "$symlink_marker" -p9 -Tudp -m1 -s; then
+	echo "FAIL: tcpflood followed symlink marker path"
+	error_exit 1
+fi
+content_check "unchanged" "$symlink_target"
+
+exit_test

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -86,6 +86,9 @@
  *      contains the port number followed by a line feed and is only valid
  *      when a single connection is created. Works with TCP and UDP transports;
  *      using it with RELP results in an error.
+ * -q   write a proper-termination marker to the specified file as the final
+ *      normal action before exiting. Used by the testbench to distinguish a
+ *      clean tcpflood run from a crash or abort.
  *
  * Part of the testbench for rsyslog.
  *
@@ -215,6 +218,14 @@ char *test_rs_strerror_r(int errnum, char *buf, size_t buflen) {
 #define MAX_EXTRADATA_LEN 512 * 1024
 #define MAX_SENDBUF 2 * MAX_EXTRADATA_LEN
 #define MAX_RCVBUF 16 * 1024 + 1 /* TLS RFC 8449: max size of buffer for message reception */
+#ifndef O_CLOEXEC
+    #define O_CLOEXEC 0
+#endif
+#ifdef O_NOFOLLOW
+    #define TCPFLOOD_MARKER_OPEN_FLAGS O_NOFOLLOW
+#else
+    #define TCPFLOOD_MARKER_OPEN_FLAGS 0
+#endif
 
 static int nThreadsConnOpen = 25; /* Number for threads for openeing the connections */
 static char *targetIP = "127.0.0.1";
@@ -244,6 +255,7 @@ static char *hostname = "172.20.245.8"; /* this is the "tratditional" default, a
 static int bBinaryFile = 0; /* is -I file binary */
 static char *dataFile = NULL; /* name of data file, if NULL, generate own data */
 static char *portFile = NULL; /* file to store local port number */
+static char *properTerminationFile = NULL; /* file to prove tcpflood reached normal main exit */
 static int numFileIterations = 1; /* how often is file data to be sent? */
 static char frameDelim = '\n'; /* default frame delimiter */
 FILE *dataFP = NULL; /* file pointer for data file, if used */
@@ -306,6 +318,7 @@ struct instdata {
     unsigned long long numMsgs; /* number of messages to send */
     unsigned long long numSent; /* number of messages already sent */
     unsigned idx; /**< index of fd to be used for sending */
+    int failed; /**< set when this generator saw a send error */
     pthread_t thread; /**< thread processing this instance */
 } *instarray = NULL;
 
@@ -509,9 +522,6 @@ int openConn(const int connIdx) {
         sockArray[connIdx] = 1; /* mimic "all ok" state TODO: this looks invalid! */
 #endif
     } else { /* TCP, with or without TLS */
-        if ((sock = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
-            return (1);
-        }
         memset((char *)&addr, 0, sizeof(addr));
         addr.sin_family = AF_INET;
         addr.sin_port = htons(port);
@@ -520,10 +530,14 @@ int openConn(const int connIdx) {
             return (1);
         }
         while (1) { /* loop broken inside */
+            if ((sock = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
+                return (1);
+            }
             if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
                 break;
             } else {
                 fprintf(stderr, "warning: connect failed, retrying... %s\n", strerror(errno));
+                close(sock);
                 if (retries++ == 50) {
                     perror("connect()");
                     fprintf(stderr, "connect(%d) failed\n", port);
@@ -1075,6 +1089,7 @@ static void *thrdStarter(void *arg) {
     }
     pthread_mutex_unlock(&thrdMgmt);
     if (sendMessages(inst) != 0) {
+        inst->failed = 1;
         printf("error sending messages\n");
     }
     return NULL;
@@ -1140,15 +1155,20 @@ static void runGenerators(void) {
 
 /* Wait for all traffic generators to stop.
  */
-static void waitGenerators(void) {
+static int waitGenerators(void) {
     int i;
+    int failed = 0;
     for (i = 0; i < numThrds; ++i) {
         pthread_join(instarray[i].thread, NULL);
+        if (instarray[i].failed) {
+            failed = 1;
+        }
         /*printf("thread %x stopped\n", (unsigned) instarray[i].thread);*/
     }
     pthread_mutex_destroy(&thrdMgmt);
     pthread_cond_destroy(&condStarted);
     pthread_cond_destroy(&condDoRun);
+    return failed;
 }
 
 /* functions related to computing statistics on the runtime of a test. This is
@@ -1226,7 +1246,10 @@ static int runTests(void) {
         prepareGenerators();
         gettimeofday(&tvStart, NULL);
         runGenerators();
-        waitGenerators();
+        if (waitGenerators() != 0) {
+            endTiming(&tvStart, &stats);
+            return 1;
+        }
         endTiming(&tvStart, &stats);
         if (run == numRuns) break;
         if (!bSilent) printf("sleeping %d seconds before next run\n", sleepBetweenRuns);
@@ -2092,17 +2115,103 @@ static void setTargetPorts(const char *const port_arg) {
 
     char *saveptr;
     char *ports = strdup(port_arg);
-    char *port = strtok_r(ports, ":", &saveptr);
+    char *port;
+    if (ports == NULL) {
+        perror("strdup");
+        exit(1);
+    }
+    port = strtok_r(ports, ":", &saveptr);
     while (port != NULL) {
+        char *endptr;
+        long parsed_port;
         if (i == sizeof(targetPort) / sizeof(int)) {
             fprintf(stderr, "too many ports specified, max %d\n", (int)(sizeof(targetPort) / sizeof(int)));
             exit(1);
         }
-        targetPort[i] = atoi(port);
+        errno = 0;
+        parsed_port = strtol(port, &endptr, 10);
+        if (errno != 0 || *port == '\0' || *endptr != '\0' || parsed_port < 1 || parsed_port > 65535) {
+            fprintf(stderr, "invalid target port '%s'\n", port);
+            exit(1);
+        }
+        targetPort[i] = (int)parsed_port;
         i++;
         port = strtok_r(NULL, ":", &saveptr);
     }
+    if (i == 0) {
+        fprintf(stderr, "empty target port list\n");
+        exit(1);
+    }
     free(ports);
+}
+
+static int writeAll(const int fd, const char *buf, const size_t len) {
+    size_t done = 0;
+
+    while (done < len) {
+        ssize_t written = write(fd, buf + done, len - done);
+        if (written < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        if (written == 0) {
+            errno = EIO;
+            return -1;
+        }
+        done += (size_t)written;
+    }
+    return 0;
+}
+
+static int writeProperTerminationFile(void) {
+    char content[256];
+    int fd;
+    int len;
+    int saved_errno;
+
+    if (properTerminationFile == NULL) {
+        return 0;
+    }
+
+#ifndef O_NOFOLLOW
+    fprintf(stderr, "tcpflood: proper termination marker is not supported without O_NOFOLLOW\n");
+    return 1;
+#endif
+
+    len = snprintf(content, sizeof(content),
+                   "status=ok\n"
+                   "pid=%ld\n"
+                   "version=%s\n"
+                   "phase=main-exit\n",
+                   (long)getpid(), VERSION);
+    if (len < 0 || (size_t)len >= sizeof(content)) {
+        fprintf(stderr, "tcpflood: proper termination marker content too large\n");
+        return 1;
+    }
+
+    fd = open(properTerminationFile, O_WRONLY | O_CREAT | O_TRUNC | TCPFLOOD_MARKER_OPEN_FLAGS | O_CLOEXEC, 0600);
+    if (fd < 0) {
+        saved_errno = errno;
+        fprintf(stderr, "tcpflood: cannot open proper termination marker '%s': %s\n", properTerminationFile,
+                strerror(saved_errno));
+        return 1;
+    }
+    if (writeAll(fd, content, (size_t)len) != 0) {
+        saved_errno = errno;
+        fprintf(stderr, "tcpflood: cannot write proper termination marker '%s': %s\n", properTerminationFile,
+                strerror(saved_errno));
+        close(fd);
+        return 1;
+    }
+    if (close(fd) != 0) {
+        saved_errno = errno;
+        fprintf(stderr, "tcpflood: cannot close proper termination marker '%s': %s\n", properTerminationFile,
+                strerror(saved_errno));
+        return 1;
+    }
+    return 0;
 }
 
 
@@ -2110,7 +2219,6 @@ static void setTargetPorts(const char *const port_arg) {
  * rgerhards, 2009-04-03
  */
 int main(int argc, char *argv[]) {
-    int ret = 0;
     int opt;
     struct sigaction sigAct;
     struct rlimit maxFiles;
@@ -2138,7 +2246,7 @@ int main(int argc, char *argv[]) {
 
     while ((opt = getopt(argc, argv,
                          "a:ABb:c:C:d:DeE:f:F:g:h:i:I:j:K:k:l:L:m:M:n:o:OP:p:rR:"
-                         "sS:t:T:u:vW:w:x:XyYz:Z:H")) != -1) {
+                         "q:sS:t:T:u:vW:w:x:XyYz:Z:H")) != -1) {
         switch (opt) {
             case 'b':
                 batchsize = atoll(optarg);
@@ -2345,6 +2453,9 @@ int main(int argc, char *argv[]) {
                 break;
             case 'w':
                 portFile = optarg;
+                break;
+            case 'q':
+                properTerminationFile = optarg;
                 break;
             case 'H':
                 handshakeOnly = true;
@@ -2569,5 +2680,8 @@ int main(int argc, char *argv[]) {
         exitTLS();
     }
 
-    exit(ret);
+    if (writeProperTerminationFile() != 0) {
+        exit(1);
+    }
+    exit(0);
 }


### PR DESCRIPTION
## Summary

This adds explicit abort detection for `tcpflood`, the most-used testbench helper, using a final proper-termination marker plus stricter exit-status propagation.

Key points:
- add `tcpflood -q <file>` as a single-character marker option for non-GNU getopt portability
- write the marker as the final normal action with `O_NOFOLLOW` and complete-write handling
- fail closed when marker creation is unsupported or unsafe
- propagate generator send failures to the tcpflood process exit status
- have `tests/diag.sh` add and validate per-invocation tcpflood markers automatically
- keep intentional negative send-failure tests working via `--check-only`
- add a focused marker/symlink/write-failure test
- document the helper-oracle behavior for test authors and agents

## Validation

- `make -j$(nproc) check TESTS=""`
- `cd tests && ./tcpflood-proper-termination.sh`
- malformed-port negative check: no marker written and stderr reports `invalid target port '-p9'`
- `bash -n tests/diag.sh tests/tcpflood-proper-termination.sh tests/allowed-sender-tcp-fail.sh tests/allowed-sender-tcp-hostname-fail.sh`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `devtools/check-test-antipatterns.sh tests/tcpflood-proper-termination.sh tests/allowed-sender-tcp-fail.sh tests/allowed-sender-tcp-hostname-fail.sh`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs "$(nproc)"`
- `cubic review --base upstream/main ...` after fix: `No issues found.`
- static analyzer container on Ubuntu 26.04 image: `scan-build: No bugs found.`
- Ubuntu 26.04 change-gated container run: `TOTAL: 1250`, `PASS: 1217`, `SKIP: 33`, `FAIL: 0`, `ERROR: 0`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`

`devtools/local-validation-plan.sh --run` was also tried, but it stopped on pre-existing shellcheck warnings in `tests/diag.sh`, so the relevant checks were run directly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

