### PR TITLE
rainerscript: accept hex object string escapes

### DIFF
--- a/doc/source/configuration/modules/mmutf8fix.rst
+++ b/doc/source/configuration/modules/mmutf8fix.rst
@@ -120,7 +120,10 @@ This sample replaces each invalid byte with the UTF-8 byte sequence for
 .. code-block:: rsyslog
 
   module(load="mmutf8fix")
-  action(type="mmutf8fix" replacementSequence="\357\277\275")
+  action(type="mmutf8fix" replacementSequence="\xef\xbf\xbd")
+
+The equivalent octal spelling is ``\357\277\275``. Hexadecimal escapes use
+exactly two digits, and octal escapes use exactly three digits.
 
 The same setting can be expressed through YAML configuration.
 
@@ -132,7 +135,7 @@ The same setting can be expressed through YAML configuration.
   rulesets:
     - name: main
       script: |
-        action(type="mmutf8fix" replacementSequence="\357\277\275")
+        action(type="mmutf8fix" replacementSequence="\xef\xbf\xbd")
 
 .. toctree::
    :hidden:

--- a/doc/source/rainerscript/constant_strings.rst
+++ b/doc/source/rainerscript/constant_strings.rst
@@ -1,8 +1,16 @@
+.. meta::
+   :description: RainerScript string constants and escape sequences.
+   :keywords: rsyslog, rainerscript, string constants, escapes, hex, octal
+
 Rsyslog Parameter String Constants
 ==================================
 
+.. summary-start
+
 String constants provide values that are evaluated at startup and remain unchanged
 for the lifetime of the rsyslog process.
+
+.. summary-end
 
 Uses
 ----
@@ -13,8 +21,30 @@ function arguments, among other places.
 Escaping
 --------
 
-In string constants, special characters are escaped by prepending a backslash,
-similar to C or PHP.
+In string constants, special characters are escaped by prepending a backslash.
+The defined escape sequences are:
+
+- ``\\`` - single backslash
+- ``\'`` - single quote inside single-quoted strings
+- ``\"`` - double quote inside double-quoted strings
+- ``\?`` - question mark
+- ``\a`` - alert
+- ``\b`` - backspace
+- ``\f`` - form feed
+- ``\n`` - LF
+- ``\r`` - CR
+- ``\t`` - horizontal tab
+- ``\v`` - vertical tab
+- ``\ooo`` - byte value written as exactly three octal digits
+- ``\xhh`` - byte value written as exactly two hexadecimal digits
+
+Use the full-width forms for byte escapes. For example, ``\101`` and
+``\x41`` both produce ``A``. Shorter octal spellings are not a documented
+interface and should not be used in new configurations. To emit literal text
+that otherwise looks like a byte escape, escape the backslash itself; for
+example, write ``\\x41`` for literal ``\x41`` in a regular parameter. Some
+parameters, such as template ``constant(value=...)``, interpret escapes again
+after configuration parsing and therefore need escaping for that second pass.
 
 If in doubt how to escape properly, use the
 `RainerScript String Escape Online Tool

--- a/doc/source/reference/parameters/mmutf8fix-replacementsequence.rst
+++ b/doc/source/reference/parameters/mmutf8fix-replacementsequence.rst
@@ -41,8 +41,10 @@ invalid two-byte sequence is detected and ``replacementSequence`` is set
 to the UTF-8 bytes for ``U+FFFD``, the output contains two replacement
 markers.
 
-Use octal byte escapes in object-parameter strings. For example, write the
-UTF-8 bytes for ``U+FFFD`` as ``\357\277\275``.
+Use byte escapes in object-parameter strings. For example, write the UTF-8
+bytes for ``U+FFFD`` as ``\xef\xbf\xbd``. The equivalent octal spelling is
+``\357\277\275``. Hexadecimal escapes use exactly two digits, and octal
+escapes use exactly three digits.
 
 Input usage
 -----------
@@ -53,7 +55,7 @@ Input usage
    module(load="mmutf8fix")
 
    # U+FFFD encoded as UTF-8 bytes.
-   action(type="mmutf8fix" replacementSequence="\357\277\275")
+   action(type="mmutf8fix" replacementSequence="\xef\xbf\xbd")
 
 YAML usage
 ----------
@@ -66,7 +68,7 @@ YAML usage
    rulesets:
      - name: main
        script: |
-         action(type="mmutf8fix" replacementSequence="\357\277\275")
+         action(type="mmutf8fix" replacementSequence="\xef\xbf\xbd")
 
 See also
 --------

--- a/doc/source/reference/templates/templates-statement-constant.rst
+++ b/doc/source/reference/templates/templates-statement-constant.rst
@@ -20,7 +20,7 @@ included. Example from the testbench:
         constant(value="\n")
     }
 
-The following escape sequences are recognized inside the constant text:
+The following common escape sequences are recognized inside the constant text:
 
 - ``\\`` – single backslash
 - ``\n`` – LF
@@ -28,6 +28,14 @@ The following escape sequences are recognized inside the constant text:
   ``"A"``). Exactly three digits must be given.
 - ``\xhh`` – two hexadecimal digits representing a character
   (``\x41`` is ``"A"``). Exactly two digits must be given.
+
+For the complete list, see
+:doc:`/rainerscript/constant_strings`.
+
+The ``value`` parameter is parsed by the generic configuration parser and then
+interpreted again as template constant text. To output literal text that looks
+like a byte escape, escape the backslash for both layers. For example,
+``constant(value="\\\\x41")`` emits literal ``\x41``.
 
 If an unsupported character follows a backslash, behavior is
 unpredictable.

--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -320,12 +320,12 @@ static void cnfPrintToken(const char *token);
 "foreach"			{ cnfPrintToken(yytext); BEGIN EXPR; return FOREACH; }
 "reload_lookup_table"		{ cnfPrintToken(yytext); BEGIN IN_PROCEDURE_CALL; return RELOAD_LOOKUP_TABLE_PROCEDURE; }
 <IN_PROCEDURE_CALL>"("		{ cnfPrintToken(yytext); return yytext[0]; }
-<IN_PROCEDURE_CALL>\'([^'\\]|\\['"\\$bntr]|\\x[0-9a-f][0-9a-f]|\\[0-7][0-7][0-7])*\'	 {
+<IN_PROCEDURE_CALL>\'([^'\\]|\\['"\\$bntr]|\\x[0-9a-fA-F][0-9a-fA-F]|\\[0-7][0-7][0-7])*\'	 {
 				  cnfPrintToken(yytext);  yytext[yyleng-1] = '\0';
 				   unescapeStr((uchar*)yytext+1, yyleng-2);
 				   yylval.estr = es_newStrFromBuf(yytext+1, strlen(yytext)-1);
 				   return STRING; }
-<IN_PROCEDURE_CALL>\"([^"\\$]|\\["'\\$bntr]|\\x[0-9a-f][0-9a-f]|\\[0-7][0-7][0-7])*\" {
+<IN_PROCEDURE_CALL>\"([^"\\$]|\\["'\\$bntr]|\\x[0-9a-fA-F][0-9a-fA-F]|\\[0-7][0-7][0-7])*\" {
 				   cnfPrintToken(yytext); yytext[yyleng-1] = '\0';
 				   unescapeStr((uchar*)yytext+1, yyleng-2);
 				   yylval.estr = es_newStrFromBuf(yytext+1, strlen(yytext)-1);
@@ -371,22 +371,22 @@ static void cnfPrintToken(const char *token);
 <EXPR>0x[0-9a-f]+ |		/* hex number, following rule is dec; strtoll handles all! */
 <EXPR>([1-9][0-9]*|0)		{ cnfPrintToken(yytext); yylval.n = strtoll(yytext, NULL, 0); return NUMBER; }
 <EXPR>\$[$!./]{0,1}[@a-z_]*[!@a-z0-9\-_\.\[\]]*	{ cnfPrintToken(yytext); yylval.s = strdup(yytext+1); return VAR; }
-<EXPR>\'([^'\\]|\\['"\\$bntr]|\\x[0-9a-f][0-9a-f]|\\[0-7][0-7][0-7])*\'	 {
+<EXPR>\'([^'\\]|\\['"\\$bntr]|\\x[0-9a-fA-F][0-9a-fA-F]|\\[0-7][0-7][0-7])*\'	 {
 				   cnfPrintToken(yytext); yytext[yyleng-1] = '\0';
 				   unescapeStr((uchar*)yytext+1, yyleng-2);
 				   yylval.estr = es_newStrFromBuf(yytext+1, strlen(yytext)-1);
 				   return STRING; }
-<EXPR>`([^`\\]|\\['`"\\bntr]|\\x[0-9a-f][0-9a-f]|\\[0-7][0-7][0-7])*`	 {
+<EXPR>`([^`\\]|\\['`"\\bntr]|\\x[0-9a-fA-F][0-9a-fA-F]|\\[0-7][0-7][0-7])*`	 {
 				   cnfPrintToken(yytext); yytext[yyleng-1] = '\0';
 				   unescapeStr((uchar*)yytext+1, yyleng-2);
 				   yylval.estr = expand_backticks(yytext+1);
 				   return STRING; }
-<EXPR>\"([^"\\$]|\\["'\\$bntr]|\\x[0-9a-f][0-9a-f]|\\[0-7][0-7][0-7])*\" {
+<EXPR>\"([^"\\$]|\\["'\\$bntr]|\\x[0-9a-fA-F][0-9a-fA-F]|\\[0-7][0-7][0-7])*\" {
 				   cnfPrintToken(yytext); yytext[yyleng-1] = '\0';
 				   unescapeStr((uchar*)yytext+1, yyleng-2);
 				   yylval.estr = es_newStrFromBuf(yytext+1, strlen(yytext)-1);
 				   return STRING; }
-<EXPR>\"([^"\\]|\\["'\\$bntr]|\\x[0-9a-f][0-9a-f]|\\[0-7][0-7][0-7])*\" {
+<EXPR>\"([^"\\]|\\["'\\$bntr]|\\x[0-9a-fA-F][0-9a-fA-F]|\\[0-7][0-7][0-7])*\" {
 				   cnfPrintToken(yytext); parser_errmsg("$-sign in double quotes must be "
 					        "escaped, problem string is: %s",
 						yytext); }

--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -479,12 +479,12 @@ static void cnfPrintToken(const char *token);
 <INOBJ>"[" |
 <INOBJ>"]" |
 <INOBJ>"="			{ cnfPrintToken(yytext); return(yytext[0]); }
-<INOBJ>\"([^"\\]|\\['"?\\abfnrtv]|\\[0-7]{1,3})*\" {
+<INOBJ>\"([^"\\]|\\['"?\\abfnrtv]|\\x[0-9a-fA-F][0-9a-fA-F]|\\[0-7]{1,3})*\" {
 				   cnfPrintToken(yytext); yytext[yyleng-1] = '\0';
 				   unescapeStr((uchar*)yytext+1, yyleng-2);
 				   yylval.estr = es_newStrFromBuf(yytext+1, strlen(yytext)-1);
 				   return STRING; }
-<INOBJ>`([^`\\]|\\['`?\\abfnrtv]|\\[0-7]{1,3})*` {
+<INOBJ>`([^`\\]|\\['`?\\abfnrtv]|\\x[0-9a-fA-F][0-9a-fA-F]|\\[0-7]{1,3})*` {
 				   cnfPrintToken(yytext); yytext[yyleng-1] = '\0';
 				   unescapeStr((uchar*)yytext+1, yyleng-2);
 				   yylval.estr = expand_backticks(yytext+1);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,6 +21,9 @@ TESTS_TEMPLATE_REGEX_BOUNDS = template-regex-index-bounds.sh
 TESTS_TEMPLATE_REGEX_BOUNDS_LIBYAML = yaml-template-regex-index-bounds.sh
 EXTRA_DIST += $(TESTS_TEMPLATE_REGEX_BOUNDS) $(TESTS_TEMPLATE_REGEX_BOUNDS_LIBYAML)
 
+TESTS_RSCRIPT_OBJECT_STRINGS = rscript-object-string-escapes.sh
+EXTRA_DIST += $(TESTS_RSCRIPT_OBJECT_STRINGS)
+
 TESTS_IMFIFO = imfifo.sh imfifo-vg.sh yaml-imfifo.sh
 EXTRA_DIST += $(TESTS_IMFIFO)
 
@@ -195,6 +198,7 @@ TESTS_DEFAULT = \
 	json-nonstring.sh \
 	json-onempty-at-end.sh \
 	template-json.sh \
+	$(TESTS_RSCRIPT_OBJECT_STRINGS) \
 	template-property-transformations.sh \
         template-pure-json.sh \
 	template-jsonf-nested.sh \

--- a/tests/lookup_table_rscript_reload.sh
+++ b/tests/lookup_table_rscript_reload.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-# test for lookup-table reload by rscript-fn
-# added 2015-12-18 by singh.janmejay
+# Test lookup-table reload by the RainerScript reload_lookup_table statement.
+# The second reload uses uppercase hex escapes in procedure-call strings; the
+# output oracle proves those strings parsed to the intended table and stub
+# values before the reload failure fallback is applied.
+# Added 2015-12-18 by singh.janmejay.
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 skip_platform "FreeBSD"  "This test currently does not work on FreeBSD"
@@ -13,7 +16,7 @@ template(name="outfmt" type="string" string="- %msg% %$.lkp%\n")
 set $.lkp = lookup("xlate", $msg);
 
 if ($msg == " msgnum:00000002:") then {
-  reload_lookup_table("xlate", "reload_failed");
+  reload_lookup_table("\x78\x6C\x61\x74\x65", "\x72\x65\x6C\x6F\x61\x64\x5F\x66\x61\x69\x6C\x65\x64");
 }
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/mmutf8fix_replacement_sequence.sh
+++ b/tests/mmutf8fix_replacement_sequence.sh
@@ -22,7 +22,7 @@ input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_tag_
       ruleset="tagtest")
 
 ruleset(name="sdtest") {
-	action(type="mmutf8fix" replacementSequence="\357\277\275")
+	action(type="mmutf8fix" replacementSequence="\xef\xbf\xbd")
 	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="sdoutfmt")
 }
 

--- a/tests/rscript-object-string-escapes.sh
+++ b/tests/rscript-object-string-escapes.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Verify that RainerScript object/action parameter strings accept the same
+# documented byte escapes that the unescape layer decodes. The oracle is the
+# configured omfile output after synchronized shutdown, proving hex and octal
+# forms reached the normal template/action path as the intended bytes.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+template(name="outfmt" type="list") {
+	constant(value="hex_lower=\x41\n")
+	constant(value="hex_upper=\x5a\n")
+	constant(value="hex_upper_digits=\x5A\n")
+	constant(value="octal=\101\n")
+	constant(value="literal=\\\\x41\n")
+}
+
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+			         file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+
+cat > "$RSYSLOG_OUT_LOG.expect" <<'EOF'
+hex_lower=A
+hex_upper=Z
+hex_upper_digits=Z
+octal=A
+literal=\x41
+EOF
+
+cmp_exact_file "$RSYSLOG_OUT_LOG.expect" "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript-object-string-escapes.sh
+++ b/tests/rscript-object-string-escapes.sh
@@ -1,17 +1,27 @@
 #!/bin/bash
-# Verify that RainerScript object/action parameter strings accept the same
-# documented byte escapes that the unescape layer decodes. The oracle is the
-# configured omfile output after synchronized shutdown, proving hex and octal
-# forms reached the normal template/action path as the intended bytes.
+# Verify that RainerScript object/action parameter strings and expression
+# strings accept the same documented byte escapes that the unescape layer
+# decodes. The oracle is the configured omfile output after synchronized
+# shutdown, proving hex and octal forms reached the normal template/action path
+# as the intended bytes.
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 
 generate_conf
 add_conf '
+set $.expr_hex_upper = "\x5A";
+set $.expr_hex_upper_digits = "\x4A";
+
 template(name="outfmt" type="list") {
 	constant(value="hex_lower=\x41\n")
 	constant(value="hex_upper=\x5a\n")
 	constant(value="hex_upper_digits=\x5A\n")
+	constant(value="expr_hex_upper=")
+	property(name="$.expr_hex_upper")
+	constant(value="\n")
+	constant(value="expr_hex_upper_digits=")
+	property(name="$.expr_hex_upper_digits")
+	constant(value="\n")
 	constant(value="octal=\101\n")
 	constant(value="literal=\\\\x41\n")
 }
@@ -28,6 +38,8 @@ cat > "$RSYSLOG_OUT_LOG.expect" <<'EOF'
 hex_lower=A
 hex_upper=Z
 hex_upper_digits=Z
+expr_hex_upper=Z
+expr_hex_upper_digits=J
 octal=A
 literal=\x41
 EOF

--- a/tests/yaml-mmutf8fix-replacement-sequence.sh
+++ b/tests/yaml-mmutf8fix-replacement-sequence.sh
@@ -30,7 +30,7 @@ templates:
 rulesets:
   - name: main
     script: |
-      action(type="mmutf8fix" replacementSequence="\357\277\275")
+      action(type="mmutf8fix" replacementSequence="\xef\xbf\xbd")
       action(type="omfile" file="${RSYSLOG_OUT_LOG}" template="outfmt")
 YAMLEOF
 


### PR DESCRIPTION
## Summary

- allow RainerScript object/action parameter strings to parse documented `\xhh` byte escapes
- document the aligned string escape rules, including exactly-two-digit hex and exactly-three-digit octal forms
- switch mmutf8fix `replacementSequence` examples/tests to the clearer hex spelling while keeping octal regression coverage

## Notes

The shared unescape layer already decoded `\xhh`; the INOBJ lexer rejected that spelling before it could reach the decoder. This patch keeps the existing octal lexer acceptance behavior for compatibility, but documents the portable/defined octal form as exactly three digits.

Template `constant(value=...)` has an extra interpretation pass after generic config parsing, so the docs now call out the extra escaping needed for literal escape-looking output.

## Validation

- `bash -n tests/rscript-object-string-escapes.sh tests/mmutf8fix_replacement_sequence.sh tests/yaml-mmutf8fix-replacement-sequence.sh`
- `shellcheck -S warning tests/rscript-object-string-escapes.sh tests/mmutf8fix_replacement_sequence.sh tests/yaml-mmutf8fix-replacement-sequence.sh`
- `devtools/check-test-antipatterns.sh tests/rscript-object-string-escapes.sh tests/mmutf8fix_replacement_sequence.sh tests/yaml-mmutf8fix-replacement-sequence.sh`
- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout`
- `./configure --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --enable-imtcp --enable-mmutf8fix` (`--enable-imtcp` is ignored by configure; imtcp tests were enabled in the summary)
- `make -j60 check TESTS=""`
- `make -C tests check TESTS="rscript-object-string-escapes.sh mmutf8fix_replacement_sequence.sh yaml-mmutf8fix-replacement-sequence.sh"` (3 pass)
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs 60`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j60`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `cubic review --print-logs --base upstream/main` (no issues found)
- Docker image: `rsyslog/rsyslog_dev_base_ubuntu:26.04`, id `sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`
- Static analyzer container: `RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 SCAN_BUILD=scan-build SCAN_BUILD_CC=clang SCAN_BUILD_REPORT_DIR=scan-build-report CI_MAKE_OPT=-j20 ... devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh` (No bugs found, real 188.32s)
- Ubuntu 26.04 change-gated container: `RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 CC=gcc CFLAGS=-g CI_MAKE_OPT=-j60 CI_MAKE_CHECK_OPT=-j60 CI_CHECK_CMD=check VERBOSE=1 devtools/devcontainer.sh --rm devtools/run-ci.sh` after default PR service relevance application (1421 total, 1392 pass, 29 skip, 0 fail; real 304.76s)
- Ubuntu 26.04 SAN container: `RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 CC=clang-21 CFLAGS='-fstack-protector -D_FORTIFY_SOURCE=2 -fsanitize=address,undefined,nullability,unsigned-integer-overflow -fno-sanitize-recover=undefined,nullability,unsigned-integer-overflow -fno-sanitize=function -g -O3 -fno-omit-frame-pointer -fno-color-diagnostics' RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--disable-elasticsearch-tests --disable-libfaketime --without-valgrind-testbench --disable-valgrind --enable-omotel --disable-kafka-tests --enable-imdtls --enable-omdtls --enable-mmsnareparse' CI_MAKE_OPT=-j60 CI_MAKE_CHECK_OPT=-j60 CI_CHECK_CMD=check VERBOSE=1 devtools/devcontainer.sh --rm devtools/run-ci.sh` (1224 total, 1193 pass, 31 skip, 0 fail; real 288.84s)

Relaxations/skips: default PR relevance kept service families enabled for the broad Ubuntu 26.04 run because `tests/Makefile.am` changed. SAN lane used the workflow's normal sanitizer relaxations: Elasticsearch and Kafka tests disabled, libfaketime/Valgrind disabled because ASAN/UBSAN binaries are not Valgrind-compatible.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

