### PR TITLE
imbeats: harden maxSessions and seq wrap tests

### DIFF
--- a/doc/source/reference/parameters/imbeats-maxsessions.rst
+++ b/doc/source/reference/parameters/imbeats-maxsessions.rst
@@ -36,6 +36,8 @@ are rejected while existing sessions continue to run.
 Use this limit to bound file descriptors, per-session memory, and sender fan-in
 for a listener. Size it for the number of Beats or Elastic Agent senders that
 may be connected at the same time, including reconnect overlap during restarts.
+Values larger than ``UINT_MAX`` are accepted with a warning and capped at
+``UINT_MAX``.
 
 Input usage
 -----------

--- a/plugins/imbeats/Makefile.am
+++ b/plugins/imbeats/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = imbeats.la
 
-imbeats_la_SOURCES = imbeats.c lj_parser.c lj_parser.h
+imbeats_la_SOURCES = imbeats.c lj_parser.c lj_parser.h seqnum.h
 imbeats_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(ZLIB_CFLAGS)
 imbeats_la_LDFLAGS = -module -avoid-version $(ZLIB_LIBS)
 imbeats_la_LIBADD =

--- a/plugins/imbeats/imbeats.c
+++ b/plugins/imbeats/imbeats.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <stdint.h>
 #include <unistd.h>
@@ -43,6 +44,7 @@
 #include "tcpsrv.h"
 
 #include "lj_parser.h"
+#include "seqnum.h"
 
 MODULE_TYPE_INPUT;
 MODULE_TYPE_NOKEEP;
@@ -309,6 +311,16 @@ static rsRetVal validateSizeLimit(const char *const name, const int64_t value, c
     }
     *target = (size_t)value;
     return RS_RET_OK;
+}
+
+static unsigned normalizeMaxSessions(const int64_t value) {
+    assert(value > 0);
+    if (value > (int64_t)UINT_MAX) {
+        LogMsg(0, RS_RET_OK_WARN, LOG_WARNING,
+               "imbeats: maxSessions value %" PRId64 " exceeds UINT_MAX (%u) - capped at UINT_MAX", value, UINT_MAX);
+        return UINT_MAX;
+    }
+    return (unsigned)value;
 }
 
 static rsRetVal setCnfString(uchar **const target, es_str_t *const value) {
@@ -581,8 +593,7 @@ static rsRetVal sessionValidateBatch(session_t *const sess) {
     size_t idx;
     assert(sess != NULL);
     for (idx = 0; idx < sess->batch.count; ++idx) {
-        const uint32_t expected = sess->lastAckedSeq + (uint32_t)idx + 1;
-        if (sess->batch.events[idx].seq != expected) {
+        if (!imbeats_seq_is_expected(sess->lastAckedSeq, idx, sess->batch.events[idx].seq)) {
             return RS_RET_INVALID_VALUE;
         }
     }
@@ -1408,7 +1419,7 @@ BEGINnewInpInst
             CHKiRet(validateSizeLimit("maxBatchBytes", pvals[i].val.d.n, IMBEATS_MAX_BYTE_SIZE_LIMIT,
                                       &inst->maxBatchBytes));
         } else if (!strcmp(inppblk.descr[i].name, "maxsessions")) {
-            inst->maxSessions = (unsigned)pvals[i].val.d.n;
+            inst->maxSessions = normalizeMaxSessions(pvals[i].val.d.n);
         } else if (!strcmp(inppblk.descr[i].name, "workerthreads")) {
             if (pvals[i].val.d.n > IMBEATS_MAX_WORKER_THREADS) {
                 LogError(0, RS_RET_PARAM_ERROR,

--- a/plugins/imbeats/lj_parser.c
+++ b/plugins/imbeats/lj_parser.c
@@ -132,9 +132,9 @@ static rsRetVal parse_frames_from_memory(struct lj_batch_s *batch,
                 off += v2;
                 break;
             case LJ_FRAME_COMPRESSED:
-                if (off + 4 > len) {
-                    return RS_RET_INVALID_VALUE;
-                }
+                /* Compressed frames are only valid as top-level session frames.
+                 * After inflation this helper accepts JSON frames only; accepting
+                 * another compressed frame would enable unsupported nesting. */
                 return RS_RET_INVALID_VALUE;
             default:
                 return RS_RET_INVALID_VALUE;

--- a/plugins/imbeats/seqnum.h
+++ b/plugins/imbeats/seqnum.h
@@ -1,0 +1,36 @@
+/* imbeats sequence-number helpers.
+ *
+ * Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IMBEATS_SEQNUM_H
+#define IMBEATS_SEQNUM_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+static inline int imbeats_seq_is_expected(const uint32_t lastAckedSeq,
+                                          const size_t batchIndex,
+                                          const uint32_t actualSeq) {
+    const uint64_t expectedWide = (uint64_t)lastAckedSeq + (uint64_t)(uint32_t)batchIndex + 1u;
+    const uint32_t expected = (uint32_t)expectedWide;
+    return actualSeq == expected;
+}
+
+#endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -35,6 +35,7 @@ TESTS_GSSAPI_LIBYAML = \
 EXTRA_DIST += $(TESTS_GSSAPI) $(TESTS_GSSAPI_LIBYAML) unit/gss_token_util_test.c
 
 EXTRA_DIST += unit/impcap_arp_parser_test.c
+EXTRA_DIST += unit/imbeats_seq_test.c
 
 TESTS_IMPTCP_TABESCAPE = \
 	tabescape_dflt.sh \
@@ -1232,6 +1233,7 @@ TESTS_IMBEATS = \
 	imbeats-limits-impstats.sh \
 	imbeats-shutdown-open-session.sh \
 	imbeats-maxsessions.sh \
+	imbeats-maxsessions-cap-warning.sh \
 	imbeats-multiplex-idle-sessions.sh \
 	imbeats-filebeat-docker.sh
 
@@ -2411,6 +2413,18 @@ runtime_unit_gss_token_util_SOURCES = \
 runtime_unit_gss_token_util_CPPFLAGS = \
 	$(runtime_unit_linkedlist_CPPFLAGS)
 runtime_unit_gss_token_util_LDADD = $(PTHREADS_LIBS) $(SOL_LIBS)
+endif
+
+if ENABLE_IMBEATS
+check_PROGRAMS += runtime_unit_imbeats_seq
+TESTS += runtime_unit_imbeats_seq
+
+runtime_unit_imbeats_seq_SOURCES = \
+	unit/imbeats_seq_test.c
+
+runtime_unit_imbeats_seq_CPPFLAGS = \
+	$(runtime_unit_linkedlist_CPPFLAGS)
+runtime_unit_imbeats_seq_LDADD = $(PTHREADS_LIBS) $(SOL_LIBS)
 endif
 
 runtime_unit_linkedlist_CPPFLAGS = \

--- a/tests/imbeats-maxsessions-cap-warning.sh
+++ b/tests/imbeats-maxsessions-cap-warning.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Validate that an excessively large imbeats maxSessions value is not rejected
+# during config load. The oracle is rsyslogd -N1 succeeding while emitting the
+# explicit cap warning, so the test avoids opening listeners or sending traffic.
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+input(type="imbeats"
+      port="0"
+      maxSessions="4294967296")
+'
+
+if ! ../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M../runtime/.libs:../.libs >"${RSYSLOG_DYNNAME}.log" 2>&1; then
+	cat "${RSYSLOG_DYNNAME}.log"
+	error_exit 1
+fi
+
+content_check 'imbeats: maxSessions value 4294967296 exceeds UINT_MAX' "${RSYSLOG_DYNNAME}.log"
+content_check 'capped at UINT_MAX' "${RSYSLOG_DYNNAME}.log"
+
+exit_test

--- a/tests/unit/imbeats_seq_test.c
+++ b/tests/unit/imbeats_seq_test.c
@@ -1,0 +1,35 @@
+#include "config.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "plugins/imbeats/seqnum.h"
+
+static void expect_seq(const uint32_t lastAckedSeq,
+                       const size_t batchIndex,
+                       const uint32_t actualSeq,
+                       const int expected,
+                       const char *const label) {
+    const int actual = imbeats_seq_is_expected(lastAckedSeq, batchIndex, actualSeq);
+    if (actual != expected) {
+        fprintf(stderr, "%s: last=%u index=%zu actual=%u expected result=%d got=%d\n", label, lastAckedSeq, batchIndex,
+                actualSeq, expected, actual);
+        exit(1);
+    }
+}
+
+int main(void) {
+    /* The imbeats Lumberjack sequence check is intentionally uint32 modulo
+     * arithmetic. These cases document the wraparound invariant without sending
+     * a huge protocol batch to drive the live session state to UINT32_MAX. */
+    expect_seq(0, 0, 1, 1, "initial sequence");
+    expect_seq(1, 0, 2, 1, "next one-event batch");
+    expect_seq(1, 1, 3, 1, "second event in batch");
+    expect_seq(1, 0, 1, 0, "reset rejected");
+    expect_seq(UINT32_MAX, 0, 0, 1, "wrap from UINT32_MAX to zero");
+    expect_seq(UINT32_MAX - 1u, 0, UINT32_MAX, 1, "pre-wrap event");
+    expect_seq(UINT32_MAX - 1u, 1, 0, 1, "wrap within batch");
+    expect_seq(UINT32_MAX, 0, 1, 0, "wrap gap rejected");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- cap oversized imbeats maxSessions values at UINT_MAX with an explicit warning
- add a config-only regression test for the warning path
- add a tiny sequence-number helper and unit test covering uint32 wraparound
- clarify why nested compressed Lumberjack frames are rejected

## Validation
- devtools/format-code.sh --git-changed
- devtools/format-code.sh --git-changed --check --check-if-available
- git diff --check
- devtools/check-test-antipatterns.sh tests/imbeats-maxsessions-cap-warning.sh tests/unit/imbeats_seq_test.c
- shellcheck -S warning tests/imbeats-maxsessions-cap-warning.sh
- make -C plugins/imbeats -j${RSYSLOG_LOCAL_BUILD_JOBS:-10}
- make -C tests -o Makefile.in -o Makefile runtime_unit_imbeats_seq
- ./tests/runtime_unit_imbeats_seq
- ./tests/imbeats-maxsessions-cap-warning.sh

Full local/container validation was intentionally not run yet. A narrow make check TESTS=... attempt recursed into tools/ and failed before running the tests because this local build configuration references missing MongoDB headers under /usr/include/mongoc-2.2.2 and /usr/include/bson-2.2.2.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

