### PR TITLE
runtime: fix uint64 atomic fallback return

### DIFF
--- a/runtime/atomic.h
+++ b/runtime/atomic.h
@@ -375,7 +375,7 @@ static inline void ATOMIC_STORE_time_t_RELAXED(time_t *data, pthread_mutex_t *ph
     pthread_mutex_unlock(phlpmut);
 }
 
-static inline unsigned ATOMIC_INC_AND_FETCH_uint64(uint64 *data, pthread_mutex_t *phlpmut) {
+static inline uint64 ATOMIC_INC_AND_FETCH_uint64(uint64 *data, pthread_mutex_t *phlpmut) {
     uint64 val;
     pthread_mutex_lock(phlpmut);
     val = ++(*data);


### PR DESCRIPTION
## Summary

Fix the no-atomic fallback signature for `ATOMIC_INC_AND_FETCH_uint64()` so it returns `uint64` instead of `unsigned`.

The fallback already stores the incremented value in a `uint64`; only the function return type was narrower than the atomic-build helper contract.

## Validation

- `git diff --check`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- Ubuntu 26.04 devcontainer no-atomic compile:
  - `RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 CC=clang-21 CFLAGS=-g RSYSLOG_CONFIGURE_OPTIONS_EXTRA=--enable-atomic-operations=no devtools/devcontainer.sh --rm devtools/run-configure.sh`
  - `RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 devtools/devcontainer.sh --rm make -j60`

Focused local validation only; CI should cover the regular matrix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

