### PR TITLE
imkubernetes: bound unfinished CRI partial records

### DIFF
--- a/contrib/imkubernetes/MODULE_METADATA.yaml
+++ b/contrib/imkubernetes/MODULE_METADATA.yaml
@@ -8,7 +8,11 @@ runtime_dependencies:
   - Kubernetes node log files mounted from the host, typically under /var/log/pods or /var/log/containers
   - Kubernetes API reachability and credentials when EnrichKubernetes is enabled
 ci_targets:
+  - imkubernetes-cri-partial-accept.sh
   - imkubernetes-cri-basic.sh
+  - imkubernetes-cri-partial-bound.sh
+  - imkubernetes-cri-partial-hard-cap.sh
+  - imkubernetes-cri-partial-split.sh
   - imkubernetes-dockerjson-basic.sh
   - yaml-imkubernetes-dockerjson-basic.sh
 documentation:

--- a/contrib/imkubernetes/imkubernetes.c
+++ b/contrib/imkubernetes/imkubernetes.c
@@ -85,6 +85,7 @@ typedef struct partial_msg_s {
     struct syslogTime st;
     time_t ttGenTime;
     sbool hasTime;
+    sbool discarding;
 } partial_msg_t;
 
 typedef struct path_meta_s {
@@ -290,6 +291,44 @@ static rsRetVal partialAppend(partial_msg_t *partial, const uchar *msg, size_t l
 
 finalize_it:
     RETiRet;
+}
+
+static void partialInitFromRecord(partial_msg_t *partial, const parsed_record_t *record) {
+    assert(partial != NULL);
+    assert(record != NULL);
+
+    partial->stream_type = record->stream_type;
+    partial->hasTime = record->hasTime;
+    partial->ttGenTime = record->ttGenTime;
+    if (record->hasTime) {
+        memcpy(&partial->st, &record->st, sizeof(record->st));
+    }
+}
+
+static size_t getPartialMessageLimit(void) {
+    const int maxLine = glbl.GetMaxLine(runModConf != NULL ? runModConf->pConf : NULL);
+    return maxLine > 0 ? (size_t)maxLine : 0;
+}
+
+static sbool partialWouldExceedLimit(const partial_msg_t *partial, size_t len) {
+    const size_t limit = getPartialMessageLimit();
+
+    assert(partial != NULL);
+    if (limit == 0) {
+        return 0;
+    }
+    return partial->len > limit || len > limit - partial->len;
+}
+
+static void discardOversizedPartial(partial_msg_t *partial, const parsed_record_t *record) {
+    const size_t limit = getPartialMessageLimit();
+
+    freePartialMsg(partial);
+    partialInitFromRecord(partial, record);
+    partial->discarding = 1;
+    LogError(0, NO_ERRCODE,
+             "imkubernetes: CRI partial message exceeded maxMessageSize (%zu), discarding unfinished partial record",
+             limit);
 }
 
 static void trimTrailingNewline(const char *line, size_t *len) {
@@ -1011,32 +1050,38 @@ static rsRetVal emitPartialIfComplete(file_state_t *state, const parsed_record_t
     parsed_record_t finalRecord = {0};
     DEFiRet;
 
-    if (!record->is_partial && state->partial.len == 0) {
+    if (!record->is_partial && state->partial.len == 0 && !state->partial.discarding) {
         CHKiRet(enqMsg(state, record));
         FINALIZE;
     }
 
-    if (record->is_partial && state->partial.len == 0) {
-        state->partial.stream_type = record->stream_type;
-        state->partial.hasTime = record->hasTime;
-        state->partial.ttGenTime = record->ttGenTime;
-        if (record->hasTime) {
-            memcpy(&state->partial.st, &record->st, sizeof(record->st));
-        }
+    if (record->is_partial && state->partial.len == 0 && !state->partial.discarding) {
+        partialInitFromRecord(&state->partial, record);
     }
 
-    if (state->partial.len > 0 && state->partial.stream_type != record->stream_type) {
+    if ((state->partial.len > 0 || state->partial.discarding) &&
+        state->partial.stream_type != record->stream_type) {
         freePartialMsg(&state->partial);
-        state->partial.stream_type = record->stream_type;
-        state->partial.hasTime = record->hasTime;
-        state->partial.ttGenTime = record->ttGenTime;
-        if (record->hasTime) {
-            memcpy(&state->partial.st, &record->st, sizeof(record->st));
+        if (record->is_partial) {
+            partialInitFromRecord(&state->partial, record);
         }
     }
 
     if (record->is_partial) {
+        if (state->partial.discarding) {
+            FINALIZE;
+        }
+        if (partialWouldExceedLimit(&state->partial, record->len)) {
+            discardOversizedPartial(&state->partial, record);
+            FINALIZE;
+        }
         CHKiRet(partialAppend(&state->partial, record->msg, record->len));
+        FINALIZE;
+    }
+
+    if (state->partial.discarding) {
+        freePartialMsg(&state->partial);
+        CHKiRet(enqMsg(state, record));
         FINALIZE;
     }
 

--- a/contrib/imkubernetes/imkubernetes.c
+++ b/contrib/imkubernetes/imkubernetes.c
@@ -346,8 +346,7 @@ static void markPartialTruncated(partial_msg_t *partial, size_t limit, sbool har
     assert(partial != NULL);
     if (!partial->truncated) {
         partial->truncated = 1;
-        LogError(0, NO_ERRCODE,
-                 "imkubernetes: CRI partial message exceeded %s (%zu), truncating logical record",
+        LogError(0, NO_ERRCODE, "imkubernetes: CRI partial message exceeded %s (%zu), truncating logical record",
                  hardLimit ? "partial hard limit" : "maxMessageSize", limit);
     }
 }
@@ -1099,7 +1098,8 @@ finalize_it:
  * oversize input modes are honored by letting the completed logical record
  * reach the core submit path, but still capping the accumulator at a
  * maxMessageSize-derived hard limit so an unfinished run cannot grow forever.
- * Once capped, consume later fragments until the closing F flushes state.
+ * Once capped, consume later fragments until the closing F flushes state; the
+ * closing fragment must never be emitted as a standalone record.
  */
 static rsRetVal emitPartialIfComplete(file_state_t *state, const parsed_record_t *record) {
     parsed_record_t finalRecord = {0};

--- a/contrib/imkubernetes/imkubernetes.c
+++ b/contrib/imkubernetes/imkubernetes.c
@@ -74,6 +74,7 @@ MODULE_CNFNAME("imkubernetes")
 #define DFLT_enrichKubernetes 1
 #define DFLT_SEVERITY pri2sev(LOG_INFO)
 #define DFLT_FACILITY pri2fac(LOG_USER)
+#define CRI_PARTIAL_HARD_LIMIT_FACTOR 10
 
 enum { dst_invalid = -1, dst_stdout, dst_stderr };
 
@@ -310,22 +311,50 @@ static void partialInitFromRecord(partial_msg_t *partial, const parsed_record_t 
     }
 }
 
-static size_t getPartialMessageLimit(void) {
-    const int maxLine = glbl.GetMaxLine(runModConf != NULL ? runModConf->pConf : NULL);
-    return maxLine > 0 ? (size_t)maxLine : 0;
+static rsconf_t *getActiveConf(void) {
+    return runModConf != NULL ? runModConf->pConf : NULL;
 }
 
-static void markPartialTruncated(partial_msg_t *partial, size_t limit) {
+static size_t multiplyPartialLimit(size_t limit, size_t factor) {
+    if (factor != 0 && limit > (size_t)-1 / factor) {
+        return (size_t)-1;
+    }
+    return limit * factor;
+}
+
+static size_t getPartialMessageLimit(sbool *hardLimit) {
+    rsconf_t *const cnf = getActiveConf();
+    const int maxLine = glbl.GetMaxLine(cnf);
+    const int oversizeMode = cnf != NULL ? glblGetOversizeMsgInputMode(cnf) : glblOversizeMsgInputMode_Truncate;
+
+    if (hardLimit != NULL) {
+        *hardLimit = 0;
+    }
+    if (maxLine <= 0) {
+        return 0;
+    }
+    if (oversizeMode == glblOversizeMsgInputMode_Truncate) {
+        return (size_t)maxLine;
+    }
+    if (hardLimit != NULL) {
+        *hardLimit = 1;
+    }
+    return multiplyPartialLimit((size_t)maxLine, CRI_PARTIAL_HARD_LIMIT_FACTOR);
+}
+
+static void markPartialTruncated(partial_msg_t *partial, size_t limit, sbool hardLimit) {
     assert(partial != NULL);
     if (!partial->truncated) {
         partial->truncated = 1;
         LogError(0, NO_ERRCODE,
-                 "imkubernetes: CRI partial message exceeded maxMessageSize (%zu), truncating logical record", limit);
+                 "imkubernetes: CRI partial message exceeded %s (%zu), truncating logical record",
+                 hardLimit ? "partial hard limit" : "maxMessageSize", limit);
     }
 }
 
 static rsRetVal partialAppendBounded(partial_msg_t *partial, const uchar *msg, size_t len) {
-    const size_t limit = getPartialMessageLimit();
+    sbool hardLimit = 0;
+    const size_t limit = getPartialMessageLimit(&hardLimit);
     size_t appendLen = len;
     DEFiRet;
 
@@ -337,7 +366,7 @@ static rsRetVal partialAppendBounded(partial_msg_t *partial, const uchar *msg, s
             appendLen = limit - partial->len;
         }
         if (appendLen < len) {
-            markPartialTruncated(partial, limit);
+            markPartialTruncated(partial, limit, hardLimit);
         }
     }
 
@@ -1065,9 +1094,12 @@ finalize_it:
 }
 
 /*
- * Cap CRI P fragments at global(maxMessageSize).
- * Once capped, consume later fragments until the closing F flushes
- * state.
+ * CRI P fragments are accumulated until their closing F record, so they need
+ * their own memory guard. In truncate mode the guard is maxMessageSize. Other
+ * oversize input modes are honored by letting the completed logical record
+ * reach the core submit path, but still capping the accumulator at a
+ * maxMessageSize-derived hard limit so an unfinished run cannot grow forever.
+ * Once capped, consume later fragments until the closing F flushes state.
  */
 static rsRetVal emitPartialIfComplete(file_state_t *state, const parsed_record_t *record) {
     parsed_record_t finalRecord = {0};

--- a/contrib/imkubernetes/imkubernetes.c
+++ b/contrib/imkubernetes/imkubernetes.c
@@ -320,8 +320,7 @@ static void markPartialTruncated(partial_msg_t *partial, size_t limit) {
     if (!partial->truncated) {
         partial->truncated = 1;
         LogError(0, NO_ERRCODE,
-                 "imkubernetes: CRI partial message exceeded maxMessageSize (%zu), truncating logical record",
-                 limit);
+                 "imkubernetes: CRI partial message exceeded maxMessageSize (%zu), truncating logical record", limit);
     }
 }
 
@@ -1065,12 +1064,10 @@ finalize_it:
     RETiRet;
 }
 
-/**
- * CRI partial records marked with P are buffered until the same logical
- * message closes with an F record. The buffer is capped at global(maxMessageSize):
- * once that limit is reached, excess P fragments and excess bytes from the
- * closing F are consumed but not emitted as standalone records. The closing F
- * finalizes and emits the stored prefix, then clears state for the next record.
+/*
+ * Cap CRI P fragments at global(maxMessageSize).
+ * Once capped, consume later fragments until the closing F flushes
+ * state.
  */
 static rsRetVal emitPartialIfComplete(file_state_t *state, const parsed_record_t *record) {
     parsed_record_t finalRecord = {0};

--- a/contrib/imkubernetes/imkubernetes.c
+++ b/contrib/imkubernetes/imkubernetes.c
@@ -85,7 +85,7 @@ typedef struct partial_msg_s {
     struct syslogTime st;
     time_t ttGenTime;
     sbool hasTime;
-    sbool discarding;
+    sbool truncated;
 } partial_msg_t;
 
 typedef struct path_meta_s {
@@ -293,6 +293,11 @@ finalize_it:
     RETiRet;
 }
 
+static sbool partialIsActive(const partial_msg_t *partial) {
+    assert(partial != NULL);
+    return partial->len > 0 || partial->truncated;
+}
+
 static void partialInitFromRecord(partial_msg_t *partial, const parsed_record_t *record) {
     assert(partial != NULL);
     assert(record != NULL);
@@ -310,25 +315,39 @@ static size_t getPartialMessageLimit(void) {
     return maxLine > 0 ? (size_t)maxLine : 0;
 }
 
-static sbool partialWouldExceedLimit(const partial_msg_t *partial, size_t len) {
-    const size_t limit = getPartialMessageLimit();
-
+static void markPartialTruncated(partial_msg_t *partial, size_t limit) {
     assert(partial != NULL);
-    if (limit == 0) {
-        return 0;
+    if (!partial->truncated) {
+        partial->truncated = 1;
+        LogError(0, NO_ERRCODE,
+                 "imkubernetes: CRI partial message exceeded maxMessageSize (%zu), truncating logical record",
+                 limit);
     }
-    return partial->len > limit || len > limit - partial->len;
 }
 
-static void discardOversizedPartial(partial_msg_t *partial, const parsed_record_t *record) {
+static rsRetVal partialAppendBounded(partial_msg_t *partial, const uchar *msg, size_t len) {
     const size_t limit = getPartialMessageLimit();
+    size_t appendLen = len;
+    DEFiRet;
 
-    freePartialMsg(partial);
-    partialInitFromRecord(partial, record);
-    partial->discarding = 1;
-    LogError(0, NO_ERRCODE,
-             "imkubernetes: CRI partial message exceeded maxMessageSize (%zu), discarding unfinished partial record",
-             limit);
+    assert(partial != NULL);
+    if (limit > 0) {
+        if (partial->len >= limit) {
+            appendLen = 0;
+        } else if (appendLen > limit - partial->len) {
+            appendLen = limit - partial->len;
+        }
+        if (appendLen < len) {
+            markPartialTruncated(partial, limit);
+        }
+    }
+
+    if (appendLen > 0) {
+        CHKiRet(partialAppend(partial, msg, appendLen));
+    }
+
+finalize_it:
+    RETiRet;
 }
 
 static void trimTrailingNewline(const char *line, size_t *len) {
@@ -1046,21 +1065,27 @@ finalize_it:
     RETiRet;
 }
 
+/**
+ * CRI partial records marked with P are buffered until the same logical
+ * message closes with an F record. The buffer is capped at global(maxMessageSize):
+ * once that limit is reached, excess P fragments and excess bytes from the
+ * closing F are consumed but not emitted as standalone records. The closing F
+ * finalizes and emits the stored prefix, then clears state for the next record.
+ */
 static rsRetVal emitPartialIfComplete(file_state_t *state, const parsed_record_t *record) {
     parsed_record_t finalRecord = {0};
     DEFiRet;
 
-    if (!record->is_partial && state->partial.len == 0 && !state->partial.discarding) {
+    if (!record->is_partial && !partialIsActive(&state->partial)) {
         CHKiRet(enqMsg(state, record));
         FINALIZE;
     }
 
-    if (record->is_partial && state->partial.len == 0 && !state->partial.discarding) {
+    if (record->is_partial && !partialIsActive(&state->partial)) {
         partialInitFromRecord(&state->partial, record);
     }
 
-    if ((state->partial.len > 0 || state->partial.discarding) &&
-        state->partial.stream_type != record->stream_type) {
+    if (partialIsActive(&state->partial) && state->partial.stream_type != record->stream_type) {
         freePartialMsg(&state->partial);
         if (record->is_partial) {
             partialInitFromRecord(&state->partial, record);
@@ -1068,25 +1093,12 @@ static rsRetVal emitPartialIfComplete(file_state_t *state, const parsed_record_t
     }
 
     if (record->is_partial) {
-        if (state->partial.discarding) {
-            FINALIZE;
-        }
-        if (partialWouldExceedLimit(&state->partial, record->len)) {
-            discardOversizedPartial(&state->partial, record);
-            FINALIZE;
-        }
-        CHKiRet(partialAppend(&state->partial, record->msg, record->len));
+        CHKiRet(partialAppendBounded(&state->partial, record->msg, record->len));
         FINALIZE;
     }
 
-    if (state->partial.discarding) {
-        freePartialMsg(&state->partial);
-        CHKiRet(enqMsg(state, record));
-        FINALIZE;
-    }
-
-    if (state->partial.len > 0) {
-        CHKiRet(partialAppend(&state->partial, record->msg, record->len));
+    if (partialIsActive(&state->partial)) {
+        CHKiRet(partialAppendBounded(&state->partial, record->msg, record->len));
         finalRecord.msg = state->partial.data;
         finalRecord.len = state->partial.len;
         finalRecord.stream_type = state->partial.stream_type;

--- a/doc/source/configuration/modules/imkubernetes.rst
+++ b/doc/source/configuration/modules/imkubernetes.rst
@@ -48,6 +48,26 @@ For CRI logs, ``imkubernetes`` merges partial records before submission. For
 Docker ``json-file`` logs, it extracts the embedded timestamp, message payload,
 and stream.
 
+CRI partial records and oversized messages
+===========================================
+
+CRI ``P`` records are buffered per log file until an ``F`` record closes the
+logical message. The buffer follows the global oversized-message input mode:
+
+* In ``truncate`` mode, ``imkubernetes`` retains at most
+  ``global(maxMessageSize)`` bytes. It discards later bytes, consumes the
+  closing ``F`` as part of the same logical message, and then resumes with the
+  next independent record.
+* In ``accept`` and ``split`` modes, completed logical messages reach the core
+  input path intact so the selected global policy can handle them. To keep an
+  unfinished sequence of ``P`` records from growing without bound, the module
+  still applies a per-file hard limit of ``10 * global(maxMessageSize)``.
+
+When the hard limit is reached, the retained prefix is submitted after the
+closing ``F`` arrives; excess bytes and the closing fragment's excess content
+are not emitted as a separate record. This limit applies independently to each
+tailed log file.
+
 Message metadata
 ================
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2234,8 +2234,11 @@ TESTS_MMKUBERNETES_VALGRIND = \
 	mmkubernetes-cache-expire-vg.sh
 
 TESTS_IMKUBERNETES = \
+	imkubernetes-cri-partial-accept.sh \
 	imkubernetes-cri-basic.sh \
 	imkubernetes-cri-partial-bound.sh \
+	imkubernetes-cri-partial-hard-cap.sh \
+	imkubernetes-cri-partial-split.sh \
 	imkubernetes-dockerjson-basic.sh \
 	yaml-imkubernetes-dockerjson-basic.sh
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2235,6 +2235,7 @@ TESTS_MMKUBERNETES_VALGRIND = \
 
 TESTS_IMKUBERNETES = \
 	imkubernetes-cri-basic.sh \
+	imkubernetes-cri-partial-bound.sh \
 	imkubernetes-dockerjson-basic.sh \
 	yaml-imkubernetes-dockerjson-basic.sh
 

--- a/tests/imkubernetes-cri-partial-accept.sh
+++ b/tests/imkubernetes-cri-partial-accept.sh
@@ -2,6 +2,8 @@
 # Verify that CRI partial assembly honors oversizemsg.input.mode="accept".
 # A properly closed P...F record that is larger than maxMessageSize but below
 # the imkubernetes partial hard cap must reach the core submit path intact.
+# The API helper signals readiness after binding; its 2m timeout is hang
+# protection, while the explicit kill and wait below own normal cleanup.
 . ${srcdir:=.}/diag.sh init
 require_plugin imkubernetes ../contrib/imkubernetes
 check_command_available timeout

--- a/tests/imkubernetes-cri-partial-accept.sh
+++ b/tests/imkubernetes-cri-partial-accept.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-# Verify that unfinished CRI partial records are bounded before enqueue.
-# The closing F record after an oversized partial run still belongs to that
-# logical message and must not be emitted as a standalone tail record.
+# Verify that CRI partial assembly honors oversizemsg.input.mode="accept".
+# A properly closed P...F record that is larger than maxMessageSize but below
+# the imkubernetes partial hard cap must reach the core submit path intact.
 . ${srcdir:=.}/diag.sh init
 require_plugin imkubernetes ../contrib/imkubernetes
 check_command_available timeout
 
 export NUMMESSAGES=2
 pwd=$( pwd )
-testsrv=imk8s-partial-bound-server
+testsrv=imk8s-partial-accept-server
 k8s_srv_port=0
 k8s_srv_port_file=${RSYSLOG_DYNNAME}${testsrv}.port
 logdir="${RSYSLOG_DYNNAME}.spool/pods/namespace-name1_pod-name1_uid1/container-a"
@@ -21,7 +21,7 @@ MMK8S_INCLUDE_NODE_NAME=1 timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server
 	${RSYSLOG_DYNNAME}${testsrv}.pid \
 	${RSYSLOG_DYNNAME}${testsrv}.started \
 	$k8s_srv_port_file \
-	> ${RSYSLOG_DYNNAME}.spool/imkubernetes_partial_bound_srv.log 2>&1 &
+	> ${RSYSLOG_DYNNAME}.spool/imkubernetes_partial_accept_srv.log 2>&1 &
 BGPROCESS=$!
 wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
 assign_file_content k8s_srv_port "$k8s_srv_port_file"
@@ -30,7 +30,7 @@ generate_conf
 add_conf '
 global(workDirectory="'$RSYSLOG_DYNNAME.spool'"
        maxMessageSize="128"
-       oversizemsg.input.mode="truncate")
+       oversizemsg.input.mode="accept")
 module(load="../contrib/imkubernetes/.libs/imkubernetes"
        LogFileGlob="'$pwd/$logdir'/*.log"
        PollingInterval="1"
@@ -55,8 +55,8 @@ startup
 		printf '2026-04-20T10:00:%02d.000000000Z stdout P %s\n' "$i" \
 			'partial-fragment-0123456789'
 	done
-	printf '%s\n' '2026-04-20T10:00:30.000000000Z stdout F closing-tail-must-not-standalone'
-	printf '%s\n' '2026-04-20T10:00:31.000000000Z stdout F after partial cap'
+	printf '%s\n' '2026-04-20T10:00:30.000000000Z stdout F closing-tail-kept'
+	printf '%s\n' '2026-04-20T10:00:31.000000000Z stdout F after accepted partial'
 } > "$logfile"
 
 wait_file_lines "$RSYSLOG_OUT_LOG" 2
@@ -76,20 +76,20 @@ records = [json.loads(line) for line in open(path)]
 records = [item for item in records if item.get("format") == "cri"]
 assert len(records) == 2, records
 
-expected_prefix = ("partial-fragment-0123456789" * 8)[:128]
+expected = ("partial-fragment-0123456789" * 8) + "closing-tail-kept"
 partial = records[0]
-assert partial["msg"] == expected_prefix, partial
-assert "closing-tail-must-not-standalone" not in partial["msg"], partial
+assert partial["msg"] == expected, partial
+assert len(partial["msg"]) > 128, partial
 assert partial["stream"] == "stdout", partial
 assert partial["pod_id"] == "pod-name1-id", partial
 
 independent = records[1]
-assert independent["msg"] == "after partial cap", independent
+assert independent["msg"] == "after accepted partial", independent
 assert independent["stream"] == "stdout", independent
 assert independent["pod_id"] == "pod-name1-id", independent
 PY
 then
-	error_exit 1 "imkubernetes did not preserve oversized CRI partial truncation semantics"
+	error_exit 1 "imkubernetes truncated CRI partial despite oversizemsg.input.mode=accept"
 fi
 
 exit_test

--- a/tests/imkubernetes-cri-partial-bound.sh
+++ b/tests/imkubernetes-cri-partial-bound.sh
@@ -2,6 +2,8 @@
 # Verify that unfinished CRI partial records are bounded before enqueue.
 # The closing F record after an oversized partial run still belongs to that
 # logical message and must not be emitted as a standalone tail record.
+# The API helper signals readiness after binding; its 2m timeout is hang
+# protection, while the explicit kill and wait below own normal cleanup.
 . ${srcdir:=.}/diag.sh init
 require_plugin imkubernetes ../contrib/imkubernetes
 check_command_available timeout

--- a/tests/imkubernetes-cri-partial-bound.sh
+++ b/tests/imkubernetes-cri-partial-bound.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Verify that unfinished CRI partial records are bounded before enqueue.
+# A final record after an oversized partial run must be handled as a fresh
+# complete record, while normal imkubernetes parsing still uses the mocked
+# Kubernetes API path.
+. ${srcdir:=.}/diag.sh init
+require_plugin imkubernetes ../contrib/imkubernetes
+check_command_available timeout
+
+export NUMMESSAGES=1
+pwd=$( pwd )
+testsrv=imk8s-partial-bound-server
+k8s_srv_port=0
+k8s_srv_port_file=${RSYSLOG_DYNNAME}${testsrv}.port
+logdir="${RSYSLOG_DYNNAME}.spool/pods/namespace-name1_pod-name1_uid1/container-a"
+logfile="${logdir}/0.log"
+
+mkdir -p "$logdir"
+echo starting kubernetes test server
+MMK8S_INCLUDE_NODE_NAME=1 timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server.py \
+	0 \
+	${RSYSLOG_DYNNAME}${testsrv}.pid \
+	${RSYSLOG_DYNNAME}${testsrv}.started \
+	$k8s_srv_port_file \
+	> ${RSYSLOG_DYNNAME}.spool/imkubernetes_partial_bound_srv.log 2>&1 &
+BGPROCESS=$!
+wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
+assign_file_content k8s_srv_port "$k8s_srv_port_file"
+
+generate_conf
+add_conf '
+global(workDirectory="'$RSYSLOG_DYNNAME.spool'" maxMessageSize="128")
+module(load="../contrib/imkubernetes/.libs/imkubernetes"
+       LogFileGlob="'$pwd/$logdir'/*.log"
+       PollingInterval="1"
+       KubernetesUrl="http://localhost:'$k8s_srv_port'"
+       Token="dummy"
+       cacheEntryTtl="60")
+
+template(name="outfmt" type="list" option.jsonf="on") {
+    property(outname="msg" name="msg" format="jsonf")
+    property(outname="stream" name="$!kubernetes!stream" format="jsonf")
+    property(outname="format" name="$!kubernetes!log_format" format="jsonf")
+    property(outname="pod_id" name="$!kubernetes!pod_id" format="jsonf")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+startup
+
+{
+	for i in $(seq 1 8); do
+		printf '2026-04-20T10:00:%02d.000000000Z stdout P %s\n' "$i" \
+			'partial-fragment-0123456789'
+	done
+	printf '%s\n' '2026-04-20T10:00:30.000000000Z stdout F after partial cap'
+} > "$logfile"
+
+wait_file_lines "$RSYSLOG_OUT_LOG" 1
+wait_queueempty
+shutdown_when_empty
+wait_shutdown
+
+kill $BGPROCESS
+wait_pid_termination ${RSYSLOG_DYNNAME}${testsrv}.pid
+
+if ! $PYTHON - "$RSYSLOG_OUT_LOG" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+records = [json.loads(line) for line in open(path)]
+records = [item for item in records if item.get("format") == "cri"]
+assert len(records) == 1, records
+record = records[0]
+assert record["msg"] == "after partial cap", record
+assert record["stream"] == "stdout", record
+assert record["pod_id"] == "pod-name1-id", record
+PY
+then
+	error_exit 1 "imkubernetes did not reset oversized CRI partial state"
+fi
+
+exit_test

--- a/tests/imkubernetes-cri-partial-bound.sh
+++ b/tests/imkubernetes-cri-partial-bound.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 # Verify that unfinished CRI partial records are bounded before enqueue.
-# A final record after an oversized partial run must be handled as a fresh
-# complete record, while normal imkubernetes parsing still uses the mocked
-# Kubernetes API path.
+# The closing F record after an oversized partial run still belongs to that
+# logical message and must not be emitted as a standalone tail record.
 . ${srcdir:=.}/diag.sh init
 require_plugin imkubernetes ../contrib/imkubernetes
 check_command_available timeout
 
-export NUMMESSAGES=1
+export NUMMESSAGES=2
 pwd=$( pwd )
 testsrv=imk8s-partial-bound-server
 k8s_srv_port=0
@@ -54,10 +53,11 @@ startup
 		printf '2026-04-20T10:00:%02d.000000000Z stdout P %s\n' "$i" \
 			'partial-fragment-0123456789'
 	done
-	printf '%s\n' '2026-04-20T10:00:30.000000000Z stdout F after partial cap'
+	printf '%s\n' '2026-04-20T10:00:30.000000000Z stdout F closing-tail-must-not-standalone'
+	printf '%s\n' '2026-04-20T10:00:31.000000000Z stdout F after partial cap'
 } > "$logfile"
 
-wait_file_lines "$RSYSLOG_OUT_LOG" 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 2
 wait_queueempty
 shutdown_when_empty
 wait_shutdown
@@ -72,14 +72,22 @@ import sys
 path = sys.argv[1]
 records = [json.loads(line) for line in open(path)]
 records = [item for item in records if item.get("format") == "cri"]
-assert len(records) == 1, records
-record = records[0]
-assert record["msg"] == "after partial cap", record
-assert record["stream"] == "stdout", record
-assert record["pod_id"] == "pod-name1-id", record
+assert len(records) == 2, records
+
+expected_prefix = ("partial-fragment-0123456789" * 8)[:128]
+partial = records[0]
+assert partial["msg"] == expected_prefix, partial
+assert "closing-tail-must-not-standalone" not in partial["msg"], partial
+assert partial["stream"] == "stdout", partial
+assert partial["pod_id"] == "pod-name1-id", partial
+
+independent = records[1]
+assert independent["msg"] == "after partial cap", independent
+assert independent["stream"] == "stdout", independent
+assert independent["pod_id"] == "pod-name1-id", independent
 PY
 then
-	error_exit 1 "imkubernetes did not reset oversized CRI partial state"
+	error_exit 1 "imkubernetes did not preserve oversized CRI partial truncation semantics"
 fi
 
 exit_test

--- a/tests/imkubernetes-cri-partial-hard-cap.sh
+++ b/tests/imkubernetes-cri-partial-hard-cap.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
-# Verify that unfinished CRI partial records are bounded before enqueue.
-# The closing F record after an oversized partial run still belongs to that
-# logical message and must not be emitted as a standalone tail record.
+# Verify that non-truncate oversize modes still have an imkubernetes partial
+# hard cap, so an unfinished CRI P run cannot grow without bound.
 . ${srcdir:=.}/diag.sh init
 require_plugin imkubernetes ../contrib/imkubernetes
 check_command_available timeout
 
 export NUMMESSAGES=2
 pwd=$( pwd )
-testsrv=imk8s-partial-bound-server
+testsrv=imk8s-partial-hard-cap-server
 k8s_srv_port=0
 k8s_srv_port_file=${RSYSLOG_DYNNAME}${testsrv}.port
 logdir="${RSYSLOG_DYNNAME}.spool/pods/namespace-name1_pod-name1_uid1/container-a"
@@ -21,7 +20,7 @@ MMK8S_INCLUDE_NODE_NAME=1 timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server
 	${RSYSLOG_DYNNAME}${testsrv}.pid \
 	${RSYSLOG_DYNNAME}${testsrv}.started \
 	$k8s_srv_port_file \
-	> ${RSYSLOG_DYNNAME}.spool/imkubernetes_partial_bound_srv.log 2>&1 &
+	> ${RSYSLOG_DYNNAME}.spool/imkubernetes_partial_hard_cap_srv.log 2>&1 &
 BGPROCESS=$!
 wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
 assign_file_content k8s_srv_port "$k8s_srv_port_file"
@@ -30,7 +29,7 @@ generate_conf
 add_conf '
 global(workDirectory="'$RSYSLOG_DYNNAME.spool'"
        maxMessageSize="128"
-       oversizemsg.input.mode="truncate")
+       oversizemsg.input.mode="accept")
 module(load="../contrib/imkubernetes/.libs/imkubernetes"
        LogFileGlob="'$pwd/$logdir'/*.log"
        PollingInterval="1"
@@ -51,12 +50,12 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 startup
 
 {
-	for i in $(seq 1 8); do
+	for i in $(seq 1 50); do
 		printf '2026-04-20T10:00:%02d.000000000Z stdout P %s\n' "$i" \
 			'partial-fragment-0123456789'
 	done
-	printf '%s\n' '2026-04-20T10:00:30.000000000Z stdout F closing-tail-must-not-standalone'
-	printf '%s\n' '2026-04-20T10:00:31.000000000Z stdout F after partial cap'
+	printf '%s\n' '2026-04-20T10:01:00.000000000Z stdout F closing-tail-must-not-standalone'
+	printf '%s\n' '2026-04-20T10:01:01.000000000Z stdout F after partial hard cap'
 } > "$logfile"
 
 wait_file_lines "$RSYSLOG_OUT_LOG" 2
@@ -76,20 +75,22 @@ records = [json.loads(line) for line in open(path)]
 records = [item for item in records if item.get("format") == "cri"]
 assert len(records) == 2, records
 
-expected_prefix = ("partial-fragment-0123456789" * 8)[:128]
+hard_cap = 128 * 10
+expected_prefix = ("partial-fragment-0123456789" * 50)[:hard_cap]
 partial = records[0]
 assert partial["msg"] == expected_prefix, partial
+assert len(partial["msg"]) == hard_cap, partial
 assert "closing-tail-must-not-standalone" not in partial["msg"], partial
 assert partial["stream"] == "stdout", partial
 assert partial["pod_id"] == "pod-name1-id", partial
 
 independent = records[1]
-assert independent["msg"] == "after partial cap", independent
+assert independent["msg"] == "after partial hard cap", independent
 assert independent["stream"] == "stdout", independent
 assert independent["pod_id"] == "pod-name1-id", independent
 PY
 then
-	error_exit 1 "imkubernetes did not preserve oversized CRI partial truncation semantics"
+	error_exit 1 "imkubernetes did not enforce the CRI partial hard cap"
 fi
 
 exit_test

--- a/tests/imkubernetes-cri-partial-hard-cap.sh
+++ b/tests/imkubernetes-cri-partial-hard-cap.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Verify that non-truncate oversize modes still have an imkubernetes partial
 # hard cap, so an unfinished CRI P run cannot grow without bound.
+# The API helper signals readiness after binding; its 2m timeout is hang
+# protection, while the explicit kill and wait below own normal cleanup.
 . ${srcdir:=.}/diag.sh init
 require_plugin imkubernetes ../contrib/imkubernetes
 check_command_available timeout

--- a/tests/imkubernetes-cri-partial-split.sh
+++ b/tests/imkubernetes-cri-partial-split.sh
@@ -2,6 +2,8 @@
 # Verify that CRI partial assembly honors oversizemsg.input.mode="split".
 # The partial accumulator must not truncate at maxMessageSize; instead the
 # completed logical record reaches the core submit path and is split there.
+# The API helper signals readiness after binding; its 2m timeout is hang
+# protection, while the explicit kill and wait below own normal cleanup.
 . ${srcdir:=.}/diag.sh init
 require_plugin imkubernetes ../contrib/imkubernetes
 check_command_available timeout

--- a/tests/imkubernetes-cri-partial-split.sh
+++ b/tests/imkubernetes-cri-partial-split.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-# Verify that unfinished CRI partial records are bounded before enqueue.
-# The closing F record after an oversized partial run still belongs to that
-# logical message and must not be emitted as a standalone tail record.
+# Verify that CRI partial assembly honors oversizemsg.input.mode="split".
+# The partial accumulator must not truncate at maxMessageSize; instead the
+# completed logical record reaches the core submit path and is split there.
 . ${srcdir:=.}/diag.sh init
 require_plugin imkubernetes ../contrib/imkubernetes
 check_command_available timeout
 
-export NUMMESSAGES=2
+export NUMMESSAGES=3
 pwd=$( pwd )
-testsrv=imk8s-partial-bound-server
+testsrv=imk8s-partial-split-server
 k8s_srv_port=0
 k8s_srv_port_file=${RSYSLOG_DYNNAME}${testsrv}.port
 logdir="${RSYSLOG_DYNNAME}.spool/pods/namespace-name1_pod-name1_uid1/container-a"
@@ -21,7 +21,7 @@ MMK8S_INCLUDE_NODE_NAME=1 timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server
 	${RSYSLOG_DYNNAME}${testsrv}.pid \
 	${RSYSLOG_DYNNAME}${testsrv}.started \
 	$k8s_srv_port_file \
-	> ${RSYSLOG_DYNNAME}.spool/imkubernetes_partial_bound_srv.log 2>&1 &
+	> ${RSYSLOG_DYNNAME}.spool/imkubernetes_partial_split_srv.log 2>&1 &
 BGPROCESS=$!
 wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
 assign_file_content k8s_srv_port "$k8s_srv_port_file"
@@ -30,7 +30,8 @@ generate_conf
 add_conf '
 global(workDirectory="'$RSYSLOG_DYNNAME.spool'"
        maxMessageSize="128"
-       oversizemsg.input.mode="truncate")
+       oversizemsg.input.mode="split"
+       oversizemsg.report="off")
 module(load="../contrib/imkubernetes/.libs/imkubernetes"
        LogFileGlob="'$pwd/$logdir'/*.log"
        PollingInterval="1"
@@ -55,11 +56,11 @@ startup
 		printf '2026-04-20T10:00:%02d.000000000Z stdout P %s\n' "$i" \
 			'partial-fragment-0123456789'
 	done
-	printf '%s\n' '2026-04-20T10:00:30.000000000Z stdout F closing-tail-must-not-standalone'
-	printf '%s\n' '2026-04-20T10:00:31.000000000Z stdout F after partial cap'
+	printf '%s\n' '2026-04-20T10:00:30.000000000Z stdout F closing-tail-split'
+	printf '%s\n' '2026-04-20T10:00:31.000000000Z stdout F after split partial'
 } > "$logfile"
 
-wait_file_lines "$RSYSLOG_OUT_LOG" 2
+wait_file_lines "$RSYSLOG_OUT_LOG" 3
 wait_queueempty
 shutdown_when_empty
 wait_shutdown
@@ -74,22 +75,24 @@ import sys
 path = sys.argv[1]
 records = [json.loads(line) for line in open(path)]
 records = [item for item in records if item.get("format") == "cri"]
-assert len(records) == 2, records
+assert len(records) == 3, records
 
-expected_prefix = ("partial-fragment-0123456789" * 8)[:128]
-partial = records[0]
-assert partial["msg"] == expected_prefix, partial
-assert "closing-tail-must-not-standalone" not in partial["msg"], partial
-assert partial["stream"] == "stdout", partial
-assert partial["pod_id"] == "pod-name1-id", partial
+expected = ("partial-fragment-0123456789" * 8) + "closing-tail-split"
+first = records[0]
+second = records[1]
+assert first["msg"] == expected[:128], first
+assert second["msg"] == expected[128:], second
+for item in (first, second):
+    assert item["stream"] == "stdout", item
+    assert item["pod_id"] == "pod-name1-id", item
 
-independent = records[1]
-assert independent["msg"] == "after partial cap", independent
+independent = records[2]
+assert independent["msg"] == "after split partial", independent
 assert independent["stream"] == "stdout", independent
 assert independent["pod_id"] == "pod-name1-id", independent
 PY
 then
-	error_exit 1 "imkubernetes did not preserve oversized CRI partial truncation semantics"
+	error_exit 1 "imkubernetes did not pass oversized CRI partials to core split handling"
 fi
 
 exit_test


### PR DESCRIPTION
## Summary

- Bound CRI `P...F` assembly per tailed file so an unfinished partial run cannot grow indefinitely.
- Preserve the global oversized-message policy:
  - `truncate` retains at most `global(maxMessageSize)` bytes.
  - `accept` and `split` pass a properly closed logical record to the core input path intact.
  - unfinished non-truncate runs have a fixed hard cap of `10 * global(maxMessageSize)`.
- Keep the closing `F` fragment attached to the oversized logical record; it is consumed for resynchronization and is never emitted as a standalone tail.
- Add regression coverage for truncate, accept, split, and hard-cap behavior, plus user-facing documentation.

## Rationale

CRI partial records may remain unfinished when a producer stops emitting a closing `F` record. The old accumulator could therefore grow without a module-side bound.

The non-truncate hard cap remains fixed at `10 * global(maxMessageSize)`, following the maintainer guidance on this PR. I did not add a separate imkubernetes parameter; that can be added later if operators need independent tuning.

## Validation

Validation used `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`).

- Targeted Ubuntu 26.04 tests: 7/7 passed
  - four new CRI partial tests
  - existing CRI basic test
  - existing Docker JSON basic test
  - existing YAML Docker JSON basic test
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j10`: 1350 passed, 9 skipped, 0 failed
- Clang static analyzer with `--enable-imkubernetes`: no bugs found
- Sphinx HTML build: succeeded
- clang-format 18.1.8 write/read-only checks: passed
- `git diff --check`, Bash syntax, registration, and test-antipattern checks: passed
- Memory-lifecycle audit of the changed accumulator and cleanup paths: clean

The prior hosted `ubuntu_26_san` run for the same runtime logic passed. This refreshed push will run hosted CI again on the rebased SHA.