### PR TITLE
runtime: optimize atomic helper usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -366,7 +366,6 @@ AC_ARG_ENABLE(atomic-operations,
 )
 if test "$enable_atomic_operations" = "yes"; then
 	RS_ATOMIC_OPERATIONS
-	RS_ATOMIC_LOAD_STORE_OPERATIONS
 	RS_ATOMIC_OPERATIONS_64BIT
 fi
 

--- a/contrib/impcap/impcap.c
+++ b/contrib/impcap/impcap.c
@@ -586,8 +586,8 @@ void packet_parse(uchar *arg, const struct pcap_pkthdr *pkthdr, const uchar *pac
  */
 static void doSIGTTIN(int __attribute__((unused)) sig) {
     pthread_t tid = pthread_self();
-    const int bTerminate = ATOMIC_FETCH_32BIT(&bTerminateInputs, &mutTerminateInputs);
-    DBGPRINTF("impcap: awoken via SIGTTIN; bTerminateInputs: %d\n", bTerminate);
+    const int bTerminate = PREFER_LOAD_INT(&bTerminateInputsSigSafe);
+    DBGPRINTF("impcap: awoken via SIGTTIN; bTerminateInputsSigSafe: %d\n", bTerminate);
     if (bTerminate) {
         for (instanceConf_t *inst = runModConf->root; inst != NULL; inst = inst->next) {
             if (pthread_equal(tid, inst->tid)) {

--- a/m4/atomic_operations.m4
+++ b/m4/atomic_operations.m4
@@ -11,46 +11,59 @@ AC_DEFUN([RS_ATOMIC_OPERATIONS],
 [AC_CACHE_CHECK([whether the compiler provides atomic builtins], [ap_cv_atomic_builtins],
 [AC_TRY_RUN([
 #include <sys/types.h>
+#include <time.h>
 int main()
 {
     unsigned long val = 1010, tmp, *mem = &val;
     time_t tval = 1010, ttmp, *tmem = &tval;
+    void *ptr = &val, *expected_ptr, *new_ptr;
 
-    if (__sync_fetch_and_add(&val, 1010) != 1010 || val != 2020)
+    if (__atomic_fetch_add(&val, 1010, __ATOMIC_SEQ_CST) != 1010 || val != 2020)
         return 1;
     tmp = val;
-    if (__sync_fetch_and_sub(mem, 1010) != tmp || val != 1010)
+    if (__atomic_fetch_sub(mem, 1010, __ATOMIC_SEQ_CST) != tmp || val != 1010)
         return 1;
-    if (__sync_sub_and_fetch(&val, 1010) != 0 || val != 0)
+    if (__atomic_sub_fetch(&val, 1010, __ATOMIC_SEQ_CST) != 0 || val != 0)
         return 1;
     tmp = 3030;
-    if (__sync_val_compare_and_swap(mem, 0, tmp) != 0 || val != tmp)
+    {
+        unsigned long expected = 0;
+        if (!__atomic_compare_exchange_n(mem, &expected, tmp, 0,
+                __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST) ||
+            val != tmp)
+            return 1;
+    }
+    __atomic_store_n(&val, 4040, __ATOMIC_RELEASE);
+    if (__atomic_load_n(&val, __ATOMIC_ACQUIRE) != 4040)
         return 1;
-    if (__sync_lock_test_and_set(&val, 4040) != 3030)
-        return 1;
-    mem = &tmp;
-    if (__sync_val_compare_and_swap(&mem, &tmp, &val) != &tmp)
+    expected_ptr = &val;
+    new_ptr = &tmp;
+    if (!__atomic_compare_exchange_n(&ptr, &expected_ptr, new_ptr, 0,
+            __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST))
         return 1;
 
-    if (__sync_fetch_and_add(&tval, 1010) != 1010 || tval != 2020)
+    if (__atomic_fetch_add(&tval, 1010, __ATOMIC_SEQ_CST) != 1010 || tval != 2020)
         return 1;
     ttmp = tval;
-    if (__sync_fetch_and_sub(tmem, 1010) != ttmp || tval != 1010)
+    if (__atomic_fetch_sub(tmem, 1010, __ATOMIC_SEQ_CST) != ttmp || tval != 1010)
         return 1;
-    if (__sync_sub_and_fetch(&tval, 1010) != 0 || tval != 0)
+    if (__atomic_sub_fetch(&tval, 1010, __ATOMIC_SEQ_CST) != 0 || tval != 0)
         return 1;
     ttmp = 3030;
-    if (__sync_val_compare_and_swap(tmem, 0, ttmp) != 0 || tval != ttmp)
-        return 1;
-    if (__sync_lock_test_and_set(&tval, 4040) != 3030)
-        return 1;
-    tmem = &ttmp;
-    if (__sync_val_compare_and_swap(&tmem, &ttmp, &tval) != &ttmp)
+    {
+        time_t expected = 0;
+        if (!__atomic_compare_exchange_n(tmem, &expected, ttmp, 0,
+                __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST) ||
+            tval != ttmp)
+            return 1;
+    }
+    __atomic_store_n(&tval, 4040, __ATOMIC_RELEASE);
+    if (__atomic_load_n(&tval, __ATOMIC_ACQUIRE) != 4040)
         return 1;
 
-    __sync_synchronize();
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
 
-    if (mem != &val)
+    if (ptr != &tmp)
         return 1;
 
     if (tmem != &tval)
@@ -61,33 +74,6 @@ int main()
 
 if test "$ap_cv_atomic_builtins" = "yes"; then
     AC_DEFINE(HAVE_ATOMIC_BUILTINS, 1, [Define if compiler provides atomic builtins])
-fi
-
-])
-
-AC_DEFUN([RS_ATOMIC_LOAD_STORE_OPERATIONS],
-[AC_CACHE_CHECK([whether the compiler provides __atomic load/store builtins], [rs_cv_atomic_load_store_builtins],
-[AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-#include <stdint.h>
-]], [[
-    int val = 1;
-    unsigned uval = 2;
-    void *ptr = &val;
-    int loaded;
-    unsigned uloaded;
-    void *loaded_ptr;
-
-    loaded = __atomic_load_n(&val, __ATOMIC_ACQUIRE);
-    __atomic_store_n(&val, loaded + 1, __ATOMIC_RELEASE);
-    uloaded = __atomic_load_n(&uval, __ATOMIC_ACQUIRE);
-    __atomic_store_n(&uval, uloaded + 1, __ATOMIC_RELEASE);
-    loaded_ptr = __atomic_load_n(&ptr, __ATOMIC_ACQUIRE);
-    __atomic_store_n(&ptr, loaded_ptr, __ATOMIC_RELEASE);
-    return 0;
-]])], [rs_cv_atomic_load_store_builtins=yes], [rs_cv_atomic_load_store_builtins=no])])
-
-if test "$rs_cv_atomic_load_store_builtins" = "yes"; then
-    AC_DEFINE(HAVE_ATOMIC_LOAD_STORE_BUILTINS, 1, [Define if compiler provides __atomic load/store builtins])
 fi
 
 ])

--- a/m4/atomic_operations_64bit.m4
+++ b/m4/atomic_operations_64bit.m4
@@ -13,34 +13,41 @@ AC_DEFUN([RS_ATOMIC_OPERATIONS_64BIT],
 int main()
 {
     unsigned long long val = 1010, tmp, *mem = &val;
+    void *ptr = &val, *expected_ptr, *new_ptr;
 
-    if (__sync_fetch_and_add(&val, 1010) != 1010 || val != 2020)
+    if (__atomic_fetch_add(&val, 1010, __ATOMIC_SEQ_CST) != 1010 || val != 2020)
         return 1;
 
     tmp = val;
 
-    if (__sync_fetch_and_sub(mem, 1010) != tmp || val != 1010)
+    if (__atomic_fetch_sub(mem, 1010, __ATOMIC_SEQ_CST) != tmp || val != 1010)
         return 1;
 
-    if (__sync_sub_and_fetch(&val, 1010) != 0 || val != 0)
+    if (__atomic_sub_fetch(&val, 1010, __ATOMIC_SEQ_CST) != 0 || val != 0)
         return 1;
 
     tmp = 3030;
 
-    if (__sync_val_compare_and_swap(mem, 0, tmp) != 0 || val != tmp)
+    {
+        unsigned long long expected = 0;
+        if (!__atomic_compare_exchange_n(mem, &expected, tmp, 0,
+                __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST) ||
+            val != tmp)
+            return 1;
+    }
+    __atomic_store_n(&val, 4040, __ATOMIC_RELEASE);
+    if (__atomic_load_n(&val, __ATOMIC_ACQUIRE) != 4040)
         return 1;
 
-    if (__sync_lock_test_and_set(&val, 4040) != 3030)
+    expected_ptr = &val;
+    new_ptr = &tmp;
+    if (!__atomic_compare_exchange_n(&ptr, &expected_ptr, new_ptr, 0,
+            __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST))
         return 1;
 
-    mem = &tmp;
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
 
-    if (__sync_val_compare_and_swap(&mem, &tmp, &val) != &tmp)
-        return 1;
-
-    __sync_synchronize();
-
-    if (mem != &val)
+    if (ptr != &tmp)
         return 1;
 
     return 0;

--- a/packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec
+++ b/packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec
@@ -16,6 +16,8 @@ Summary: Enhanced system logging and kernel message trapping daemon
 Name: rsyslog
 Version: 8.2602.0
 Release: 2%{?dist}
+# Build-time generated file list for optional liboverride_*.so modules.
+%global liboverride_filelist %{_builddir}/%{name}-%{version}/liboverride.files
 License: (GPLv3+ and ASL 2.0)
 Group: System Environment/Daemons
 URL: https://www.rsyslog.com/
@@ -713,6 +715,17 @@ install -p -m 644 plugins/ompgsql/createDB.sql %{buildroot}%{rsyslog_docdir}/pgs
 # extract documentation (Sphinx output is in doc/build/ when built in-tree)
 cp -r doc/build/* %{buildroot}%{rsyslog_docdir}/html
 
+# Generate file list for optional liboverride modules.
+# Older sources may not build these files; newer ones do.
+# Keep file non-empty for older sources where no liboverride modules exist.
+# rpmbuild errors out on an empty %files -f input file.
+echo "%%exclude %{_libdir}/rsyslog/__liboverride_filelist_placeholder__.so" > %{liboverride_filelist}
+for so in %{buildroot}%{_libdir}/rsyslog/liboverride_*.so
+do
+	[ -e "$so" ] || continue
+	echo "${so#%{buildroot}}" >> %{liboverride_filelist}
+done
+
 # get rid of libtool libraries
 rm -f %{buildroot}%{_libdir}/rsyslog/*.la
 
@@ -733,7 +746,7 @@ done
 %postun
 %systemd_postun_with_restart rsyslog.service
 
-%files
+%files -f %{liboverride_filelist}
 %defattr(-,root,root,-)
 %doc AUTHORS COPYING* ChangeLog
 %exclude %{rsyslog_docdir}/html

--- a/plugins/imbeats/imbeats.c
+++ b/plugins/imbeats/imbeats.c
@@ -1234,6 +1234,11 @@ static void *listenerThread(void *arg) {
             }
         }
     }
+    /* Workers may still process session events queued before shutdown and call
+     * epoll_ctl() from rearmSession()/closeSession(). Join them before closing
+     * the shared epoll fd so shutdown does not race with those operations.
+     */
+    stopWorkerPool(inst);
     close(inst->epoll_fd);
     inst->epoll_fd = -1;
 #else
@@ -1256,7 +1261,9 @@ static void *listenerThread(void *arg) {
         free(pfds);
     }
 #endif
+#if !defined(IMBEATS_HAVE_EPOLL)
     stopWorkerPool(inst);
+#endif
     return NULL;
 }
 

--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -539,7 +539,7 @@ static rsRetVal blockStatsReporting(tcps_sess_t *pSess) {
     CHKiConcCtrl(pthread_mutex_lock(&mutStatsReporterWatch));
     statsReported = 0;
     CHKiConcCtrl(pthread_mutex_unlock(&mutStatsReporterWatch));
-    ATOMIC_STORE_0_TO_INT(&allowOnlyOnce, &mutAllowOnlyOnce);
+    ATOMIC_STORE_32BIT(&allowOnlyOnce, &mutAllowOnlyOnce, 0);
     statsReportingBlockStartTimeMs = currentTimeMills();
     LogError(0, RS_RET_OK, "imdiag: blocked stats reporting");
     CHKiRet(sendResponse(pSess, "next stats reporting call will be blocked\n"));
@@ -563,7 +563,7 @@ static rsRetVal awaitStatsReport(uchar *pszCmd, tcps_sess_t *pSess) {
     if (statsReportingBlockStartTimeMs > 0) {
         long delta = currentTimeMills() - statsReportingBlockStartTimeMs;
         if (blockAgain) {
-            ATOMIC_STORE_1_TO_INT(&allowOnlyOnce, &mutAllowOnlyOnce);
+            ATOMIC_STORE_32BIT(&allowOnlyOnce, &mutAllowOnlyOnce, 1);
             LogError(0, RS_RET_OK, "imdiag: un-blocking ONLY the next cycle of stats reporting");
         } else {
             statsReportingBlockStartTimeMs = 0;

--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -1174,7 +1174,7 @@ static void shutdownKafkaWorkers(void) {
     instanceConf_t *inst;
 
     assert(kafkaWrkrInfo != NULL);
-    ATOMIC_STORE_1_TO_INT(&stopKafkaWorkers, &mutStopImkafkaWorkers);
+    ATOMIC_STORE_32BIT(&stopKafkaWorkers, &mutStopImkafkaWorkers, 1);
     DBGPRINTF("imkafka: waiting on imkafka workerthread termination\n");
     for (i = 0; i < activeKafkaworkers; ++i) {
         pthread_join(kafkaWrkrInfo[i].tid, NULL);
@@ -1222,7 +1222,7 @@ BEGINrunInput
     CODESTARTrunInput;
     DBGPRINTF("imkafka: runInput loop started ...\n");
     activeKafkaworkers = 0;
-    ATOMIC_STORE_0_TO_INT(&stopKafkaWorkers, &mutStopImkafkaWorkers);
+    ATOMIC_STORE_32BIT(&stopKafkaWorkers, &mutStopImkafkaWorkers, 0);
     for (inst = runModConf->root; inst != NULL; inst = inst->next) {
         if (inst->rk != NULL) {
             ++workerSlots;
@@ -1395,7 +1395,7 @@ static void *imkafkawrkr(void *myself) {
     DBGPRINTF("imkafka: started kafka consumer workerthread on group %s/%s with %d topics\n", me->inst->consumergroup,
               me->inst->brokers, me->inst->nTopics);
     do {
-        if (ATOMIC_FETCH_32BIT(&stopKafkaWorkers, &mutStopImkafkaWorkers) || glbl.GetGlobalInputTermState() == 1) {
+        if (ATOMIC_LOAD_32BIT(&stopKafkaWorkers, &mutStopImkafkaWorkers) || glbl.GetGlobalInputTermState() == 1) {
             break; /* terminate input! */
         }
         if (me->inst->rk == NULL) {
@@ -1413,10 +1413,10 @@ static void *imkafkawrkr(void *myself) {
          * of 0 seconds. It doesn't hurt any other valid scenario. So do not remove.
          * rgerhards, 2008-02-14
          */
-        if (glbl.GetGlobalInputTermState() == 0 && !ATOMIC_FETCH_32BIT(&stopKafkaWorkers, &mutStopImkafkaWorkers)) {
+        if (glbl.GetGlobalInputTermState() == 0 && !ATOMIC_LOAD_32BIT(&stopKafkaWorkers, &mutStopImkafkaWorkers)) {
             srSleep(0, 100000);
         }
-    } while (!ATOMIC_FETCH_32BIT(&stopKafkaWorkers, &mutStopImkafkaWorkers) && glbl.GetGlobalInputTermState() == 0);
+    } while (!ATOMIC_LOAD_32BIT(&stopKafkaWorkers, &mutStopImkafkaWorkers) && glbl.GetGlobalInputTermState() == 0);
     DBGPRINTF("imkafka: stopped kafka consumer workerthread on group %s/%s with %d topics\n", me->inst->consumergroup,
               me->inst->brokers, me->inst->nTopics);
     return NULL;

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -2193,7 +2193,7 @@ static sbool claimSessWork(epolld_t *const epd) {
 static void releaseSessWork(epolld_t *const epd) {
     ptcpsess_t *const pSess = (ptcpsess_t *)epd->ptr;
 
-    ATOMIC_STORE_0_TO_INT(&pSess->bWorkQueued, &pSess->mutWorkQueued);
+    ATOMIC_STORE_32BIT(&pSess->bWorkQueued, &pSess->mutWorkQueued, 0);
 }
 
 /* This function is called to process a single request. Listener work can run

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -873,7 +873,7 @@ ENDfreeCnf
  * only *after this function is done*. So we do not have a race!
  */
 static void doSIGTTIN(int __attribute__((unused)) sig) {
-    const int bTerminate = ATOMIC_FETCH_32BIT(&bTerminateInputs, &mutTerminateInputs);
+    const int bTerminate = PREFER_LOAD_INT(&bTerminateInputsSigSafe);
     if (bTerminate && (pRelpEngine != NULL)) {
         relpEngineSetStop(pRelpEngine);
     }

--- a/plugins/mmutf8fix/mmutf8fix.c
+++ b/plugins/mmutf8fix/mmutf8fix.c
@@ -443,6 +443,10 @@ static rsRetVal doUTF8Seq(instanceData *pData, const uchar *msg, int lenMsg, uch
 
         if (j < seqLen) {
             CHKiRet(beginSeqChange(pData, msg, lenMsg, out, &pos, i));
+            /* Match doUTF8(): replace bytes accepted as part of the
+             * malformed sequence and reprocess the non-continuation byte as
+             * the start of the next sequence.
+             */
             CHKiRet(appendReplacements(pData, *out, &pos, j));
             i += j;
         } else if (invalidCodepoint(codepoint, seqLen)) {

--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -309,7 +309,7 @@ typedef struct wrkrInstanceData {
 static void *pollCallbackThread(void *arg) {
     instanceData *const pData = (instanceData *)arg;
 
-    while (!ATOMIC_FETCH_32BIT(&pData->stopPollThread, &pData->mutStopPollThread)) {
+    while (!ATOMIC_LOAD_32BIT(&pData->stopPollThread, &pData->mutStopPollThread)) {
         if (pthread_mutex_trylock(&pData->mut_doAction) == 0) {
             pthread_rwlock_rdlock(&pData->rkLock);
             if (pData->bIsOpen && pData->rk != NULL) {
@@ -333,7 +333,7 @@ static rsRetVal startPollCallbackThread(instanceData *const pData) {
         FINALIZE;
     }
 
-    ATOMIC_STORE_0_TO_INT(&pData->stopPollThread, &pData->mutStopPollThread);
+    ATOMIC_STORE_32BIT(&pData->stopPollThread, &pData->mutStopPollThread, 0);
     const int r = pthread_create(&pData->pollThread, NULL, pollCallbackThread, pData);
     if (r != 0) {
         LogError(r, RS_RET_ERR, "omkafka: unable to create librdkafka callback poller thread");
@@ -350,7 +350,7 @@ static void stopPollCallbackThread(instanceData *const pData) {
         return;
     }
 
-    ATOMIC_STORE_1_TO_INT(&pData->stopPollThread, &pData->mutStopPollThread);
+    ATOMIC_STORE_32BIT(&pData->stopPollThread, &pData->mutStopPollThread, 1);
     const int r = pthread_join(pData->pollThread, NULL);
     if (r != 0) {
         LogError(r, RS_RET_ERR, "omkafka: unable to join librdkafka callback poller thread");
@@ -1833,7 +1833,7 @@ BEGINcreateInstance
     INIT_ATOMIC_HELPER_MUT(pData->mutCurrPartition);
     INIT_ATOMIC_HELPER_MUT(pData->mutStopPollThread);
     pData->pollThreadRunning = 0;
-    ATOMIC_STORE_0_TO_INT(&pData->stopPollThread, &pData->mutStopPollThread);
+    ATOMIC_STORE_32BIT(&pData->stopPollThread, &pData->mutStopPollThread, 0);
 finalize_it:
 ENDcreateInstance
 

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -235,7 +235,7 @@ static void onAuthErr(void *pUsr, char *authinfo, char *errmesg, __attribute__((
              "omrelp[%s:%s]: authentication error '%s', peer "
              "is '%s' - %s",
              pData->target, getRelpPt(pData), errmesg, authinfo, authFailActionText(pData));
-    ATOMIC_STORE_1_TO_INT(&pData->bHadAuthFail, &pData->mutHadAuthFail);
+    ATOMIC_STORE_32BIT(&pData->bHadAuthFail, &pData->mutHadAuthFail, 1);
 }
 
 static int relpRetIsAuthErr(const relpRetVal relpRet) {
@@ -635,7 +635,7 @@ static rsRetVal ATTR_NONNULL() doConnect(wrkrInstanceData_t *const pWrkrData) {
     if (iRet == RELP_RET_OK) {
         pWrkrData->bIsConnected = 1;
         pWrkrData->bIsSuspended = 0;
-        ATOMIC_STORE_0_TO_INT(&pWrkrData->pData->bHadAuthFail, &pWrkrData->pData->mutHadAuthFail);
+        ATOMIC_STORE_32BIT(&pWrkrData->pData->bHadAuthFail, &pWrkrData->pData->mutHadAuthFail, 0);
     } else if (iRet == RELP_RET_ERR_NO_TLS) {
         LogError(0, iRet,
                  "omrelp: Could not connect, librelp does NOT "
@@ -678,7 +678,7 @@ finalize_it:
 
 BEGINtryResume
     CODESTARTtryResume;
-    if (ATOMIC_FETCH_32BIT(&pWrkrData->pData->bHadAuthFail, &pWrkrData->pData->mutHadAuthFail) &&
+    if (ATOMIC_LOAD_32BIT(&pWrkrData->pData->bHadAuthFail, &pWrkrData->pData->mutHadAuthFail) &&
         pWrkrData->pData->bTlsPermFailDisablesAction) {
         ABORT_FINALIZE(RS_RET_DISABLE_ACTION);
     }
@@ -743,7 +743,7 @@ BEGINdoAction
         doRebind(pWrkrData);
     }
 finalize_it:
-    if (ATOMIC_FETCH_32BIT(&pData->bHadAuthFail, &pData->mutHadAuthFail)) iRet = authFailActionRet(pData);
+    if (ATOMIC_LOAD_32BIT(&pData->bHadAuthFail, &pData->mutHadAuthFail)) iRet = authFailActionRet(pData);
     if (iRet == RS_RET_OK) {
         /* we mimic non-commit, as otherwise our endTransaction handler
          * will not get called. While this is not 100% correct, the worst

--- a/plugins/omsendertrack/omsendertrack.c
+++ b/plugins/omsendertrack/omsendertrack.c
@@ -554,9 +554,9 @@ static void *bgWriter(void *arg) {
     }
 #endif
 
-    while (ATOMIC_FETCH_32BIT(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter) == 0) {
+    while (ATOMIC_LOAD_32BIT(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter) == 0) {
         srSleep(pData->interval, 0);
-        if (ATOMIC_FETCH_32BIT(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter) == 1) {
+        if (ATOMIC_LOAD_32BIT(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter) == 1) {
             break;
         }
         dbgprintf("bgwriter writing report file\n");
@@ -668,7 +668,7 @@ BEGINfreeInstance
     CODESTARTfreeInstance;
     /* stop bgWriter */
     if (pData->bgw_initialized) {
-        ATOMIC_STORE_1_TO_INT(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter);
+        ATOMIC_STORE_32BIT(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter, 1);
         pthread_kill(pData->bgw_tid, SIGTTIN);
 
         /* wait until stopped */

--- a/runtime/action.c
+++ b/runtime/action.c
@@ -795,20 +795,12 @@ static void ATTR_NONNULL() actionRetry(action_t *const pThis, wti_t *const pWti)
 }
 
 static time_t actionGetResumeRetryTime(const action_t *const pThis) {
-#ifdef HAVE_ATOMIC_BUILTINS64
-    return __atomic_load_n(&pThis->ttResumeRtry, __ATOMIC_RELAXED);
-#else
-    return pThis->ttResumeRtry;
-#endif
+    return PREFER_LOAD_time_t(&pThis->ttResumeRtry);
 }
 
 
 static void actionSetResumeRetryTime(action_t *const pThis, const time_t ttResumeRtry) {
-#ifdef HAVE_ATOMIC_BUILTINS64
-    __atomic_store_n(&pThis->ttResumeRtry, ttResumeRtry, __ATOMIC_RELAXED);
-#else
-    pThis->ttResumeRtry = ttResumeRtry;
-#endif
+    PREFER_STORE_time_t(&pThis->ttResumeRtry, ttResumeRtry);
 }
 
 
@@ -1020,7 +1012,7 @@ static rsRetVal actionCheckAndCreateWrkrInstance(action_t *const pThis, const wt
      * to ensure proper memory ordering and visibility across threads.
      */
 #ifdef HAVE_ATOMIC_BUILTINS
-    existingInstance = ATOMIC_FETCH_PTR(&pWti->actWrkrInfo[pThis->iActionNbr].actWrkrData, &pThis->mutWrkrDataTable);
+    existingInstance = ATOMIC_LOAD_PTR(&pWti->actWrkrInfo[pThis->iActionNbr].actWrkrData, &pThis->mutWrkrDataTable);
     if (existingInstance != NULL) {
         FINALIZE; /* Common case: instance exists, return immediately */
     }
@@ -1038,7 +1030,7 @@ static rsRetVal actionCheckAndCreateWrkrInstance(action_t *const pThis, const wt
 
 #ifdef HAVE_ATOMIC_BUILTINS
     /* Recheck under lock (double-checked locking pattern with atomics) */
-    existingInstance = ATOMIC_FETCH_PTR(&pWti->actWrkrInfo[pThis->iActionNbr].actWrkrData, &pThis->mutWrkrDataTable);
+    existingInstance = ATOMIC_LOAD_PTR(&pWti->actWrkrInfo[pThis->iActionNbr].actWrkrData, &pThis->mutWrkrDataTable);
 #else
     existingInstance = pWti->actWrkrInfo[pThis->iActionNbr].actWrkrData;
 #endif

--- a/runtime/action.h
+++ b/runtime/action.h
@@ -120,14 +120,14 @@ struct action_s {
 };
 
 static inline int actionLoadDisabled(action_t *const pAction) {
-    return ATOMIC_FETCH_32BIT(&pAction->bDisabled, &pAction->mutCAS);
+    return ATOMIC_LOAD_32BIT(&pAction->bDisabled, &pAction->mutCAS);
 }
 
 static inline void actionStoreDisabled(action_t *const pAction, const int value) {
     if (value == 0) {
-        ATOMIC_STORE_0_TO_INT(&pAction->bDisabled, &pAction->mutCAS);
+        ATOMIC_STORE_32BIT(&pAction->bDisabled, &pAction->mutCAS, 0);
     } else {
-        ATOMIC_STORE_1_TO_INT(&pAction->bDisabled, &pAction->mutCAS);
+        ATOMIC_STORE_32BIT(&pAction->bDisabled, &pAction->mutCAS, 1);
     }
 }
 

--- a/runtime/atomic.h
+++ b/runtime/atomic.h
@@ -55,50 +55,49 @@
  * They simply came in too late. -- rgerhards, 2008-04-02
  */
 #ifdef HAVE_ATOMIC_BUILTINS
-    #define ATOMIC_SUB(data, val, phlpmut) __sync_fetch_and_sub(data, val)
-    #define ATOMIC_SUB_unsigned(data, val, phlpmut) __sync_fetch_and_sub(data, val)
-    #define ATOMIC_ADD(data, val) __sync_fetch_and_add(&(data), val)
-    #define ATOMIC_INC(data, phlpmut) ((void)__sync_fetch_and_add(data, 1))
-    #define ATOMIC_INC_AND_FETCH_int(data, phlpmut) __sync_fetch_and_add(data, 1)
-    #define ATOMIC_INC_AND_FETCH_unsigned(data, phlpmut) __sync_fetch_and_add(data, 1)
-    #define ATOMIC_DEC(data, phlpmut) ((void)__sync_sub_and_fetch(data, 1))
-    #define ATOMIC_DEC_AND_FETCH(data, phlpmut) __sync_sub_and_fetch(data, 1)
-    #define ATOMIC_FETCH_32BIT(data, phlpmut) ((int)__sync_fetch_and_and(data, 0xffffffff))
-    #define ATOMIC_FETCH_32BIT_unsigned(data, phlpmut) ((unsigned)__sync_fetch_and_and(data, 0xffffffff))
-    #ifdef HAVE_ATOMIC_LOAD_STORE_BUILTINS
-        #define ATOMIC_LOAD_32BIT(data, phlpmut) ((int)__atomic_load_n((data), __ATOMIC_ACQUIRE))
-        #define ATOMIC_LOAD_32BIT_unsigned(data, phlpmut) ((unsigned)__atomic_load_n((data), __ATOMIC_ACQUIRE))
-        #define ATOMIC_STORE_32BIT(data, phlpmut, val) ((void)__atomic_store_n((data), (val), __ATOMIC_RELEASE))
-        #define ATOMIC_STORE_32BIT_unsigned(data, phlpmut, val) \
-            ((void)__atomic_store_n((data), (val), __ATOMIC_RELEASE))
-    #else
-        #define ATOMIC_LOAD_32BIT(data, phlpmut) ATOMIC_FETCH_32BIT(data, phlpmut)
-        #define ATOMIC_LOAD_32BIT_unsigned(data, phlpmut) ATOMIC_FETCH_32BIT_unsigned(data, phlpmut)
-        /*
-         * Keep load/store users on the same synchronization family when only
-         * the older __sync builtins are available; mixing __sync loads with
-         * mutex stores would reintroduce data races.
-         */
-        #define ATOMIC_STORE_32BIT(data, phlpmut, val) ((void)__sync_lock_test_and_set((data), (val)))
-        #define ATOMIC_STORE_32BIT_unsigned(data, phlpmut, val) ((void)__sync_lock_test_and_set((data), (val)))
-    #endif
-    #define ATOMIC_STORE_1_TO_32BIT(data) __sync_lock_test_and_set(&(data), 1)
-    #define ATOMIC_STORE_0_TO_INT(data, phlpmut) __sync_fetch_and_and(data, 0)
-    #define ATOMIC_STORE_1_TO_INT(data, phlpmut) __sync_fetch_and_or(data, 1)
-    #define ATOMIC_STORE_INT(data, phlpmut, val) ((void)__sync_lock_test_and_set((data), (val)))
-    #define ATOMIC_OR_INT_TO_INT(data, phlpmut, val) __sync_fetch_and_or((data), (val))
-    #define ATOMIC_CAS(data, oldVal, newVal, phlpmut) __sync_bool_compare_and_swap((data), (oldVal), (newVal))
-    #define ATOMIC_CAS_time_t(data, oldVal, newVal, phlpmut) __sync_bool_compare_and_swap((data), (oldVal), (newVal))
-    #define ATOMIC_CAS_VAL(data, oldVal, newVal, phlpmut) __sync_val_compare_and_swap((data), (oldVal), (newVal))
+    /*
+     * Return-value helpers mirror their names and the mutex fallback below:
+     * *_AND_FETCH returns the value after the operation.
+     */
+    #define ATOMIC_SUB(data, val, phlpmut) __atomic_fetch_sub((data), (val), __ATOMIC_SEQ_CST)
+    #define ATOMIC_SUB_unsigned(data, val, phlpmut) __atomic_fetch_sub((data), (val), __ATOMIC_SEQ_CST)
+    #define ATOMIC_ADD(data, val) __atomic_fetch_add(&(data), (val), __ATOMIC_SEQ_CST)
+    #define ATOMIC_INC(data, phlpmut) ((void)__atomic_fetch_add((data), 1, __ATOMIC_SEQ_CST))
+    #define ATOMIC_INC_AND_FETCH_int(data, phlpmut) __atomic_add_fetch((data), 1, __ATOMIC_SEQ_CST)
+    #define ATOMIC_INC_AND_FETCH_unsigned(data, phlpmut) __atomic_add_fetch((data), 1, __ATOMIC_SEQ_CST)
+    #define ATOMIC_DEC(data, phlpmut) ((void)__atomic_sub_fetch((data), 1, __ATOMIC_SEQ_CST))
+    #define ATOMIC_DEC_AND_FETCH(data, phlpmut) __atomic_sub_fetch((data), 1, __ATOMIC_SEQ_CST)
+    #define ATOMIC_LOAD_32BIT(data, phlpmut) ((int)__atomic_load_n((data), __ATOMIC_ACQUIRE))
+    #define ATOMIC_LOAD_32BIT_unsigned(data, phlpmut) ((unsigned)__atomic_load_n((data), __ATOMIC_ACQUIRE))
+    #define ATOMIC_STORE_32BIT(data, phlpmut, val) ((void)__atomic_store_n((data), (val), __ATOMIC_RELEASE))
+    #define ATOMIC_STORE_32BIT_unsigned(data, phlpmut, val) ((void)__atomic_store_n((data), (val), __ATOMIC_RELEASE))
+    #define ATOMIC_STORE_1_TO_32BIT(data) ((void)__atomic_store_n(&(data), 1, __ATOMIC_RELEASE))
+    #define ATOMIC_OR_INT_TO_INT(data, phlpmut, val) __atomic_fetch_or((data), (val), __ATOMIC_SEQ_CST)
+    #define ATOMIC_CAS(data, oldVal, newVal, phlpmut)                                                                  \
+        ({                                                                                                             \
+            __typeof__(*(data)) rs_atomic_expected = (oldVal);                                                         \
+            __atomic_compare_exchange_n((data), &rs_atomic_expected, (newVal), 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); \
+        })
+    #define ATOMIC_CAS_time_t(data, oldVal, newVal, phlpmut)                                                           \
+        ({                                                                                                             \
+            __typeof__(*(data)) rs_atomic_expected = (oldVal);                                                         \
+            __atomic_compare_exchange_n((data), &rs_atomic_expected, (newVal), 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); \
+        })
+    #define ATOMIC_CAS_VAL(data, oldVal, newVal, phlpmut)                                                 \
+        ({                                                                                                \
+            __typeof__(*(data)) rs_atomic_expected = (oldVal);                                            \
+            (void)__atomic_compare_exchange_n((data), &rs_atomic_expected, (newVal), 0, __ATOMIC_SEQ_CST, \
+                                              __ATOMIC_SEQ_CST);                                          \
+            rs_atomic_expected;                                                                           \
+        })
     /* Atomic operations for pointers (word-sized on all supported platforms) */
-    #define ATOMIC_FETCH_PTR(data, phlpmut) ((void *)__sync_fetch_and_add(data, 0))
-    #ifdef HAVE_ATOMIC_LOAD_STORE_BUILTINS
-        #define ATOMIC_LOAD_PTR(data, phlpmut) ((void *)__atomic_load_n((data), __ATOMIC_ACQUIRE))
-    #else
-        #define ATOMIC_LOAD_PTR(data, phlpmut) ATOMIC_FETCH_PTR(data, phlpmut)
-    #endif
-    #define ATOMIC_STORE_PTR(data, phlpmut, val) ((void)__sync_lock_test_and_set((data), (val)))
-    #define ATOMIC_CAS_PTR(data, oldVal, newVal, phlpmut) __sync_bool_compare_and_swap(data, (oldVal), (newVal))
+    #define ATOMIC_LOAD_PTR(data, phlpmut) ((void *)__atomic_load_n((data), __ATOMIC_ACQUIRE))
+    #define ATOMIC_STORE_PTR(data, phlpmut, val) ((void)__atomic_store_n((data), (val), __ATOMIC_RELEASE))
+    #define ATOMIC_CAS_PTR(data, oldVal, newVal, phlpmut)                                                              \
+        ({                                                                                                             \
+            __typeof__(*(data)) rs_atomic_expected = (oldVal);                                                         \
+            __atomic_compare_exchange_n((data), &rs_atomic_expected, (newVal), 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); \
+        })
 
     /* functions below are not needed if we have atomics */
     #define DEF_ATOMIC_HELPER_MUT(x)
@@ -109,10 +108,17 @@
      * not fatal if not -- that means we can live with some missed updates. So be
      * sure to use these macros only if that really does not matter!
      */
-    #define PREFER_ATOMIC_INC(data) ((void)__sync_fetch_and_add(&(data), 1))
-    #define PREFER_FETCH_32BIT(data) ((unsigned)__sync_fetch_and_and(&(data), 0xffffffff))
-    #define PREFER_STORE_0_TO_INT(data) __sync_fetch_and_and(data, 0)
-    #define PREFER_STORE_1_TO_INT(data) __sync_fetch_and_or(data, 1)
+    /*
+     * PREFER_* keeps its weak contract: the no-atomics build below still uses
+     * plain accesses. PREFER_FETCH_32BIT callers pass a scalar lvalue, not a
+     * pointer; the atomic branch takes its address locally.
+     */
+    #define PREFER_ATOMIC_INC(data) ((void)__atomic_fetch_add(&(data), 1, __ATOMIC_RELAXED))
+    #define PREFER_LOAD_INT(data) ((int)__atomic_load_n((data), __ATOMIC_RELAXED))
+    #define PREFER_FETCH_32BIT(data) ((unsigned)__atomic_load_n(&(data), __ATOMIC_RELAXED))
+    #define PREFER_STORE_INT(data, val) ((void)__atomic_store_n((data), (val), __ATOMIC_RELAXED))
+    #define PREFER_STORE_0_TO_INT(data) ((void)__atomic_store_n((data), 0, __ATOMIC_RELAXED))
+    #define PREFER_STORE_1_TO_INT(data) ((void)__atomic_store_n((data), 1, __ATOMIC_RELAXED))
 #else
     /* note that we gained practical proof that theoretical problems DO occur
      * if we do not properly address them. See this blog post for details:
@@ -128,27 +134,6 @@
             ++(*(data));                   \
             pthread_mutex_unlock(phlpmut); \
         }
-
-    #define ATOMIC_STORE_0_TO_INT(data, hlpmut) \
-        {                                       \
-            pthread_mutex_lock(hlpmut);         \
-            *(data) = 0;                        \
-            pthread_mutex_unlock(hlpmut);       \
-        }
-
-    #define ATOMIC_STORE_1_TO_INT(data, hlpmut) \
-        {                                       \
-            pthread_mutex_lock(hlpmut);         \
-            *(data) = 1;                        \
-            pthread_mutex_unlock(hlpmut);       \
-        }
-
-    #define ATOMIC_STORE_INT(data, hlpmut, val) \
-        do {                                    \
-            pthread_mutex_lock(hlpmut);         \
-            *(data) = (val);                    \
-            pthread_mutex_unlock(hlpmut);       \
-        } while (0)
 
     #define ATOMIC_OR_INT_TO_INT(data, hlpmut, val) \
         {                                           \
@@ -226,16 +211,12 @@ static inline int ATOMIC_DEC_AND_FETCH(int *data, pthread_mutex_t *phlpmut) {
     return (val);
 }
 
-static inline int ATOMIC_FETCH_32BIT(int *data, pthread_mutex_t *phlpmut) {
+static inline int ATOMIC_LOAD_32BIT(int *data, pthread_mutex_t *phlpmut) {
     int val;
     pthread_mutex_lock(phlpmut);
     val = (*data);
     pthread_mutex_unlock(phlpmut);
-    return (val);
-}
-
-static inline int ATOMIC_LOAD_32BIT(int *data, pthread_mutex_t *phlpmut) {
-    return ATOMIC_FETCH_32BIT(data, phlpmut);
+    return val;
 }
 
 static inline void ATOMIC_STORE_32BIT(int *data, pthread_mutex_t *phlpmut, int val) {
@@ -244,16 +225,12 @@ static inline void ATOMIC_STORE_32BIT(int *data, pthread_mutex_t *phlpmut, int v
     pthread_mutex_unlock(phlpmut);
 }
 
-static inline int ATOMIC_FETCH_32BIT_unsigned(unsigned *data, pthread_mutex_t *phlpmut) {
-    int val;
+static inline unsigned ATOMIC_LOAD_32BIT_unsigned(unsigned *data, pthread_mutex_t *phlpmut) {
+    unsigned val;
     pthread_mutex_lock(phlpmut);
     val = (*data);
     pthread_mutex_unlock(phlpmut);
-    return (val);
-}
-
-static inline unsigned ATOMIC_LOAD_32BIT_unsigned(unsigned *data, pthread_mutex_t *phlpmut) {
-    return ATOMIC_FETCH_32BIT_unsigned(data, phlpmut);
+    return val;
 }
 
 static inline void ATOMIC_STORE_32BIT_unsigned(unsigned *data, pthread_mutex_t *phlpmut, unsigned val) {
@@ -275,16 +252,12 @@ static inline void ATOMIC_SUB_unsigned(unsigned *data, int val, pthread_mutex_t 
 }
 
 /* Atomic operations for pointers - fallback to mutex-protected operations */
-static inline void *ATOMIC_FETCH_PTR(void **data, pthread_mutex_t *phlpmut) {
+static inline void *ATOMIC_LOAD_PTR(void **data, pthread_mutex_t *phlpmut) {
     void *val;
     pthread_mutex_lock(phlpmut);
     val = *data;
     pthread_mutex_unlock(phlpmut);
     return val;
-}
-
-static inline void *ATOMIC_LOAD_PTR(void **data, pthread_mutex_t *phlpmut) {
-    return ATOMIC_FETCH_PTR(data, phlpmut);
 }
 
 static inline void ATOMIC_STORE_PTR(void **data, pthread_mutex_t *phlpmut, void *val) {
@@ -311,7 +284,12 @@ static inline int ATOMIC_CAS_PTR(void **data, void *oldVal, void *newVal, pthrea
     #define DESTROY_ATOMIC_HELPER_MUT(x) pthread_mutex_destroy(&(x))
 
     #define PREFER_ATOMIC_INC(data) ((void)++data)
+    #define PREFER_LOAD_INT(data) (*(data))
+    /* Caller passes the scalar object, not its address. No-atomic builds deliberately
+     * use a plain read for these weak flags/counters where a racy value is acceptable.
+     */
     #define PREFER_FETCH_32BIT(data) ((unsigned)(data))
+    #define PREFER_STORE_INT(data, val) (*(data) = (val))
     #define PREFER_STORE_0_TO_INT(data) (*(data) = 0)
     #define PREFER_STORE_1_TO_INT(data) (*(data) = 1)
 
@@ -321,11 +299,23 @@ static inline int ATOMIC_CAS_PTR(void **data, void *oldVal, void *newVal, pthrea
  * 32 bit atomics, but not 64 bit ones... -- rgerhards, 2010-12-01
  */
 #ifdef HAVE_ATOMIC_BUILTINS64
-    #define ATOMIC_INC_uint64(data, phlpmut) ((void)__sync_fetch_and_add(data, 1))
-    #define ATOMIC_ADD_uint64(data, phlpmut, value) ((void)__sync_fetch_and_add(data, value))
-    #define ATOMIC_DEC_uint64(data, phlpmut) ((void)__sync_sub_and_fetch(data, 1))
-    #define ATOMIC_INC_AND_FETCH_uint64(data, phlpmut) __sync_fetch_and_add(data, 1)
-    #define ATOMIC_STORE_uint64(data, phlpmut, value) ((void)__sync_lock_test_and_set((data), (value)))
+    #define ATOMIC_INC_uint64(data, phlpmut) ((void)__atomic_fetch_add((data), 1, __ATOMIC_SEQ_CST))
+    #define ATOMIC_ADD_uint64(data, phlpmut, value) ((void)__atomic_fetch_add((data), (value), __ATOMIC_SEQ_CST))
+    #define ATOMIC_DEC_uint64(data, phlpmut) ((void)__atomic_sub_fetch((data), 1, __ATOMIC_SEQ_CST))
+    #define ATOMIC_INC_AND_FETCH_uint64(data, phlpmut) __atomic_add_fetch((data), 1, __ATOMIC_SEQ_CST)
+    #define ATOMIC_STORE_uint64(data, phlpmut, value) ((void)__atomic_store_n((data), (value), __ATOMIC_RELEASE))
+    #define ATOMIC_INC_uint64_RELAXED(data, phlpmut) ((void)__atomic_fetch_add((data), 1, __ATOMIC_RELAXED))
+    #define ATOMIC_ADD_uint64_RELAXED(data, phlpmut, value) \
+        ((void)__atomic_fetch_add((data), (value), __ATOMIC_RELAXED))
+    #define ATOMIC_DEC_uint64_RELAXED(data, phlpmut) ((void)__atomic_sub_fetch((data), 1, __ATOMIC_RELAXED))
+    #define ATOMIC_LOAD_time_t_ACQUIRE(data, phlpmut) ((time_t)__atomic_load_n((data), __ATOMIC_ACQUIRE))
+    #define ATOMIC_LOAD_time_t_RELAXED(data, phlpmut) ((time_t)__atomic_load_n((data), __ATOMIC_RELAXED))
+    #define ATOMIC_STORE_time_t_RELAXED(data, phlpmut, value) \
+        ((void)__atomic_store_n((data), (value), __ATOMIC_RELAXED))
+    #define PREFER_LOAD_time_t(data) ((time_t)__atomic_load_n((data), __ATOMIC_RELAXED))
+    #define PREFER_STORE_time_t(data, value) ((void)__atomic_store_n((data), (value), __ATOMIC_RELAXED))
+    #define PREFER_LOAD_uint64(data) ((uint64)__atomic_load_n((data), __ATOMIC_RELAXED))
+    #define PREFER_STORE_uint64(data, value) ((void)__atomic_store_n((data), (value), __ATOMIC_RELAXED))
 
     #define DEF_ATOMIC_HELPER_MUT64(x)
     #define INIT_ATOMIC_HELPER_MUT64(x)
@@ -349,12 +339,41 @@ static inline int ATOMIC_CAS_PTR(void **data, void *oldVal, void *newVal, pthrea
             --(*(data));                     \
             pthread_mutex_unlock(phlpmut);   \
         }
+    #define ATOMIC_INC_uint64_RELAXED(data, phlpmut) ATOMIC_INC_uint64(data, phlpmut)
+    #define ATOMIC_ADD_uint64_RELAXED(data, phlpmut, value) ATOMIC_ADD_uint64(data, phlpmut, value)
+    #define ATOMIC_DEC_uint64_RELAXED(data, phlpmut) ATOMIC_DEC_uint64(data, phlpmut)
+    #define PREFER_LOAD_time_t(data) (*(data))
+    #define PREFER_STORE_time_t(data, value) (*(data) = (value))
+    #define PREFER_LOAD_uint64(data) (*(data))
+    #define PREFER_STORE_uint64(data, value) (*(data) = (value))
     #define ATOMIC_STORE_uint64(data, phlpmut, value) \
         {                                             \
             pthread_mutex_lock(phlpmut);              \
             *(data) = (value);                        \
             pthread_mutex_unlock(phlpmut);            \
         }
+
+static inline time_t ATOMIC_LOAD_time_t_ACQUIRE(time_t *data, pthread_mutex_t *phlpmut) {
+    time_t val;
+    pthread_mutex_lock(phlpmut);
+    val = *data;
+    pthread_mutex_unlock(phlpmut);
+    return val;
+}
+
+static inline time_t ATOMIC_LOAD_time_t_RELAXED(time_t *data, pthread_mutex_t *phlpmut) {
+    time_t val;
+    pthread_mutex_lock(phlpmut);
+    val = *data;
+    pthread_mutex_unlock(phlpmut);
+    return val;
+}
+
+static inline void ATOMIC_STORE_time_t_RELAXED(time_t *data, pthread_mutex_t *phlpmut, time_t value) {
+    pthread_mutex_lock(phlpmut);
+    *data = value;
+    pthread_mutex_unlock(phlpmut);
+}
 
 static inline unsigned ATOMIC_INC_AND_FETCH_uint64(uint64 *data, pthread_mutex_t *phlpmut) {
     uint64 val;

--- a/runtime/dynstats.c
+++ b/runtime/dynstats.c
@@ -142,8 +142,8 @@ static void dynstats_destroyBucket(dynstats_bucket_t *b) {
     }
 
     pthread_rwlock_rdlock(&b->lock);
-    need_persist =
-        (b->persist_state_write_count_interval || b->persist_state_interval_secs || b->persist_expiration_time);
+    need_persist = (b->persist_state_write_count_interval || b->persist_state_interval_secs ||
+                    ATOMIC_LOAD_time_t_RELAXED(&b->persist_expiration_time, &b->mutPersistExpirationTime));
     pthread_rwlock_unlock(&b->lock);
 
     /* Persist state BEFORE taking lock for destruction to avoid holding lock during I/O.
@@ -175,6 +175,7 @@ static void dynstats_destroyBucket(dynstats_bucket_t *b) {
     pthread_rwlock_unlock(&b->lock);
     pthread_rwlock_destroy(&b->lock);
     pthread_mutex_destroy(&b->mutMetricCount);
+    DESTROY_ATOMIC_HELPER_MUT64(b->mutPersistExpirationTime);
     dynstats_destroyStatsCounter(bkts->global_stats, &b->pOpsOverflowCtr);
     dynstats_destroyStatsCounter(bkts->global_stats, &b->pNewMetricAddCtr);
     dynstats_destroyStatsCounter(bkts->global_stats, &b->pNoMetricCtr);
@@ -529,11 +530,11 @@ static rsRetVal dynstats_newBucket(const uchar *name,
                                    const uchar *stateFileDirectory) {
     dynstats_bucket_t *b;
     dynstats_buckets_t *bkts;
-    uint8_t lock_initialized, metric_count_mutex_initialized;
+    uint8_t lock_initialized, metric_count_mutex_initialized, persist_expiration_mutex_initialized;
     pthread_rwlockattr_t bucket_lock_attr;
     DEFiRet;
 
-    lock_initialized = metric_count_mutex_initialized = 0;
+    lock_initialized = metric_count_mutex_initialized = persist_expiration_mutex_initialized = 0;
     b = NULL;
 
     bkts = &loadConf->dynstats_buckets;
@@ -566,6 +567,8 @@ static rsRetVal dynstats_newBucket(const uchar *name,
         lock_initialized = 1;
         pthread_mutex_init(&b->mutMetricCount, NULL);
         metric_count_mutex_initialized = 1;
+        INIT_ATOMIC_HELPER_MUT64(b->mutPersistExpirationTime);
+        persist_expiration_mutex_initialized = 1;
 
         CHKiRet(dynstats_initNewBucketStats(b));
 
@@ -586,7 +589,8 @@ static rsRetVal dynstats_newBucket(const uchar *name,
             }
             pthread_rwlock_wrlock(&b->lock);
             if (persistStateTimeInterval > 0) {
-                b->persist_expiration_time = now + persistStateTimeInterval;
+                ATOMIC_STORE_time_t_RELAXED(&b->persist_expiration_time, &b->mutPersistExpirationTime,
+                                            now + persistStateTimeInterval);
             }
             pthread_rwlock_unlock(&b->lock);
 
@@ -614,6 +618,9 @@ finalize_it:
             if (lock_initialized) {
                 if (!metric_count_mutex_initialized) {
                     pthread_mutex_init(&b->mutMetricCount, NULL);
+                }
+                if (!persist_expiration_mutex_initialized) {
+                    INIT_ATOMIC_HELPER_MUT64(b->mutPersistExpirationTime);
                 }
                 dynstats_destroyBucket(b);
             } else {
@@ -1038,7 +1045,7 @@ static rsRetVal dynstats_addNewCtr(dynstats_bucket_t *b,
     created = 0;
     ctr = NULL;
 
-    if ((unsigned)ATOMIC_FETCH_32BIT_unsigned(&b->metricCount, &b->mutMetricCount) >= b->maxCardinality) {
+    if ((unsigned)ATOMIC_LOAD_32BIT_unsigned(&b->metricCount, &b->mutMetricCount) >= b->maxCardinality) {
         ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
     }
 
@@ -1156,13 +1163,7 @@ static sbool dynstats_shouldPersist(dynstats_bucket_t *b, time_t now) {
         }
     }
 
-#ifdef HAVE_ATOMIC_BUILTINS64
-    expire = (time_t)__sync_fetch_and_add((uint64_t *)&b->persist_expiration_time, 0);
-#else
-    pthread_rwlock_rdlock(&b->lock);
-    expire = b->persist_expiration_time;
-    pthread_rwlock_unlock(&b->lock);
-#endif
+    expire = ATOMIC_LOAD_time_t_ACQUIRE(&b->persist_expiration_time, &b->mutPersistExpirationTime);
 
     if (!shouldPersist && expire && now >= expire) {
         shouldPersist = TRUE;
@@ -1171,12 +1172,13 @@ static sbool dynstats_shouldPersist(dynstats_bucket_t *b, time_t now) {
 }
 
 static sbool dynstats_shouldPersistLocked(dynstats_bucket_t *b, time_t now) {
+    const time_t expire = ATOMIC_LOAD_time_t_RELAXED(&b->persist_expiration_time, &b->mutPersistExpirationTime);
     if (b->persist_state_write_count_interval > 0 &&
-        (uint32_t)ATOMIC_FETCH_32BIT_unsigned(&b->n_updates, &b->mutMetricCount) >=
+        (uint32_t)ATOMIC_LOAD_32BIT_unsigned(&b->n_updates, &b->mutMetricCount) >=
             b->persist_state_write_count_interval) {
         return TRUE;
     }
-    if (b->persist_expiration_time && now >= b->persist_expiration_time) {
+    if (expire && now >= expire) {
         return TRUE;
     }
     return FALSE;
@@ -1224,7 +1226,8 @@ rsRetVal dynstats_inc(dynstats_bucket_t *b, uchar *metric) {
                         ATOMIC_SUB_unsigned(&b->n_updates, b->persist_state_write_count_interval, &b->mutMetricCount);
                     }
                     if (b->persist_state_interval_secs) {
-                        b->persist_expiration_time = now + b->persist_state_interval_secs;
+                        ATOMIC_STORE_time_t_RELAXED(&b->persist_expiration_time, &b->mutPersistExpirationTime,
+                                                    now + b->persist_state_interval_secs);
                     }
                 }
             }

--- a/runtime/dynstats.h
+++ b/runtime/dynstats.h
@@ -82,6 +82,7 @@ struct dynstats_bucket_s {
     uint32_t persist_state_write_count_interval; /* count of bucket updates before persisting */
     uint32_t persist_state_interval_secs; /* interval in secs bucket before persisting bucket state */
     time_t persist_expiration_time;
+    DEF_ATOMIC_HELPER_MUT64(mutPersistExpirationTime);
     uint32_t n_updates; /* number of bucket updates before persisting the stream */
 };
 

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -89,6 +89,7 @@ static uchar *LocalFQDNName = NULL; /* our hostname as FQDN - read-only after st
 static uchar *LocalDomain = NULL; /* our local domain name  - read-only after startup, except HUP */
 static int iMaxLine = 8096;
 int bTerminateInputs = 0; /* global switch that inputs shall terminate ASAP (1=> terminate) */
+volatile sig_atomic_t bTerminateInputsSigSafe = 0;
 int glblUnloadModules = 1;
 int glblAbortOnProgramError = 0;
 char **glblDbgFiles = NULL;
@@ -301,7 +302,7 @@ SIMP_PROP_GET(ParserEscapeControlCharacterTab, parser.bEscapeTab, int)
  * rgerhards, 2009-07-20
  */
 static int GetGlobalInputTermState(void) {
-    return ATOMIC_FETCH_32BIT(&bTerminateInputs, &mutTerminateInputs);
+    return ATOMIC_LOAD_32BIT(&bTerminateInputs, &mutTerminateInputs);
 }
 
 
@@ -309,7 +310,12 @@ static int GetGlobalInputTermState(void) {
  * "once in a lifetime" action which can not be undone. -- gerhards, 2009-07-20
  */
 static void SetGlobalInputTermination(void) {
-    ATOMIC_STORE_1_TO_INT(&bTerminateInputs, &mutTerminateInputs);
+    /* Signal handlers must not take mutTerminateInputs in no-atomic builds.
+     * Publish this one-way mirror first so a shutdown signal delivered during
+     * termination setup may already break input-side blocking calls.
+     */
+    PREFER_STORE_INT(&bTerminateInputsSigSafe, 1);
+    ATOMIC_STORE_32BIT(&bTerminateInputs, &mutTerminateInputs, 1);
 }
 
 

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -30,6 +30,7 @@
 #ifndef GLBL_H_INCLUDED
 #define GLBL_H_INCLUDED
 
+#include <signal.h>
 #include <sys/types.h>
 #ifdef ENABLE_LIBLOGGING_STDLOG
     #include <liblogging/stdlog.h>
@@ -127,6 +128,7 @@ extern int glblDbgWhitelist;
 extern int glblPermitCtlC;
 extern int glblAbortOnProgramError;
 extern int bTerminateInputs;
+extern volatile sig_atomic_t bTerminateInputsSigSafe;
 #ifndef HAVE_ATOMIC_BUILTINS
 extern DEF_ATOMIC_HELPER_MUT(mutTerminateInputs);
 #endif

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -1166,7 +1166,7 @@ finalize_it:
  */
 /* Note on atomic operations:
  * ifIsLoaded uses PREFER_FETCH_32BIT for reads to prevent data races on platforms with atomics.
- * Writes always occur under mutObjGlobalOp and use plain assignment.
+ * Writes always occur under mutObjGlobalOp and use matching PREFER stores.
  * On platforms without atomics, PREFER_* degrades to plain operations (acceptable for 20+ years).
  * The mutex provides full synchronization; atomics only improve diagnostic cleanliness (TSAN).
  */
@@ -1202,7 +1202,7 @@ static ATTR_NO_SANITIZE_UNDEFINED rsRetVal UseObj(const char *srcFile,
      * and set it to "fully initialized" when the load succeeded. It's a bit hackish, but
      * looks like a good solution. -- rgerhards, 2008-03-07
      */
-    pIf->ifIsLoaded = 2; /* plain write: protected by mutObjGlobalOp */
+    PREFER_STORE_INT(&pIf->ifIsLoaded, 2);
 
     iRet = FindObjInfo((const char *)pObjName, &pObjInfo);
     if (iRet == RS_RET_NOT_FOUND) {
@@ -1227,7 +1227,7 @@ static ATTR_NO_SANITIZE_UNDEFINED rsRetVal UseObj(const char *srcFile,
     //       The supression is just an interim solution until the pointer issue
     //       has been fully analyzed and aligned (or considered OK w/ reasoning).
     CHKiRet(pObjInfo->QueryIF(pIf));
-    pIf->ifIsLoaded = 1; /* plain write: protected by mutObjGlobalOp */
+    PREFER_STORE_1_TO_INT(&pIf->ifIsLoaded);
 
 finalize_it:
     pthread_mutex_unlock(&mutObjGlobalOp);
@@ -1254,7 +1254,7 @@ static rsRetVal ReleaseObj(const char *srcFile, uchar *pObjName, uchar *pObjFile
         FINALIZE; /* we are not loaded - this is perfectly OK... */
     } else if (PREFER_FETCH_32BIT(pIf->ifIsLoaded) == 2) {
         /* Clean up failed load attempt */
-        pIf->ifIsLoaded = 0; /* plain write: protected by mutObjGlobalOp */
+        PREFER_STORE_0_TO_INT(&pIf->ifIsLoaded);
         FINALIZE; /* we had a load error and can not/must not continue */
     }
 
@@ -1263,7 +1263,7 @@ static rsRetVal ReleaseObj(const char *srcFile, uchar *pObjName, uchar *pObjFile
     /* if we reach this point, we have a valid pObjInfo */
     module.Release(srcFile, &pObjInfo->pModInfo); /* decrease refcount */
 
-    pIf->ifIsLoaded = 0; /* plain write: protected by mutObjGlobalOp */
+    PREFER_STORE_0_TO_INT(&pIf->ifIsLoaded);
 
 finalize_it:
     pthread_mutex_unlock(&mutObjGlobalOp);

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -503,12 +503,12 @@ static int getLogicalQueueSize(qqueue_t *pThis) {
 
 
 static int qqueueIsShutdownImmediate(qqueue_t *const pThis) {
-    return ATOMIC_FETCH_32BIT(&pThis->bShutdownImmediate, &pThis->mutShutdownImmediate);
+    return ATOMIC_LOAD_32BIT(&pThis->bShutdownImmediate, &pThis->mutShutdownImmediate);
 }
 
 
 static void qqueueSetShutdownImmediate(qqueue_t *const pThis, const int value) {
-    ATOMIC_STORE_INT(&pThis->bShutdownImmediate, &pThis->mutShutdownImmediate, value);
+    ATOMIC_STORE_32BIT(&pThis->bShutdownImmediate, &pThis->mutShutdownImmediate, value);
 }
 
 

--- a/runtime/statsobj.c
+++ b/runtime/statsobj.c
@@ -309,38 +309,22 @@ static void destructCounter(statsobj_t *pThis, ctr_t *pCtr) {
 }
 
 static intctr_t getIntCtrValue(const intctr_t *const ctr) {
-#ifdef HAVE_ATOMIC_BUILTINS64
-    return __atomic_load_n(ctr, __ATOMIC_RELAXED);
-#else
-    return *ctr;
-#endif
+    return PREFER_LOAD_uint64(ctr);
 }
 
 
 static void resetIntCtrValue(intctr_t *const ctr) {
-#ifdef HAVE_ATOMIC_BUILTINS64
-    __atomic_store_n(ctr, 0, __ATOMIC_RELAXED);
-#else
-    *ctr = 0;
-#endif
+    PREFER_STORE_uint64(ctr, 0);
 }
 
 
 static int getIntValue(const int *const ctr) {
-#ifdef HAVE_ATOMIC_BUILTINS
-    return __atomic_load_n(ctr, __ATOMIC_RELAXED);
-#else
-    return *ctr;
-#endif
+    return PREFER_LOAD_INT(ctr);
 }
 
 
 static void resetIntValue(int *const ctr) {
-#ifdef HAVE_ATOMIC_BUILTINS
-    __atomic_store_n(ctr, 0, __ATOMIC_RELAXED);
-#else
-    *ctr = 0;
-#endif
+    PREFER_STORE_INT(ctr, 0);
 }
 
 
@@ -815,7 +799,7 @@ finalize_it:
  * again, as this is right now not needed.
  */
 static rsRetVal enableStats(void) {
-    GatherStats = 1;
+    PREFER_STORE_1_TO_INT(&GatherStats);
     return RS_RET_OK;
 }
 

--- a/runtime/statsobj.h
+++ b/runtime/statsobj.h
@@ -282,20 +282,22 @@ void checkGoneAwaySenders(time_t);
     INIT_ATOMIC_HELPER_MUT64(mut);  \
     ctr = 0;
 
+#define STATSCOUNTER_ENABLED() (PREFER_FETCH_32BIT(GatherStats) != 0)
+
 #define STATSCOUNTER_INC(ctr, mut) \
-    if (GatherStats) ATOMIC_INC_uint64(&ctr, &mut);
+    if (STATSCOUNTER_ENABLED()) ATOMIC_INC_uint64_RELAXED(&ctr, &mut);
 
 #define STATSCOUNTER_ADD(ctr, mut, delta) \
-    if (GatherStats) ATOMIC_ADD_uint64(&ctr, &mut, delta);
+    if (STATSCOUNTER_ENABLED()) ATOMIC_ADD_uint64_RELAXED(&ctr, &mut, delta);
 
 #define STATSCOUNTER_DEC(ctr, mut) \
-    if (GatherStats) ATOMIC_DEC_uint64(&ctr, &mut);
+    if (STATSCOUNTER_ENABLED()) ATOMIC_DEC_uint64_RELAXED(&ctr, &mut);
 
 /* the next macro works only if the variable is already guarded
  * by mutex (or the users risks a wrong result). It is assumed
  * that there are not concurrent operations that modify the counter.
  */
 #define STATSCOUNTER_SETMAX_NOMUT(ctr, newmax) \
-    if (GatherStats && ((newmax) > (ctr))) ctr = newmax;
+    if (STATSCOUNTER_ENABLED() && ((newmax) > (ctr))) ctr = newmax;
 
 #endif /* #ifndef INCLUDED_STATSOBJ_H */

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -216,7 +216,7 @@ static rsRetVal ATTR_NONNULL()
         pWorkset[i] = event[i].data.ptr;
         /* default is no error, on error we terminate, so we need only to set in error case! */
         if (event[i].events & EPOLLERR) {
-            ATOMIC_STORE_1_TO_INT(&pWorkset[i]->isInError, &pWorkset[i]->mut_isInError);
+            ATOMIC_STORE_32BIT(&pWorkset[i]->isInError, &pWorkset[i]->mut_isInError, 1);
         }
     }
     *numEntries = nfds;
@@ -1006,8 +1006,8 @@ static rsRetVal ATTR_NONNULL(1)
 
 #if defined(ENABLE_IMTCP_EPOLL)
     /* If we had EPOLLERR, log additional info; processing continues. */
-    if (ATOMIC_FETCH_32BIT(&pioDescr->isInError, &pioDescr->mut_isInError)) {
-        ATOMIC_STORE_0_TO_INT(&pioDescr->isInError, &pioDescr->mut_isInError);
+    if (ATOMIC_LOAD_32BIT(&pioDescr->isInError, &pioDescr->mut_isInError)) {
+        ATOMIC_STORE_32BIT(&pioDescr->isInError, &pioDescr->mut_isInError, 0);
         int error = 0;
         socklen_t len = sizeof(error);
         const int sock = pioDescr->sock;
@@ -1721,6 +1721,12 @@ static rsRetVal ATTR_NONNULL() RunEpoll(tcpsrv_t *const pThis) {
 
         processWorkset(numEntries, workset);
     }
+
+    /* Workers can still process listener events queued just before shutdown.
+     * Join them before freeing listener descriptors so rearmIoEvent() cannot
+     * observe descriptor storage that RunEpoll() is tearing down.
+     */
+    stopWrkrPool(pThis);
 
     /* remove the tcp listen sockets from the epoll set */
     for (i = 0; i < pThis->iLstnCurr; ++i) {

--- a/runtime/threads.h
+++ b/runtime/threads.h
@@ -39,11 +39,11 @@ struct thrdInfo {
 };
 
 static inline int thrdGetShallStop(thrdInfo_t *pThis) {
-    return ATOMIC_FETCH_32BIT(&pThis->bShallStop, &pThis->mutShallStop);
+    return ATOMIC_LOAD_32BIT(&pThis->bShallStop, &pThis->mutShallStop);
 }
 
 static inline void thrdSetShallStop(thrdInfo_t *pThis) {
-    ATOMIC_STORE_1_TO_INT(&pThis->bShallStop, &pThis->mutShallStop);
+    ATOMIC_STORE_32BIT(&pThis->bShallStop, &pThis->mutShallStop, 1);
 }
 
 /* prototypes */

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -76,7 +76,7 @@ uchar *ATTR_NONNULL() wtiGetDbgHdr(const wti_t *const pThis) {
  * simplicity, we do not use the iRet interface. -- rgerhards, 2009-07-17
  */
 int ATTR_NONNULL() wtiGetState(wti_t *pThis) {
-    return ATOMIC_FETCH_32BIT(&pThis->bIsRunning, &pThis->mutIsRunning);
+    return ATOMIC_LOAD_32BIT(&pThis->bIsRunning, &pThis->mutIsRunning);
 }
 
 /* join terminated worker thread
@@ -116,7 +116,7 @@ rsRetVal ATTR_NONNULL() wtiSetAlwaysRunning(wti_t *pThis) {
 rsRetVal ATTR_NONNULL() wtiSetState(wti_t *pThis, const int newVal) {
     ISOBJ_TYPE_assert(pThis, wti);
     if (newVal == WRKTHRD_STOPPED) {
-        ATOMIC_STORE_0_TO_INT(&pThis->bIsRunning, &pThis->mutIsRunning);
+        ATOMIC_STORE_32BIT(&pThis->bIsRunning, &pThis->mutIsRunning, 0);
     } else {
         ATOMIC_OR_INT_TO_INT(&pThis->bIsRunning, &pThis->mutIsRunning, newVal);
     }

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -98,9 +98,9 @@ struct wti_s {
 
 static inline int wtiIsShutdownImmediate(const wti_t *const pWti) {
 #ifdef HAVE_ATOMIC_BUILTINS
-    return ATOMIC_FETCH_32BIT(pWti->pbShutdownImmediate, NULL);
+    return ATOMIC_LOAD_32BIT(pWti->pbShutdownImmediate, NULL);
 #else
-    return ATOMIC_FETCH_32BIT(pWti->pbShutdownImmediate, pWti->pmutShutdownImmediate);
+    return ATOMIC_LOAD_32BIT(pWti->pbShutdownImmediate, pWti->pmutShutdownImmediate);
 #endif
 }
 

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -200,7 +200,7 @@ ENDobjDestruct(wtp)
  */
 rsRetVal wtpSetState(wtp_t *pThis, wtpState_t iNewState) {
     ISOBJ_TYPE_assert(pThis, wtp);
-    ATOMIC_STORE_INT((int *)&pThis->wtpState, &pThis->mutWtpState, iNewState);
+    ATOMIC_STORE_32BIT((int *)&pThis->wtpState, &pThis->mutWtpState, iNewState);
     return RS_RET_OK;
 }
 
@@ -224,9 +224,9 @@ rsRetVal wtpChkStopWrkr(wtp_t *pThis, int bLockUsrMutex) {
 
     ISOBJ_TYPE_assert(pThis, wtp);
     /* we need a consistent value, but it doesn't really matter if it is changed
-     * right after the fetch - then we simply do one more iteration in the worker
+     * right after the load - then we simply do one more iteration in the worker
      */
-    wtpState = (wtpState_t)ATOMIC_FETCH_32BIT((int *)&pThis->wtpState, &pThis->mutWtpState);
+    wtpState = (wtpState_t)ATOMIC_LOAD_32BIT((int *)&pThis->wtpState, &pThis->mutWtpState);
 
     if (wtpState == wtpState_SHUTDOWN_IMMEDIATE) {
         ABORT_FINALIZE(RS_RET_TERMINATE_NOW);
@@ -279,10 +279,10 @@ PRAGMA_IGNORE_Wempty_body
      * worker threads. Even though we hold mutWtp, workers update this counter
      * atomically, so we must read it atomically to ensure we see the latest value.
      */
-    while (ATOMIC_FETCH_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd) > 0 && !bTimedOut) {
+    while (ATOMIC_LOAD_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd) > 0 && !bTimedOut) {
         wtpJoinTerminatedWrkr(pThis);
         DBGPRINTF("%s: waiting %ldms on worker thread termination, %d still running\n", wtpGetDbgHdr(pThis),
-                  timeoutVal(ptTimeout), ATOMIC_FETCH_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
+                  timeoutVal(ptTimeout), ATOMIC_LOAD_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
 
         if (d_pthread_cond_timedwait(&pThis->condThrdTrm, &pThis->mutWtp, ptTimeout) != 0) {
             DBGPRINTF("%s: timeout waiting on worker thread termination\n", wtpGetDbgHdr(pThis));
@@ -348,7 +348,7 @@ static void wtpWrkrExecCleanup(wti_t *pWti) {
     /* note: numWorkersNow is only for message generation, so we do not try
      * hard to get it 100% accurate (as curently done, it is not).
      */
-    const int numWorkersNow = ATOMIC_FETCH_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd);
+    const int numWorkersNow = ATOMIC_LOAD_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd);
     DBGPRINTF("%s: Worker thread %lx, terminated, num workers now %d\n", wtpGetDbgHdr(pThis), (unsigned long)pWti,
               numWorkersNow);
     if (numWorkersNow > 0) {
@@ -463,7 +463,7 @@ static rsRetVal ATTR_NONNULL() wtpStartWrkr(wtp_t *const pThis, const int permit
     // TESTBENCH bughunt - remove when done! 2018-11-05 rgerhards
     if (dbgTimeoutToStderr) {
         fprintf(stderr, "%s: worker start requested, num workers currently %d\n", wtpGetDbgHdr(pThis),
-                ATOMIC_FETCH_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
+                ATOMIC_LOAD_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
     }
 
     d_pthread_mutex_lock(&pThis->mutWtp);
@@ -476,7 +476,7 @@ static rsRetVal ATTR_NONNULL() wtpStartWrkr(wtp_t *const pThis, const int permit
      * lock (mutWtpState). This lock on mutWtp ensures the check and
      * subsequent worker creation are an atomic unit, fixing the TOCTOU race.
      */
-    const wtpState_t wtpState = (wtpState_t)ATOMIC_FETCH_32BIT((int *)&pThis->wtpState, &pThis->mutWtpState);
+    const wtpState_t wtpState = (wtpState_t)ATOMIC_LOAD_32BIT((int *)&pThis->wtpState, &pThis->mutWtpState);
     if (wtpState != wtpState_RUNNING && !permit_during_shutdown) {
         d_pthread_mutex_unlock(&pThis->mutWtp);
         DBGPRINTF("%s: worker start requested during shutdown - ignored\n", wtpGetDbgHdr(pThis));
@@ -513,10 +513,10 @@ static rsRetVal ATTR_NONNULL() wtpStartWrkr(wtp_t *const pThis, const int permit
     // TESTBENCH bughunt - remove when done! 2018-11-05 rgerhards
     if (dbgTimeoutToStderr) {
         fprintf(stderr, "%s: wrkr start initiated with state %d, num workers now %d\n", wtpGetDbgHdr(pThis), iState,
-                ATOMIC_FETCH_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
+                ATOMIC_LOAD_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
     }
     DBGPRINTF("%s: started with state %d, num workers now %d\n", wtpGetDbgHdr(pThis), iState,
-              ATOMIC_FETCH_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
+              ATOMIC_LOAD_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
 
     /* wait for the new thread to initialize its signal mask and
      * cancellation cleanup handler before proceeding
@@ -525,11 +525,11 @@ static rsRetVal ATTR_NONNULL() wtpStartWrkr(wtp_t *const pThis, const int permit
         d_pthread_cond_wait(&pThis->condThrdInitDone, &pThis->mutWtp);
     } while ((iState = wtiGetState(pWti)) == WRKTHRD_INITIALIZING);
     DBGPRINTF("%s: new worker finished initialization with state %d, num workers now %d\n", wtpGetDbgHdr(pThis), iState,
-              ATOMIC_FETCH_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
+              ATOMIC_LOAD_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
     // TESTBENCH bughunt - remove when done! 2018-11-05 rgerhards
     if (dbgTimeoutToStderr) {
         fprintf(stderr, "rsyslog debug: %s: started with state %d, num workers now %d\n", wtpGetDbgHdr(pThis), iState,
-                ATOMIC_FETCH_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
+                ATOMIC_LOAD_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
     }
 
 finalize_it:
@@ -560,14 +560,14 @@ rsRetVal ATTR_NONNULL() wtpAdviseMaxWorkers(wtp_t *const pThis, int nMaxWrkr, co
     if (nMaxWrkr > pThis->iNumWorkerThreads) /* limit to configured maximum */
         nMaxWrkr = pThis->iNumWorkerThreads;
 
-    nMissing = nMaxWrkr - ATOMIC_FETCH_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd);
+    nMissing = nMaxWrkr - ATOMIC_LOAD_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd);
 
     if (nMissing > 0) {
-        if (ATOMIC_FETCH_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd) > 0) {
+        if (ATOMIC_LOAD_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd) > 0) {
             LogMsg(0, RS_RET_OPERATION_STATUS, LOG_INFO,
                    "%s: high activity - starting %d additional worker thread(s), "
                    "currently %d active worker threads.",
-                   wtpGetDbgHdr(pThis), nMissing, ATOMIC_FETCH_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
+                   wtpGetDbgHdr(pThis), nMissing, ATOMIC_LOAD_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
         }
         /* start the rqtd nbr of workers */
         for (i = 0; i < nMissing; ++i) {

--- a/tests/known_issues.supp
+++ b/tests/known_issues.supp
@@ -82,6 +82,21 @@
    fun:(below main)
 }
 {
+   <Helgrind does not recognize __atomic global input termination store>
+   Helgrind:Race
+   fun:SetGlobalInputTermination
+   fun:deinitAll
+   fun:main
+}
+{
+   <Helgrind does not recognize __atomic global input termination load>
+   Helgrind:Race
+   fun:GetGlobalInputTermState
+   fun:RunEpoll
+   fun:Run
+   ...
+}
+{
    <glibc 2.4[01] failures for fc4[12].aarch64>
    Memcheck:Leak
    match-leak-kinds: definite

--- a/tests/mmutf8fix_replacement_sequence.sh
+++ b/tests/mmutf8fix_replacement_sequence.sh
@@ -37,6 +37,9 @@ wait_file_exists "$RSYSLOG_DYNNAME.tcpflood_tag_port"
 printf '<134>1 2026-06-01T00:00:00Z host app proc msgid [test@32473 dirty="Brain\xa0Twist"] bad\xc0\x80 utf8\n' \
   > "$RSYSLOG_DYNNAME.input"
 tcpflood -p"$(cat "$RSYSLOG_DYNNAME.tcpflood_sd_port")" -m1 -I "$RSYSLOG_DYNNAME.input"
+printf '<134>1 2026-06-01T00:00:00Z host app proc msgid [test@32473 clean="ok"] split\xe0\xa0Xtail\n' \
+  > "$RSYSLOG_DYNNAME.input"
+tcpflood -p"$(cat "$RSYSLOG_DYNNAME.tcpflood_sd_port")" -m1 -I "$RSYSLOG_DYNNAME.input"
 printf '<129>Mar 10 01:00:00 host bad\xc0tag: tag payload\n' > "$RSYSLOG_DYNNAME.input"
 tcpflood -p"$(cat "$RSYSLOG_DYNNAME.tcpflood_tag_port")" -m1 -I "$RSYSLOG_DYNNAME.input"
 rm -f "$RSYSLOG_DYNNAME.input"
@@ -45,6 +48,7 @@ wait_shutdown
 
 {
   printf '[test@32473 dirty="Brain\357\277\275Twist"]|bad\357\277\275\357\277\275 utf8\n'
+  printf '[test@32473 clean="ok"]|split\357\277\275\357\277\275Xtail\n'
   printf 'bad\357\277\275tag:| tag payload\n'
 } > "$RSYSLOG_OUT_LOG.expect"
 

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -1572,7 +1572,7 @@ static void countActiveTargets(const wrkrInstanceData_t *const pWrkrData) {
     /* Use atomic CAS to update the value safely */
     int oldVal, newVal;
     do {
-        oldVal = ATOMIC_FETCH_32BIT(&pWrkrData->pData->nActiveTargets, &pWrkrData->pData->mut_nActiveTargets);
+        oldVal = ATOMIC_LOAD_32BIT(&pWrkrData->pData->nActiveTargets, &pWrkrData->pData->mut_nActiveTargets);
         if (oldVal == activeTargets) {
             break; /* no change, so no log message either */
         }
@@ -1630,7 +1630,7 @@ static rsRetVal doTryResume(targetData_t *pTarget) {
     const char *address;
     DEFiRet;
 
-    const int nActiveTargets = ATOMIC_FETCH_32BIT(&pTarget->pData->nActiveTargets, &pTarget->pData->mut_nActiveTargets);
+    const int nActiveTargets = ATOMIC_LOAD_32BIT(&pTarget->pData->nActiveTargets, &pTarget->pData->mut_nActiveTargets);
 
     DBGPRINTF("doTryResume: isConnected: %d, ttResume %lld, LastActiveTargets: %d\n", pTarget->bIsConnected,
               (long long)pTarget->ttResume, nActiveTargets);
@@ -1725,7 +1725,7 @@ BEGINtryResume
     iRet = poolTryResume(pWrkrData);
     countActiveTargets(pWrkrData);
     const int nActiveTargets =
-        ATOMIC_FETCH_32BIT(&pWrkrData->pData->nActiveTargets, &pWrkrData->pData->mut_nActiveTargets);
+        ATOMIC_LOAD_32BIT(&pWrkrData->pData->nActiveTargets, &pWrkrData->pData->mut_nActiveTargets);
 
     LogMsg(0, RS_RET_DEBUG, LOG_DEBUG,
            "omfwd: [wrkr %u/%" PRIuPTR
@@ -1958,7 +1958,7 @@ finalize_it:
 
     countActiveTargets(pWrkrData);
     const int nActiveTargets =
-        ATOMIC_FETCH_32BIT(&pWrkrData->pData->nActiveTargets, &pWrkrData->pData->mut_nActiveTargets);
+        ATOMIC_LOAD_32BIT(&pWrkrData->pData->nActiveTargets, &pWrkrData->pData->mut_nActiveTargets);
 
     if (bFlushRetry || nActiveTargets == 0) {
         /*

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -217,15 +217,11 @@ void rsyslogdDoDie(int sig);
 #endif
 
 /* global data items */
-static pthread_mutex_t mutChildDied;
-static int bChildDied = 0;
-static pthread_mutex_t mutHadHUP;
-static int bHadHUP;
+static volatile sig_atomic_t bChildDied = 0;
+static volatile sig_atomic_t bHadHUP = 0;
+static volatile sig_atomic_t bHUPInProgress = 0;
 static int doFork = 1; /* fork - run in daemon mode - read-only after startup */
-int bFinished = 0; /* used by termination signal handler, read-only except there
-                    * is either 0 or the number of the signal that requested the
-                    * termination.
-                    */
+static volatile sig_atomic_t bFinished = 0; /* signal number requesting termination, or 0 */
 const char *PidFile = NULL;
 #define NO_PIDFILE "NONE"
 int iConfigVerify = 0; /* is this just a config verify run? */
@@ -266,17 +262,14 @@ static int setsid(void) {
 }
 #endif
 
-/* helper for imdiag. Returns if HUP processing has been requested or
- * is not yet finished. We know this is racy, but imdiag handles this
- * part by repeating operations. The mutex look is primarily to force
- * a memory barrier, so that we have a change to see changes already
- * written, but not present in the core's cache.
+/* helper for imdiag. Returns if HUP processing has been requested or is not
+ * yet finished. We know this is racy, but imdiag handles this part by
+ * repeating operations. sig_atomic_t keeps access signal-handler safe; callers
+ * must treat the answer as a transient observation.
  * 2023-07-26 Rainer Gerhards
  */
 int get_bHadHUP(void) {
-    pthread_mutex_lock(&mutHadHUP);
-    const int ret = bHadHUP;
-    pthread_mutex_unlock(&mutHadHUP);
+    const int ret = PREFER_LOAD_INT(&bHadHUP) || PREFER_LOAD_INT(&bHUPInProgress);
     /* note: at this point ret can already be invalid */
     return ret;
 }
@@ -1425,9 +1418,7 @@ static void hdlr_enable(int sig, void (*hdlr)()) {
 }
 
 static void hdlr_sighup(void) {
-    pthread_mutex_lock(&mutHadHUP);
-    bHadHUP = 1;
-    pthread_mutex_unlock(&mutHadHUP);
+    PREFER_STORE_INT(&bHadHUP, 1);
     /* at least on FreeBSD we seem not to necessarily awake the main thread.
      * So let's do it explicitely.
      */
@@ -1436,9 +1427,7 @@ static void hdlr_sighup(void) {
 }
 
 static void hdlr_sigchld(void) {
-    pthread_mutex_lock(&mutChildDied);
-    bChildDied = 1;
-    pthread_mutex_unlock(&mutChildDied);
+    PREFER_STORE_INT(&bChildDied, 1);
 }
 
 static void rsyslogdDebugSwitch(void) {
@@ -2143,7 +2132,7 @@ static void doHUP(void) {
 void rsyslogdDoDie(int sig) {
 #define MSG1 "DoDie called.\n"
 #define MSG2 "DoDie called 5 times - unconditional exit\n"
-    static int iRetries = 0; /* debug aid */
+    static volatile sig_atomic_t iRetries = 0; /* debug aid */
     dbgprintf(MSG1);
     if (Debug == DEBUG_FULL) {
         if (write(1, MSG1, sizeof(MSG1) - 1) == -1) {
@@ -2245,13 +2234,9 @@ static rsRetVal wait_timeout(const sigset_t *sigmask, int timeout_ms) {
             stepTimeout.tv_sec = step_ms / 1000;
             stepTimeout.tv_nsec = (step_ms % 1000) * 1000000L;
 
-            pthread_mutex_lock(&mutHadHUP);
-            if (bFinished || bHadHUP) {
-                pthread_mutex_unlock(&mutHadHUP);
+            if (bFinished || PREFER_LOAD_INT(&bHadHUP)) {
                 break;
             }
-            pthread_mutex_unlock(&mutHadHUP);
-
             FD_ZERO(&rfds);
             if (rswatch_fd != -1) {
                 FD_SET(rswatch_fd, &rfds);
@@ -2381,7 +2366,6 @@ static void mainloop(void) {
     time_t tTime;
     sigset_t origmask;
     sigset_t sigblockset;
-    int need_free_mutex;
     uint64_t next_janitor_run_ms;
 
     sigemptyset(&sigblockset);
@@ -2395,30 +2379,16 @@ static void mainloop(void) {
 
         sigemptyset(&origmask);
         pthread_sigmask(SIG_BLOCK, &sigblockset, &origmask);
-        pthread_mutex_lock(&mutChildDied);
-        need_free_mutex = 1;
-        if (bChildDied) {
-            bChildDied = 0;
-            pthread_mutex_unlock(&mutChildDied);
-            need_free_mutex = 0;
+        if (PREFER_LOAD_INT(&bChildDied)) {
+            PREFER_STORE_INT(&bChildDied, 0);
             reapChild();
         }
-        if (need_free_mutex) {
-            pthread_mutex_unlock(&mutChildDied);
-        }
 
-        pthread_mutex_lock(&mutHadHUP);
-        need_free_mutex = 1;
-        if (bHadHUP) {
-            need_free_mutex = 0;
-            pthread_mutex_unlock(&mutHadHUP);
+        if (PREFER_LOAD_INT(&bHadHUP)) {
+            PREFER_STORE_INT(&bHadHUP, 0);
+            PREFER_STORE_INT(&bHUPInProgress, 1);
             doHUP();
-            pthread_mutex_lock(&mutHadHUP);
-            bHadHUP = 0;
-            pthread_mutex_unlock(&mutHadHUP);
-        }
-        if (need_free_mutex) {
-            pthread_mutex_unlock(&mutHadHUP);
+            PREFER_STORE_INT(&bHUPInProgress, 0);
         }
 
         processImInternal();
@@ -2502,7 +2472,7 @@ int rsyslogdWriteTerminationMarker(const char *status, const char *reason, const
     const int len = snprintf(buf, sizeof(buf),
                              "status=%s\nreason=%s\npid=%d\nsignal=%d\nversion=%s\nphase=%s\n"
                              "queue.overall.size=%u\n",
-                             status, reason, (int)getpid(), bFinished, VERSION, phase, overallQueueSize);
+                             status, reason, (int)getpid(), (int)bFinished, VERSION, phase, overallQueueSize);
     if (len < 0 || (size_t)len >= sizeof(buf)) {
         fprintf(stderr, "rsyslogd: error formatting proper termination file '%s'\n",
                 (const char *)properTerminationFile);
@@ -2551,7 +2521,7 @@ static void rsyslogd_destructAllActions(void) {
 static void deinitAll(void) {
     char buf[256];
 
-    DBGPRINTF("exiting on signal %d\n", bFinished);
+    DBGPRINTF("exiting on signal %d\n", (int)bFinished);
 
     /* IMPORTANT: we should close the inputs first, and THEN send our termination
      * message. If we do it the other way around, logmsgInternal() may block on
@@ -2578,7 +2548,7 @@ static void deinitAll(void) {
                        "swVersion=\"" VERSION
                        "\" x-pid=\"%d\" x-info=\"https://www.rsyslog.com\"]"
                        " exiting on signal %d.",
-                       (int)glblGetOurPid(), bFinished);
+                       (int)glblGetOurPid(), (int)bFinished);
         errno = 0;
         logmsgInternal(NO_ERRCODE, LOG_SYSLOG | LOG_INFO, (uchar *)buf, 0);
     }
@@ -2653,8 +2623,6 @@ int main(int argc, char **argv) {
      * internally by rsyslogd.
      */
 
-    pthread_mutex_init(&mutHadHUP, NULL);
-    pthread_mutex_init(&mutChildDied, NULL);
     rs_cstr_copy(progname, argv[0], sizeof(progname));
     addrsz = sizeof(srcaddr);
     if ((rc = getsockname(0, &srcaddr, &addrsz)) < 0) {
@@ -2715,7 +2683,5 @@ int main(int argc, char **argv) {
     LogMsg(0, RS_RET_OK, LOG_DEBUG, "rsyslogd shutting down");
     deinitAll();
     osf_close();
-    pthread_mutex_destroy(&mutChildDied);
-    pthread_mutex_destroy(&mutHadHUP);
     return rsyslogdWriteTerminationMarker("ok", "normal", "main-return");
 }


### PR DESCRIPTION
## Summary
- add load/store-oriented atomic helper macros with old-platform fallbacks
- switch low-risk stats, object-state, action retry-time, and dynstats paths to the helpers
- remove pthread mutex use from rsyslogd signal flag handlers while preserving legacy point behavior
- keep direct compiler atomic builtins centralized in runtime/atomic.h

## Validation
- `devtools/local-validation-plan.sh --run`
  - C format check passed
  - raw allocation advisory reported existing `plugins/mmutf8fix/mmutf8fix.c` direct malloc from earlier branch stack
  - test antipattern scans passed
  - Ubuntu 26.04 container `make check`: 1420 total, 1391 pass, 29 skip, 0 fail
  - Ubuntu 26.04 static analyzer: `scan-build: No bugs found`
  - local Cubic review: No issues found
- Initial full validation attempt hit a flaky `imfile-logrotate-async.sh` timeout; direct rerun passed, and the second full Ubuntu 26.04 run also passed that test.

## Manual Audit Notes
- canned memory-lifecycle prompt applied to the touched C/H paths; no new allocation ownership issues found
- canned concurrency/resource prompt applied to atomic helper and signal-flag changes; no blocker found
- verified no direct `__atomic_*`/`__sync_*` callers remain outside `runtime/atomic.h`
- verified removed legacy helper spellings have no remaining callers

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

