### PR TITLE
Override test libs

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2326,7 +2326,7 @@ CLEANFILES+= \
 # there exists no such hook. Se we at least delete it on make clean.
 
 
-pkglib_LTLIBRARIES =
+check_LTLIBRARIES =
 
 # TODO: reenable TESTRUNS = rt_init rscript
 check_PROGRAMS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace \
@@ -2411,44 +2411,37 @@ runtime_unit_parser_pri_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
 runtime_unit_msg_replace_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
 endif
 
-# Shipped even when testbench is disabled: dist tarballs are often built with
-# --disable-testbench, but downstream builds may enable testbench + imptcp.
-EXTRA_DIST += override_epoll_ctl.c override_libnet_write_fail.c
+TEST_LIBOVERRIDE_LDFLAGS = -module -shared -avoid-version -rpath $(abs_builddir)
 
 if ENABLE_TESTBENCH
-pkglib_LTLIBRARIES += liboverride_gethostname.la
+check_LTLIBRARIES += liboverride_gethostname.la
 liboverride_gethostname_la_SOURCES = override_gethostname.c
 liboverride_gethostname_la_CFLAGS =
-liboverride_gethostname_la_LDFLAGS = -avoid-version -shared
+liboverride_gethostname_la_LDFLAGS = $(TEST_LIBOVERRIDE_LDFLAGS)
 
-pkglib_LTLIBRARIES += liboverride_gethostname_nonfqdn.la
+check_LTLIBRARIES += liboverride_gethostname_nonfqdn.la
 liboverride_gethostname_nonfqdn_la_SOURCES = override_gethostname_nonfqdn.c
 liboverride_gethostname_nonfqdn_la_CFLAGS =
-liboverride_gethostname_nonfqdn_la_LDFLAGS = -avoid-version -shared
+liboverride_gethostname_nonfqdn_la_LDFLAGS = $(TEST_LIBOVERRIDE_LDFLAGS)
 
-pkglib_LTLIBRARIES += liboverride_getaddrinfo.la
+check_LTLIBRARIES += liboverride_getaddrinfo.la
 liboverride_getaddrinfo_la_SOURCES = override_getaddrinfo.c
 liboverride_getaddrinfo_la_CFLAGS =
-liboverride_getaddrinfo_la_LDFLAGS = -avoid-version -shared
+liboverride_getaddrinfo_la_LDFLAGS = $(TEST_LIBOVERRIDE_LDFLAGS)
 
 if ENABLE_IMPTCP
-pkglib_LTLIBRARIES += liboverride_epoll_ctl.la
+check_LTLIBRARIES += liboverride_epoll_ctl.la
 liboverride_epoll_ctl_la_SOURCES = override_epoll_ctl.c
 liboverride_epoll_ctl_la_CFLAGS =
-liboverride_epoll_ctl_la_LDFLAGS = -avoid-version -shared
+liboverride_epoll_ctl_la_LDFLAGS = $(TEST_LIBOVERRIDE_LDFLAGS)
 liboverride_epoll_ctl_la_LIBADD = $(DL_LIBS)
 endif
 
 if ENABLE_OMUDPSPOOF
-check_DATA += liboverride_libnet_write_fail.so
-CLEANFILES += liboverride_libnet_write_fail.so
-
-liboverride_libnet_write_fail.so: override_libnet_write_fail.c
-	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
-		$(AM_CPPFLAGS) $(CPPFLAGS) $(CFLAGS) -fPIC -shared \
-		-o $@ $<
-
-omudpspoof-fragment-send-failure.log: liboverride_libnet_write_fail.so
+check_LTLIBRARIES += liboverride_libnet_write_fail.la
+liboverride_libnet_write_fail_la_SOURCES = override_libnet_write_fail.c
+liboverride_libnet_write_fail_la_CFLAGS =
+liboverride_libnet_write_fail_la_LDFLAGS = $(TEST_LIBOVERRIDE_LDFLAGS)
 endif
 
 check_PROGRAMS += $(TESTRUNS) ourtail tcpflood chkseq msleep randomgen \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2327,7 +2327,6 @@ CLEANFILES+= \
 
 
 pkglib_LTLIBRARIES =
-check_DATA =
 
 # TODO: reenable TESTRUNS = rt_init rscript
 check_PROGRAMS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace \
@@ -2433,15 +2432,11 @@ liboverride_getaddrinfo_la_CFLAGS =
 liboverride_getaddrinfo_la_LDFLAGS = -avoid-version -shared
 
 if ENABLE_IMPTCP
-check_DATA += liboverride_epoll_ctl.so
-CLEANFILES += liboverride_epoll_ctl.so
-
-liboverride_epoll_ctl.so: override_epoll_ctl.c
-	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
-		$(AM_CPPFLAGS) $(CPPFLAGS) $(CFLAGS) -fPIC -shared \
-		-o $@ $< $(DL_LIBS)
-
-imptcp-epoll-add-failure.log: liboverride_epoll_ctl.so
+pkglib_LTLIBRARIES += liboverride_epoll_ctl.la
+liboverride_epoll_ctl_la_SOURCES = override_epoll_ctl.c
+liboverride_epoll_ctl_la_CFLAGS =
+liboverride_epoll_ctl_la_LDFLAGS = -avoid-version -shared
+liboverride_epoll_ctl_la_LIBADD = $(DL_LIBS)
 endif
 
 if ENABLE_OMUDPSPOOF

--- a/tests/imptcp-epoll-add-failure.sh
+++ b/tests/imptcp-epoll-add-failure.sh
@@ -4,17 +4,13 @@
 # post-accept error path ran, and then shut down cleanly without walking a
 # dangling session list entry left by that failure.
 . ${srcdir:=.}/diag.sh init
-platform="$(uname)"
-if [ "$platform" != "Linux" ]; then
-	echo "platform is \"$platform\" - test requires Linux epoll and LD_PRELOAD support"
-	skip_test
-fi
+skip_platform "FreeBSD" "requires Linux epoll and LD_PRELOAD support"
 skip_ASAN "LD_PRELOAD conflicts with ASan runtime load order"
 require_plugin imptcp
 
 export NUMMESSAGES=1
 export RSYSLOG_TEST_EPOLL_CTL_FAIL_MARKER="${RSYSLOG_DYNNAME}.fail-session-epoll"
-export RSYSLOG_PRELOAD=./liboverride_epoll_ctl.so
+export RSYSLOG_PRELOAD=.libs/liboverride_epoll_ctl.so
 STARTED_LOG="${RSYSLOG_DYNNAME}.started"
 EXPECTED_STR="imptcp: failed to fully accept session"
 

--- a/tests/imptcp-epoll-add-failure.sh
+++ b/tests/imptcp-epoll-add-failure.sh
@@ -4,7 +4,11 @@
 # post-accept error path ran, and then shut down cleanly without walking a
 # dangling session list entry left by that failure.
 . ${srcdir:=.}/diag.sh init
-skip_platform "FreeBSD" "requires Linux epoll and LD_PRELOAD support"
+platform="$(uname)"
+if [ "$platform" != "Linux" ]; then
+	echo "platform is \"$platform\" - test requires Linux epoll and LD_PRELOAD support"
+	skip_test
+fi
 skip_ASAN "LD_PRELOAD conflicts with ASan runtime load order"
 require_plugin imptcp
 

--- a/tests/omudpspoof-fragment-send-failure.sh
+++ b/tests/omudpspoof-fragment-send-failure.sh
@@ -11,7 +11,7 @@ fi
 . ${srcdir:=.}/diag.sh init
 skip_ASAN "LD_PRELOAD conflicts with ASan runtime load order"
 
-export RSYSLOG_PRELOAD=./liboverride_libnet_write_fail.so
+export RSYSLOG_PRELOAD=.libs/liboverride_libnet_write_fail.so
 export TCPFLOOD_EXTRA_OPTS="-b1 -W1"
 export NUMMESSAGES=1
 export MESSAGESIZE=65000


### PR DESCRIPTION
Use `check_LTLIBRARIES` to generate liboverride_* test libraries

`check_LITLIBRARIES` is almost exactly what we want aside from generating
a .so. To force libtool to generate a .so, specify a dummy rpath.

See https://stackoverflow.com/a/8278784

Fixes: #7320


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

