### PR TITLE
runtime: add atomic read load helpers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -366,6 +366,7 @@ AC_ARG_ENABLE(atomic-operations,
 )
 if test "$enable_atomic_operations" = "yes"; then
 	RS_ATOMIC_OPERATIONS
+	RS_ATOMIC_LOAD_STORE_OPERATIONS
 	RS_ATOMIC_OPERATIONS_64BIT
 fi
 

--- a/m4/atomic_operations.m4
+++ b/m4/atomic_operations.m4
@@ -64,3 +64,30 @@ if test "$ap_cv_atomic_builtins" = "yes"; then
 fi
 
 ])
+
+AC_DEFUN([RS_ATOMIC_LOAD_STORE_OPERATIONS],
+[AC_CACHE_CHECK([whether the compiler provides __atomic load/store builtins], [rs_cv_atomic_load_store_builtins],
+[AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#include <stdint.h>
+]], [[
+    int val = 1;
+    unsigned uval = 2;
+    void *ptr = &val;
+    int loaded;
+    unsigned uloaded;
+    void *loaded_ptr;
+
+    loaded = __atomic_load_n(&val, __ATOMIC_ACQUIRE);
+    __atomic_store_n(&val, loaded + 1, __ATOMIC_RELEASE);
+    uloaded = __atomic_load_n(&uval, __ATOMIC_ACQUIRE);
+    __atomic_store_n(&uval, uloaded + 1, __ATOMIC_RELEASE);
+    loaded_ptr = __atomic_load_n(&ptr, __ATOMIC_ACQUIRE);
+    __atomic_store_n(&ptr, loaded_ptr, __ATOMIC_RELEASE);
+    return 0;
+]])], [rs_cv_atomic_load_store_builtins=yes], [rs_cv_atomic_load_store_builtins=no])])
+
+if test "$rs_cv_atomic_load_store_builtins" = "yes"; then
+    AC_DEFINE(HAVE_ATOMIC_LOAD_STORE_BUILTINS, 1, [Define if compiler provides __atomic load/store builtins])
+fi
+
+])

--- a/runtime/atomic.h
+++ b/runtime/atomic.h
@@ -65,6 +65,23 @@
     #define ATOMIC_DEC_AND_FETCH(data, phlpmut) __sync_sub_and_fetch(data, 1)
     #define ATOMIC_FETCH_32BIT(data, phlpmut) ((int)__sync_fetch_and_and(data, 0xffffffff))
     #define ATOMIC_FETCH_32BIT_unsigned(data, phlpmut) ((unsigned)__sync_fetch_and_and(data, 0xffffffff))
+    #ifdef HAVE_ATOMIC_LOAD_STORE_BUILTINS
+        #define ATOMIC_LOAD_32BIT(data, phlpmut) ((int)__atomic_load_n((data), __ATOMIC_ACQUIRE))
+        #define ATOMIC_LOAD_32BIT_unsigned(data, phlpmut) ((unsigned)__atomic_load_n((data), __ATOMIC_ACQUIRE))
+        #define ATOMIC_STORE_32BIT(data, phlpmut, val) ((void)__atomic_store_n((data), (val), __ATOMIC_RELEASE))
+        #define ATOMIC_STORE_32BIT_unsigned(data, phlpmut, val) \
+            ((void)__atomic_store_n((data), (val), __ATOMIC_RELEASE))
+    #else
+        #define ATOMIC_LOAD_32BIT(data, phlpmut) ATOMIC_FETCH_32BIT(data, phlpmut)
+        #define ATOMIC_LOAD_32BIT_unsigned(data, phlpmut) ATOMIC_FETCH_32BIT_unsigned(data, phlpmut)
+        /*
+         * Keep load/store users on the same synchronization family when only
+         * the older __sync builtins are available; mixing __sync loads with
+         * mutex stores would reintroduce data races.
+         */
+        #define ATOMIC_STORE_32BIT(data, phlpmut, val) ((void)__sync_lock_test_and_set((data), (val)))
+        #define ATOMIC_STORE_32BIT_unsigned(data, phlpmut, val) ((void)__sync_lock_test_and_set((data), (val)))
+    #endif
     #define ATOMIC_STORE_1_TO_32BIT(data) __sync_lock_test_and_set(&(data), 1)
     #define ATOMIC_STORE_0_TO_INT(data, phlpmut) __sync_fetch_and_and(data, 0)
     #define ATOMIC_STORE_1_TO_INT(data, phlpmut) __sync_fetch_and_or(data, 1)
@@ -75,6 +92,11 @@
     #define ATOMIC_CAS_VAL(data, oldVal, newVal, phlpmut) __sync_val_compare_and_swap((data), (oldVal), (newVal))
     /* Atomic operations for pointers (word-sized on all supported platforms) */
     #define ATOMIC_FETCH_PTR(data, phlpmut) ((void *)__sync_fetch_and_add(data, 0))
+    #ifdef HAVE_ATOMIC_LOAD_STORE_BUILTINS
+        #define ATOMIC_LOAD_PTR(data, phlpmut) ((void *)__atomic_load_n((data), __ATOMIC_ACQUIRE))
+    #else
+        #define ATOMIC_LOAD_PTR(data, phlpmut) ATOMIC_FETCH_PTR(data, phlpmut)
+    #endif
     #define ATOMIC_STORE_PTR(data, phlpmut, val) ((void)__sync_lock_test_and_set((data), (val)))
     #define ATOMIC_CAS_PTR(data, oldVal, newVal, phlpmut) __sync_bool_compare_and_swap(data, (oldVal), (newVal))
 
@@ -212,12 +234,32 @@ static inline int ATOMIC_FETCH_32BIT(int *data, pthread_mutex_t *phlpmut) {
     return (val);
 }
 
+static inline int ATOMIC_LOAD_32BIT(int *data, pthread_mutex_t *phlpmut) {
+    return ATOMIC_FETCH_32BIT(data, phlpmut);
+}
+
+static inline void ATOMIC_STORE_32BIT(int *data, pthread_mutex_t *phlpmut, int val) {
+    pthread_mutex_lock(phlpmut);
+    *data = val;
+    pthread_mutex_unlock(phlpmut);
+}
+
 static inline int ATOMIC_FETCH_32BIT_unsigned(unsigned *data, pthread_mutex_t *phlpmut) {
     int val;
     pthread_mutex_lock(phlpmut);
     val = (*data);
     pthread_mutex_unlock(phlpmut);
     return (val);
+}
+
+static inline unsigned ATOMIC_LOAD_32BIT_unsigned(unsigned *data, pthread_mutex_t *phlpmut) {
+    return ATOMIC_FETCH_32BIT_unsigned(data, phlpmut);
+}
+
+static inline void ATOMIC_STORE_32BIT_unsigned(unsigned *data, pthread_mutex_t *phlpmut, unsigned val) {
+    pthread_mutex_lock(phlpmut);
+    *data = val;
+    pthread_mutex_unlock(phlpmut);
 }
 
 static inline void ATOMIC_SUB(int *data, int val, pthread_mutex_t *phlpmut) {
@@ -239,6 +281,10 @@ static inline void *ATOMIC_FETCH_PTR(void **data, pthread_mutex_t *phlpmut) {
     val = *data;
     pthread_mutex_unlock(phlpmut);
     return val;
+}
+
+static inline void *ATOMIC_LOAD_PTR(void **data, pthread_mutex_t *phlpmut) {
+    return ATOMIC_FETCH_PTR(data, phlpmut);
 }
 
 static inline void ATOMIC_STORE_PTR(void **data, pthread_mutex_t *phlpmut, void *val) {

--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -59,52 +59,24 @@ DEFobjStaticHelpers;
 DEFobjCurrIf(glbl) DEFobjCurrIf(datetime) DEFobjCurrIf(parser) DEFobjCurrIf(statsobj)
 
 
-    static inline unsigned int ratelimitSharedLoadUInt(const unsigned int *value, pthread_mutex_t *mut) {
-#ifdef HAVE_ATOMIC_BUILTINS
+    static inline unsigned int ratelimitSharedLoadUInt(unsigned int *value, pthread_mutex_t *mut) {
     (void)mut;
-    return __atomic_load_n(value, __ATOMIC_RELAXED);
-#else
-    unsigned int snapshot;
-    pthread_mutex_lock(mut);
-    snapshot = *value;
-    pthread_mutex_unlock(mut);
-    return snapshot;
-#endif
+    return ATOMIC_LOAD_32BIT_unsigned(value, mut);
 }
 
 static inline void ratelimitSharedStoreUInt(unsigned int *value, pthread_mutex_t *mut, unsigned int newval) {
-#ifdef HAVE_ATOMIC_BUILTINS
     (void)mut;
-    __atomic_store_n(value, newval, __ATOMIC_RELAXED);
-#else
-    pthread_mutex_lock(mut);
-    *value = newval;
-    pthread_mutex_unlock(mut);
-#endif
+    ATOMIC_STORE_32BIT_unsigned(value, mut, newval);
 }
 
-static inline int ratelimitSharedLoadSeverity(const int *value, pthread_mutex_t *mut) {
-#ifdef HAVE_ATOMIC_BUILTINS
+static inline int ratelimitSharedLoadSeverity(int *value, pthread_mutex_t *mut) {
     (void)mut;
-    return __atomic_load_n(value, __ATOMIC_RELAXED);
-#else
-    int snapshot;
-    pthread_mutex_lock(mut);
-    snapshot = *value;
-    pthread_mutex_unlock(mut);
-    return snapshot;
-#endif
+    return ATOMIC_LOAD_32BIT(value, mut);
 }
 
 static inline void ratelimitSharedStoreSeverity(int *value, pthread_mutex_t *mut, int newval) {
-#ifdef HAVE_ATOMIC_BUILTINS
     (void)mut;
-    __atomic_store_n(value, newval, __ATOMIC_RELAXED);
-#else
-    pthread_mutex_lock(mut);
-    *value = newval;
-    pthread_mutex_unlock(mut);
-#endif
+    ATOMIC_STORE_32BIT(value, mut, newval);
 }
 
 static void ratelimitUnregisterSharedWatchers(ratelimit_shared_t *shared);


### PR DESCRIPTION
## Summary
- add a configure probe for `__atomic_load_n` / `__atomic_store_n`
- add `ATOMIC_LOAD_32BIT`, `ATOMIC_LOAD_32BIT_unsigned`, and `ATOMIC_LOAD_PTR` helpers with existing fallback behavior
- convert the ratelimit shared setting read path to use the new helpers as a small, safe runtime sample
- guard ratelimit direct `__atomic_store_n` use with the new load/store probe so older atomic-capable compilers fall back safely

## Scope
This PR intentionally does **not** include the lock-free hashtable work. It only introduces the atomic read-helper capability and one minimal sample use in `runtime/ratelimit.c`.

## Validation
- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout`
- `make -j60 check TESTS=""`
- `./configure --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --disable-atomic-operations`
- `make -j60 check TESTS=""`
- focused ratelimit tests in both atomic and no-atomic builds:
  - `./tests/imtcp-persource-ratelimit.sh`
  - `./tests/ratelimit-legacy-persource-discard.sh`
  - `./tests/ratelimit-policy-persource-topn-default-reload.sh`
- `devtools/local-validation-plan.sh --base upstream/main --run`
  - `make distcheck TEST_RUN_TYPE=MOCK-OK`
  - Ubuntu 26.04 container `make check`: 1420 total, 1391 pass, 29 skip, 0 fail/error
  - Ubuntu 26.04 `scan-build`: no bugs found
  - Cubic review against `upstream/main`: no issues found
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check upstream/main`

With the help of AI-Agents: Codex


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

