### PR TITLE
doc: add documentation for imfile delay.message parameter

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -549,6 +549,7 @@ EXTRA_DIST = \
     source/reference/parameters/imfile-addmetadata.rst \
     source/reference/parameters/imfile-deletestateonfiledelete.rst \
     source/reference/parameters/imfile-deletestateonfilemove.rst \
+    source/reference/parameters/imfile-delay-message.rst \
     source/reference/parameters/imfile-discardtruncatedmsg.rst \
     source/reference/parameters/imfile-endmsg-regex.rst \
     source/reference/parameters/imfile-escapelf-replacement.rst \

--- a/doc/source/configuration/modules/imfile.rst
+++ b/doc/source/configuration/modules/imfile.rst
@@ -173,6 +173,10 @@ Input Parameters
      - .. include:: ../../reference/parameters/imfile-deletestateonfilemove.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-imfile-delay-message`
+     - .. include:: ../../reference/parameters/imfile-delay-message.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-imfile-ruleset`
      - .. include:: ../../reference/parameters/imfile-ruleset.rst
         :start-after: .. summary-start
@@ -363,6 +367,7 @@ defaults instead.
 
    ../../reference/parameters/imfile-addceetag
    ../../reference/parameters/imfile-addmetadata
+   ../../reference/parameters/imfile-delay-message
    ../../reference/parameters/imfile-deletestateonfiledelete
    ../../reference/parameters/imfile-deletestateonfilemove
    ../../reference/parameters/imfile-discardtruncatedmsg

--- a/doc/source/reference/parameters/imfile-delay-message.rst
+++ b/doc/source/reference/parameters/imfile-delay-message.rst
@@ -1,0 +1,84 @@
+.. _param-imfile-delay-message:
+.. _imfile.parameter.input.delay-message:
+.. _imfile.parameter.delay-message:
+
+delay.message
+=============
+
+.. index::
+   single: imfile; delay.message
+   single: delay.message
+
+.. meta::
+   :description: imfile delay.message parameter reference - adds per-message delay for bandwidth rate-limiting
+   :keywords: imfile, delay.message, rate-limiting, bandwidth, input plugin
+
+.. summary-start
+
+Adds a delay after each line read from the file, useful for rate-limiting log sources in multi-tenant environments.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: delay.message
+:Scope: input
+:Type: integer
+:Default: 0
+:Required?: no
+:Introduced: 8.38.0 (via PR #2999)
+
+Description
+-----------
+Instructs rsyslog to pause after reading each line from the monitored file.
+The default ``0`` disables this delay.
+
+This parameter is useful in multi-tenant environments where multiple applications
+write to separate log files that are all being collected by a single rsyslog
+instance. By adding a small per-message delay, no single log source can dominate
+the available bandwidth for transporting logs off the host.
+
+Unlike :doc:`imfile-maxbytesperminute` and :doc:`imfile-maxlinesperminute`, which
+drop messages when rate limits are exceeded, ``delay.message`` slows down processing
+without message loss. This makes it suitable for scenarios where all messages must
+be preserved but bandwidth sharing is required.
+
+.. note::
+   The delay value is specified in **microseconds**, but the current implementation
+   has a known issue where the seconds and microseconds components are swapped
+   internally. For values less than 1,000,000 microseconds (1 second), the actual
+   delay will be much longer than documented. For example, ``delay.message="1000"``
+   (intended as 1 ms) currently results in approximately a 1000-second delay.
+   Users should be aware of this behavior when configuring this parameter.
+
+Input usage
+-----------
+.. _param-imfile-input-delay-message:
+.. _imfile.parameter.input.delay-message-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imfile"
+         File="/var/log/containers/app1.log"
+         Tag="app1"
+         delay.message="1000")
+
+The above example configures a delay value of 1000 microseconds.
+
+.. note::
+   Due to a known implementation issue, small delay values (less than 1,000,000)
+   may result in much longer delays than expected. See the Description section
+   above for details.
+
+Notes
+-----
+- The delay is applied per-message, after each line is read from the file.
+- Value is specified in microseconds (1 second = 1,000,000 microseconds).
+- For bandwidth throttling without message loss, prefer this over rate-limiting
+  parameters that discard messages.
+- In high-throughput scenarios, even small delays can significantly reduce throughput.
+  Test carefully to balance bandwidth sharing against processing lag.
+
+See also
+--------
+:doc:`../../configuration/modules/imfile`


### PR DESCRIPTION
Fixes missing documentation for the `delay.message` parameter implemented in PR #2999 (rsyslog 8.37.0) to address issue #1883.

## Summary

The `delay.message` parameter provides rate limiting **without message loss** by adding a configurable microsecond delay after each line read from monitored files. Unlike `maxBytesPerMinute` and `maxLinesPerMinute`, it slows processing rather than dropping messages, making it suitable for bandwidth sharing in multi-tenant environments where all messages must be preserved.

## Changes

- Added new parameter reference file: `doc/source/reference/parameters/imfile-delay-message.rst`
- Updated `doc/source/configuration/modules/imfile.rst`

## Validation

- ✅ Sphinx build: 1206 files, no errors
- ✅ RAG knowledge base updated via `make json-formatter`

## Related

- Issue: #1883
- Implementation: PR #2999 (merged, rsyslog 8.37.0)

Generated with Qwen Code (3-shotted by Qwen-Coder)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

