### PR TITLE
runtime: synchronize action retry shutdown state

### DIFF
--- a/runtime/action.c
+++ b/runtime/action.c
@@ -884,7 +884,7 @@ static rsRetVal ATTR_NONNULL() actionDoRetry(action_t *const pThis, wti_t *const
     assert(pThis != NULL);
 
     iRetries = 0;
-    while ((*pWti->pbShutdownImmediate == 0) && getActionState(pWti, pThis) == ACT_STATE_RTRY) {
+    while (!wtiIsShutdownImmediate(pWti) && getActionState(pWti, pThis) == ACT_STATE_RTRY) {
         if (actionIsDisabled(pThis)) {
             break;
         }
@@ -927,7 +927,7 @@ static rsRetVal ATTR_NONNULL() actionDoRetry(action_t *const pThis, wti_t *const
                     pThis->pszName, pThis->iResumeInterval, (long long)actionGetResumeRetryTime(pThis),
                     (long long)ttTemp, iRetries);
                 srSleep(pThis->iResumeInterval, 0);
-                if (*pWti->pbShutdownImmediate) {
+                if (wtiIsShutdownImmediate(pWti)) {
                     ABORT_FINALIZE(RS_RET_FORCE_TERM);
                 }
             }
@@ -957,7 +957,7 @@ static rsRetVal ATTR_NONNULL() actionDoRetry_extFile(action_t *const pThis, wti_
 
     DBGPRINTF("actionDoRetry_extFile: enter, actionState: %d\n", getActionState(pWti, pThis));
     iRetries = 0;
-    while ((*pWti->pbShutdownImmediate == 0) && getActionState(pWti, pThis) == ACT_STATE_RTRY) {
+    while (!wtiIsShutdownImmediate(pWti) && getActionState(pWti, pThis) == ACT_STATE_RTRY) {
         if (actionIsDisabled(pThis)) {
             break;
         }
@@ -988,7 +988,7 @@ static rsRetVal ATTR_NONNULL() actionDoRetry_extFile(action_t *const pThis, wti_
             } else {
                 ++iRetries;
                 srSleep(pThis->iResumeInterval, 0);
-                if (*pWti->pbShutdownImmediate) {
+                if (wtiIsShutdownImmediate(pWti)) {
                     ABORT_FINALIZE(RS_RET_FORCE_TERM);
                 }
             }
@@ -1742,7 +1742,7 @@ static rsRetVal ATTR_NONNULL() actionCommit(action_t *__restrict__ const pThis, 
     DBGPRINTF("actionCommit[%s]: unhappy, we still have %d uncommitted messages.\n", pThis->pszName, nMsgs);
     int bDone = 0;
     do {
-        if (*pWti->pbShutdownImmediate) {
+        if (wtiIsShutdownImmediate(pWti)) {
             ABORT_FINALIZE(RS_RET_FORCE_TERM);
         }
         iRet = actionTryCommit(pThis, pWti, iparams, nMsgs);
@@ -1872,7 +1872,7 @@ static rsRetVal ATTR_NONNULL() processBatchMain(void *__restrict__ const pVoid,
         FINALIZE;
     }
 
-    for (i = 0; i < batchNumMsgs(pBatch) && !*pWti->pbShutdownImmediate; ++i) {
+    for (i = 0; i < batchNumMsgs(pBatch) && !wtiIsShutdownImmediate(pWti); ++i) {
         if (batchIsValidElem(pBatch, i)) {
             /* we do not check error state below, because aborting would be
              * more harmful than continuing.

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -502,6 +502,24 @@ static int getLogicalQueueSize(qqueue_t *pThis) {
 }
 
 
+static int qqueueIsShutdownImmediate(qqueue_t *const pThis) {
+    return ATOMIC_FETCH_32BIT(&pThis->bShutdownImmediate, &pThis->mutShutdownImmediate);
+}
+
+
+static void qqueueSetShutdownImmediate(qqueue_t *const pThis, const int value) {
+    ATOMIC_STORE_INT(&pThis->bShutdownImmediate, &pThis->mutShutdownImmediate, value);
+}
+
+
+static void qqueueSetWtiShutdownImmediate(qqueue_t *const pThis, wti_t *const pWti) {
+    pWti->pbShutdownImmediate = &pThis->bShutdownImmediate;
+#ifndef HAVE_ATOMIC_BUILTINS
+    pWti->pmutShutdownImmediate = &pThis->mutShutdownImmediate;
+#endif
+}
+
+
 /* This function drains the queue in cases where this needs to be done. The most probable
  * reason is a HUP which needs to discard data (because the queue is configured to be lossy).
  * During a shutdown, this is typically not needed, as the OS frees up resources and does
@@ -1933,7 +1951,7 @@ static rsRetVal qAddDirect(qqueue_t *pThis, smsg_t *pMsg) {
     DEFiRet;
 
     pWti = wtiGetDummy();
-    pWti->pbShutdownImmediate = &pThis->bShutdownImmediate;
+    qqueueSetWtiShutdownImmediate(pThis, pWti);
     iRet = qAddDirectWithWti(pThis, pMsg, pWti);
     RETiRet;
 }
@@ -2078,11 +2096,11 @@ static rsRetVal tryShutdownWorkersWithinActionTimeout(qqueue_t *pThis) {
     DBGOPRINT((obj_t *)pThis, "trying to shutdown workers within Action Timeout");
     DBGOPRINT((obj_t *)pThis, "setting EnqOnly mode\n");
     pThis->bEnqOnly = 1;
-    pThis->bShutdownImmediate = 1;
+    qqueueSetShutdownImmediate(pThis, 1);
     /* now DA queue */
     if (pThis->bIsDA) {
         pThis->pqDA->bEnqOnly = 1;
-        pThis->pqDA->bShutdownImmediate = 1;
+        qqueueSetShutdownImmediate(pThis->pqDA, 1);
     }
 
     /* now give the queue workers a last chance to gracefully shut down (based on action timeout setting) */
@@ -2294,6 +2312,7 @@ rsRetVal qqueueConstruct(qqueue_t **ppThis,
 
     INIT_ATOMIC_HELPER_MUT(pThis->mutQueueSize);
     INIT_ATOMIC_HELPER_MUT(pThis->mutLogDeq);
+    INIT_ATOMIC_HELPER_MUT(pThis->mutShutdownImmediate);
     CHKiRet(qqueueSetiNumWorkerThreads(pThis, iWorkerThreads));
 
 finalize_it:
@@ -2900,7 +2919,7 @@ static rsRetVal ATTR_NONNULL() DequeueConsumableElements(qqueue_t *const pThis,
         pWti->batch.eltState[nDequeued] = BATCH_STATE_RDY;
         ++nDequeued;
         if (nDequeued < iMinDeqBatchSize && getLogicalQueueSize(pThis) == 0) {
-            while (!pThis->bShutdownImmediate && keep_running && nDequeued < iMinDeqBatchSize &&
+            while (!qqueueIsShutdownImmediate(pThis) && keep_running && nDequeued < iMinDeqBatchSize &&
                    getLogicalQueueSize(pThis) == 0) {
                 dbgprintf(
                     "%s minDeqBatchSize doing wait, batch is %d messages, "
@@ -3191,7 +3210,7 @@ static rsRetVal ConsumerReg(qqueue_t *pThis, wti_t *pWti) {
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &iCancelStateSave);
 
 
-    pWti->pbShutdownImmediate = &pThis->bShutdownImmediate;
+    qqueueSetWtiShutdownImmediate(pThis, pWti);
     CHKiRet(pThis->pConsumer(pThis->pAction, &pWti->batch, pWti));
 
     /* we now need to check if we should deliberately delay processing a bit
@@ -3245,7 +3264,7 @@ static rsRetVal ConsumerDA(qqueue_t *pThis, wti_t *pWti) {
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &iCancelStateSave);
 
     /* iterate over returned results and enqueue them in DA queue */
-    for (i = 0; i < pWti->batch.nElem && !pThis->bShutdownImmediate; i++) {
+    for (i = 0; i < pWti->batch.nElem && !qqueueIsShutdownImmediate(pThis); i++) {
         iRet = qqueueEnqMsg(pThis->pqDA, eFLOWCTL_NO_DELAY, MsgAddRef(pWti->batch.pElem[i].pMsg));
         if (iRet != RS_RET_OK) {
             if (iRet == RS_RET_ERR_QUEUE_EMERGENCY) {
@@ -3705,7 +3724,7 @@ static rsRetVal DoSaveOnShutdown(qqueue_t *pThis) {
      * it is reached.
      */
     DBGOPRINT((obj_t *)pThis, "bSaveOnShutdown set, restarting DA worker...\n");
-    pThis->bShutdownImmediate = 0; /* would termiante the DA worker! */
+    qqueueSetShutdownImmediate(pThis, 0); /* would termiante the DA worker! */
     pThis->iLowWtrMrk = 0;
     wtpSetState(pThis->pWtpDA, wtpState_SHUTDOWN); /* shutdown worker (only) when done (was _IMMEDIATE!) */
     wtpAdviseMaxWorkers(pThis->pWtpDA, 1, PERMIT_WORKER_START_DURING_SHUTDOWN); /* restart DA worker */
@@ -3809,6 +3828,7 @@ BEGINobjDestruct(qqueue) /* be sure to specify the object type also in END and C
 
         DESTROY_ATOMIC_HELPER_MUT(pThis->mutQueueSize);
         DESTROY_ATOMIC_HELPER_MUT(pThis->mutLogDeq);
+        DESTROY_ATOMIC_HELPER_MUT(pThis->mutShutdownImmediate);
 
         /* type-specific destructor */
         iRet = pThis->qDestruct(pThis);
@@ -4090,7 +4110,7 @@ static rsRetVal qqueueMultiEnqObjDirect(qqueue_t *pThis, multi_submit_t *pMultiS
     DEFiRet;
 
     pWti = wtiGetDummy();
-    pWti->pbShutdownImmediate = &pThis->bShutdownImmediate;
+    qqueueSetWtiShutdownImmediate(pThis, pWti);
 
     for (i = 0; i < pMultiSub->nElem; ++i) {
         CHKiRet(qAddDirectWithWti(pThis, (void *)pMultiSub->ppMsgs[i], pWti));

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -94,6 +94,7 @@ struct queue_s {
         queueType_t qType;
         int nLogDeq; /* number of elements currently logically dequeued */
         int bShutdownImmediate; /* should all workers cease processing messages? */
+        DEF_ATOMIC_HELPER_MUT(mutShutdownImmediate);
         sbool bEnqOnly; /* does queue run in enqueue-only mode (1) or not (0)? */
         sbool bSaveOnShutdown; /* persists everthing on shutdown (if DA!)? 1-yes, 0-no */
         sbool bQueueStarted; /* has queueStart() been called on this queue? 1-yes, 0-no */

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -538,7 +538,7 @@ static rsRetVal ATTR_NONNULL(2, 3) scriptExec(struct cnfstmt *const root, smsg_t
     DEFiRet;
 
     for (stmt = root; stmt != NULL; stmt = stmt->next) {
-        if (*pWti->pbShutdownImmediate) {
+        if (wtiIsShutdownImmediate(pWti)) {
             DBGPRINTF(
                 "scriptExec: ShutdownImmediate set, "
                 "force terminating\n");
@@ -608,7 +608,7 @@ static rsRetVal processBatch(batch_t *pBatch, wti_t *pWti) {
     wtiResetExecState(pWti, pBatch);
 
     /* execution phase */
-    for (i = 0; i < batchNumMsgs(pBatch) && !*(pWti->pbShutdownImmediate); ++i) {
+    for (i = 0; i < batchNumMsgs(pBatch) && !wtiIsShutdownImmediate(pWti); ++i) {
         pMsg = pBatch->pElem[i].pMsg;
         DBGPRINTF("processBATCH: next msg %d: %.128s\n", i, pMsg->pszRawMsg);
         pRuleset = (pMsg->pRuleset == NULL) ? runConf->rulesets.pDflt : pMsg->pRuleset;

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -75,6 +75,7 @@ struct wti_s {
         int bIsRunning; /* is this thread currently running? (must be int for atomic op!) */
         sbool bAlwaysRunning; /* should this thread always run? */
         int *pbShutdownImmediate; /* end processing of this batch immediately if set to 1 */
+        DEF_ATOMIC_HELPER_MUT(*pmutShutdownImmediate); /* fallback mutex for atomic access */
         wtp_t *pWtp; /* my worker thread pool (important if only the work thread instance is passed! */
         batch_t batch; /* pointer to an object array meaningful for current user
                   pointer (e.g. queue pUsr data elemt) */
@@ -93,6 +94,15 @@ struct wti_s {
             uint16_t rulesetCallDepth; /* synchronous ruleset call nesting depth */
         } execState; /* state for the execution engine */
 };
+
+
+static inline int wtiIsShutdownImmediate(const wti_t *const pWti) {
+#ifdef HAVE_ATOMIC_BUILTINS
+    return ATOMIC_FETCH_32BIT(pWti->pbShutdownImmediate, NULL);
+#else
+    return ATOMIC_FETCH_32BIT(pWti->pbShutdownImmediate, pWti->pmutShutdownImmediate);
+#endif
+}
 
 
 /* prototypes */

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -816,7 +816,7 @@ finalize_it:
  * it helps us keep up the overall concurrency level.
  * rgerhards, 2010-06-09
  */
-static rsRetVal preprocessBatch(batch_t *pBatch, int *pbShutdownImmediate) {
+static rsRetVal preprocessBatch(batch_t *pBatch, wti_t *pWti) {
     prop_t *ip;
     prop_t *fqdn;
     prop_t *localName;
@@ -826,7 +826,7 @@ static rsRetVal preprocessBatch(batch_t *pBatch, int *pbShutdownImmediate) {
     rsRetVal localRet;
     DEFiRet;
 
-    for (i = 0; i < pBatch->nElem && !*pbShutdownImmediate; i++) {
+    for (i = 0; i < pBatch->nElem && !wtiIsShutdownImmediate(pWti); i++) {
         pMsg = pBatch->pElem[i].pMsg;
         if ((pMsg->msgFlags & NEEDS_ACLCHK_U) != 0) {
             DBGPRINTF("msgConsumer: UDP ACL must be checked for message (hostname-based)\n");
@@ -872,12 +872,12 @@ finalize_it:
 static rsRetVal msgConsumer(void __attribute__((unused)) * notNeeded, batch_t *pBatch, wti_t *pWti) {
     DEFiRet;
     assert(pBatch != NULL);
-    preprocessBatch(pBatch, pWti->pbShutdownImmediate);
+    preprocessBatch(pBatch, pWti);
     ruleset.ProcessBatch(pBatch, pWti);
     // TODO: the BATCH_STATE_COMM must be set somewhere down the road, but we
     // do not have this yet and so we emulate -- 2010-06-10
     int i;
-    for (i = 0; i < pBatch->nElem && !*pWti->pbShutdownImmediate; i++) {
+    for (i = 0; i < pBatch->nElem && !wtiIsShutdownImmediate(pWti); i++) {
         pBatch->eltState[i] = BATCH_STATE_COMM;
     }
     RETiRet;


### PR DESCRIPTION
## Summary
- synchronize queue shutdown-immediate state with the existing atomic-helper discipline
- route action retry, ruleset, queue, and main consumer reads through shared helpers
- keep shutdown semantics intact while removing unsynchronized core reads

## TSAN race signature
Observed in PR #7328 artifacts after the workflow began preserving macOS failures:

- lane: macOS 15 arm64 TSAN
- failing tests seen: omfwd-tls-gtls-auto-sni.sh, earlier sndrcv_tls_certvalid_expired.sh
- summary: ThreadSanitizer: data race action.c:887 in actionDoRetry
- read: actionDoRetry() reading queue shutdown-immediate state
- write: qqueueShutdownWorkers() via queue.c around the shutdown-immediate update
- failed run/job/artifact: run 28426415139, job 84230545979, artifact ci-failure-28426415139-1-macos-15-arm64-tsan, artifact id 7973485717

## Why this is treated as real
The report points at queue_s.bShutdownImmediate, a shared queue lifecycle flag allocated with qqueueConstruct(). The read and write are on different worker/shutdown paths with no common synchronization in the old code. Even though the observed evidence is intermittent and macOS arm64 TSAN-only so far, this is a latent cross-platform race rather than a macOS-specific test problem.

## Validation
Local validation on Ubuntu WSL with Docker container image rsyslog/rsyslog_dev_base_ubuntu:26.04, image/digest sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09:

- devtools/format-code.sh --git-changed
- devtools/format-code.sh --git-changed --check --check-if-available
- make -C runtime -j$(nproc) check
- tests/omfwd-tls-gtls-auto-sni.sh
- tests/sndrcv_tls_certvalid_expired.sh
- devtools/local-validation-plan.sh --base upstream/main --run
- Ubuntu 26 TSAN targeted rerun in the dev container after fixing remaining direct reads: localvar-concurrency.sh, msgvar-concurrency.sh, exec_tpl-concurrency.sh, omfile_hup.sh, omfwd-tls-gtls-auto-sni.sh, sndrcv_tls_certvalid_expired.sh

The macOS 15 arm64 TSAN CI lane remains the decisive confirmation lane for the originally observed failure.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

