### PR TITLE
ci: improve macOS timeout evidence

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -895,7 +895,7 @@ jobs:
             arch: arm64
             sanitizer: tsan
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     name: macOS CI (${{ matrix.os }}, ${{ matrix.arch }}, ${{ matrix.sanitizer }})
     env:
       USE_AUTO_DEBUG: true
@@ -1049,11 +1049,46 @@ jobs:
             echo "Running without sanitizers"
           fi
 
+          export MAKE_CHECK_TIMEOUT_SECONDS=1200
+
           set +e
-          make -j10 check VERBOSE=1
+          python3 - <<'PY'
+          import os
+          import signal
+          import subprocess
+          import sys
+
+          timeout = int(os.environ["MAKE_CHECK_TIMEOUT_SECONDS"])
+          proc = subprocess.Popen(
+              ["make", "-j10", "check", "VERBOSE=1"],
+              start_new_session=True,
+          )
+          try:
+              sys.exit(proc.wait(timeout=timeout))
+          except subprocess.TimeoutExpired:
+              print(f"make check exceeded {timeout}s", flush=True)
+              try:
+                  os.killpg(proc.pid, signal.SIGTERM)
+              except ProcessLookupError:
+                  pass
+              try:
+                  proc.wait(timeout=10)
+              except subprocess.TimeoutExpired:
+                  try:
+                      os.killpg(proc.pid, signal.SIGKILL)
+                  except ProcessLookupError:
+                      pass
+                  proc.wait()
+              sys.exit(124)
+          PY
           EXIT_CODE=$?
+
           STATUS=success
-          if [ "$EXIT_CODE" -ne 0 ]; then STATUS=failure; fi
+          if [ "$EXIT_CODE" -eq 124 ]; then
+            STATUS=timed_out
+          elif [ "$EXIT_CODE" -ne 0 ]; then
+            STATUS=failure
+          fi
           echo "status=$STATUS" >> "$GITHUB_OUTPUT"
           exit 0
 
@@ -1091,8 +1126,49 @@ jobs:
           CORE_COUNT=$(find_core_files | wc -l || echo 0)
           echo "Total core files found: $CORE_COUNT"
 
+      - name: Prepare CI failure evidence
+        if: >-
+          ${{
+            steps.code_changes.outputs.any_changed == 'true' &&
+            steps.run_tests.outputs.status != '' &&
+            steps.run_tests.outputs.status != 'success'
+          }}
+        run: |
+          devtools/gather-check-logs.sh || true
+          for path in failed-tests.log tests config.log; do
+            if [ -e "$path" ]; then
+              sudo chmod -R a+rX "$path" || true
+            fi
+          done
+
+      - name: Upload CI failure evidence
+        if: >-
+          ${{
+            steps.code_changes.outputs.any_changed == 'true' &&
+            steps.run_tests.outputs.status != '' &&
+            steps.run_tests.outputs.status != 'success'
+          }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: >-
+            ci-failure-${{ github.run_id }}-${{ github.run_attempt }}-${{
+            matrix.os }}-${{ matrix.arch }}-${{ matrix.sanitizer }}
+          path: |
+            failed-tests.log
+            tests/failed-tests.log
+            tests/test-suite.log
+            tests/*.log
+            tests/*.trs
+            config.log
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: show error logs and fail if tests failed
-        if: steps.run_tests.outputs.status == 'failure'
+        if: >-
+          ${{
+            steps.run_tests.outputs.status != '' &&
+            steps.run_tests.outputs.status != 'success'
+          }}
         run: |
           echo "=== Post-failure diagnostics ==="
           echo "Note: Comprehensive error analysis including core dumps,"


### PR DESCRIPTION
## Summary

- raise the PR macOS CI job timeout from 15 to 25 minutes
- bound `make check` to 20 minutes inside the job with a process-group watchdog
- upload `ci-failure-*` evidence artifacts for macOS test failures and bounded make-check timeouts

## Rationale

The macOS arm64 TSAN lane has recently run close to the old 15 minute job cap. A hard job-level timeout gives the flake collector little or no chance to capture failure evidence. This keeps a 5 minute margin for diagnostics and artifact upload while preserving a firm test-run timeout.

## Validation

Workflow-only validation, per maintainer direction:

- `actionlint .github/workflows/run_checks.yml`
- `zizmor .github/workflows/run_checks.yml`
- `git diff --check`

A broader local container/static-analyzer run was intentionally not used because this change only affects GitHub Actions workflow plumbing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

