### PR TITLE
testbench: preserve tcpflood marker counter

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -3311,13 +3311,18 @@ tcpflood_marker_is_valid() {
 }
 
 tcpflood_next_marker() {
-	local marker=""
+	local marker_var="${1:-}"
+	local marker_value=""
 	if [ -n "${RSYSLOG_DYNNAME:-}" ] && [ "${RSTB_NO_TCPFLOOD_MARKER:-}" != "YES" ]; then
 		TCPFLOOD_MARKER_ID=$(( ${TCPFLOOD_MARKER_ID:-0} + 1 ))
-		marker="${RSYSLOG_DYNNAME}.tcpflood.${TCPFLOOD_MARKER_ID}.proper-termination"
-		rm -f "$marker"
+		marker_value="${RSYSLOG_DYNNAME}.tcpflood.${TCPFLOOD_MARKER_ID}.proper-termination"
+		rm -f "$marker_value"
 	fi
-	printf '%s' "$marker"
+	if [ -n "$marker_var" ]; then
+		printf -v "$marker_var" '%s' "$marker_value"
+	else
+		printf '%s' "$marker_value"
+	fi
 }
 
 print_tcpflood_marker_file() {
@@ -3420,7 +3425,7 @@ tcpflood() {
 	else
 		check_only="no"
 	fi
-	marker="$(tcpflood_next_marker)"
+	tcpflood_next_marker marker
 	tcpflood_build_command "$marker" "$@"
 	"${TCPFLOOD_CMD[@]}"
 	res=$?
@@ -3454,7 +3459,7 @@ start_tcpflood_async() {
 	local marker
 	local -a TCPFLOOD_CMD
 	shift 2
-	marker="$(tcpflood_next_marker)"
+	tcpflood_next_marker marker
 	tcpflood_build_command "$marker" "$@"
 	"${TCPFLOOD_CMD[@]}" &
 	printf -v "$pid_var" '%s' "$!"


### PR DESCRIPTION
### Motivation
- Fix a testbench race where `tcpflood_next_marker` was invoked via command substitution so the `TCPFLOOD_MARKER_ID` increment happened only in a subshell and did not persist in the parent shell, causing marker reuse and test collisions.
- Ensure foreground and async `tcpflood` helpers get distinct proper-termination marker files so concurrent helper runs cannot satisfy the wrong completion oracle.

### Description
- Change `tcpflood_next_marker` to accept an optional caller variable name and assign the generated marker into the caller via `printf -v` while preserving the legacy stdout return path when no argument is passed.
- Replace command-substitution calls in `tcpflood()` and `start_tcpflood_async()` with `tcpflood_next_marker marker` so `TCPFLOOD_MARKER_ID` is incremented in the parent shell and the returned marker value is stable for subsequent checks.
- Keep the change minimal and localized to `tests/diag.sh` to avoid altering test semantics beyond marker allocation.

### Testing
- Ran `bash -n tests/diag.sh` to validate shell syntax and it passed successfully.
- Executed a focused shell probe using a fake `tcpflood` to verify sequential calls produce unique markers and that async and foreground helpers do not collide; the probe confirmed marker progression and correct parent-shell `TCPFLOOD_MARKER_ID` updates.
- Ran `shellcheck -S warning tests/diag.sh` and `devtools/check-test-antipatterns.sh tests/diag.sh` which completed with existing baseline warnings/advisories unrelated to this fix.
- Executed `./devtools/local-validation-plan.sh` but full PR-ready local container validation was not run because Docker/Podman and `cubic` were not available in the environment, so the change is not fully container-validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e796824f483329fe804dc47ddd0de)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

