### PR TITLE
ommail: harden subject template header output

### DIFF
--- a/plugins/ommail/ommail.c
+++ b/plugins/ommail/ommail.c
@@ -560,6 +560,40 @@ finalize_it:
 }
 
 
+/* Header field values must not carry raw CR/LF. A subject.template may render
+ * message-derived structured fields, so normalize line breaks before emitting
+ * the RFC822 Subject header.
+ */
+static rsRetVal write_header_value(mailWriteFunc_t writeFunc, void *ctx, const char *value) {
+    DEFiRet;
+    char szBuf[2048];
+    size_t iSrc;
+    size_t iBuf = 0;
+
+    assert(writeFunc != NULL);
+    assert(value != NULL);
+    if (value == NULL) {
+        /* Subject rendering is expected to always provide a value. Treat an
+         * unexpected NULL as an empty header value in production builds.
+         */
+        FINALIZE;
+    }
+
+    for (iSrc = 0; value[iSrc] != '\0'; ++iSrc) {
+        if (iBuf == sizeof(szBuf)) {
+            CHKiRet(writeBytes(writeFunc, ctx, szBuf, iBuf));
+            iBuf = 0;
+        }
+        szBuf[iBuf++] = (value[iSrc] == '\r' || value[iSrc] == '\n') ? ' ' : value[iSrc];
+    }
+
+    if (iBuf > 0) CHKiRet(writeBytes(writeFunc, ctx, szBuf, iBuf));
+
+finalize_it:
+    RETiRet;
+}
+
+
 /* send body text to a generic sink. SMTP requires escaping a leading dot inside a line. */
 static rsRetVal bodyWrite(mailWriteFunc_t writeFunc, void *ctx, char *msg, size_t len, sbool bEscapeDot) {
     DEFiRet;
@@ -617,7 +651,7 @@ static rsRetVal writeMailMessage(
     CHKiRet(writeTos(writeFunc, ctx, pData));
 
     CHKiRet(writeStr(writeFunc, ctx, "Subject: "));
-    CHKiRet(writeStr(writeFunc, ctx, (char *)subject));
+    CHKiRet(write_header_value(writeFunc, ctx, (char *)subject));
     CHKiRet(writeStr(writeFunc, ctx, "\r\n"));
 
     CHKiRet(writeStr(writeFunc, ctx, "X-Mailer: rsyslog-ommail\r\n"));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -817,6 +817,10 @@ TESTS_MAIL = \
 	ommail-sendmail-exec-fail.sh \
 	ommail-sendmail-default-binary.sh
 
+TESTS_MAIL_MMJSONPARSE = \
+	ommail-subject-template-header-sendmail.sh \
+	ommail-subject-template-header-smtp.sh
+
 TESTS_MMANON = \
 	mmanon_with_debug.sh \
 	mmanon_random_32_ipv4.sh \
@@ -2143,6 +2147,7 @@ EXTRA_DIST += $(TESTS_MMUTF8FIX)
 EXTRA_DIST += $(TESTS_MMUTF8FIX_SD)
 EXTRA_DIST += $(TESTS_MMAITAG)
 EXTRA_DIST += $(TESTS_MAIL)
+EXTRA_DIST += $(TESTS_MAIL_MMJSONPARSE)
 EXTRA_DIST += $(TESTS_MMANON)
 EXTRA_DIST += $(TESTS_CLICKHOUSE)
 EXTRA_DIST += $(TESTS_CLICKHOUSE_VALGRIND)
@@ -2742,6 +2747,9 @@ endif
 
 if ENABLE_MAIL
 TESTS += $(TESTS_MAIL)
+if ENABLE_MMJSONPARSE
+TESTS += $(TESTS_MAIL_MMJSONPARSE)
+endif # if ENABLE_MMJSONPARSE
 endif # if ENABLE_MAIL
 
 

--- a/tests/ommail-subject-template-header-sendmail.sh
+++ b/tests/ommail-subject-template-header-sendmail.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Regression coverage for ommail subject hardening in sendmail mode. A
+# message-controlled JSON field is decoded by mmjsonparse and rendered by
+# subject.template. The oracle is the captured sendmail stdin: CR/LF from the
+# rendered subject must stay inside the Subject header value and must not create
+# a new RFC822 header or premature header/body boundary.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+module(load="../plugins/ommail/.libs/ommail")
+
+template(name="mailBody" type="string" string="body %msg%\\r\\n")
+template(name="mailSubject" type="string" string="%$!subject%")
+
+if $rawmsg contains "trigger-ommail-subject" then {
+	action(type="mmjsonparse" cookie="")
+	action(
+		type="ommail"
+		mode="sendmail"
+		sendmail.binary="'$srcdir'/testsuites/ommail-sendmail-bin.sh"
+		mailfrom="rsyslog@example.net"
+		mailto="operator@example.net"
+		subject.template="mailSubject"
+		body.enable="on"
+		template="mailBody"
+	)
+}
+'
+
+startup
+injectmsg_literal '<167>1 2003-08-24T05:14:15.000003-07:00 host app proc msgid - {"subject":"legit\r\nX-Injected-Header: injected\r\n\r\nInjected pre-body","trigger":"trigger-ommail-subject"}'
+shutdown_when_empty
+wait_shutdown
+
+content_check "Subject: legit  X-Injected-Header: injected    Injected pre-body"
+if grep -Fx -- "X-Injected-Header: injected" "$RSYSLOG_OUT_LOG" >/dev/null; then
+	error_exit 1
+fi
+if grep -Fx -- "Injected pre-body" "$RSYSLOG_OUT_LOG" >/dev/null; then
+	error_exit 1
+fi
+
+if [ -n "${OMMAIL_REPRO_CAPTURE:-}" ]; then
+	cp "$RSYSLOG_OUT_LOG" "$OMMAIL_REPRO_CAPTURE"
+fi
+
+exit_test

--- a/tests/ommail-subject-template-header-smtp.sh
+++ b/tests/ommail-subject-template-header-smtp.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Regression coverage for ommail subject hardening in SMTP mode. A
+# message-controlled JSON field is decoded by mmjsonparse and rendered by
+# subject.template. The oracle is the captured SMTP DATA transcript: CR/LF from
+# the rendered subject must stay inside the Subject header value and must not
+# create a new RFC822 header or premature header/body boundary.
+. ${srcdir:=.}/diag.sh init
+
+if ! command -v python3 >/dev/null 2>&1; then
+	echo "python3 not available, skipping ommail SMTP helper test"
+	skip_test
+fi
+
+PORT_FILE="$RSYSLOG_DYNNAME.ommail-smtp.port"
+SMTP_OUT="$RSYSLOG_DYNNAME.ommail-smtp.out"
+SMTP_DONE="$RSYSLOG_DYNNAME.ommail-smtp.done"
+
+python3 "$srcdir/testsuites/ommail-smtp-server.py" \
+	--port-file "$PORT_FILE" \
+	--output "$SMTP_OUT" \
+	--done-file "$SMTP_DONE" &
+SMTP_PID=$!
+trap 'kill "$SMTP_PID" 2>/dev/null' EXIT
+
+wait_file_exists "$PORT_FILE"
+SMTP_PORT=$(cat "$PORT_FILE")
+
+generate_conf
+add_conf '
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+module(load="../plugins/ommail/.libs/ommail")
+
+template(name="mailBody" type="string" string="body %msg%\\r\\n")
+template(name="mailSubject" type="string" string="%$!subject%")
+
+if $rawmsg contains "trigger-ommail-subject" then {
+	action(type="mmjsonparse" cookie="")
+	action(
+		type="ommail"
+		mode="smtp"
+		server="127.0.0.1"
+		port="'$SMTP_PORT'"
+		mailfrom="rsyslog@example.net"
+		mailto="operator@example.net"
+		subject.template="mailSubject"
+		body.enable="on"
+		template="mailBody"
+	)
+}
+'
+
+startup
+injectmsg_literal '<167>1 2003-08-24T05:14:15.000003-07:00 host app proc msgid - {"subject":"legit\r\nX-Injected-Header: injected\r\n\r\nInjected pre-body","trigger":"trigger-ommail-subject"}'
+shutdown_when_empty
+wait_shutdown
+
+wait_file_exists "$SMTP_DONE"
+wait "$SMTP_PID"
+trap - EXIT
+
+content_check "DATA_BEGIN" "$SMTP_OUT"
+content_check "Subject: legit  X-Injected-Header: injected    Injected pre-body" "$SMTP_OUT"
+if grep -Fx -- "X-Injected-Header: injected" "$SMTP_OUT" >/dev/null; then
+	error_exit 1
+fi
+if grep -Fx -- "Injected pre-body" "$SMTP_OUT" >/dev/null; then
+	error_exit 1
+fi
+content_check "DATA_END" "$SMTP_OUT"
+
+if [ -n "${OMMAIL_SMTP_REPRO_CAPTURE:-}" ]; then
+	cp "$SMTP_OUT" "$OMMAIL_SMTP_REPRO_CAPTURE"
+fi
+
+exit_test


### PR DESCRIPTION
## Summary

This is a hardening change for `ommail` subject rendering. `subject.template` can intentionally render message-derived structured fields, for example fields decoded by `mmjsonparse`. If such a rendered value contains CR/LF bytes, the mail writer should keep those bytes inside the `Subject` field value instead of allowing them to shape the RFC822 header block.

The practical preconditions are narrow: `ommail` must be configured, `subject.template` must include a message-derived field that can contain decoded CR/LF, and the resulting message is an operator alert email generated by that action. This is therefore framed as defense-in-depth hardening, not as a complex disclosure item.

## Change

- Normalize CR/LF to spaces when emitting the `Subject` header.
- Apply the normalization in the common mail-message writer, so both `sendmail` and `smtp` modes use the same behavior.
- Add regression tests for both modes using a JSON field decoded by `mmjsonparse` and rendered through `subject.template`.

## Validation

- Reproduced the pre-fix behavior in both sendmail and SMTP mode with a decoded JSON field rendered into `subject.template`.
- `tests/ommail-subject-template-header-sendmail.sh`: pass
- `tests/ommail-subject-template-header-smtp.sh`: pass
- `devtools/format-code.sh --git-changed`: pass
- `devtools/format-code.sh --git-changed --check --check-if-available`: pass
- `devtools/check-test-antipatterns.sh tests/ommail-subject-template-header-sendmail.sh tests/ommail-subject-template-header-smtp.sh`: advisory only for the SMTP helper background process, matching the existing deterministic port-file/done-file helper pattern
- `shellcheck -S warning` on the two new tests: pass
- `./devtools/local-validation-plan.sh --base upstream/main --run`: pass
  - test summary: 1251 total, 1218 pass, 33 skip, 0 fail, 0 error
  - local Cubic review: no issues found
  - Ubuntu 26.04 dev image ID: `sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

