### PR TITLE
testbench: stabilize template transformation oracle

### DIFF
--- a/tests/template-property-transformations.sh
+++ b/tests/template-property-transformations.sh
@@ -3,7 +3,9 @@
 # transformations without network timing: field extraction, substring bounds,
 # regex match/no-match handling, control-character modes, string modifiers,
 # timestamp formatting, secure-path sanitizing, and CSV/JSON formatting. The
-# exact omfile output is the oracle.
+# sorted omfile output is the oracle: imdiag-injected messages may reach the
+# action queue in a different order under parallel CI, but every rendered
+# property line and duplicate count must match exactly.
 # Note that spifno1stsp emits only a conditional separator space, not the
 # original property value, so its expected output is intentionally just markers
 # around an inserted or suppressed space.
@@ -319,5 +321,9 @@ shape_app_name=shape3164notag
 shape_procid=-
 shape_msgid=-
 shape_rawmsg_after_pri=Aug 24 05:14:15 oddhost shape3164notag'
-cmp_exact
+expected_sorted="${RSYSLOG_DYNNAME}.expected.sorted"
+actual_sorted="${RSYSLOG_DYNNAME}.actual.sorted"
+printf '%s\n' "$EXPECTED" | LC_ALL=C $RS_SORTCMD > "$expected_sorted"
+LC_ALL=C $RS_SORTCMD "$RSYSLOG_OUT_LOG" > "$actual_sorted"
+cmp_exact_file "$expected_sorted" "$actual_sorted"
 exit_test


### PR DESCRIPTION
## Summary
- stabilize `template-property-transformations.sh` by sorting expected and actual output before exact comparison
- document that the oracle validates rendered property lines and duplicate counts, not inter-message scheduling order

## Rationale
OpenEuler retries on PR #7366 showed the same valid output blocks in a different order: the `shape3164` block could be written before the main transformation block. The test injects separate messages through imdiag and writes them to one omfile target, so cross-message ordering is not the behavior under test.

## Validation
- `bash -n tests/template-property-transformations.sh`
- `shellcheck -S warning tests/template-property-transformations.sh`
- `devtools/check-test-antipatterns.sh tests/template-property-transformations.sh` (only timestamp literal expected-output matches)
- `./tests/template-property-transformations.sh`
- 20x local stress loop of `./tests/template-property-transformations.sh`
- Focused Ubuntu 26.04 dev-container run:
  - `RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04`
  - `CI_MAKE_OPT=-j60`
  - `CI_MAKE_CHECK_OPT='-j10 TESTS=template-property-transformations.sh'`
  - `devtools/devcontainer.sh --rm devtools/run-ci.sh`
  - result: `PASS: template-property-transformations.sh`

## Local audit
- `devtools/local-validation-plan.sh` classified the diff as `test-shell-only` and recommended focused container validation.
- No test registration, Makefile, distribution, timing, port, or process-lifecycle behavior changed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

