### PR TITLE
packaging: drop liboverride package exceptions

### DIFF
--- a/packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec
+++ b/packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec
@@ -16,8 +16,6 @@ Summary: Enhanced system logging and kernel message trapping daemon
 Name: rsyslog
 Version: 8.2602.0
 Release: 2%{?dist}
-# Build-time generated file list for optional liboverride_*.so modules.
-%global liboverride_filelist %{_builddir}/%{name}-%{version}/liboverride.files
 License: (GPLv3+ and ASL 2.0)
 Group: System Environment/Daemons
 URL: https://www.rsyslog.com/
@@ -715,21 +713,6 @@ install -p -m 644 plugins/ompgsql/createDB.sql %{buildroot}%{rsyslog_docdir}/pgs
 # extract documentation (Sphinx output is in doc/build/ when built in-tree)
 cp -r doc/build/* %{buildroot}%{rsyslog_docdir}/html
 
-# Generate file list for optional liboverride modules.
-# Older sources may not build these files; newer ones do.
-# Keep file non-empty for older sources where no liboverride modules exist.
-# rpmbuild errors out on an empty %files -f input file.
-echo "%%exclude %{_libdir}/rsyslog/__liboverride_filelist_placeholder__.so" > %{liboverride_filelist}
-for so in \
-  liboverride_getaddrinfo.so \
-  liboverride_gethostname.so \
-  liboverride_gethostname_nonfqdn.so
-do
-  if [ -f %{buildroot}%{_libdir}/rsyslog/$so ]; then
-    echo %{_libdir}/rsyslog/$so >> %{liboverride_filelist}
-  fi
-done
-
 # get rid of libtool libraries
 rm -f %{buildroot}%{_libdir}/rsyslog/*.la
 
@@ -750,7 +733,7 @@ done
 %postun
 %systemd_postun_with_restart rsyslog.service
 
-%files -f %{liboverride_filelist}
+%files
 %defattr(-,root,root,-)
 %doc AUTHORS COPYING* ChangeLog
 %exclude %{rsyslog_docdir}/html

--- a/packaging/ubuntu/noble/v8-stable/debian/not-installed
+++ b/packaging/ubuntu/noble/v8-stable/debian/not-installed
@@ -1,6 +1,2 @@
 usr/lib/${DEB_HOST_MULTIARCH}/rsyslog/imdiag.so
-usr/lib/${DEB_HOST_MULTIARCH}/rsyslog/liboverride_getaddrinfo.so
-usr/lib/${DEB_HOST_MULTIARCH}/rsyslog/liboverride_gethostname.so
-usr/lib/${DEB_HOST_MULTIARCH}/rsyslog/liboverride_gethostname_nonfqdn.so
 usr/lib/${DEB_HOST_MULTIARCH}/rsyslog/omtesting.so
-usr/lib/${DEB_HOST_MULTIARCH}/rsyslog/imdiag.so


### PR DESCRIPTION
## Summary

Follow-up cleanup after #7321 / #7320.

Now that the `liboverride_*` helper libraries are built as `check_LTLIBRARIES` and are no longer installed, remove stale packaging metadata that still accounted for installed copies:

- drop the three `liboverride_*` entries from `packaging/ubuntu/noble/v8-stable/debian/not-installed`
- remove the duplicate `imdiag.so` entry from `packaging/ubuntu/noble/v8-stable/debian/not-installed`
- remove the RPM-generated `liboverride.files` machinery from `packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec`
- restore the RPM spec to a plain `%files` section

## Validation

Local branch: `/tmp/rsyslog-i-7320-packaging-cleanup`, commit `0027b8136`.

Checks run:

- `git diff --check` passed
- `devtools/local-validation-plan.sh --base HEAD~1` classified the diff as only:
  - `packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec`
  - `packaging/ubuntu/noble/v8-stable/debian/not-installed`
- `trivy config --quiet packaging/ubuntu/noble/v8-stable/debian` completed with no findings
- `trivy config --quiet packaging/rpm/rpmbuild/SPECS` completed with no findings
- `./autogen.sh --disable-testbench --disable-docs` passed
- `make -C tests distdir distdir=/tmp/rsyslog-distcheck-no-testbench/tests` passed
- verified the distdir still contains both conditional helper sources:
  - `/tmp/rsyslog-distcheck-no-testbench/tests/override_epoll_ctl.c`
  - `/tmp/rsyslog-distcheck-no-testbench/tests/override_libnet_write_fail.c`

Note: `devtools/local-validation-plan.sh --base HEAD --run` reached the container/Cubic lane before this review cleanup. Cubic reported a potential #7321 dist concern about those two helper sources, but the direct `--disable-testbench` distdir check above showed both files are still distributed, so I treated that as a false positive for this cleanup PR.