### PR TITLE
imjournal: warn when failing to get the MESSAGE field

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -598,7 +598,11 @@ static rsRetVal readjournal(struct journalContext_s *journalContext, ruleset_t *
     int facility = cs.iDfltFacility;
 
     /* Get message text */
-    if (journalGetData(journalContext, "MESSAGE", &get, &length) < 0) {
+    r = journalGetData(journalContext, "MESSAGE", &get, &length);
+    if (r < 0) {
+        LogMsg(-r, RS_RET_OK_WARN, LOG_WARNING,
+               "imjournal: failed to retrieve 'MESSAGE' field from journal entry "
+               ", submitting empty message");
         CHKmalloc(message = strdup(""));
     } else {
         CHKiRet(sanitizeValue(((const char *)get) + 8, length - 8, &message));


### PR DESCRIPTION
This PR prints a warning if `MESSAGE` field could not be retrieved. This is important to understand root cause for such issue.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

