### PR TITLE
runtime: add relaxed 32-bit atomic helpers

### DIFF
--- a/runtime/atomic.h
+++ b/runtime/atomic.h
@@ -69,8 +69,13 @@
     #define ATOMIC_DEC_AND_FETCH(data, phlpmut) __atomic_sub_fetch((data), 1, __ATOMIC_SEQ_CST)
     #define ATOMIC_LOAD_32BIT(data, phlpmut) ((int)__atomic_load_n((data), __ATOMIC_ACQUIRE))
     #define ATOMIC_LOAD_32BIT_unsigned(data, phlpmut) ((unsigned)__atomic_load_n((data), __ATOMIC_ACQUIRE))
+    #define ATOMIC_LOAD_32BIT_RELAXED(data, phlpmut) ((int)__atomic_load_n((data), __ATOMIC_RELAXED))
+    #define ATOMIC_LOAD_32BIT_RELAXED_unsigned(data, phlpmut) ((unsigned)__atomic_load_n((data), __ATOMIC_RELAXED))
     #define ATOMIC_STORE_32BIT(data, phlpmut, val) ((void)__atomic_store_n((data), (val), __ATOMIC_RELEASE))
     #define ATOMIC_STORE_32BIT_unsigned(data, phlpmut, val) ((void)__atomic_store_n((data), (val), __ATOMIC_RELEASE))
+    #define ATOMIC_STORE_32BIT_RELAXED(data, phlpmut, val) ((void)__atomic_store_n((data), (val), __ATOMIC_RELAXED))
+    #define ATOMIC_STORE_32BIT_RELAXED_unsigned(data, phlpmut, val) \
+        ((void)__atomic_store_n((data), (val), __ATOMIC_RELAXED))
     #define ATOMIC_STORE_1_TO_32BIT(data) ((void)__atomic_store_n(&(data), 1, __ATOMIC_RELEASE))
     #define ATOMIC_OR_INT_TO_INT(data, phlpmut, val) __atomic_fetch_or((data), (val), __ATOMIC_SEQ_CST)
     #define ATOMIC_CAS(data, oldVal, newVal, phlpmut)                                                                  \
@@ -219,7 +224,21 @@ static inline int ATOMIC_LOAD_32BIT(int *data, pthread_mutex_t *phlpmut) {
     return val;
 }
 
+static inline int ATOMIC_LOAD_32BIT_RELAXED(int *data, pthread_mutex_t *phlpmut) {
+    int val;
+    pthread_mutex_lock(phlpmut);
+    val = (*data);
+    pthread_mutex_unlock(phlpmut);
+    return val;
+}
+
 static inline void ATOMIC_STORE_32BIT(int *data, pthread_mutex_t *phlpmut, int val) {
+    pthread_mutex_lock(phlpmut);
+    *data = val;
+    pthread_mutex_unlock(phlpmut);
+}
+
+static inline void ATOMIC_STORE_32BIT_RELAXED(int *data, pthread_mutex_t *phlpmut, int val) {
     pthread_mutex_lock(phlpmut);
     *data = val;
     pthread_mutex_unlock(phlpmut);
@@ -233,7 +252,21 @@ static inline unsigned ATOMIC_LOAD_32BIT_unsigned(unsigned *data, pthread_mutex_
     return val;
 }
 
+static inline unsigned ATOMIC_LOAD_32BIT_RELAXED_unsigned(unsigned *data, pthread_mutex_t *phlpmut) {
+    unsigned val;
+    pthread_mutex_lock(phlpmut);
+    val = (*data);
+    pthread_mutex_unlock(phlpmut);
+    return val;
+}
+
 static inline void ATOMIC_STORE_32BIT_unsigned(unsigned *data, pthread_mutex_t *phlpmut, unsigned val) {
+    pthread_mutex_lock(phlpmut);
+    *data = val;
+    pthread_mutex_unlock(phlpmut);
+}
+
+static inline void ATOMIC_STORE_32BIT_RELAXED_unsigned(unsigned *data, pthread_mutex_t *phlpmut, unsigned val) {
     pthread_mutex_lock(phlpmut);
     *data = val;
     pthread_mutex_unlock(phlpmut);

--- a/runtime/threads.h
+++ b/runtime/threads.h
@@ -39,11 +39,11 @@ struct thrdInfo {
 };
 
 static inline int thrdGetShallStop(thrdInfo_t *pThis) {
-    return ATOMIC_LOAD_32BIT(&pThis->bShallStop, &pThis->mutShallStop);
+    return ATOMIC_LOAD_32BIT_RELAXED(&pThis->bShallStop, &pThis->mutShallStop);
 }
 
 static inline void thrdSetShallStop(thrdInfo_t *pThis) {
-    ATOMIC_STORE_32BIT(&pThis->bShallStop, &pThis->mutShallStop, 1);
+    ATOMIC_STORE_32BIT_RELAXED(&pThis->bShallStop, &pThis->mutShallStop, 1);
 }
 
 /* prototypes */


### PR DESCRIPTION
## Summary

Add mutex-backed relaxed 32-bit atomic load/store helpers and use them for the runtime thread stop flag.

This gives callers a middle ground between full acquire/release `ATOMIC_LOAD_32BIT()` / `ATOMIC_STORE_32BIT()` and weak `PREFER_*` helpers: atomic platforms use relaxed ordering, while no-atomic platforms still synchronize through the existing helper mutex.

## Details

- Adds signed and unsigned `ATOMIC_LOAD_32BIT_RELAXED*` helpers.
- Adds signed and unsigned `ATOMIC_STORE_32BIT_RELAXED*` helpers.
- Converts `thrdGetShallStop()` / `thrdSetShallStop()` to the relaxed signed helpers as a conservative sample user.

## Validation

- `devtools/format-code.sh --git-changed`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `devtools/local-validation-plan.sh --base upstream/main`
- Ubuntu 26.04 devcontainer default atomic compile:
  - `RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 CC=gcc CFLAGS=-g devtools/devcontainer.sh --rm devtools/run-configure.sh`
  - `RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 devtools/devcontainer.sh --rm make -j60`
- Ubuntu 26.04 devcontainer no-atomic compile:
  - `RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 CC=clang-21 CFLAGS=-g RSYSLOG_CONFIGURE_OPTIONS_EXTRA=--enable-atomic-operations=no devtools/devcontainer.sh --rm devtools/run-configure.sh`
  - `RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 devtools/devcontainer.sh --rm make -j60`

Focused compile validation only; CI should cover the broader matrix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

