### PR TITLE
testbench: route tcpflood sends through wrapper

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -90,7 +90,11 @@ minimal containers. Findings are review prompts, not automatic blockers.
   directly instead of expecting generic core-file scanning to catch crashes.
   Prefer the ``tcpflood`` shell helper, which configures and validates a
   per-invocation proper-termination marker. Direct ``./tcpflood`` calls can opt
-  in with ``-q <file>`` when tcpflood completion is part of the oracle.
+  in with ``-q <file>`` when tcpflood completion is part of the oracle. Normal
+  foreground message injection should call ``tcpflood`` through the shell
+  helper, even when passing an explicit ``-p`` port. Use direct ``./tcpflood``
+  only for tcpflood self-tests, intentional non-zero status handling, or
+  background clients whose lifecycle is explicitly controlled by the test.
 - **Queue tests assuming immediate drain or shutdown ordering**: use
   queue-specific synchronization where possible. Do not assume that input
   completion, shutdown start, or a fixed delay means all queued messages reached

--- a/tests/imdtls-basic-timeout.sh
+++ b/tests/imdtls-basic-timeout.sh
@@ -36,11 +36,11 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 startup
 assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 #	valgrind --tool=helgrind $RS_TEST_VALGRIND_EXTRA_OPTS $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 
-./tcpflood -b1 -W1000 -p$PORT_RCVR -m$SENDESSAGES -Tdtls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem -L0
+tcpflood -b1 -W1000 -p"$PORT_RCVR" -m"$SENDESSAGES" -Tdtls -x"$srcdir/tls-certs/ca.pem" -Z"$srcdir/tls-certs/cert.pem" -z"$srcdir/tls-certs/key.pem" -L0
 # ./msleep 500
-./tcpflood -b1 -W1000 -i500 -p$PORT_RCVR -m$SENDESSAGES -Tdtls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem -L0
-./tcpflood -b1 -W1000 -i1000 -p$PORT_RCVR -m$SENDESSAGES -Tdtls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem -L0
-./tcpflood -b1 -W1000 -i1500 -p$PORT_RCVR -m$SENDESSAGES -Tdtls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem -L0
+tcpflood -b1 -W1000 -i500 -p"$PORT_RCVR" -m"$SENDESSAGES" -Tdtls -x"$srcdir/tls-certs/ca.pem" -Z"$srcdir/tls-certs/cert.pem" -z"$srcdir/tls-certs/key.pem" -L0
+tcpflood -b1 -W1000 -i1000 -p"$PORT_RCVR" -m"$SENDESSAGES" -Tdtls -x"$srcdir/tls-certs/ca.pem" -Z"$srcdir/tls-certs/cert.pem" -z"$srcdir/tls-certs/key.pem" -L0
+tcpflood -b1 -W1000 -i1500 -p"$PORT_RCVR" -m"$SENDESSAGES" -Tdtls -x"$srcdir/tls-certs/ca.pem" -Z"$srcdir/tls-certs/cert.pem" -z"$srcdir/tls-certs/key.pem" -L0
 
 wait_file_lines
 shutdown_when_empty

--- a/tests/imdtls-basic.sh
+++ b/tests/imdtls-basic.sh
@@ -32,7 +32,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 startup
 assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 #	valgrind --tool=helgrind $RS_TEST_VALGRIND_EXTRA_OPTS $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 
-./tcpflood -b1 -W1000 -p$PORT_RCVR -m$NUMMESSAGES -Tdtls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem -L0
+tcpflood -b1 -W1000 -p"$PORT_RCVR" -m"$NUMMESSAGES" -Tdtls -x"$srcdir/tls-certs/ca.pem" -Z"$srcdir/tls-certs/cert.pem" -z"$srcdir/tls-certs/key.pem" -L0
 
 wait_file_lines
 shutdown_when_empty

--- a/tests/imptcp-persource-ratelimit-policy.sh
+++ b/tests/imptcp-persource-ratelimit-policy.sh
@@ -59,7 +59,7 @@ for i in $(seq 1 5); do
     echo "<13>Jan 1 00:00:00 quiethost app: msgnum:$i" >> "$INPUT_FILE"
 done
 
-./tcpflood -p"$ptcp_port" -I "$INPUT_FILE"
+tcpflood -p"$ptcp_port" -I "$INPUT_FILE"
 
 sleep 2
 shutdown_when_empty

--- a/tests/imrelp-tls-chainedcert.sh
+++ b/tests/imrelp-tls-chainedcert.sh
@@ -32,7 +32,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 '
 
 startup
-./tcpflood -u openssl -Trelp-tls -acertvalid -p$TCPFLOOD_PORT -m$NUMMESSAGES -z "$srcdir/tls-certs/key.pem" -Z "$srcdir/tls-certs/certchained.pem" -Ersyslog 2> $RSYSLOG_DYNNAME.tcpflood
+tcpflood -u openssl -Trelp-tls -acertvalid -p"$TCPFLOOD_PORT" -m"$NUMMESSAGES" -z "$srcdir/tls-certs/key.pem" -Z "$srcdir/tls-certs/certchained.pem" -Ersyslog 2> "$RSYSLOG_DYNNAME.tcpflood"
 cat -n $RSYSLOG_DYNNAME.tcpflood
 shutdown_when_empty
 wait_shutdown

--- a/tests/imrelp-tls-mixed-chainedcert.sh
+++ b/tests/imrelp-tls-mixed-chainedcert.sh
@@ -39,7 +39,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 '
 
 startup
-./tcpflood -u gnutls -Trelp-tls -acertvalid -p$TCPFLOOD_PORT -m$NUMMESSAGES -z "$srcdir/tls-certs/key.pem" -Z "$srcdir/tls-certs/certchained.pem" -Ersyslog 2> $RSYSLOG_DYNNAME.tcpflood
+tcpflood -u gnutls -Trelp-tls -acertvalid -p"$TCPFLOOD_PORT" -m"$NUMMESSAGES" -z "$srcdir/tls-certs/key.pem" -Z "$srcdir/tls-certs/certchained.pem" -Ersyslog 2> "$RSYSLOG_DYNNAME.tcpflood"
 cat -n $RSYSLOG_DYNNAME.tcpflood
 shutdown_when_empty
 wait_shutdown

--- a/tests/imrelp-tls-mixed-chainedcert2.sh
+++ b/tests/imrelp-tls-mixed-chainedcert2.sh
@@ -39,7 +39,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 '
 
 startup
-./tcpflood -u openssl -Trelp-tls -acertvalid -p$TCPFLOOD_PORT -m$NUMMESSAGES -z "$srcdir/tls-certs/key.pem" -Z "$srcdir/tls-certs/certchained.pem" -Ersyslog 2> $RSYSLOG_DYNNAME.tcpflood
+tcpflood -u openssl -Trelp-tls -acertvalid -p"$TCPFLOOD_PORT" -m"$NUMMESSAGES" -z "$srcdir/tls-certs/key.pem" -Z "$srcdir/tls-certs/certchained.pem" -Ersyslog 2> "$RSYSLOG_DYNNAME.tcpflood"
 cat -n $RSYSLOG_DYNNAME.tcpflood
 shutdown_when_empty
 wait_shutdown

--- a/tests/imrelp-tls.sh
+++ b/tests/imrelp-tls.sh
@@ -18,7 +18,9 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 			         file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup
-./tcpflood -Trelp-tls -acertvalid -p$TCPFLOOD_PORT -m$NUMMESSAGES -x "$srcdir/tls-certs/ca.pem" -z "$srcdir/tls-certs/key.pem" -Z "$srcdir/tls-certs/cert.pem" -Ersyslog 2> $RSYSLOG_DYNNAME.tcpflood
+# Use the tcpflood binary directly here because this test intentionally accepts
+# tcpflood rc=1 when older RELP/TLS stacks cannot set certvalid mode.
+./tcpflood -Trelp-tls -acertvalid -p"$TCPFLOOD_PORT" -m"$NUMMESSAGES" -x "$srcdir/tls-certs/ca.pem" -z "$srcdir/tls-certs/key.pem" -Z "$srcdir/tls-certs/cert.pem" -Ersyslog 2> "$RSYSLOG_DYNNAME.tcpflood"
 if [ $? -eq 1 ]; then
 	cat $RSYSLOG_DYNNAME.tcpflood
 	if ! grep "could net set.*certvalid" < "$RSYSLOG_DYNNAME.tcpflood" ; then

--- a/tests/imtcp-listen-port-file-2.sh
+++ b/tests/imtcp-listen-port-file-2.sh
@@ -25,8 +25,8 @@ ruleset(name="rs2") {
 startup
 assign_file_content RCVR_PORT "$RSYSLOG_DYNNAME.rcvr_port"
 assign_file_content RCVR_PORT2 "$RSYSLOG_DYNNAME.rcvr_port2"
-./tcpflood -p $RCVR_PORT -m10 
-./tcpflood -p $RCVR_PORT2 -m10 -i10
+tcpflood -p "$RCVR_PORT" -m10
+tcpflood -p "$RCVR_PORT2" -m10 -i10
 shutdown_when_empty
 wait_shutdown
 printf 'checking receiver 1\n'

--- a/tests/imtcp-persource-ratelimit.sh
+++ b/tests/imtcp-persource-ratelimit.sh
@@ -51,7 +51,7 @@ for i in $(seq 1 5); do
     echo "<13>Jan 1 00:00:00 quiethost app: msgnum:$i" >> "$INPUT_FILE"
 done
 
-./tcpflood -p"$tcp_port" -I "$INPUT_FILE"
+tcpflood -p"$tcp_port" -I "$INPUT_FILE"
 
 shutdown_when_empty
 wait_shutdown

--- a/tests/imudp-persource-ratelimit-policy.sh
+++ b/tests/imudp-persource-ratelimit-policy.sh
@@ -47,7 +47,7 @@ if $msg contains "msgnum:" then
 startup
 assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
-./tcpflood -Tudp -p"$PORT_RCVR" -m "$SENDMESSAGES"
+tcpflood -Tudp -p"$PORT_RCVR" -m "$SENDMESSAGES"
 
 sleep 2
 shutdown_when_empty

--- a/tests/imudp-ratelimit-programname.sh
+++ b/tests/imudp-ratelimit-programname.sh
@@ -29,7 +29,7 @@ if $msg contains "rate-limit identity" then {
 startup
 assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
-./tcpflood -Tudp -p"$PORT_RCVR" -m2 -M "<29>1 2026-02-19T13:00:00.000Z router1 rpd 1234 TEST_MSG - rate-limit identity"
+tcpflood -Tudp -p"$PORT_RCVR" -m2 -M "<29>1 2026-02-19T13:00:00.000Z router1 rpd 1234 TEST_MSG - rate-limit identity"
 
 shutdown_when_empty
 wait_shutdown

--- a/tests/imudp_ratelimit_name.sh
+++ b/tests/imudp_ratelimit_name.sh
@@ -26,7 +26,7 @@ startup
 assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
 # Send 20 messages via UDP
-./tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES
+tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES
 
 shutdown_when_empty
 wait_shutdown

--- a/tests/ratelimit-legacy-persource-discard.sh
+++ b/tests/ratelimit-legacy-persource-discard.sh
@@ -56,7 +56,7 @@ for i in $(seq 1 5); do
     echo "<13>Jan 1 00:00:00 quiethost app: msgnum:$i" >> "$INPUT_FILE"
 done
 
-./tcpflood -p"$tcp_port" -I "$INPUT_FILE"
+tcpflood -p"$tcp_port" -I "$INPUT_FILE"
 
 sleep 2
 shutdown_when_empty

--- a/tests/ratelimit-persource-repeat-summary.sh
+++ b/tests/ratelimit-persource-repeat-summary.sh
@@ -50,7 +50,7 @@ for _ in $(seq 1 4); do
 done
 echo "<13>Jan 1 00:00:00 noisyhost app: distinct over limit" >> "$INPUT_FILE"
 
-./tcpflood -p"$tcp_port" -I "$INPUT_FILE"
+tcpflood -p"$tcp_port" -I "$INPUT_FILE"
 
 shutdown_when_empty
 wait_shutdown

--- a/tests/ratelimit-policy-persource-topn-default-reload.sh
+++ b/tests/ratelimit-policy-persource-topn-default-reload.sh
@@ -34,7 +34,7 @@ send_host_messages() {
     for i in $(seq 1 "$count"); do
         echo "<13>Jan 1 00:00:00 $host app: msgnum:$host:$i" >> "$INPUT_FILE"
     done
-    ./tcpflood -p"$PORT_RCVR" -I "$INPUT_FILE"
+    tcpflood -p"$PORT_RCVR" -I "$INPUT_FILE"
 }
 
 wait_stats_contains() {

--- a/tests/ratelimit_hup.sh
+++ b/tests/ratelimit_hup.sh
@@ -33,7 +33,7 @@ assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 export SENDMESSAGES=20
 echo "Checking ports for $PORT_RCVR:"
 ss -ulpn | grep $PORT_RCVR
-./tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
+tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
 
 # Allow time for processing
 ./msleep 3000
@@ -63,7 +63,7 @@ ps aux | grep rsyslogd | grep -v grep
 ./msleep 1000 # wait for HUP to be processed
 
 # Send 20 messages. 0 should pass.
-./tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
+tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
 
 # Allow time for processing
 ./msleep 1000

--- a/tests/ratelimit_name.sh
+++ b/tests/ratelimit_name.sh
@@ -21,10 +21,10 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 startup
 # Send messages to TCP port
 tcp_port=$(cat $RSYSLOG_DYNNAME.tcp.port)
-./tcpflood -p$tcp_port -m 20
+tcpflood -p$tcp_port -m 20
 # Send messages to PTCP port
 ptcp_port=$(cat $RSYSLOG_DYNNAME.ptcp.port)
-./tcpflood -p$ptcp_port -m 20
+tcpflood -p$ptcp_port -m 20
 
 shutdown_when_empty
 wait_shutdown

--- a/tests/ratelimit_policy_watch.sh
+++ b/tests/ratelimit_policy_watch.sh
@@ -35,7 +35,7 @@ ruleset(name="main") {
 startup
 assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
-./tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
+tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
 wait_file_lines "$RSYSLOG_OUT_LOG" 20 100
 
 : > "$RSYSLOG_OUT_LOG"
@@ -47,7 +47,7 @@ severity: 0
 YAML
 ./msleep 1500
 
-./tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
+tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
 ./msleep 1000
 wait_queueempty
 
@@ -65,7 +65,7 @@ YAML
 mv -f "$POLICY_TMP" "$POLICY_FILE"
 ./msleep 1500
 
-./tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
+tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
 wait_file_lines "$RSYSLOG_OUT_LOG" 20 100
 
 shutdown_when_empty

--- a/tests/ratelimit_policy_watch_debounce.sh
+++ b/tests/ratelimit_policy_watch_debounce.sh
@@ -52,7 +52,7 @@ YAML
 
 ./msleep 1500
 
-./tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
+tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
 ./msleep 1000
 wait_queueempty
 

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -116,6 +116,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <signal.h>
+#include <stdarg.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
@@ -345,13 +346,13 @@ static int sendDTLS(char *buf, size_t lenBuf);
 static void closeDTLSSess(void);
 
 #ifdef ENABLE_RELP
-    /* RELP subsystem */
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wformat-security"
 static void relp_dbgprintf(char __attribute__((unused)) * fmt, ...) {
-    printf(fmt);
+    va_list ap;
+
+    va_start(ap, fmt);
+    vprintf(fmt, ap);
+    va_end(ap);
 }
-    #pragma GCC diagnostic pop
 
 static relpEngine_t *pRelpEngine;
     #define CHKRELP(f)                   \

--- a/tests/yaml-ratelimit-policywatch.sh
+++ b/tests/yaml-ratelimit-policywatch.sh
@@ -49,7 +49,7 @@ sed -i \
 startup
 assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
-./tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
+tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
 wait_file_lines "$RSYSLOG_OUT_LOG" 20 100
 
 : > "$RSYSLOG_OUT_LOG"
@@ -61,7 +61,7 @@ severity: 0
 YAML
 ./msleep 1500
 
-./tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
+tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
 ./msleep 1000
 wait_queueempty
 


### PR DESCRIPTION
## Summary
- convert normal foreground `./tcpflood` sends to the `tcpflood` shell wrapper so they use the proper-termination oracle from #7312
- document when direct `./tcpflood` remains acceptable
- leave `imrelp-tls.sh` direct because it intentionally handles `tcpflood` rc=1 for older RELP/TLS stacks

## Validation
- `bash -n` on changed shell tests
- `devtools/check-test-antipatterns.sh` on changed shell tests; advisory-only pre-existing sleep/timeout matches remain
- `git diff --check`
- `shellcheck -S warning` on changed shell tests
- `./devtools/run-configure.sh` with compact testbench profile
- `make -j10`
- `make -j10 check TESTS=""`
- `make -C tests check TESTS="imtcp-listen-port-file-2.sh tcpflood-proper-termination.sh"`
- `make -C tests check TESTS="imudp_ratelimit_name.sh"`

With the help of AI-Agents: Codex


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

