### PR TITLE
queue: keep DA child workers alive while idle

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -3322,8 +3322,9 @@ static rsRetVal qqueueChkStopWrkrDA(qqueue_t *pThis) {
 
 /* must only be called when the queue mutex is locked, else results
  * are not stable!
- * If we are a child, we have done our duty when the queue is empty. In that case,
- * we can terminate. Version for the regular worker thread.
+ * Version for the regular worker thread. DA child queues intentionally keep
+ * their regular worker alive while idle so worker-instance state, such as
+ * output connections, survives short refill gaps.
  */
 static rsRetVal ChkStopWrkrReg(qqueue_t *pThis) {
     DEFiRet;
@@ -3331,8 +3332,6 @@ static rsRetVal ChkStopWrkrReg(qqueue_t *pThis) {
     pThis->iLowWtrMrk, getLogicalQueueSize(pThis), getPhysicalQueueSize(pThis), pThis->bEnqOnly);*/
     if (pThis->bEnqOnly) {
         iRet = RS_RET_TERMINATE_NOW;
-    } else if (pThis->pqParent != NULL) {
-        iRet = RS_RET_TERMINATE_WHEN_IDLE;
     }
 
     RETiRet;


### PR DESCRIPTION
## Summary

DA child queues no longer terminate their regular worker just because the child queue is briefly idle. This preserves output worker-instance state, such as omfwd TCP connections, across short refill gaps while the parent disk-assisted queue feeds the child queue in bursts.

## Root cause

The DA child regular-worker stop check returned `RS_RET_TERMINATE_WHEN_IDLE` for child queues. When the child queue briefly drained, the worker exited, `omfwd` freed its worker instance, and the TCP connection was closed. The next refill burst started a new worker and opened a new connection.

## Impact

This intentionally keeps one DA child regular worker parked while idle. Enqueue-only and shutdown paths still terminate workers explicitly.

## Validation

- `devtools/format-code.sh --git-changed`
- Ubuntu 26.04 local container `devtools/run-ci.sh` with `CI_MAKE_OPT='-j60'` and `CI_MAKE_CHECK_OPT='-j60'`: `1417` total, `1388` passed, `29` skipped, `0` failed, `0` errors
- Local Cubic review: noted the intended resource-retention tradeoff; also reported one unrelated out-of-diff `mmutf8fix` finding

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

