### PR TITLE
core: relax selected atomic flag reads

### DIFF
--- a/plugins/omsendertrack/omsendertrack.c
+++ b/plugins/omsendertrack/omsendertrack.c
@@ -554,9 +554,9 @@ static void *bgWriter(void *arg) {
     }
 #endif
 
-    while (ATOMIC_LOAD_32BIT(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter) == 0) {
+    while (ATOMIC_LOAD_32BIT_RELAXED(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter) == 0) {
         srSleep(pData->interval, 0);
-        if (ATOMIC_LOAD_32BIT(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter) == 1) {
+        if (ATOMIC_LOAD_32BIT_RELAXED(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter) == 1) {
             break;
         }
         dbgprintf("bgwriter writing report file\n");
@@ -668,7 +668,7 @@ BEGINfreeInstance
     CODESTARTfreeInstance;
     /* stop bgWriter */
     if (pData->bgw_initialized) {
-        ATOMIC_STORE_32BIT(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter, 1);
+        ATOMIC_STORE_32BIT_RELAXED(&pData->bShutdownBackgroundWriter, &pData->mutShutdownBackgroundWriter, 1);
         pthread_kill(pData->bgw_tid, SIGTTIN);
 
         /* wait until stopped */

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -1569,10 +1569,10 @@ static void countActiveTargets(const wrkrInstanceData_t *const pWrkrData) {
         }
     }
 
-    /* Use atomic CAS to update the value safely */
+    /* nActiveTargets is a scheduling snapshot; ordering comes from the CAS update, not from readers. */
     int oldVal, newVal;
     do {
-        oldVal = ATOMIC_LOAD_32BIT(&pWrkrData->pData->nActiveTargets, &pWrkrData->pData->mut_nActiveTargets);
+        oldVal = ATOMIC_LOAD_32BIT_RELAXED(&pWrkrData->pData->nActiveTargets, &pWrkrData->pData->mut_nActiveTargets);
         if (oldVal == activeTargets) {
             break; /* no change, so no log message either */
         }
@@ -1630,7 +1630,8 @@ static rsRetVal doTryResume(targetData_t *pTarget) {
     const char *address;
     DEFiRet;
 
-    const int nActiveTargets = ATOMIC_LOAD_32BIT(&pTarget->pData->nActiveTargets, &pTarget->pData->mut_nActiveTargets);
+    const int nActiveTargets =
+        ATOMIC_LOAD_32BIT_RELAXED(&pTarget->pData->nActiveTargets, &pTarget->pData->mut_nActiveTargets);
 
     DBGPRINTF("doTryResume: isConnected: %d, ttResume %lld, LastActiveTargets: %d\n", pTarget->bIsConnected,
               (long long)pTarget->ttResume, nActiveTargets);
@@ -1725,7 +1726,7 @@ BEGINtryResume
     iRet = poolTryResume(pWrkrData);
     countActiveTargets(pWrkrData);
     const int nActiveTargets =
-        ATOMIC_LOAD_32BIT(&pWrkrData->pData->nActiveTargets, &pWrkrData->pData->mut_nActiveTargets);
+        ATOMIC_LOAD_32BIT_RELAXED(&pWrkrData->pData->nActiveTargets, &pWrkrData->pData->mut_nActiveTargets);
 
     LogMsg(0, RS_RET_DEBUG, LOG_DEBUG,
            "omfwd: [wrkr %u/%" PRIuPTR
@@ -1958,7 +1959,7 @@ finalize_it:
 
     countActiveTargets(pWrkrData);
     const int nActiveTargets =
-        ATOMIC_LOAD_32BIT(&pWrkrData->pData->nActiveTargets, &pWrkrData->pData->mut_nActiveTargets);
+        ATOMIC_LOAD_32BIT_RELAXED(&pWrkrData->pData->nActiveTargets, &pWrkrData->pData->mut_nActiveTargets);
 
     if (bFlushRetry || nActiveTargets == 0) {
         /*


### PR DESCRIPTION
## Summary
- Use relaxed 32-bit atomic helpers for `omsendertrack` background-writer shutdown checks.
- Use relaxed 32-bit atomic loads for `omfwd` active-target count snapshots.
- Keep `imptcp` `bWorkQueued` release semantics unchanged because that flag is an ownership handoff for session processing, not a pure status snapshot.

## Validation
- `./devtools/format-code.sh --git-changed`
- `./devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `RSYSLOG_LOCAL_CHECK_JOBS=60 RSYSLOG_LOCAL_BUILD_JOBS=60 ./devtools/local-validation-plan.sh --base upstream/main`
- Ubuntu 26.04 dev container default atomic configure + `make -j60`
- Ubuntu 26.04 dev container `--enable-atomic-operations=no` configure + `make -j60`

Focused compile validation only for this small helper-use change; hosted CI covers the broader matrix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

