### PR TITLE
testbench: isolate diag core classification cores

### DIFF
--- a/tests/diag-core-classification.sh
+++ b/tests/diag-core-classification.sh
@@ -6,24 +6,32 @@
 # policies that make local generic core scanning unreliable.
 . ${srcdir:=.}/diag.sh init
 
+# Keep synthetic core files out of the shared tests directory: parallel tests
+# run broad core* cleanup during diag.sh init.
+core_classification_dir="${PWD}/${RSYSLOG_DYNNAME}.core-classification.$$"
+core_scan_log="${PWD}/${RSYSLOG_DYNNAME}.core-scan.log"
+
 test_error_exit_handler() {
-	rm -f core.foreign core.rsyslogd.424242 core.${RSYSLOG_DYNNAME}.weak
+	rm -rf "$core_classification_dir"
 }
 
-touch core.foreign
-if core_candidate_owner_matches core.foreign ../tools/rsyslogd 424242; then
+rm -rf "$core_classification_dir"
+mkdir "$core_classification_dir" || error_exit 1
+
+touch "$core_classification_dir/core.foreign"
+if core_candidate_owner_matches "$core_classification_dir/core.foreign" ../tools/rsyslogd 424242; then
 	echo "FAIL: generic core without pid/executable ownership was accepted"
 	error_exit 1
 fi
 
-touch core.rsyslogd.424242
-if ! core_candidate_owner_matches core.rsyslogd.424242 ../tools/rsyslogd 424242; then
+touch "$core_classification_dir/core.rsyslogd.424242"
+if ! core_candidate_owner_matches "$core_classification_dir/core.rsyslogd.424242" ../tools/rsyslogd 424242; then
 	echo "FAIL: pid/executable filename hint was not accepted"
 	error_exit 1
 fi
 
-touch core.${RSYSLOG_DYNNAME}.weak
-if ! core_candidate_owner_matches core.${RSYSLOG_DYNNAME}.weak ../tools/rsyslogd ""; then
+touch "$core_classification_dir/core.${RSYSLOG_DYNNAME}.weak"
+if ! core_candidate_owner_matches "$core_classification_dir/core.${RSYSLOG_DYNNAME}.weak" ../tools/rsyslogd ""; then
 	echo "FAIL: test-specific core name fallback was not accepted"
 	error_exit 1
 fi
@@ -35,14 +43,17 @@ if ! core_policy_uses_external_collector; then
 fi
 
 core_dumps_found=0
-analyze_owned_core_candidates ../tools/rsyslogd "" rsyslogd > "${RSYSLOG_DYNNAME}.core-scan.log" 2>&1
+oldpwd="$PWD"
+cd "$core_classification_dir" || error_exit 1
+analyze_owned_core_candidates ../../tools/rsyslogd "" rsyslogd > "$core_scan_log" 2>&1
+cd "$oldpwd" || error_exit 1
 if [ "$core_dumps_found" -ne 1 ]; then
 	echo "FAIL: external-collector scan should analyze only the test-specific fallback core"
-	cat "${RSYSLOG_DYNNAME}.core-scan.log"
+	cat "$core_scan_log"
 	error_exit 1
 fi
 content_check "skipping generic local core scan because core_pattern uses an external collector" \
-	"${RSYSLOG_DYNNAME}.core-scan.log"
+	"$core_scan_log"
 
-rm -f core.foreign core.rsyslogd.424242 core.${RSYSLOG_DYNNAME}.weak
+rm -rf "$core_classification_dir"
 exit_test

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -629,7 +629,7 @@ print_core_policy() {
 core_path_is_test_specific() {
 	local corefile="$1"
 	[ -n "${RSYSLOG_DYNNAME:-}" ] || return 1
-	case "$corefile" in
+	case "$(basename "$corefile")" in
 	*"$RSYSLOG_DYNNAME"*) return 0 ;;
 	*) return 1 ;;
 	esac


### PR DESCRIPTION
## Summary
- move `diag-core-classification.sh` synthetic core files into a private per-test directory
- keep the core-scan log in the normal tests directory for failure artifacts
- preserve the existing broad startup cleanup in `diag.sh`

## Why
`diag-core-classification.sh` creates `core.${RSYSLOG_DYNNAME}.weak` as a synthetic fallback-core candidate. Parallel tests that start at the wrong time run `diag.sh init`, which still does broad `core*` cleanup in the shared tests directory. That can delete the synthetic candidate before `analyze_owned_core_candidates` counts it.

Observed on PR #7185: run `28743011862`, attempt 1, artifact `8092541975` failed with `No owned rsyslogd core dumps found`; attempt 2 passed this test and failed elsewhere.

## Validation
- `./tests/diag-core-classification.sh`
- 50x local race stress while repeatedly running shared `core*` cleanup
- `bash -n tests/diag-core-classification.sh`
- `shellcheck -S warning tests/diag-core-classification.sh`
- `devtools/check-test-antipatterns.sh tests/diag-core-classification.sh`
- `git diff --check`
- focused Ubuntu 26.04 container lane: `CI_MAKE_CHECK_OPT='-j10 TESTS=diag-core-classification.sh' devtools/run-ci.sh`, passed 1/1

This is targeted validation for a shell-only testbench fix, not a full matrix run.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

