### PR TITLE
tests: cover OpenSSL SAN priority identity checks

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1496,6 +1496,9 @@ TESTS_LIBYAML_IMTCP = \
 	config-translate-yaml-roundtrip.sh \
 	yaml-include-recursion.sh
 
+TESTS_LIBYAML_IMTCP_OSSL = \
+	yaml-imtcp-tls-ossl-prioritize-san-reject-cn.sh
+
 TESTS_LIBYAML_IMHTTP = \
 	yaml-imhttp-apikeyfile.sh \
 	yaml-imhttp-metrics-apikeyfile.sh
@@ -1714,6 +1717,8 @@ TESTS_OSSL = \
 	sndrcv_tls_ossl_intermediate_ca_chain.sh \
 	imtcp-tls-ossl-x509valid.sh \
 	imtcp-tls-ossl-x509name.sh \
+	imtcp-tls-ossl-prioritize-san-cn-fallback.sh \
+	imtcp-tls-ossl-prioritize-san-reject-cn.sh \
 	imtcp-tls-ossl-manycon.sh \
 	imtcp-tls-ossl-x509name-wildcard.sh \
 	imtcp-tls-ossl-x509name-wildcard-invld.sh \
@@ -2155,6 +2160,7 @@ EXTRA_DIST += $(TESTS_LIBYAML)
 EXTRA_DIST += $(TESTS_RATELIMIT_WATCH)
 EXTRA_DIST += $(TESTS_LIBYAML_IMPTCP_MMJSONPARSE)
 EXTRA_DIST += $(TESTS_LIBYAML_IMTCP)
+EXTRA_DIST += $(TESTS_LIBYAML_IMTCP_OSSL)
 EXTRA_DIST += $(TESTS_LIBYAML_IMHTTP)
 EXTRA_DIST += $(TESTS_LIBYAML_OMSTDOUT)
 EXTRA_DIST += $(TESTS_IMTCP)
@@ -2636,6 +2642,9 @@ endif # ENABLE_MMJSONPARSE
 endif # ENABLE_IMPTCP
 if ENABLE_IMTCP_TESTS
 TESTS += $(TESTS_LIBYAML_IMTCP)
+if ENABLE_OSSL
+TESTS += $(TESTS_LIBYAML_IMTCP_OSSL)
+endif # ENABLE_OSSL
 endif # ENABLE_IMTCP_TESTS
 if ENABLE_IMHTTP
 TESTS += $(TESTS_LIBYAML_IMHTTP)

--- a/tests/imtcp-tls-ossl-prioritize-san-cn-fallback.sh
+++ b/tests/imtcp-tls-ossl-prioritize-san-cn-fallback.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Verify the legacy OpenSSL x509/name behavior for certificates that contain a
+# DNS SAN and a different CN. With PrioritizeSAN left at its default off value,
+# rsyslog may authorize the peer by the CN after the SAN does not match. The
+# oracle is exact receipt of the tcpflood sequence after the listener reports
+# its kernel-assigned port.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=10
+generate_conf
+add_conf '
+global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+)
+
+module(	load="../plugins/imtcp/.libs/imtcp"
+	StreamDriver.Name="ossl"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="x509/name"
+	PermittedPeer="rsyslog-client"
+	)
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+tcpflood -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+wait_file_lines
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test

--- a/tests/imtcp-tls-ossl-prioritize-san-reject-cn.sh
+++ b/tests/imtcp-tls-ossl-prioritize-san-reject-cn.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Verify strict OpenSSL x509/name behavior when StreamDriver.PrioritizeSAN is
+# enabled. The fixture certificate has CN=rsyslog-client and DNS SAN
+# testbench.rsyslog.com. Authorizing only the CN must fail when any SAN exists;
+# otherwise a certificate with an unrelated SAN could bypass SAN-first identity
+# policy. The oracle is the receiver-side "peer name not authorized" diagnostic
+# after a checked tcpflood attempt and synchronized shutdown.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=3
+generate_conf
+add_conf '
+global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+)
+
+module(	load="../plugins/imtcp/.libs/imtcp"
+	StreamDriver.Name="ossl"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="x509/name"
+	StreamDriver.PrioritizeSAN="on"
+	PermittedPeer="rsyslog-client"
+	)
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+tcpflood --check-only -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+shutdown_when_empty
+wait_shutdown
+content_check "peer name not authorized"
+check_not_present "msgnum:"
+exit_test

--- a/tests/yaml-imtcp-tls-ossl-prioritize-san-reject-cn.sh
+++ b/tests/yaml-imtcp-tls-ossl-prioritize-san-reject-cn.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Verify YAML parsing of the imtcp StreamDriver.PrioritizeSAN parameter for
+# OpenSSL x509/name authorization. The fixture certificate has
+# CN=rsyslog-client and DNS SAN testbench.rsyslog.com. The listener is loaded
+# from YAML with PrioritizeSAN enabled and must reject CN-only authorization
+# when a SAN exists. The oracle is the receiver-side "peer name not authorized"
+# diagnostic routed by the testbench action after a checked tcpflood attempt
+# and synchronized shutdown.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=3
+generate_conf
+add_conf '
+include(file="'${TESTCONF_NM}'.yaml")
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+add_yaml_conf 'modules:'
+add_yaml_conf '  - load: "../plugins/imtcp/.libs/imtcp"'
+add_yaml_conf '    StreamDriver.Name: "ossl"'
+add_yaml_conf '    StreamDriver.Mode: "1"'
+add_yaml_conf '    StreamDriver.AuthMode: "x509/name"'
+add_yaml_conf '    StreamDriver.PrioritizeSAN: "on"'
+add_yaml_conf "    StreamDriver.CAFile: \"${srcdir}/tls-certs/ca.pem\""
+add_yaml_conf "    StreamDriver.CertFile: \"${srcdir}/tls-certs/cert.pem\""
+add_yaml_conf "    StreamDriver.KeyFile: \"${srcdir}/tls-certs/key.pem\""
+add_yaml_conf '    PermittedPeer: ["rsyslog-client"]'
+add_yaml_conf ''
+add_yaml_conf 'inputs:'
+add_yaml_conf '  - type: imtcp'
+add_yaml_conf '    port: "0"'
+add_yaml_conf "    listenPortFileName: \"${RSYSLOG_DYNNAME}.tcpflood_port\""
+startup
+assign_tcpflood_port "$RSYSLOG_DYNNAME.tcpflood_port"
+tcpflood --check-only -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+shutdown_when_empty
+wait_shutdown
+content_check "peer name not authorized"
+check_not_present "msgnum:"
+exit_test


### PR DESCRIPTION
Adds two focused imtcp OpenSSL x509/name tests for StreamDriver.PrioritizeSAN. The tests use existing cert fixtures with CN and DNS SAN mismatch to verify legacy CN fallback still accepts while strict SAN priority rejects CN-only authorization when a SAN exists.

Validation: direct host scripts passed; make check TESTS for both scripts passed; bash -n, shellcheck, check-test-antipatterns, and git diff --check passed; mock distcheck passed; focused Ubuntu 26.04 devcontainer run with CI_MAKE_CHECK_TESTS for both scripts passed; Cubic review found no issues.

Note: broad local-validation full-suite run hit an unrelated tabescape_off-udp fixed-port/missing-output failure; the new tests passed in focused container validation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

