### PR TITLE
testbench: check async tcpflood completion

### DIFF
--- a/doc/source/development/dev_testbench.rst
+++ b/doc/source/development/dev_testbench.rst
@@ -123,6 +123,10 @@ the test oracle; the option stays single-character for portability to platforms
 without GNU-style long options.
 Tests that intentionally provoke a tcpflood send failure should use the
 ``tcpflood --check-only`` wrapper form and assert the rsyslog-side oracle.
+Background tcpflood clients that are expected to finish normally should use
+``start_tcpflood_async`` and ``wait_tcpflood_async``. These helpers preserve the
+intended concurrency while still checking the helper pid status and
+proper-termination marker.
 
 Do not add helper cleanup or observer processes to prove daemon shutdown. They
 have historically caused their own races. ``timeoutGuard`` remains mandatory

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -92,9 +92,12 @@ minimal containers. Findings are review prompts, not automatic blockers.
   per-invocation proper-termination marker. Direct ``./tcpflood`` calls can opt
   in with ``-q <file>`` when tcpflood completion is part of the oracle. Normal
   foreground message injection should call ``tcpflood`` through the shell
-  helper, even when passing an explicit ``-p`` port. Use direct ``./tcpflood``
-  only for tcpflood self-tests, intentional non-zero status handling, or
-  background clients whose lifecycle is explicitly controlled by the test.
+  helper, even when passing an explicit ``-p`` port. Background tcpflood
+  clients that are expected to complete cleanly should use
+  ``start_tcpflood_async`` and ``wait_tcpflood_async`` so both the pid status
+  and proper-termination marker are checked. Use direct ``./tcpflood`` only for
+  tcpflood self-tests, intentional non-zero status handling, or background
+  clients whose lifecycle is explicitly controlled by the test.
 - **Queue tests assuming immediate drain or shutdown ordering**: use
   queue-specific synchronization where possible. Do not assume that input
   completion, shutdown start, or a fixed delay means all queued messages reached

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -3310,6 +3310,16 @@ tcpflood_marker_is_valid() {
 		grep -qx 'phase=main-exit' "$file"
 }
 
+tcpflood_next_marker() {
+	local marker=""
+	if [ -n "${RSYSLOG_DYNNAME:-}" ] && [ "${RSTB_NO_TCPFLOOD_MARKER:-}" != "YES" ]; then
+		TCPFLOOD_MARKER_ID=$(( ${TCPFLOOD_MARKER_ID:-0} + 1 ))
+		marker="${RSYSLOG_DYNNAME}.tcpflood.${TCPFLOOD_MARKER_ID}.proper-termination"
+		rm -f "$marker"
+	fi
+	printf '%s' "$marker"
+}
+
 print_tcpflood_marker_file() {
 	local file="$1"
 	if [ -z "$file" ]; then
@@ -3385,26 +3395,10 @@ tcpflood_append_args() {
 	done
 }
 
-tcpflood() {
-	local check_only marker res use_marker
-	local -a TCPFLOOD_CMD TCPFLOOD_EXTRA_ARGS
-	if [ "$1" == "--check-only" ]; then
-		check_only="yes"
-		shift
-	else
-		check_only="no"
-	fi
-	use_marker="yes"
-	if [ "${RSTB_NO_TCPFLOOD_MARKER:-}" = "YES" ]; then
-		use_marker="no"
-	fi
-	if [ -n "${RSYSLOG_DYNNAME:-}" ] && [ "$use_marker" = "yes" ]; then
-		TCPFLOOD_MARKER_ID=$(( ${TCPFLOOD_MARKER_ID:-0} + 1 ))
-		marker="${RSYSLOG_DYNNAME}.tcpflood.${TCPFLOOD_MARKER_ID}.proper-termination"
-		rm -f "$marker"
-	else
-		marker=""
-	fi
+tcpflood_build_command() {
+	local marker="$1"
+	shift
+	local -a TCPFLOOD_EXTRA_ARGS
 	TCPFLOOD_CMD=(./tcpflood)
 	if [ -n "$marker" ]; then
 		TCPFLOOD_CMD+=(-q "$marker")
@@ -3415,6 +3409,19 @@ tcpflood() {
 		eval "TCPFLOOD_EXTRA_ARGS=( $TCPFLOOD_EXTRA_OPTS )"
 		TCPFLOOD_CMD+=("${TCPFLOOD_EXTRA_ARGS[@]}")
 	fi
+}
+
+tcpflood() {
+	local check_only marker res
+	local -a TCPFLOOD_CMD
+	if [ "$1" == "--check-only" ]; then
+		check_only="yes"
+		shift
+	else
+		check_only="no"
+	fi
+	marker="$(tcpflood_next_marker)"
+	tcpflood_build_command "$marker" "$@"
 	"${TCPFLOOD_CMD[@]}"
 	res=$?
 	if [ "$res" -eq 0 ] && [ -n "$marker" ] && ! tcpflood_marker_is_valid "$marker"; then
@@ -3438,6 +3445,42 @@ tcpflood() {
 			cp ${RSYSLOG_OUT_LOG} ${RSYSLOG_OUT_LOG}.save
 			error_exit 1 stacktrace
 		fi
+	fi
+}
+
+start_tcpflood_async() {
+	local pid_var="$1"
+	local marker_var="$2"
+	local marker
+	local -a TCPFLOOD_CMD
+	shift 2
+	marker="$(tcpflood_next_marker)"
+	tcpflood_build_command "$marker" "$@"
+	"${TCPFLOOD_CMD[@]}" &
+	printf -v "$pid_var" '%s' "$!"
+	printf -v "$marker_var" '%s' "$marker"
+}
+
+wait_tcpflood_async() {
+	local pid="$1"
+	local marker="${2:-}"
+	local res
+	wait "$pid"
+	res=$?
+	if [ "$res" -eq 0 ] && [ -n "$marker" ] && ! tcpflood_marker_is_valid "$marker"; then
+		echo "error during async tcpflood: proper termination marker missing or invalid"
+		print_tcpflood_marker_file "$marker"
+		error_exit 1
+	fi
+	if [ "$res" -gt 128 ]; then
+		echo "error during async tcpflood: process aborted with status $res"
+		print_tcpflood_marker_file "$marker"
+		error_exit 1
+	fi
+	if [ "$res" -ne 0 ]; then
+		echo "error during async tcpflood: process exited with status $res"
+		print_tcpflood_marker_file "$marker"
+		error_exit 1
 	fi
 }
 

--- a/tests/gzipwr_hup.sh
+++ b/tests/gzipwr_hup.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released  under ASL 2.0
 # Written 2019-06-12 by Rainer Gerhards
+# Exercise gzip writer shutdown across repeated HUPs while tcpflood is still
+# sending. The async tcpflood helper pid plus marker prove the sender completed
+# normally before the gzip sequence oracle checks all generated messages.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=${NUMMESSAGES:-2000000}
 export COUNT_FILE_IS_ZIPPED=yes
@@ -22,13 +25,12 @@ template(name="dynfile" type="string" string="'$RSYSLOG_OUT_LOG'")
 			         dynafile="dynfile")
 '
 startup
-./tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES & # TCPFlood needs to run async!
-BGPROCESS=$!
+start_tcpflood_async BGPROCESS TCPFLOOD_MARKER -m"$NUMMESSAGES"
 for i in $(seq 1 20); do
 	printf '\nsending HUP %d\n' $i
 	issue_HUP --sleep 100
 done
-wait $BGPROCESS
+wait_tcpflood_async "$BGPROCESS" "$TCPFLOOD_MARKER"
 shutdown_when_empty
 wait_shutdown
 gzip_seq_check

--- a/tests/gzipwr_hup_multi_file.sh
+++ b/tests/gzipwr_hup_multi_file.sh
@@ -2,6 +2,9 @@
 # This file is part of the rsyslog project, released  under ASL 2.0
 # Written 2019-06-12 by Rainer Gerhards
 export TEST_MAX_RUNTIME=7200
+# Exercise multi-file async gzip writing across repeated HUPs. The tcpflood pid
+# and marker prove the background sender completed normally before shutdown and
+# cross-file sequence validation.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=100000
 generate_conf
@@ -29,12 +32,13 @@ if $msg contains "msgnum" then {
 }
 '
 startup
-./tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES & # TCPFlood needs to run async!
+start_tcpflood_async TCPFLOOD_PID TCPFLOOD_MARKER -m"$NUMMESSAGES"
 for i in $(seq 0 20); do
 	printf '\nsending HUP %d\n' $i
 	issue_HUP
 	./msleep 10
 done
+wait_tcpflood_async "$TCPFLOOD_PID" "$TCPFLOOD_MARKER"
 shutdown_when_empty
 wait_shutdown
 ls -l ${RSYSLOG_OUT_LOG}.*

--- a/tests/gzipwr_hup_single_file.sh
+++ b/tests/gzipwr_hup_single_file.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released  under ASL 2.0
 # Written 2019-06-12 by Rainer Gerhards
+# Exercise async gzip writing while repeated HUPs happen during input. The
+# tcpflood pid and marker prove the background sender completed cleanly before
+# shutdown and the gzip sequence oracle.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=50000
 generate_conf
@@ -28,12 +31,13 @@ if $msg contains "msgnum" then {
 }
 '
 startup
-./tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES & # TCPFlood needs to run async!
+start_tcpflood_async TCPFLOOD_PID TCPFLOOD_MARKER -m"$NUMMESSAGES"
 for i in $(seq 0 20); do
 	./msleep 10
 	printf '\nsending HUP %d\n' $i
 	issue_HUP
 done
+wait_tcpflood_async "$TCPFLOOD_PID" "$TCPFLOOD_MARKER"
 shutdown_when_empty
 wait_shutdown
 gzip_seq_check

--- a/tests/imrelp-tls.sh
+++ b/tests/imrelp-tls.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 # addd 2019-01-31 by PascalWithopf, released under ASL 2.0
+# Validate RELP/TLS certvalid input with a direct tcpflood call because this
+# test intentionally accepts rc=1 for older RELP/TLS stacks. The direct call
+# still uses a proper-termination marker on rc=0 and treats abort statuses as
+# hard tcpflood failures.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=1000
 do_skip=0
+tcpflood_marker="${RSYSLOG_DYNNAME}.tcpflood.direct.proper-termination"
 generate_conf
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
@@ -20,15 +25,31 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 startup
 # Use the tcpflood binary directly here because this test intentionally accepts
 # tcpflood rc=1 when older RELP/TLS stacks cannot set certvalid mode.
-./tcpflood -Trelp-tls -acertvalid -p"$TCPFLOOD_PORT" -m"$NUMMESSAGES" -x "$srcdir/tls-certs/ca.pem" -z "$srcdir/tls-certs/key.pem" -Z "$srcdir/tls-certs/cert.pem" -Ersyslog 2> "$RSYSLOG_DYNNAME.tcpflood"
-if [ $? -eq 1 ]; then
-	cat $RSYSLOG_DYNNAME.tcpflood
+rm -f "$tcpflood_marker"
+./tcpflood -q "$tcpflood_marker" -Trelp-tls -acertvalid -p"$TCPFLOOD_PORT" -m"$NUMMESSAGES" -x "$srcdir/tls-certs/ca.pem" -z "$srcdir/tls-certs/key.pem" -Z "$srcdir/tls-certs/cert.pem" -Ersyslog 2> "$RSYSLOG_DYNNAME.tcpflood"
+tcpflood_rc=$?
+if [ "$tcpflood_rc" -eq 0 ]; then
+	if ! tcpflood_marker_is_valid "$tcpflood_marker"; then
+		echo "FAIL: tcpflood marker missing or invalid"
+		print_tcpflood_marker_file "$tcpflood_marker"
+		error_exit 1
+	fi
+elif [ "$tcpflood_rc" -gt 128 ]; then
+	echo "FAIL: tcpflood aborted with status $tcpflood_rc"
+	print_tcpflood_marker_file "$tcpflood_marker"
+	error_exit 1
+elif [ "$tcpflood_rc" -eq 1 ]; then
+	cat "$RSYSLOG_DYNNAME.tcpflood"
 	if ! grep "could net set.*certvalid" < "$RSYSLOG_DYNNAME.tcpflood" ; then
 		printf "librelp too old, need to skip this test\n"
 		do_skip=1
 	fi
+else
+	echo "FAIL: tcpflood exited with unexpected status $tcpflood_rc"
+	print_tcpflood_marker_file "$tcpflood_marker"
+	error_exit 1
 fi
-	cat -n $RSYSLOG_DYNNAME.tcpflood
+cat -n "$RSYSLOG_DYNNAME.tcpflood"
 shutdown_when_empty
 wait_shutdown
 if [ $do_skip -eq 1 ]; then

--- a/tests/imtcp-multi-drvr-basic-parallel.sh
+++ b/tests/imtcp-multi-drvr-basic-parallel.sh
@@ -27,11 +27,12 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 startup
 assign_tcpflood_port2 "$RSYSLOG_DYNNAME.tcpflood_port2"
 # Note: the two tcpflood instances are run in parallel with intent!
-# It stresses the rsyslog engine a bit more. If this fails, see if 
-# the non-parallel test also fails. If so, debug that one, because it
-# is easier to do!
-tcpflood -p$TCPFLOOD_PORT -m$((NUMMESSAGES / 2)) -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem &
-tcpflood -p$TCPFLOOD_PORT2 -m$((NUMMESSAGES / 2)) -i$((NUMMESSAGES / 2))
+# It stresses the rsyslog engine a bit more. The async helper pid plus marker
+# prove the TLS sender completed cleanly; if this fails, see if the non-parallel
+# test also fails, because it is easier to debug.
+start_tcpflood_async TCPFLOOD_PID TCPFLOOD_MARKER -m$((NUMMESSAGES / 2)) -Ttls -x"$srcdir/tls-certs/ca.pem" -Z"$srcdir/tls-certs/cert.pem" -z"$srcdir/tls-certs/key.pem"
+tcpflood -p"$TCPFLOOD_PORT2" -m$((NUMMESSAGES / 2)) -i$((NUMMESSAGES / 2))
+wait_tcpflood_async "$TCPFLOOD_PID" "$TCPFLOOD_MARKER"
 shutdown_when_empty
 wait_shutdown
 seq_check

--- a/tests/omfile-outchannel-many.sh
+++ b/tests/omfile-outchannel-many.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # addd 2018-08-02 by RGerhards, released under ASL 2.0
+# Exercise outchannel rotation while tcpflood runs in the background and another
+# input path injects messages. The tcpflood pid and marker prove the background
+# sender finished cleanly before rotated output is validated.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=500000
 echo "ls -l $RSYSLOG_DYNNAME.channel.*
@@ -42,10 +45,11 @@ ruleset(name="tcp") {
 }
 '
 startup
-./tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES & # TCPFlood needs to run async!
+start_tcpflood_async TCPFLOOD_PID TCPFLOOD_MARKER -m"$NUMMESSAGES"
 #./msleep 2500
 injectmsg
 sleep 1
+wait_tcpflood_async "$TCPFLOOD_PID" "$TCPFLOOD_MARKER"
 shutdown_when_empty
 wait_shutdown
 ls -l $RSYSLOG_DYNNAME.channel.*

--- a/tests/omfile_hup.sh
+++ b/tests/omfile_hup.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released  under ASL 2.0
 # Written 2019-06-21 by Rainer Gerhards
+# Exercise omfile output while HUPs are issued during a long tcpflood send. The
+# background sender is validated by pid and proper-termination marker before the
+# final sequence oracle checks all messages.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=${NUMMESSAGES:-1000000}
 export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
@@ -16,13 +19,12 @@ template(name="dynfile" type="string" string="'$RSYSLOG_OUT_LOG'")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt" dynafile="dynfile")
 '
 startup
-./tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES & # TCPFlood needs to run async!
-BGPROCESS=$!
+start_tcpflood_async BGPROCESS TCPFLOOD_MARKER -m"$NUMMESSAGES"
 for i in $(seq 1 20); do
 	printf '\nsending HUP %d\n' $i
 	issue_HUP --sleep 100
 done
-wait $BGPROCESS
+wait_tcpflood_async "$BGPROCESS" "$TCPFLOOD_MARKER"
 shutdown_when_empty
 wait_shutdown
 seq_check


### PR DESCRIPTION
## Summary
- add `start_tcpflood_async` / `wait_tcpflood_async` helpers that check both background tcpflood pid status and proper-termination markers
- convert normal-completion async tcpflood tests in HUP, gzip, outchannel, and parallel imtcp coverage to the new helper
- harden the direct `imrelp-tls.sh` tcpflood compatibility path so rc 0 requires a marker and signal-style aborts fail immediately
- document the async helper as the expected pattern for background tcpflood clients that should finish cleanly

## Validation
- `bash -n tests/diag.sh tests/gzipwr_hup.sh tests/gzipwr_hup_single_file.sh tests/gzipwr_hup_multi_file.sh tests/omfile_hup.sh tests/omfile-outchannel-many.sh tests/imtcp-multi-drvr-basic-parallel.sh tests/imrelp-tls.sh`
- `git diff --check`
- `devtools/check-test-antipatterns.sh tests/gzipwr_hup.sh tests/gzipwr_hup_single_file.sh tests/gzipwr_hup_multi_file.sh tests/omfile_hup.sh tests/omfile-outchannel-many.sh tests/imtcp-multi-drvr-basic-parallel.sh tests/imrelp-tls.sh`
- `shellcheck -S warning tests/gzipwr_hup.sh tests/gzipwr_hup_single_file.sh tests/gzipwr_hup_multi_file.sh tests/omfile_hup.sh tests/omfile-outchannel-many.sh tests/imtcp-multi-drvr-basic-parallel.sh tests/imrelp-tls.sh`
- `devtools/local-validation-plan.sh --base upstream/main`
- `RSYSLOG_CONFIGURE_OPTIONS='--enable-testbench --enable-imdiag --enable-impstats --enable-omstdout --enable-imptcp --enable-relp --enable-gnutls --enable-openssl --disable-mysql --disable-kafka-tests --disable-elasticsearch-tests --disable-snmp-tests' ./devtools/run-configure.sh`
- `make -j10 check TESTS=""`
- direct tests: `./imrelp-tls.sh`, `./imtcp-multi-drvr-basic-parallel.sh`, `./omfile_hup.sh`, `./gzipwr_hup_single_file.sh`, `./gzipwr_hup.sh`, `./gzipwr_hup_multi_file.sh`, `./omfile-outchannel-many.sh`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 10`

Notes: the test antipattern scan reports existing intentional timing/runtime patterns in these HUP tests; the touched headers now document the async sender oracle.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

