### PR TITLE
omkafka: relax poll stop flag atomics

### DIFF
--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -309,7 +309,7 @@ typedef struct wrkrInstanceData {
 static void *pollCallbackThread(void *arg) {
     instanceData *const pData = (instanceData *)arg;
 
-    while (!ATOMIC_LOAD_32BIT(&pData->stopPollThread, &pData->mutStopPollThread)) {
+    while (!ATOMIC_LOAD_32BIT_RELAXED(&pData->stopPollThread, &pData->mutStopPollThread)) {
         if (pthread_mutex_trylock(&pData->mut_doAction) == 0) {
             pthread_rwlock_rdlock(&pData->rkLock);
             if (pData->bIsOpen && pData->rk != NULL) {
@@ -333,7 +333,7 @@ static rsRetVal startPollCallbackThread(instanceData *const pData) {
         FINALIZE;
     }
 
-    ATOMIC_STORE_32BIT(&pData->stopPollThread, &pData->mutStopPollThread, 0);
+    ATOMIC_STORE_32BIT_RELAXED(&pData->stopPollThread, &pData->mutStopPollThread, 0);
     const int r = pthread_create(&pData->pollThread, NULL, pollCallbackThread, pData);
     if (r != 0) {
         LogError(r, RS_RET_ERR, "omkafka: unable to create librdkafka callback poller thread");
@@ -350,7 +350,7 @@ static void stopPollCallbackThread(instanceData *const pData) {
         return;
     }
 
-    ATOMIC_STORE_32BIT(&pData->stopPollThread, &pData->mutStopPollThread, 1);
+    ATOMIC_STORE_32BIT_RELAXED(&pData->stopPollThread, &pData->mutStopPollThread, 1);
     const int r = pthread_join(pData->pollThread, NULL);
     if (r != 0) {
         LogError(r, RS_RET_ERR, "omkafka: unable to join librdkafka callback poller thread");
@@ -1833,7 +1833,7 @@ BEGINcreateInstance
     INIT_ATOMIC_HELPER_MUT(pData->mutCurrPartition);
     INIT_ATOMIC_HELPER_MUT(pData->mutStopPollThread);
     pData->pollThreadRunning = 0;
-    ATOMIC_STORE_32BIT(&pData->stopPollThread, &pData->mutStopPollThread, 0);
+    ATOMIC_STORE_32BIT_RELAXED(&pData->stopPollThread, &pData->mutStopPollThread, 0);
 finalize_it:
 ENDcreateInstance
 


### PR DESCRIPTION
## Summary
- Use relaxed 32-bit atomic helpers for the omkafka poll callback stop flag.
- Keep existing lock-based fallback behavior on no-atomic builds.
- Leave Kafka handle/open-state synchronization on existing mutex/rwlock paths.

## Validation
- `./devtools/format-code.sh --git-changed`
- `./devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 ./devtools/local-validation-plan.sh --base upstream/main`
- Ubuntu 26.04 dev container default atomic configure + `make -j60`
- Ubuntu 26.04 dev container `--enable-atomic-operations=no` configure + `make -j60`

Focused compile validation only for this small helper-use change; hosted CI covers the broader matrix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

