### PR TITLE
ratelimit: remove per-source key hot-path overhead

### DIFF
--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -37,6 +37,12 @@ runtime_ratelimit:
     - perSourceMaxStates is enforced approximately through shard-local caps; values below the shard count keep one active state per shard, and per_source_evicted reports source-state evictions.
     - HUP snapshots named configs under shard read locks, then reloads policy files without holding registry locks.
 
+runtime_msg:
+  paths: ["runtime/msg.c", "runtime/msg.h"]
+  requires_serialization: true
+  notes:
+    - MsgGetRcvFromProp returns fromhost, fromhost-ip, or fromhost-port with the stored prop length; it resolves DNS only when NEEDS_DNSRESOL is still set.
+
 omfile:
   paths: ["plugins/omfile/"]
   requires_serialization: true

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -28,12 +28,15 @@ runtime_ratelimit:
     - type: mutex
       field: ratelimit_shared_t.per_source_policy_mut
     - type: mutex
+      field: ratelimit_shared_t.per_source_key_policy_mut
+    - type: mutex
       field: ratelimit_ps_bucket_t.mut
     - type: mutex
       field: ratelimit_t.mut
   notes:
     - Named ratelimit configs are stored in sharded hashtables; lookup and insertion lock only the shard selected by the config name.
     - Input per-source ratelimit state is stored in shard-local hashtables with embedded override data; message-time accounting locks only the source-key shard.
+    - Per-source key policy uses a versioned atomic snapshot of the template pointer and packed mode flags; readers retry across updates, and the key-policy mutex is only the no-atomics fallback.
     - perSourceMaxStates is enforced approximately through shard-local caps; values below the shard count keep one active state per shard, and per_source_evicted reports source-state evictions.
     - HUP snapshots named configs under shard read locks, then reloads policy files without holding registry locks.
 

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2431,6 +2431,40 @@ uchar *getRcvFrom(smsg_t *const pM) {
 }
 
 
+void MsgGetRcvFromProp(smsg_t *const pM, const propid_t propid, uchar **const ppsz, int *const plen) {
+    prop_t *pProp = NULL;
+
+    assert(ppsz != NULL);
+    assert(plen != NULL);
+
+    if (pM != NULL && (pM->msgFlags & NEEDS_DNSRESOL)) {
+        (void)resolveDNS(pM);
+    }
+    if (pM != NULL) {
+        switch (propid) {
+            case PROP_FROMHOST:
+                pProp = pM->rcvFrom.pRcvFrom;
+                break;
+            case PROP_FROMHOST_IP:
+                pProp = pM->pRcvFromIP;
+                break;
+            case PROP_FROMHOST_PORT:
+                pProp = pM->pRcvFromPort;
+                break;
+            default:
+                assert(0);
+                break;
+        }
+    }
+    if (pProp == NULL) {
+        *ppsz = UCHAR_CONSTANT("");
+        *plen = 0;
+    } else {
+        prop.GetString(pProp, ppsz, plen);
+    }
+}
+
+
 /* rgerhards 2004-11-24: set STRUCTURED DATA in msg object
  */
 rsRetVal MsgSetStructuredData(smsg_t *const pMsg, const char *pszStrucData) {
@@ -3722,13 +3756,13 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg,
             getInputName(pMsg, &pRes, &bufLen);
             break;
         case PROP_FROMHOST:
-            pRes = getRcvFrom(pMsg);
+            MsgGetRcvFromProp(pMsg, PROP_FROMHOST, &pRes, &bufLen);
             break;
         case PROP_FROMHOST_IP:
-            pRes = getRcvFromIP(pMsg);
+            MsgGetRcvFromProp(pMsg, PROP_FROMHOST_IP, &pRes, &bufLen);
             break;
         case PROP_FROMHOST_PORT:
-            pRes = getRcvFromPort(pMsg);
+            MsgGetRcvFromProp(pMsg, PROP_FROMHOST_PORT, &pRes, &bufLen);
             break;
         case PROP_PRI:
             pRes = (uchar *)getPRI(pMsg);

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2434,27 +2434,26 @@ uchar *getRcvFrom(smsg_t *const pM) {
 void MsgGetRcvFromProp(smsg_t *const pM, const propid_t propid, uchar **const ppsz, int *const plen) {
     prop_t *pProp = NULL;
 
+    assert(pM != NULL);
     assert(ppsz != NULL);
     assert(plen != NULL);
 
-    if (pM != NULL && (pM->msgFlags & NEEDS_DNSRESOL)) {
+    if (pM->msgFlags & NEEDS_DNSRESOL) {
         (void)resolveDNS(pM);
     }
-    if (pM != NULL) {
-        switch (propid) {
-            case PROP_FROMHOST:
-                pProp = pM->rcvFrom.pRcvFrom;
-                break;
-            case PROP_FROMHOST_IP:
-                pProp = pM->pRcvFromIP;
-                break;
-            case PROP_FROMHOST_PORT:
-                pProp = pM->pRcvFromPort;
-                break;
-            default:
-                assert(0);
-                break;
-        }
+    switch (propid) {
+        case PROP_FROMHOST:
+            pProp = pM->rcvFrom.pRcvFrom;
+            break;
+        case PROP_FROMHOST_IP:
+            pProp = pM->pRcvFromIP;
+            break;
+        case PROP_FROMHOST_PORT:
+            pProp = pM->pRcvFromPort;
+            break;
+        default:
+            assert(0);
+            break;
     }
     if (pProp == NULL) {
         *ppsz = UCHAR_CONSTANT("");

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -280,6 +280,7 @@ uchar *getProgramName(smsg_t *pM, sbool bLockMutex);
 uchar *getRcvFrom(smsg_t *pM);
 uchar *getRcvFromIP(smsg_t *pM);
 uchar *getRcvFromPort(smsg_t *pM);
+void MsgGetRcvFromProp(smsg_t *pM, propid_t propid, uchar **ppsz, int *plen);
 rsRetVal propNameToID(const uchar *pName, propid_t *pPropID);
 uchar *propIDToName(propid_t propID);
 rsRetVal ATTR_NONNULL() msgCheckVarExists(smsg_t *const pMsg, msgPropDescr_t *pProp);

--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -2610,29 +2610,17 @@ static void ratelimitPerSourceKeyCtxFree(per_source_key_ctx_t *ctx) {
     memset(ctx, 0, sizeof(*ctx));
 }
 
-static rsRetVal ratelimitGetMsgPropString(
+static rsRetVal ratelimitGetRcvFromString(
     smsg_t *pMsg, propid_t propid, const char **value, size_t *len, uchar **to_free) {
-    msgPropDescr_t prop;
-    rs_size_t prop_len = -1;
-    unsigned short must_be_freed = 0;
     uchar *prop_value;
+    int prop_len;
     DEFiRet;
 
     if (pMsg == NULL || value == NULL || len == NULL || to_free == NULL) ABORT_FINALIZE(RS_RET_PARAM_ERROR);
-    prop.id = propid;
-    prop.name = NULL;
-    prop.nameLen = 0;
-    prop_value = MsgGetProp(pMsg, NULL, &prop, &prop_len, &must_be_freed, NULL);
-    if (prop_value == NULL) {
-        *value = "";
-        *len = 0;
-        FINALIZE;
-    }
+    *to_free = NULL;
+    MsgGetRcvFromProp(pMsg, propid, &prop_value, &prop_len);
     *value = (const char *)prop_value;
-    *len = (prop_len < 0) ? strlen((const char *)prop_value) : (size_t)prop_len;
-    if (must_be_freed) {
-        *to_free = prop_value;
-    }
+    *len = (size_t)prop_len;
 
 finalize_it:
     RETiRet;
@@ -2680,19 +2668,19 @@ static rsRetVal ratelimitComputePerSourceKey(ratelimit_t *ratelimit, smsg_t *pMs
 
     switch (policy.key_mode) {
         case RL_PS_KEY_FROMHOST_IP:
-            CHKiRet(ratelimitGetMsgPropString(pMsg, PROP_FROMHOST_IP, &ctx->key, &ctx->key_len, &ctx->free_host));
+            CHKiRet(ratelimitGetRcvFromString(pMsg, PROP_FROMHOST_IP, &ctx->key, &ctx->key_len, &ctx->free_host));
             break;
         case RL_PS_KEY_FROMHOST:
-            CHKiRet(ratelimitGetMsgPropString(pMsg, PROP_FROMHOST, &ctx->key, &ctx->key_len, &ctx->free_host));
+            CHKiRet(ratelimitGetRcvFromString(pMsg, PROP_FROMHOST, &ctx->key, &ctx->key_len, &ctx->free_host));
             break;
         case RL_PS_KEY_FROMHOST_IP_PORT:
-            CHKiRet(ratelimitGetMsgPropString(pMsg, PROP_FROMHOST_IP, &host, &host_len, &ctx->free_host));
-            CHKiRet(ratelimitGetMsgPropString(pMsg, PROP_FROMHOST_PORT, &port, &port_len, &ctx->free_port));
+            CHKiRet(ratelimitGetRcvFromString(pMsg, PROP_FROMHOST_IP, &host, &host_len, &ctx->free_host));
+            CHKiRet(ratelimitGetRcvFromString(pMsg, PROP_FROMHOST_PORT, &port, &port_len, &ctx->free_port));
             CHKiRet(ratelimitComposePerSourceHostPort(ctx, host, host_len, port, port_len));
             break;
         case RL_PS_KEY_FROMHOST_PORT:
-            CHKiRet(ratelimitGetMsgPropString(pMsg, PROP_FROMHOST, &host, &host_len, &ctx->free_host));
-            CHKiRet(ratelimitGetMsgPropString(pMsg, PROP_FROMHOST_PORT, &port, &port_len, &ctx->free_port));
+            CHKiRet(ratelimitGetRcvFromString(pMsg, PROP_FROMHOST, &host, &host_len, &ctx->free_host));
+            CHKiRet(ratelimitGetRcvFromString(pMsg, PROP_FROMHOST_PORT, &port, &port_len, &ctx->free_port));
             CHKiRet(ratelimitComposePerSourceHostPort(ctx, host, host_len, port, port_len));
             break;
         case RL_PS_KEY_TPL:

--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -261,6 +261,7 @@ static void ratelimitFreeShared(void *ptr) {
     }
     free(shared->per_source_top_keys);
     free(shared->per_source_key_tpl_name);
+    pthread_mutex_destroy(&shared->per_source_key_policy_mut);
     pthread_mutex_destroy(&shared->per_source_policy_mut);
     free(shared->per_source_policy_file);
     ratelimitSharedRefsDestroy(shared);
@@ -315,9 +316,11 @@ void ratelimit_cfgsDestruct(ratelimit_cfgs_t *cfgs) {
  * Concurrency & Locking
  * - ratelimit_shared_t->mut guards shared policy updates for global limits.
  * - per-source limits use ratelimit_shared_t->per_source_policy_mut to guard
- *   low-frequency policy metadata and fallback atomics. Message-time source
- *   accounting is partitioned across ratelimit_shared_t->per_source_shards;
- *   each shard mutex guards that shard's hashtable, LRU list, and counters.
+ *   low-frequency policy metadata and fallback atomics. Versioned source-key
+ *   policy fields are atomically published; per_source_key_policy_mut is used
+ *   only as the no-atomics fallback. Message-time source accounting is
+ *   partitioned across ratelimit_shared_t->per_source_shards; each shard mutex
+ *   guards that shard's hashtable, LRU list, and counters.
  * - ratelimit_cfgs_t shards guard the named configuration registry. Config
  *   lookup and insertion lock only the shard selected by the config name.
  * - ratelimit_t->mut guards per-instance counters when thread-safe mode is enabled.
@@ -364,6 +367,17 @@ struct ratelimit_ps_policy_s {
 
 typedef struct ratelimit_ps_policy_s ratelimit_ps_policy_t;
 
+typedef struct ratelimit_ps_key_policy_s {
+    sbool key_tpl_default;
+    sbool key_needs_parsing;
+    enum ratelimit_ps_key_mode key_mode;
+    struct template *key_tpl;
+} ratelimit_ps_key_policy_t;
+
+#define RL_PS_KEY_POLICY_MODE_MASK 0xffU
+#define RL_PS_KEY_POLICY_TPL_DEFAULT (1U << 8)
+#define RL_PS_KEY_POLICY_NEEDS_PARSING (1U << 9)
+
 typedef struct ratelimit_policy_file_s {
     sbool has_scope;
     sbool has_output_mode;
@@ -395,6 +409,45 @@ static void ratelimitFreePerSourceOverrideDirect(void *ptr);
 static rsRetVal ratelimitReloadPolicyFile(ratelimit_shared_t *shared, const char *trigger);
 static rsRetVal ratelimitReloadPerSourcePolicyFile(ratelimit_shared_t *shared, const char *trigger);
 static rsRetVal ratelimitRegisterWatchTargets(ratelimit_shared_t *shared);
+
+/* The caller serializes publishers with per_source_policy_mut. The odd/even
+ * sequence lets readers reject fields observed across an update. */
+static void ratelimitPublishPerSourceKeyPolicy(ratelimit_shared_t *shared,
+                                               struct template *key_tpl,
+                                               const sbool key_tpl_default) {
+    const enum ratelimit_ps_key_mode key_mode = perSourceKeyModeFromTemplate(key_tpl);
+    unsigned int bits = (unsigned int)key_mode;
+
+    if (key_tpl_default) bits |= RL_PS_KEY_POLICY_TPL_DEFAULT;
+    if (key_mode == RL_PS_KEY_TPL) bits |= RL_PS_KEY_POLICY_NEEDS_PARSING;
+
+    ATOMIC_INC(&shared->per_source_key_policy_seq, &shared->per_source_key_policy_mut);
+    ATOMIC_STORE_PTR((void **)&shared->per_source_key_tpl, &shared->per_source_key_policy_mut, key_tpl);
+    ATOMIC_STORE_32BIT_unsigned(&shared->per_source_key_policy_bits, &shared->per_source_key_policy_mut, bits);
+    ATOMIC_INC(&shared->per_source_key_policy_seq, &shared->per_source_key_policy_mut);
+}
+
+static void ratelimitLoadPerSourceKeyPolicy(ratelimit_shared_t *shared, ratelimit_ps_key_policy_t *policy) {
+    unsigned int seq_before;
+    unsigned int seq_after;
+    unsigned int bits;
+    struct template *key_tpl;
+
+    for (;;) {
+        seq_before = ATOMIC_LOAD_32BIT_unsigned(&shared->per_source_key_policy_seq, &shared->per_source_key_policy_mut);
+        if (seq_before & 1U) continue;
+        bits = ATOMIC_LOAD_32BIT_unsigned(&shared->per_source_key_policy_bits, &shared->per_source_key_policy_mut);
+        key_tpl = (struct template *)ATOMIC_LOAD_PTR((void **)&shared->per_source_key_tpl,
+                                                     &shared->per_source_key_policy_mut);
+        seq_after = ATOMIC_LOAD_32BIT_unsigned(&shared->per_source_key_policy_seq, &shared->per_source_key_policy_mut);
+        if (seq_before == seq_after && !(seq_after & 1U)) break;
+    }
+
+    policy->key_mode = (enum ratelimit_ps_key_mode)(bits & RL_PS_KEY_POLICY_MODE_MASK);
+    policy->key_tpl_default = (bits & RL_PS_KEY_POLICY_TPL_DEFAULT) != 0;
+    policy->key_needs_parsing = (bits & RL_PS_KEY_POLICY_NEEDS_PARSING) != 0;
+    policy->key_tpl = key_tpl;
+}
 
 static rsRetVal parseDurationMillis(const char *value, unsigned int *out) {
     char *end = NULL;
@@ -1581,11 +1634,7 @@ static rsRetVal ratelimitInitPerSourceShared(ratelimit_shared_t *shared,
     if (shared->per_source_policy_file == NULL) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
     ratelimitSharedStoreUInt(&shared->per_source_default_max, &shared->mut, policy->default_max);
     ratelimitSharedStoreUInt(&shared->per_source_default_window, &shared->mut, policy->default_window);
-    shared->per_source_key_tpl_default = 0;
     shared->per_source_key_tpl_name = NULL;
-    shared->per_source_key_tpl = NULL;
-    shared->per_source_key_needs_parsing = 1;
-    shared->per_source_key_mode = RL_PS_KEY_TPL;
     shared->per_source_topn = (topn == 0) ? RATELIMIT_PERSOURCE_DEFAULT_TOPN : topn;
     pthread_mutex_unlock(&shared->per_source_policy_mut);
     bLocked = 0;
@@ -1692,7 +1741,6 @@ static rsRetVal ratelimitApplyPolicyPerSource(ratelimit_shared_t *shared,
     char *key_tpl_name = NULL;
     char *new_policy_file = NULL;
     unsigned int effective_topn;
-    enum ratelimit_ps_key_mode key_mode;
     sbool have_per_source_policy_file;
     sbool have_per_source_shards;
     DEFiRet;
@@ -1730,8 +1778,6 @@ static rsRetVal ratelimitApplyPolicyPerSource(ratelimit_shared_t *shared,
             CHKmalloc(new_policy_file = strdup(policy_file));
         }
     }
-    key_mode = perSourceKeyModeFromTemplate(key_tpl);
-
     pthread_mutex_lock(&shared->per_source_policy_mut);
     if (shared->per_source_policy_file == NULL && new_policy_file != NULL) {
         shared->per_source_policy_file = new_policy_file;
@@ -1740,10 +1786,6 @@ static rsRetVal ratelimitApplyPolicyPerSource(ratelimit_shared_t *shared,
     free(shared->per_source_key_tpl_name);
     shared->per_source_key_tpl_name = key_tpl_name;
     key_tpl_name = NULL;
-    shared->per_source_key_tpl = key_tpl;
-    shared->per_source_key_tpl_default = key_tpl_default;
-    shared->per_source_key_mode = key_mode;
-    shared->per_source_key_needs_parsing = (shared->per_source_key_mode == RL_PS_KEY_TPL);
     shared->per_source_policy_from_policy_file = 1;
     ratelimitSetPerSourceShardCaps(shared, policy->per_source_max_states);
     effective_topn = (policy->per_source_topn == 0) ? RATELIMIT_PERSOURCE_DEFAULT_TOPN : policy->per_source_topn;
@@ -1753,6 +1795,7 @@ static rsRetVal ratelimitApplyPolicyPerSource(ratelimit_shared_t *shared,
         pthread_mutex_lock(&shared->per_source_policy_mut);
         shared->per_source_topn = effective_topn;
     }
+    ratelimitPublishPerSourceKeyPolicy(shared, key_tpl, key_tpl_default);
     pthread_mutex_unlock(&shared->per_source_policy_mut);
     ratelimitPerSourceStoreEnabled(&shared->per_source_enabled, &shared->per_source_policy_mut, 1);
 
@@ -2001,6 +2044,8 @@ rsRetVal ratelimitAddConfig(rsconf_t *conf,
     DEFiRet;
     ratelimit_shared_t *shared = NULL;
     ratelimit_shared_t *existing_shared = NULL;
+    struct template *per_source_key_tpl = NULL;
+    sbool per_source_key_tpl_default = 0;
     char *key = NULL;
     ratelimit_ps_policy_t *per_source_policy = NULL;
     ratelimit_policy_file_t file_policy = {0};
@@ -2122,6 +2167,7 @@ rsRetVal ratelimitAddConfig(rsconf_t *conf,
     ratelimitSharedRefsInit(shared, 1);
     pthread_mutex_init(&shared->mut, NULL);
     pthread_mutex_init(&shared->per_source_policy_mut, NULL);
+    pthread_mutex_init(&shared->per_source_key_policy_mut, NULL);
     CHKmalloc(key = strdup(name));
     shared->name = key;
     shared->scope = scope;
@@ -2140,8 +2186,8 @@ rsRetVal ratelimitAddConfig(rsconf_t *conf,
         free(per_source_policy);
         per_source_policy = NULL;
         CHKiRet(iRet);
-        if (ratelimitLookupPerSourceTemplate(conf, per_source_key_tpl_name, &shared->per_source_key_tpl,
-                                             &shared->per_source_key_tpl_default) != RS_RET_OK) {
+        if (ratelimitLookupPerSourceTemplate(conf, per_source_key_tpl_name, &per_source_key_tpl,
+                                             &per_source_key_tpl_default) != RS_RET_OK) {
             if (per_source_key_tpl_name != NULL) {
                 LogError(0, RS_RET_CONFIG_ERROR, "ratelimit: perSourceKeyTpl '%s' not found for '%s'",
                          per_source_key_tpl_name, name);
@@ -2158,8 +2204,7 @@ rsRetVal ratelimitAddConfig(rsconf_t *conf,
         }
         pthread_mutex_lock(&shared->per_source_policy_mut);
         shared->per_source_policy_from_policy_file = per_source_from_policy_file;
-        shared->per_source_key_mode = perSourceKeyModeFromTemplate(shared->per_source_key_tpl);
-        shared->per_source_key_needs_parsing = (shared->per_source_key_mode == RL_PS_KEY_TPL);
+        ratelimitPublishPerSourceKeyPolicy(shared, per_source_key_tpl, per_source_key_tpl_default);
         pthread_mutex_unlock(&shared->per_source_policy_mut);
         ratelimitPerSourceStoreEnabled(&shared->per_source_enabled, &shared->per_source_policy_mut, 1);
     }
@@ -2199,6 +2244,7 @@ finalize_it:
         }
         free(shared->per_source_top_keys);
         free(shared->per_source_key_tpl_name);
+        pthread_mutex_destroy(&shared->per_source_key_policy_mut);
         pthread_mutex_destroy(&shared->per_source_policy_mut);
         free(shared->per_source_policy_file);
         pthread_mutex_destroy(&shared->mut);
@@ -2255,6 +2301,7 @@ rsRetVal ratelimitNewFromConfigForScope(ratelimit_t **ppThis,
     if ((*ppThis)->bOwnsShared) {
         pthread_mutex_destroy(&(*ppThis)->pShared->mut);
         ratelimitDestroyPerSourceShards((*ppThis)->pShared);
+        pthread_mutex_destroy(&(*ppThis)->pShared->per_source_key_policy_mut);
         pthread_mutex_destroy(&(*ppThis)->pShared->per_source_policy_mut);
         free((*ppThis)->pShared);
     }
@@ -2593,14 +2640,6 @@ typedef struct per_source_key_ctx_s {
     uchar *free_port;
 } per_source_key_ctx_t;
 
-typedef struct per_source_key_policy_s {
-    sbool enabled;
-    sbool key_tpl_default;
-    sbool key_needs_parsing;
-    enum ratelimit_ps_key_mode key_mode;
-    struct template *key_tpl;
-} per_source_key_policy_t;
-
 static void ratelimitPerSourceKeyCtxFree(per_source_key_ctx_t *ctx) {
     if (ctx == NULL) return;
     free(ctx->tpl_param.param);
@@ -2645,7 +2684,7 @@ finalize_it:
 
 static rsRetVal ratelimitComputePerSourceKey(ratelimit_t *ratelimit, smsg_t *pMsg, per_source_key_ctx_t *ctx) {
     ratelimit_shared_t *shared;
-    per_source_key_policy_t policy;
+    ratelimit_ps_key_policy_t policy;
     const char *host = "";
     const char *port = "";
     size_t host_len = 0;
@@ -2656,15 +2695,8 @@ static rsRetVal ratelimitComputePerSourceKey(ratelimit_t *ratelimit, smsg_t *pMs
         ABORT_FINALIZE(RS_RET_PARAM_ERROR);
     memset(ctx, 0, sizeof(*ctx));
     shared = ratelimit->pShared;
-    policy.enabled = ratelimitPerSourceLoadEnabled(&shared->per_source_enabled, &shared->per_source_policy_mut);
-    if (!policy.enabled) FINALIZE;
-
-    pthread_mutex_lock(&shared->per_source_policy_mut);
-    policy.key_tpl_default = shared->per_source_key_tpl_default;
-    policy.key_needs_parsing = shared->per_source_key_needs_parsing;
-    policy.key_mode = shared->per_source_key_mode;
-    policy.key_tpl = shared->per_source_key_tpl;
-    pthread_mutex_unlock(&shared->per_source_policy_mut);
+    if (!ratelimitPerSourceLoadEnabled(&shared->per_source_enabled, &shared->per_source_policy_mut)) FINALIZE;
+    ratelimitLoadPerSourceKeyPolicy(shared, &policy);
 
     switch (policy.key_mode) {
         case RL_PS_KEY_FROMHOST_IP:
@@ -2816,6 +2848,7 @@ rsRetVal ratelimitNew(ratelimit_t **ppThis, const char *modname, const char *dyn
     pThis->pShared->output_mode = RATELIMIT_OUTPUT_MODE_DROP;
     pthread_mutex_init(&pThis->pShared->mut, NULL);
     pthread_mutex_init(&pThis->pShared->per_source_policy_mut, NULL);
+    pthread_mutex_init(&pThis->pShared->per_source_key_policy_mut, NULL);
 
     DBGPRINTF("ratelimit:%s:new ratelimiter\n", pThis->name);
     *ppThis = pThis;
@@ -2884,6 +2917,7 @@ void ratelimitDestruct(ratelimit_t *ratelimit) {
     if (ratelimit->bOwnsShared && ratelimit->pShared != NULL) {
         pthread_mutex_destroy(&ratelimit->pShared->mut);
         ratelimitDestroyPerSourceShards(ratelimit->pShared);
+        pthread_mutex_destroy(&ratelimit->pShared->per_source_key_policy_mut);
         pthread_mutex_destroy(&ratelimit->pShared->per_source_policy_mut);
         free(ratelimit->pShared);
     } else if (ratelimit->pShared != NULL) {

--- a/runtime/ratelimit.h
+++ b/runtime/ratelimit.h
@@ -43,6 +43,14 @@ typedef struct ratelimit_ps_bucket_s {
     pthread_mutex_t mut;
 } ratelimit_ps_bucket_t;
 
+enum ratelimit_ps_key_mode {
+    RL_PS_KEY_TPL = 0,
+    RL_PS_KEY_FROMHOST_IP,
+    RL_PS_KEY_FROMHOST,
+    RL_PS_KEY_FROMHOST_IP_PORT,
+    RL_PS_KEY_FROMHOST_PORT
+};
+
 typedef enum ratelimit_scope_e { RATELIMIT_SCOPE_INPUT = 0, RATELIMIT_SCOPE_OUTPUT } ratelimit_scope_t;
 
 typedef enum ratelimit_output_mode_e {
@@ -75,17 +83,11 @@ typedef struct ratelimit_shared_s {
     unsigned int per_source_default_window;
     unsigned int per_source_max_states;
     unsigned int per_source_topn;
-    sbool per_source_key_tpl_default;
     char *per_source_key_tpl_name;
+    unsigned int per_source_key_policy_seq;
+    unsigned int per_source_key_policy_bits;
     struct template *per_source_key_tpl;
-    sbool per_source_key_needs_parsing;
-    enum ratelimit_ps_key_mode {
-        RL_PS_KEY_TPL = 0,
-        RL_PS_KEY_FROMHOST_IP,
-        RL_PS_KEY_FROMHOST,
-        RL_PS_KEY_FROMHOST_IP_PORT,
-        RL_PS_KEY_FROMHOST_PORT
-    } per_source_key_mode;
+    pthread_mutex_t per_source_key_policy_mut;
     pthread_mutex_t per_source_policy_mut;
     ratelimit_ps_bucket_t per_source_shards[RATELIMIT_PERSOURCE_SHARDS];
     sbool per_source_shards_initialized;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -876,6 +876,7 @@ TESTS_IMTCP_YAML = \
 	ratelimit-legacy-persource-discard.sh \
 	ratelimit-persource-shard-eviction.sh \
 	ratelimit-persource-repeat-summary.sh \
+	ratelimit-policy-persource-key-reload.sh \
 	ratelimit-policy-persource-topn-default-reload.sh \
 	ratelimit-policy-persource-mixed-invalid.sh
 

--- a/tests/ratelimit-policy-persource-key-reload.sh
+++ b/tests/ratelimit-policy-persource-key-reload.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+## HUP reload must atomically replace the per-source key policy while input
+## workers are active. The oracle first observes one allowance for each of two
+## hostname keys, then reloads to fromhost-ip and observes one shared allowance
+## for two new hostnames arriving from the same TCP peer address.
+
+. ${srcdir:=.}/diag.sh init
+
+export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.tcp_port"
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+export POLICY_FILE
+INPUT_FILE="$(pwd)/${RSYSLOG_DYNNAME}.input"
+export INPUT_FILE
+
+write_policy() {
+    local key_template="$1"
+    cat > "$POLICY_FILE" <<EOF
+perSource:
+  enabled: true
+  keyTemplate: "$key_template"
+  default:
+    max: 1
+    window: 30s
+EOF
+}
+
+send_host_messages() {
+    local host="$1"
+    local count="$2"
+    : > "$INPUT_FILE"
+    for i in $(seq 1 "$count"); do
+        echo "<13>Jan 1 00:00:00 $host app: msgnum:$host:$i" >> "$INPUT_FILE"
+    done
+    tcpflood -p"$PORT_RCVR" -I "$INPUT_FILE"
+}
+
+write_policy "PerSourceHostname"
+
+generate_conf
+add_conf '
+template(name="PerSourceHostname" type="string" string="%hostname%")
+template(name="PerSourceAddress" type="string" string="%fromhost-ip%")
+ratelimit(name="key_reload" policy="'$POLICY_FILE'")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'"
+      ratelimit.name="key_reload")
+
+template(name="outfmt" type="string" string="%msg%\n")
+if $msg contains "msgnum:" then
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
+
+send_host_messages alpha 2
+send_host_messages beta 2
+wait_file_lines "$RSYSLOG_OUT_LOG" 2 100
+
+write_policy "PerSourceAddress"
+issue_HUP
+
+send_host_messages gamma 2
+send_host_messages delta 2
+wait_queueempty
+
+shutdown_when_empty
+wait_shutdown
+
+content_count=$(grep -c "msgnum:" "$RSYSLOG_OUT_LOG" || true)
+if [ "$content_count" -ne 3 ]; then
+    echo "FAIL: expected two hostname allowances and one shared address allowance, got $content_count"
+    cat "$RSYSLOG_OUT_LOG"
+    error_exit 1
+fi
+content_check "msgnum:alpha:1" "$RSYSLOG_OUT_LOG"
+content_check "msgnum:beta:1" "$RSYSLOG_OUT_LOG"
+content_check "msgnum:gamma:1" "$RSYSLOG_OUT_LOG"
+check_not_present "msgnum:delta:" "$RSYSLOG_OUT_LOG"
+
+exit_test


### PR DESCRIPTION
## Summary

- add a length-aware source-property fast path for `fromhost`, `fromhost-ip`, and `fromhost-port`
- replace the per-message per-source key-policy mutex read with a versioned atomic snapshot
- retain mutex-backed correctness for builds without atomic support
- add HUP coverage for changing the per-source key template from hostname to source IP

## Why

Highly parallel inputs such as imtcp and imptcp should not serialize every message on configuration-wide key-policy metadata that changes only during policy reload.

## Validation

- C formatting check passed
- `doc/ai/module_map.yaml` parses successfully
- atomic and no-atomics host builds passed
- focused tests passed:
  - `ratelimit-policy-persource-key-reload.sh`
  - `imtcp-persource-ratelimit.sh`
  - `imptcp-persource-ratelimit-policy.sh`
  - `imudp-persource-ratelimit-policy.sh`
  - `ratelimit-policy-persource-topn-default-reload.sh`
- mock distcheck passed
- Ubuntu 26.04 clang static analyzer: no bugs found
- local Cubic findings were reviewed: the test-registration finding was false because `TESTS_IMTCP_YAML` is registered under the imtcp/libyaml gates; the docs-workflow finding was outside this branch

The broad Ubuntu 26.04 container suite reached and passed the ratelimit tests but did not reach its final summary before the local command cap; its immediate rerun was interrupted at user request so hosted CI can complete the gate. This PR is therefore **not fully container-validated locally**.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

