### PR TITLE
queue: align legacy action batch default

### DIFF
--- a/runtime/action.c
+++ b/runtime/action.c
@@ -254,7 +254,7 @@ static rsRetVal actionResetQueueParams(void) {
 
     cs.ActionQueType = QUEUETYPE_DIRECT; /* type of the main message queue above */
     cs.iActionQueueSize = 1000; /* size of the main message queue above */
-    cs.iActionQueueDeqBatchSize = 16; /* default batch size */
+    cs.iActionQueueDeqBatchSize = 128; /* default batch size */
     cs.iActionQHighWtrMark = -1; /* high water mark for disk-assisted queues */
     cs.iActionQLowWtrMark = -1; /* low water mark for disk-assisted queues */
     cs.iActionQDiscardMark = -1; /* begin to discard messages */


### PR DESCRIPTION
## Summary
- align the legacy `$ActionQueueDequeueBatchSize` default with the modern action queue default of 128
- preserve explicit legacy `$ActionQueueDequeueBatchSize` overrides
- rely on the existing DA queue inheritance path so DA child queues use the parent action queue batch size

## Why
Legacy action queue configuration still defaulted to 16 even though the documented and modern action queue default is 128. For disk-assisted action queues this means omitted legacy batch sizing creates a much smaller DA dequeue batch than expected.

## Validation
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout`
- `make -j60 check TESTS=""`
- parse-only debug check: legacy omitted batch dumps `queue.dequeuebatchsize: 128`
- parse-only debug check: explicit `$ActionQueueDequeueBatchSize 16` still dumps `queue.dequeuebatchsize: 16`
- local Cubic review: no issues found
- PR-ready local validation: `RSYSLOG_LOCAL_BUILD_JOBS=60 RSYSLOG_LOCAL_CHECK_JOBS=60 devtools/local-validation-plan.sh --base upstream/main --run`
  - image: `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`32ade478a405`)
  - result: passed on rerun

Note: an earlier container run hit one unrelated-looking `pmsnare-ccdefault-udp` failure with no output file; rerunning the final branch passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

