### PR TITLE
doc: clarify JSON array rendering

### DIFF
--- a/doc/source/configuration/modules/mmjsonparse.rst
+++ b/doc/source/configuration/modules/mmjsonparse.rst
@@ -128,6 +128,9 @@ Check Parsing Result
 ====================
 
 Use the ``$parsesuccess`` variable to check whether JSON parsing succeeded.
+Parsed JSON arrays and objects are stored as JSON values in the message tree.
+When rendered later with ``format="jsonf"`` or a subtree template, arrays remain
+arrays and objects remain objects.
 
 .. code-block:: rsyslog
 
@@ -295,6 +298,31 @@ Permit parsing messages without cookie (do not require @cee:)
 
    action(type="mmjsonparse" cookie="")
 
+Render parsed arrays with JSONF
+-------------------------------
+
+Parsed arrays can be mapped into JSON output without converting them to
+strings:
+
+.. code-block:: rsyslog
+
+   module(load="mmjsonparse")
+
+   template(name="clickhouse" type="list" option.jsonf="on") {
+       property(outname="UrlCategories" name="$!mwgLog!urlc" format="jsonf")
+   }
+
+   ruleset(name="process-json") {
+       action(type="mmjsonparse" container="$!mwgLog" cookie="")
+       if $parsesuccess == "OK" then {
+           action(type="omfile" file="/var/log/rsyslog/clickhouse.json"
+                  template="clickhouse")
+       }
+   }
+
+If ``urlc`` is a JSON array in the parsed input, ``UrlCategories`` is emitted
+as a JSON array. There is no ``dataType="array"`` template conversion; parse
+JSON text first, then render the JSON value.
 
 Find-JSON mode for embedded JSON content
 ----------------------------------------
@@ -341,4 +369,3 @@ See also
    ../../reference/parameters/mmjsonparse-allow_trailing
    ../../reference/parameters/mmjsonparse-userawmsg
    ../../reference/parameters/mmjsonparse-container
-

--- a/doc/source/configuration/templates.rst
+++ b/doc/source/configuration/templates.rst
@@ -88,6 +88,19 @@ Modern pipelines should prefer structured JSON. The recommended method is:
 
 This ensures correct escaping and avoids handcrafted JSON concatenation.
 
+JSON arrays and objects with JSONF
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a property already contains a JSON value, for example one created by
+:ref:`mmjsonparse <ref-mmjsonparse>` or :doc:`parse_json()
+<../rainerscript/functions/rs-parse_json>`, ``format="jsonf"`` emits that
+value as JSON. Arrays remain arrays and objects remain objects.
+
+``dataType`` is only for converting scalar string properties to JSON strings,
+numbers, or booleans. It does not parse strings that look like JSON, and there
+is intentionally no ``dataType="array"``. Parse JSON text first, then render
+the resulting JSON value.
+
 Detailed examples are provided in the template type pages.
 
 

--- a/doc/source/rainerscript/functions/rs-parse_json.rst
+++ b/doc/source/rainerscript/functions/rs-parse_json.rst
@@ -26,5 +26,17 @@ The output is placed in variable $.ret
 
    set $.ret = parse_json("{ \"c1\":\"data\" }", "\$!parsed");
 
+Parsed arrays can be rendered directly with JSON-aware templates:
+
+.. code-block:: none
+
+   set $.ret = parse_json("[\"Content Server\", \"Internet Services\"]",
+                          "\$!url_categories");
+
+   template(name="out" type="list" option.jsonf="on") {
+       property(outname="UrlCategories" name="$!url_categories" format="jsonf")
+   }
+
+This emits ``UrlCategories`` as a JSON array, not as a quoted string.
 
 

--- a/doc/source/reference/templates/templates-statement-property.rst
+++ b/doc/source/reference/templates/templates-statement-property.rst
@@ -111,5 +111,13 @@ Parameters
   - ``auto`` – use number if integer, otherwise string
   - ``bool`` – emit ``true`` unless value is empty or ``0``
 
+  ``dataType`` does not create JSON arrays or objects from strings. If the
+  incoming message text contains JSON such as ``["a","b"]``, parse it first
+  with :ref:`mmjsonparse <ref-mmjsonparse>`. If an already extracted property
+  contains JSON text, parse that string with :doc:`parse_json()
+  <../../rainerscript/functions/rs-parse_json>`. Then render the parsed
+  property with ``format="jsonf"``. Rsyslog intentionally does not provide
+  ``dataType="array"`` for templates.
+
 - ``onEmpty`` – for ``jsonf`` format only; handling of empty values:
   ``keep``, ``skip``, or ``null``


### PR DESCRIPTION
## Summary

- clarify that parsed JSON arrays/objects render as JSON via `format="jsonf"`
- document that `dataType` is scalar-only and no `dataType="array"` conversion is planned
- add `parse_json()` and `mmjsonparse` examples for rendering parsed arrays

## Motivation

Follows the discussion around https://github.com/rsyslog/rsyslog/issues/4804: users can render JSON arrays once they are real JSON values in the message tree, but templates should not parse JSON-looking strings implicitly.

## Validation

- `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"` passed
- `git diff --check` passed
- `make -j16 json-formatter` and `make -C doc json-formatter` could not run in this unconfigured worktree because no generated Makefile target was available

## Notes

Sample configuration review: the added example does not open listeners or weaken authentication/TLS; it only renders parsed JSON to a local file path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

