### PR TITLE
gitignore: ignore generated runtime unit binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,10 @@ plugins/impstats/remote.pb-c.c
 plugins/impstats/remote.pb-c.h
 plugins/impstats/remote.pb-c.stamp
 tests/runtime_unit_gss_token_util
+tests/runtime_unit_impcap_arp_parser
 tests/runtime_unit_linkedlist
+tests/runtime_unit_msg_replace
+tests/runtime_unit_ommongodb_date
 tests/runtime_unit_parser_pri
 tests/runtime_unit_stringbuf
 


### PR DESCRIPTION
## Summary
- add missing generated `tests/runtime_unit_*` binaries to the existing `.gitignore` block
- keep local worktrees clean after running the runtime unit tests

## Validation
- `git check-ignore -v tests/runtime_unit_msg_replace tests/runtime_unit_ommongodb_date tests/runtime_unit_impcap_arp_parser tests/runtime_unit_linkedlist`
- `git diff --check`
- practical `touch` + `git ls-files --others --exclude-standard` check for the three generated names

This is a local artifact ignore-only cleanup; no runtime or build behavior changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

