### PR TITLE
tests: avoid UDP port race in parser tests

### DIFF
--- a/tests/fieldtest-udp.sh
+++ b/tests/fieldtest-udp.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
+# Verify UDP parser field extraction from a PIX-style message. The test uses
+# an imudp-assigned port file so parallel test runs cannot cross-feed messages;
+# the extracted field in RSYSLOG_OUT_LOG is the pass/fail oracle.
 . ${srcdir:=.}/diag.sh init
 generate_conf
+PORT_RCVR_FILE="$RSYSLOG_DYNNAME.imudp.port"
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%msg:F,32:2%\n")
 
@@ -15,6 +19,7 @@ ruleset(name="ruleset1") {
 
 '
 startup
+assign_tcpflood_port "$PORT_RCVR_FILE"
 tcpflood -m1 -T "udp" -M "\"<167>Mar  6 16:57:54 172.20.245.8 %PIX-7-710005: DROP_url_www.sina.com.cn:IN=eth1 OUT=eth0 SRC=192.168.10.78 DST=61.172.201.194 LEN=1182 TOS=0x00 PREC=0x00 TTL=63 ID=14368 DF PROTO=TCP SPT=33343 DPT=80 WINDOW=92 RES=0x00 ACK PSH URGP=0\""
 shutdown_when_empty
 wait_shutdown

--- a/tests/proprepltest-nolimittag-udp.sh
+++ b/tests/proprepltest-nolimittag-udp.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
+# Verify UDP tag parsing when the sender tag has no traditional length limit.
+# The imudp listener owns an OS-assigned port before tcpflood sends, preventing
+# parallel UDP tests from sharing a preselected port; the ordered tag output is
+# the pass/fail oracle.
 . ${srcdir:=.}/diag.sh init
 generate_conf
+PORT_RCVR_FILE="$RSYSLOG_DYNNAME.imudp.port"
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="'$TCPFLOOD_PORT'")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'")
 
 template(name="outfmt" type="string" string="+%syslogtag%+\n")
 
@@ -14,6 +19,7 @@ template(name="outfmt" type="string" string="+%syslogtag%+\n")
 
 '
 startup
+assign_tcpflood_port "$PORT_RCVR_FILE"
 tcpflood -m1 -T "udp" -M "\"<167>Mar  6 16:57:54 172.20.245.8 TAG: Rest of message...\""
 tcpflood -m1 -T "udp" -M "\"<167>Mar  6 16:57:54 172.20.245.8 0 Rest of message...\""
 tcpflood -m1 -T "udp" -M "\"<167>Mar  6 16:57:54 172.20.245.8 01234567890123456789012345678901 Rest of message...\""


### PR DESCRIPTION
## Summary

- Convert `fieldtest-udp.sh` and `proprepltest-nolimittag-udp.sh` to imudp-owned UDP ports via `port="0"` and `listenPortFileName`.
- Pin the listeners to `127.0.0.1` so the port file maps to one bound socket.
- Add test intent/oracle comments while preserving the original parser assertions.

## Root Cause

The daily full distro Fedora 43 lane ran these UDP tests in parallel. Both relied on a port selected before imudp had bound it, so another parallel test could claim or receive traffic for that port. In the failed run, one test captured the other test’s messages and the other had no output.

## Validation

- `shellcheck -S warning tests/fieldtest-udp.sh tests/proprepltest-nolimittag-udp.sh`
- `devtools/check-test-antipatterns.sh tests/fieldtest-udp.sh tests/proprepltest-nolimittag-udp.sh`
- `make -j$(nproc) check TESTS=""`
- `./tests/fieldtest-udp.sh && ./tests/proprepltest-nolimittag-udp.sh`
- `make -j2 check TESTS="fieldtest-udp.sh proprepltest-nolimittag-udp.sh"`
- `devtools/local-validation-plan.sh --run --base main`
- Ubuntu 26.04 broad container run: 1290 total, 1257 pass, 33 skip, 0 fail
- Cubic review scoped to `HEAD`: no issues found

Container: `rsyslog/rsyslog_dev_base_ubuntu:26.04`, image `sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`, `RSYSLOG_LOCAL_BUILD_JOBS=10`, `RSYSLOG_LOCAL_CHECK_JOBS=10`.

Closes https://github.com/rsyslog/rsyslog/issues/7364


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

