### PR TITLE
ci: disable stale testbench failure reporting

### DIFF
--- a/.github/workflows/impstats_push_victoriametrics.yml
+++ b/.github/workflows/impstats_push_victoriametrics.yml
@@ -81,8 +81,6 @@ jobs:
           CI_CHECK_CMD: check
           ABORT_ALL_ON_TEST_FAIL: 'NO'
           CI_VALGRIND_SUPPRESSIONS: ubuntu22.04.supp
-          RSYSLOG_STATSURL: >-
-            http://build.rsyslog.com/testbench-failedtest.php
           USE_AUTO_DEBUG: 'off'
           VERBOSE: '1'
         run: |

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -501,7 +501,6 @@ jobs:
           CODECOV_commit_sha="$(git rev-parse HEAD)"
           export CODECOV_commit_sha
           export RSYSLOG_CONTAINER_UID="" # use default
-          export RSYSLOG_STATSURL='http://build.rsyslog.com/testbench-failedtest.php'
           export CFLAGS='-g'
           export CC='gcc'
           export CI_CONFIGURE_CACHE=1
@@ -1249,7 +1248,6 @@ jobs:
           CI_CHECK_CMD: check
           ABORT_ALL_ON_TEST_FAIL: 'NO'
           CI_VALGRIND_SUPPRESSIONS: ubuntu22.04.supp
-          RSYSLOG_STATSURL: http://build.rsyslog.com/testbench-failedtest.php
           CI_CONFIGURE_CACHE: '1'
           USE_AUTO_DEBUG: 'off'
           VERBOSE: '1'
@@ -1464,7 +1462,6 @@ jobs:
                  --disable-default-tests \
                  --enable-omkafka --enable-gnutls --disable-gnutls-tests --enable-imkafka"
           export RSYSLOG_CONTAINER_UID="" # use default
-          export RSYSLOG_STATSURL='http://build.rsyslog.com/testbench-failedtest.php'
           export CC='gcc'
           export CFLAGS='-g'
           export CI_CONFIGURE_CACHE=1

--- a/.github/workflows/run_distro_daily.yml
+++ b/.github/workflows/run_distro_daily.yml
@@ -94,7 +94,6 @@ jobs:
           export CODECOV_repo_slug=''
           export CODECOV_commit_sha=''
           export RSYSLOG_CONTAINER_UID=''
-          export RSYSLOG_STATSURL='http://build.rsyslog.com/testbench-failedtest.php'
           export CFLAGS='-g'
           export CC='gcc'
           export CI_CONFIGURE_CACHE=1


### PR DESCRIPTION
## Summary

- stop CI jobs from exporting `RSYSLOG_STATSURL` to the removed testbench failure-reporting backend
- leave `diag.sh` and the devcontainer pass-through unchanged so an explicit replacement URL can still be supplied later

## Why

The historical backend at `build.rsyslog.com/testbench-failedtest.php` no longer exists. CI should not keep attempting to report failed test metadata there.

## Validation

- `actionlint .github/workflows/run_checks.yml .github/workflows/run_distro_daily.yml .github/workflows/impstats_push_victoriametrics.yml`
- pinned `zizmor --strict-collection .github/workflows`
- `devtools/local-validation-plan.sh --base HEAD --run` before final upstream refresh:
  - Ubuntu 26.04 container CI passed with `1432 total, 1403 pass, 29 skip, 0 fail, 0 error`
  - static analyzer completed with no report files
  - local Cubic produced one expected note that telemetry is disabled; that is the intended behavior because the backend is gone


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

