### PR TITLE
imbeats: harden Lumberjack input resource handling

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -232,15 +232,19 @@ EXTRA_DIST = \
     source/configuration/modules/mmutf8fix.rst \
     source/configuration/modules/module_workflow.png \
     source/reference/parameters/imbeats-address.rst \
+    source/reference/parameters/imbeats-frametimeout.rst \
     source/reference/parameters/imbeats-gnutlsprioritystring.rst \
+    source/reference/parameters/imbeats-idletimeout.rst \
     source/reference/parameters/imbeats-keepalive.rst \
     source/reference/parameters/imbeats-keepalive-interval.rst \
     source/reference/parameters/imbeats-keepalive-probes.rst \
     source/reference/parameters/imbeats-keepalive-time.rst \
     source/reference/parameters/imbeats-listenportfilename.rst \
     source/reference/parameters/imbeats-maxbatchbytes.rst \
+    source/reference/parameters/imbeats-maxcompressionratio.rst \
     source/reference/parameters/imbeats-maxdecompressedsize.rst \
     source/reference/parameters/imbeats-maxframesize.rst \
+    source/reference/parameters/imbeats-maxinflightbytes.rst \
     source/reference/parameters/imbeats-maxsessions.rst \
     source/reference/parameters/imbeats-maxwindowsize.rst \
     source/reference/parameters/imbeats-name.rst \
@@ -262,6 +266,7 @@ EXTRA_DIST = \
     source/reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst \
     source/reference/parameters/imbeats-streamdriver-tlsverifydepth.rst \
     source/reference/parameters/imbeats-workerthreads.rst \
+    source/reference/parameters/imbeats-windowtimeout.rst \
     source/configuration/modules/omamqp1.rst \
     source/configuration/modules/omazuredce.rst \
     source/configuration/modules/omawslogshlc.rst \

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -163,6 +163,11 @@ imbeats:
     - Use Elastic Agent or Filebeat output.logstash to send Lumberjack v2 traffic to imbeats.
     - Concurrent Beats sessions are bounded per listener with maxSessions and processed through the listener worker/multiplexing path.
     - Use starvationProtection.maxReads to keep one busy sender from monopolizing imbeats worker time.
+    - maxInFlightBytes accounts incomplete receive buffers, inflate scratch space, event copies, and lazy window descriptors exactly across each input instance.
+    - maxCompressionRatio and maxDecompressedSize jointly bound compressed-frame expansion.
+    - idleTimeout closes sessions with no byte progress; frameTimeout bounds one frame and windowTimeout bounds one advertised window with absolute deadlines that trickle traffic cannot extend. These network deadlines pause while a complete batch is submitted and resume for its ACK. A value of 0 disables the corresponding timeout.
+    - JSON event payloads must be exactly one object, apart from surrounding whitespace. Malformed, non-object, trailing-content, resource-limited, or timed-out traffic is not acknowledged.
+    - Valid Lumberjack v2 W, J, and C flows retain cumulative A acknowledgement behavior.
     - TLS deployments require an installed rsyslog TLS stream-driver package or module, such as rsyslog-gnutls or rsyslog-openssl.
     - The common Elastic Agent TLS setup validates the rsyslog server certificate but does not present a client certificate; use streamDriver.authMode=anon for that pattern and stricter auth modes only with sender client certificates.
     - Compressed Lumberjack v2 frames are supported and should be tested with Beats compression enabled.

--- a/doc/source/configuration/modules/imbeats.rst
+++ b/doc/source/configuration/modules/imbeats.rst
@@ -47,6 +47,10 @@ common Elasticsearch-oriented pipelines:
 - transport and protocol metadata is stored under ``$!metadata!imbeats``
 - listener-side size limits reject oversized windows, frames, batches, and
   compressed payload expansion before unbounded allocation
+- instance-wide accounting bounds memory held by incomplete sessions, inflate
+  scratch space, event copies, and window descriptors
+- idle, absolute frame, and absolute window deadlines release sessions that
+  stop making progress or retain incomplete protocol state for too long
 - listener-side session limits and worker settings bound concurrent sender
   fan-in and provide fairness between active sessions
 
@@ -145,6 +149,23 @@ Troubleshooting Elastic Agent delivery
   failures.
 
 
+Protocol validation and acknowledgements
+========================================
+
+Each Lumberjack ``J`` frame payload must contain exactly one complete JSON
+object. Leading and trailing JSON whitespace is accepted. Malformed JSON,
+arrays, scalar values, concatenated values, and any trailing non-whitespace
+bytes are rejected. The original accepted JSON text remains available in
+``msg``, while the decoded object fields are mapped into ``$!``.
+
+Malformed frames, resource-limit violations, decompression-limit violations,
+and session, frame, or window timeouts fail closed. ``imbeats`` closes the affected
+session, releases its charged resources, and does not acknowledge the
+incomplete batch. Lumberjack v2 ``W``, ``J``, and ``C`` traffic retains normal
+cumulative ``A`` acknowledgement behavior when it remains within the
+configured size, resource, compression, and timeout limits.
+
+
 Configuration Parameters
 ========================
 
@@ -168,8 +189,18 @@ Input Parameters
         :start-after: .. summary-start
         :end-before: .. summary-end
 
+   * - :ref:`param-imbeats-frametimeout`
+     - .. include:: ../../reference/parameters/imbeats-frametimeout.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
    * - :ref:`param-imbeats-gnutlsprioritystring`
      - .. include:: ../../reference/parameters/imbeats-gnutlsprioritystring.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-idletimeout`
+     - .. include:: ../../reference/parameters/imbeats-idletimeout.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
 
@@ -208,6 +239,11 @@ Input Parameters
         :start-after: .. summary-start
         :end-before: .. summary-end
 
+   * - :ref:`param-imbeats-maxcompressionratio`
+     - .. include:: ../../reference/parameters/imbeats-maxcompressionratio.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
    * - :ref:`param-imbeats-maxdecompressedsize`
      - .. include:: ../../reference/parameters/imbeats-maxdecompressedsize.rst
         :start-after: .. summary-start
@@ -215,6 +251,11 @@ Input Parameters
 
    * - :ref:`param-imbeats-maxframesize`
      - .. include:: ../../reference/parameters/imbeats-maxframesize.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-maxinflightbytes`
+     - .. include:: ../../reference/parameters/imbeats-maxinflightbytes.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
 
@@ -318,6 +359,11 @@ Input Parameters
         :start-after: .. summary-start
         :end-before: .. summary-end
 
+   * - :ref:`param-imbeats-windowtimeout`
+     - .. include:: ../../reference/parameters/imbeats-windowtimeout.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
 
 Examples
 ========
@@ -332,6 +378,11 @@ RainerScript
    input(type="imbeats"
          port="5044"
          ruleset="beats_to_es"
+         maxInFlightBytes="268435456"
+         maxCompressionRatio="256"
+         idleTimeout="60"
+         frameTimeout="30"
+         windowTimeout="300"
          streamdriver.name="gtls"
          streamdriver.mode="1"
          streamdriver.authmode="anon"
@@ -356,6 +407,11 @@ YAML
      - type: imbeats
        port: "5044"
        ruleset: beats_to_es
+       maxInFlightBytes: 268435456
+       maxCompressionRatio: 256
+       idleTimeout: 60
+       frameTimeout: 30
+       windowTimeout: 300
        streamdriver.name: gtls
        streamdriver.mode: 1
        streamdriver.authmode: anon
@@ -385,21 +441,34 @@ The module exposes these ``impstats`` counters:
 - ``compressed_frames``
 - ``json_decode_failures``
 - ``ack_failures``
+- ``windows.rejected``
+- ``frames.rejected``
+- ``compressed.rejected``
+- ``connections.active``
+- ``connections.rejected``
+- ``starvation_protect``
+- ``resource_bytes`` (current bytes charged to the instance resource budget)
+- ``resource_rejected``
+- ``sessions.timed_out``
 
 
 .. toctree::
    :hidden:
 
    ../../reference/parameters/imbeats-address
+   ../../reference/parameters/imbeats-frametimeout
    ../../reference/parameters/imbeats-gnutlsprioritystring
+   ../../reference/parameters/imbeats-idletimeout
    ../../reference/parameters/imbeats-keepalive
    ../../reference/parameters/imbeats-keepalive-interval
    ../../reference/parameters/imbeats-keepalive-probes
    ../../reference/parameters/imbeats-keepalive-time
    ../../reference/parameters/imbeats-listenportfilename
    ../../reference/parameters/imbeats-maxbatchbytes
+   ../../reference/parameters/imbeats-maxcompressionratio
    ../../reference/parameters/imbeats-maxdecompressedsize
    ../../reference/parameters/imbeats-maxframesize
+   ../../reference/parameters/imbeats-maxinflightbytes
    ../../reference/parameters/imbeats-maxsessions
    ../../reference/parameters/imbeats-maxwindowsize
    ../../reference/parameters/imbeats-name
@@ -421,3 +490,4 @@ The module exposes these ``impstats`` counters:
    ../../reference/parameters/imbeats-streamdriver-tlsrevocationcheck
    ../../reference/parameters/imbeats-streamdriver-tlsverifydepth
    ../../reference/parameters/imbeats-workerthreads
+   ../../reference/parameters/imbeats-windowtimeout

--- a/doc/source/reference/parameters/imbeats-frametimeout.rst
+++ b/doc/source/reference/parameters/imbeats-frametimeout.rst
@@ -1,0 +1,64 @@
+.. _param-imbeats-frametimeout:
+.. _imbeats.parameter.input.frametimeout:
+
+frameTimeout
+============
+
+.. meta::
+   :description: Absolute deadline for completing an in-progress imbeats Lumberjack frame read.
+   :keywords: rsyslog, imbeats, frameTimeout, frame deadline, Lumberjack
+
+.. index::
+   single: imbeats; frameTimeout
+   single: frameTimeout
+
+.. summary-start
+
+Set an absolute deadline for completing an in-progress Lumberjack frame read.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: frameTimeout
+:Scope: input
+:Type: nonnegative integer
+:Default: input=30
+:Required?: no
+:Introduced: 8.2608.0
+
+Description
+-----------
+Set the maximum number of seconds allowed to complete an in-progress
+Lumberjack frame read. The deadline is absolute: receiving additional bytes
+does not extend it. This prevents a client from retaining frame state
+indefinitely by sending a slow trickle of data.
+
+When the deadline expires, ``imbeats`` closes the session and does not
+acknowledge the incomplete batch. The value ``0`` disables the frame timeout.
+The independent :ref:`param-imbeats-idletimeout` may still close a session that
+makes no byte progress.
+
+Input usage
+-----------
+.. _param-imbeats-input-frametimeout:
+.. _imbeats.parameter.input.frametimeout-usage:
+
+RainerScript:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" frameTimeout="30")
+
+YAML:
+
+.. code-block:: yaml
+
+   inputs:
+     - type: imbeats
+       port: 5044
+       frameTimeout: 30
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-idletimeout.rst
+++ b/doc/source/reference/parameters/imbeats-idletimeout.rst
@@ -1,0 +1,67 @@
+.. _param-imbeats-idletimeout:
+.. _imbeats.parameter.input.idletimeout:
+
+idleTimeout
+===========
+
+.. meta::
+   :description: Close imbeats sessions that make no byte progress for a configured interval.
+   :keywords: rsyslog, imbeats, idleTimeout, session timeout, Lumberjack
+
+.. index::
+   single: imbeats; idleTimeout
+   single: idleTimeout
+
+.. summary-start
+
+Close an imbeats session when it makes no byte progress for the configured time.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: idleTimeout
+:Scope: input
+:Type: nonnegative integer
+:Default: input=60
+:Required?: no
+:Introduced: 8.2608.0
+
+Description
+-----------
+Set the maximum number of seconds that a client session may remain connected
+without receiving any new bytes. When the timeout expires, ``imbeats`` closes
+the session and does not acknowledge any incomplete batch. The value ``0``
+disables the idle timeout.
+
+This progress-based timeout applies even when the session has not started a
+Lumberjack frame. It pauses while a complete, validated batch is submitted to
+rsyslog and resumes when ``imbeats`` prepares the acknowledgement, so slow
+local processing cannot turn a successfully submitted batch into an
+unacknowledged retransmission. The resumed interval also bounds a client that
+stops reading its acknowledgement. Use :ref:`param-imbeats-frametimeout` to
+place an absolute deadline on a partially received frame.
+
+Input usage
+-----------
+.. _param-imbeats-input-idletimeout:
+.. _imbeats.parameter.input.idletimeout-usage:
+
+RainerScript:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" idleTimeout="60")
+
+YAML:
+
+.. code-block:: yaml
+
+   inputs:
+     - type: imbeats
+       port: 5044
+       idleTimeout: 60
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-maxcompressionratio.rst
+++ b/doc/source/reference/parameters/imbeats-maxcompressionratio.rst
@@ -1,0 +1,64 @@
+.. _param-imbeats-maxcompressionratio:
+.. _imbeats.parameter.input.maxcompressionratio:
+
+maxCompressionRatio
+===================
+
+.. meta::
+   :description: Maximum decompression ratio accepted for imbeats Lumberjack compressed frames.
+   :keywords: rsyslog, imbeats, maxCompressionRatio, compression ratio, Lumberjack
+
+.. index::
+   single: imbeats; maxCompressionRatio
+   single: maxCompressionRatio
+
+.. summary-start
+
+Limit how many output bytes a Lumberjack compressed frame may produce per input byte.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: maxCompressionRatio
+:Scope: input
+:Type: positive integer
+:Default: input=256
+:Required?: no
+:Introduced: 8.2608.0
+
+Description
+-----------
+Set the maximum permitted ratio of decompressed bytes to compressed input
+bytes. The valid range is ``1`` to ``1000000``. A compressed frame is rejected
+as soon as its decompressed output would exceed the compressed input size
+multiplied by this value.
+
+This ratio limit is enforced together with
+:ref:`param-imbeats-maxdecompressedsize` and
+:ref:`param-imbeats-maxinflightbytes`. A frame must satisfy all applicable
+limits and is not acknowledged when any limit is exceeded.
+
+Input usage
+-----------
+.. _param-imbeats-input-maxcompressionratio:
+.. _imbeats.parameter.input.maxcompressionratio-usage:
+
+RainerScript:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" maxCompressionRatio="256")
+
+YAML:
+
+.. code-block:: yaml
+
+   inputs:
+     - type: imbeats
+       port: 5044
+       maxCompressionRatio: 256
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-maxinflightbytes.rst
+++ b/doc/source/reference/parameters/imbeats-maxinflightbytes.rst
@@ -1,0 +1,64 @@
+.. _param-imbeats-maxinflightbytes:
+.. _imbeats.parameter.input.maxinflightbytes:
+
+maxInFlightBytes
+================
+
+.. meta::
+   :description: Maximum memory charged to in-flight Lumberjack input state for one imbeats instance.
+   :keywords: rsyslog, imbeats, maxInFlightBytes, memory limit, Lumberjack
+
+.. index::
+   single: imbeats; maxInFlightBytes
+   single: maxInFlightBytes
+
+.. summary-start
+
+Limit the memory charged to incomplete Lumberjack input across an imbeats instance.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: maxInFlightBytes
+:Scope: input
+:Type: positive integer
+:Default: input=268435456
+:Required?: no
+:Introduced: 8.2608.0
+
+Description
+-----------
+Set the maximum number of bytes that one ``imbeats`` input instance may charge
+to incomplete receive buffers, decompression scratch space, retained event
+copies, and lazily allocated window descriptors. The valid range is ``1`` to
+``2000000000`` bytes.
+
+Accounting is exact across all sessions of the input instance. A session that
+would exceed the limit is closed, its charged resources are released, and its
+incomplete batch is not acknowledged. Increase this value only when legitimate
+concurrent batches require more aggregate memory.
+
+Input usage
+-----------
+.. _param-imbeats-input-maxinflightbytes:
+.. _imbeats.parameter.input.maxinflightbytes-usage:
+
+RainerScript:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" maxInFlightBytes="268435456")
+
+YAML:
+
+.. code-block:: yaml
+
+   inputs:
+     - type: imbeats
+       port: 5044
+       maxInFlightBytes: 268435456
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-windowtimeout.rst
+++ b/doc/source/reference/parameters/imbeats-windowtimeout.rst
@@ -1,0 +1,66 @@
+.. _param-imbeats-windowtimeout:
+.. _imbeats.parameter.input.windowtimeout:
+
+windowTimeout
+=============
+
+.. meta::
+   :description: Absolute deadline for completing an advertised imbeats Lumberjack window.
+   :keywords: rsyslog, imbeats, windowTimeout, window deadline, Lumberjack
+
+.. index::
+   single: imbeats; windowTimeout
+   single: windowTimeout
+
+.. summary-start
+
+Set an absolute deadline for completing an advertised Lumberjack event window.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: windowTimeout
+:Scope: input
+:Type: nonnegative integer
+:Default: input=300
+:Required?: no
+:Introduced: 8.2608.0
+
+Description
+-----------
+Set the maximum number of seconds allowed between accepting a Lumberjack
+``W`` frame and receiving all events it advertises. The deadline is absolute:
+receiving complete event frames does not extend it. This prevents a client from
+retaining an incomplete batch and its session slot indefinitely by periodically
+sending valid events.
+
+When the deadline expires, ``imbeats`` closes the session, releases the
+incomplete batch, and does not acknowledge it. The deadline ends before a
+complete, sequence-valid batch enters submission. The value ``0`` disables the
+window timeout. The independent :ref:`param-imbeats-idletimeout` and
+:ref:`param-imbeats-frametimeout` settings may still close the session earlier.
+
+Input usage
+-----------
+.. _param-imbeats-input-windowtimeout:
+.. _imbeats.parameter.input.windowtimeout-usage:
+
+RainerScript:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" windowTimeout="300")
+
+YAML:
+
+.. code-block:: yaml
+
+   inputs:
+     - type: imbeats
+       port: 5044
+       windowTimeout: 300
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/plugins/imbeats/MODULE_METADATA.yaml
+++ b/plugins/imbeats/MODULE_METADATA.yaml
@@ -1,9 +1,11 @@
 support_status: core-supported
 maturity_level: fresh
 primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
-last_reviewed: 2026-04-09
+last_reviewed: 2026-07-10
 build_dependencies:
   - "zlib (--enable-imbeats)"
 notes:
   - "Accepts Elastic Beats via Lumberjack protocol v2 over netstrm-backed TCP or TLS transports."
   - "Initial event mapping is optimized for Elasticsearch-oriented downstream flow; representation configurability is deferred."
+  - "JSON event payloads must contain exactly one object; malformed, non-object, or trailing-content payloads fail closed without acknowledgement."
+  - "Instance-wide maxInFlightBytes accounting, compression expansion limits, and idle/frame/window deadlines bound remotely retained work and memory."

--- a/plugins/imbeats/imbeats.c
+++ b/plugins/imbeats/imbeats.c
@@ -10,9 +10,11 @@
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
+#include <ctype.h>
 #include <inttypes.h>
 #include <limits.h>
 #include <stdint.h>
+#include <time.h>
 #include <unistd.h>
 #include <pthread.h>
 #include <poll.h>
@@ -56,6 +58,13 @@ MODULE_CNFNAME("imbeats")
 #define IMBEATS_DEFAULT_MAX_DECOMPRESSED_SIZE (64 * 1024 * 1024)
 #define IMBEATS_DEFAULT_MAX_BATCH_BYTES IMBEATS_DEFAULT_MAX_DECOMPRESSED_SIZE
 #define IMBEATS_MAX_BYTE_SIZE_LIMIT 200000000
+#define IMBEATS_DEFAULT_MAX_IN_FLIGHT_BYTES (256 * 1024 * 1024)
+#define IMBEATS_MAX_IN_FLIGHT_BYTES_LIMIT 2000000000
+#define IMBEATS_DEFAULT_MAX_COMPRESSION_RATIO 256
+#define IMBEATS_MAX_COMPRESSION_RATIO_LIMIT 1000000
+#define IMBEATS_DEFAULT_IDLE_TIMEOUT 60
+#define IMBEATS_DEFAULT_FRAME_TIMEOUT 30
+#define IMBEATS_DEFAULT_WINDOW_TIMEOUT 300
 #define IMBEATS_DEFAULT_MAX_SESSIONS 1000
 #define IMBEATS_DEFAULT_WORKER_THREADS 2
 #define IMBEATS_MAX_WORKER_THREADS 1024
@@ -107,6 +116,12 @@ typedef struct instanceConf_s {
     size_t maxFrameSize;
     size_t maxDecompressedSize;
     size_t maxBatchBytes;
+    size_t maxInFlightBytes;
+    size_t inFlightBytes;
+    uint32_t maxCompressionRatio;
+    unsigned idleTimeout;
+    unsigned frameTimeout;
+    unsigned windowTimeout;
 
     netstrms_t *pNS;
     netstrm_t **listeners;
@@ -163,11 +178,18 @@ struct session_s {
     unsigned char fixed[8];
     unsigned char *payload;
     size_t payload_len;
+    size_t payload_alloc_len;
     unsigned char *io_buf;
     size_t io_need;
     size_t io_off;
     unsigned char ack[6];
     size_t ack_off;
+    uint64_t lastProgressMs;
+    uint64_t readStartMs;
+    uint64_t windowStartMs;
+    int awaitingNetwork;
+    int timeoutsSuspended;
+    int timedOut;
     enum {
         IMBEATS_ST_READ_WINDOW_HDR,
         IMBEATS_ST_READ_WINDOW_SIZE,
@@ -227,6 +249,11 @@ static struct cnfparamdescr inppdescr[] = {
     {"maxframesize", eCmdHdlrPositiveInt, 0},
     {"maxdecompressedsize", eCmdHdlrPositiveInt, 0},
     {"maxbatchbytes", eCmdHdlrPositiveInt, 0},
+    {"maxinflightbytes", eCmdHdlrPositiveInt, 0},
+    {"maxcompressionratio", eCmdHdlrPositiveInt, 0},
+    {"idletimeout", eCmdHdlrNonNegInt, 0},
+    {"frametimeout", eCmdHdlrNonNegInt, 0},
+    {"windowtimeout", eCmdHdlrNonNegInt, 0},
     {"maxsessions", eCmdHdlrPositiveInt, 0},
     {"workerthreads", eCmdHdlrPositiveInt, 0},
     {"starvationprotection.maxreads", eCmdHdlrNonNegInt, 0},
@@ -252,6 +279,9 @@ static struct {
     STATSCOUNTER_DEF(ctrConnectionsActive, mutCtrConnectionsActive)
     STATSCOUNTER_DEF(ctrConnectionsRejected, mutCtrConnectionsRejected)
     STATSCOUNTER_DEF(ctrStarvationProtect, mutCtrStarvationProtect)
+    STATSCOUNTER_DEF(ctrResourceBytes, mutCtrResourceBytes)
+    STATSCOUNTER_DEF(ctrResourceRejected, mutCtrResourceRejected)
+    STATSCOUNTER_DEF(ctrSessionsTimedOut, mutCtrSessionsTimedOut)
 } statsCounter;
 
 #include "im-helper.h"
@@ -265,6 +295,7 @@ static rsRetVal createInstance(instanceConf_t **const pinst);
 static rsRetVal buildListeners(instanceConf_t *inst);
 static rsRetVal destroyInstanceRuntime(instanceConf_t *inst);
 static void destroySession(session_t *sess);
+static void shutdownSessionSocket(session_t *sess);
 static void *listenerThread(void *arg);
 static void *workerThread(void *arg);
 
@@ -287,6 +318,59 @@ static void clearInstanceShuttingDown(instanceConf_t *const inst) {
     pthread_mutex_lock(&inst->mutSessions);
     inst->shuttingDown = 0;
     pthread_mutex_unlock(&inst->mutSessions);
+}
+
+static uint64_t monotonicMs(void) {
+    struct timespec ts;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        return 0;
+    }
+    return (uint64_t)ts.tv_sec * 1000u + (uint64_t)ts.tv_nsec / 1000000u;
+}
+
+static rsRetVal reserveInstanceBytes(void *const ctx, const size_t amount) {
+    instanceConf_t *const inst = (instanceConf_t *)ctx;
+    rsRetVal iRet = RS_RET_OK;
+
+    if (amount == 0) {
+        return RS_RET_OK;
+    }
+    pthread_mutex_lock(&inst->mutSessions);
+    if (amount > inst->maxInFlightBytes || inst->inFlightBytes > inst->maxInFlightBytes - amount) {
+        iRet = RS_RET_OUT_OF_MEMORY;
+    } else {
+        inst->inFlightBytes += amount;
+        STATSCOUNTER_ADD(statsCounter.ctrResourceBytes, statsCounter.mutCtrResourceBytes, amount);
+    }
+    pthread_mutex_unlock(&inst->mutSessions);
+    if (iRet != RS_RET_OK) {
+        STATSCOUNTER_INC(statsCounter.ctrResourceRejected, statsCounter.mutCtrResourceRejected);
+    }
+    return iRet;
+}
+
+static void releaseInstanceBytes(void *const ctx, const size_t amount) {
+    instanceConf_t *const inst = (instanceConf_t *)ctx;
+
+    if (amount == 0) {
+        return;
+    }
+    pthread_mutex_lock(&inst->mutSessions);
+    assert(inst->inFlightBytes >= amount);
+    inst->inFlightBytes -= amount;
+    STATSCOUNTER_ADD(statsCounter.ctrResourceBytes, statsCounter.mutCtrResourceBytes, (uint64_t)(-(int64_t)amount));
+    pthread_mutex_unlock(&inst->mutSessions);
+}
+
+static rsRetVal validateTimeout(const char *const name, const int64_t value, unsigned *const target) {
+    if (value < 0 || (uint64_t)value > UINT_MAX) {
+        LogError(0, RS_RET_PARAM_ERROR, "imbeats: invalid value for '%s' parameter given is %lld, valid range is 0..%u",
+                 name, (long long)value, UINT_MAX);
+        return RS_RET_PARAM_ERROR;
+    }
+    *target = (unsigned)value;
+    return RS_RET_OK;
 }
 
 static rsRetVal validateUInt32Limit(const char *const name,
@@ -469,9 +553,120 @@ finalize_it:
     RETiRet;
 }
 
+static void sessionRecordReadStart(session_t *const sess) {
+    const uint64_t now = monotonicMs();
+
+    pthread_mutex_lock(&sess->inst->mutSessions);
+    if (sess->readStartMs == 0) {
+        sess->readStartMs = now;
+    }
+    pthread_mutex_unlock(&sess->inst->mutSessions);
+}
+
+static void sessionRecordProgress(session_t *const sess) {
+    const uint64_t now = monotonicMs();
+
+    pthread_mutex_lock(&sess->inst->mutSessions);
+    sess->lastProgressMs = now;
+    pthread_mutex_unlock(&sess->inst->mutSessions);
+}
+
+static void sessionRecordFrameComplete(session_t *const sess) {
+    pthread_mutex_lock(&sess->inst->mutSessions);
+    sess->readStartMs = 0;
+    pthread_mutex_unlock(&sess->inst->mutSessions);
+}
+
+static void sessionRecordWindowStart(session_t *const sess) {
+    const uint64_t now = monotonicMs();
+
+    pthread_mutex_lock(&sess->inst->mutSessions);
+    sess->windowStartMs = now;
+    pthread_mutex_unlock(&sess->inst->mutSessions);
+}
+
+static void sessionRecordWindowComplete(session_t *const sess) {
+    pthread_mutex_lock(&sess->inst->mutSessions);
+    sess->windowStartMs = 0;
+    sess->timeoutsSuspended = 1;
+    pthread_mutex_unlock(&sess->inst->mutSessions);
+}
+
+static void sessionResumeTimeouts(session_t *const sess) {
+    pthread_mutex_lock(&sess->inst->mutSessions);
+    sess->lastProgressMs = monotonicMs();
+    sess->timeoutsSuspended = 0;
+    pthread_mutex_unlock(&sess->inst->mutSessions);
+}
+
+static rsRetVal sessionAllocatePayload(session_t *const sess, const size_t payloadLen) {
+    const size_t allocLen = payloadLen + 1;
+    rsRetVal iRet;
+
+    if (payloadLen == SIZE_MAX) {
+        return RS_RET_INVALID_VALUE;
+    }
+    iRet = reserveInstanceBytes(sess->inst, allocLen);
+    if (iRet != RS_RET_OK) {
+        return iRet;
+    }
+    sess->payload = malloc(allocLen);
+    if (sess->payload == NULL) {
+        releaseInstanceBytes(sess->inst, allocLen);
+        return RS_RET_OUT_OF_MEMORY;
+    }
+    sess->payload_alloc_len = allocLen;
+    sess->payload[payloadLen] = '\0';
+    return RS_RET_OK;
+}
+
+static void sessionFreePayload(session_t *const sess) {
+    if (sess->payload != NULL) {
+        free(sess->payload);
+        sess->payload = NULL;
+    }
+    if (sess->payload_alloc_len != 0) {
+        releaseInstanceBytes(sess->inst, sess->payload_alloc_len);
+        sess->payload_alloc_len = 0;
+    }
+    sess->payload_len = 0;
+}
+
+static rsRetVal parseJsonEvent(const struct lj_event_s *const event, struct fjson_object **const parsed) {
+    struct json_tokener *tok = NULL;
+    struct fjson_object *json = NULL;
+    rsRetVal iRet = RS_RET_OK;
+    size_t parseEnd;
+
+    assert(event != NULL);
+    assert(parsed != NULL);
+    *parsed = NULL;
+
+    CHKmalloc(tok = json_tokener_new());
+    json = json_tokener_parse_ex(tok, (const char *)event->payload, event->payload_len);
+    parseEnd = (size_t)tok->char_offset;
+    while (parseEnd < event->payload_len && isspace((unsigned char)event->payload[parseEnd])) {
+        ++parseEnd;
+    }
+    if (tok->err != fjson_tokener_success || json == NULL || !fjson_object_is_type(json, fjson_type_object) ||
+        parseEnd != event->payload_len) {
+        ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+    }
+    *parsed = json;
+    json = NULL;
+
+finalize_it:
+    if (tok != NULL) {
+        json_tokener_free(tok);
+    }
+    if (json != NULL) {
+        fjson_object_put(json);
+    }
+    RETiRet;
+}
+
 static rsRetVal submitEvent(session_t *const sess, const struct lj_event_s *const event) {
     smsg_t *pMsg = NULL;
-    struct json_tokener *tok = NULL;
     struct fjson_object *json = NULL;
     struct fjson_object *meta = NULL;
     rsRetVal iRet = RS_RET_OK;
@@ -480,12 +675,11 @@ static rsRetVal submitEvent(session_t *const sess, const struct lj_event_s *cons
     assert(sess != NULL);
     assert(event != NULL);
 
-    CHKmalloc(tok = json_tokener_new());
-    json = json_tokener_parse_ex(tok, (const char *)event->payload, event->payload_len);
-    if (tok->err != fjson_tokener_success || json == NULL || !fjson_object_is_type(json, fjson_type_object)) {
+    iRet = parseJsonEvent(event, &json);
+    if (iRet == RS_RET_INVALID_VALUE) {
         STATSCOUNTER_INC(statsCounter.ctrJsonDecodeFailures, statsCounter.mutCtrJsonDecodeFailures);
-        ABORT_FINALIZE(RS_RET_INVALID_VALUE);
     }
+    CHKiRet(iRet);
 
     CHKiRet(msgConstruct(&pMsg));
     MsgSetFlowControlType(pMsg, eFLOWCTL_LIGHT_DELAY);
@@ -543,9 +737,6 @@ finalize_it:
             msgDestruct(&pMsg);
         }
     }
-    if (tok != NULL) {
-        json_tokener_free(tok);
-    }
     if (json != NULL) {
         fjson_object_put(json);
     }
@@ -565,6 +756,7 @@ static rsRetVal sessionReadStep(session_t *const sess, unsigned char *const buf,
         sess->io_buf = buf;
         sess->io_need = len;
         sess->io_off = 0;
+        sessionRecordReadStart(sess);
     }
     while (sess->io_off < sess->io_need) {
         ssize_t need = (ssize_t)(sess->io_need - sess->io_off);
@@ -576,6 +768,7 @@ static rsRetVal sessionReadStep(session_t *const sess, unsigned char *const buf,
                 return RS_RET_RETRY;
             }
             sess->io_off += (size_t)need;
+            sessionRecordProgress(sess);
         } else if (iRet == RS_RET_RETRY) {
             sess->ioDirection = nextIODirection;
             return RS_RET_RETRY;
@@ -591,10 +784,30 @@ static rsRetVal sessionReadStep(session_t *const sess, unsigned char *const buf,
 
 static rsRetVal sessionValidateBatch(session_t *const sess) {
     size_t idx;
+
     assert(sess != NULL);
+    /* Validate the complete batch before submitting its first event. Parsing
+     * again during submission is intentional: retaining every parsed tree
+     * here would bypass the raw-payload memory budget, while submitting during
+     * validation would partially accept a batch whose later event is invalid.
+     */
     for (idx = 0; idx < sess->batch.count; ++idx) {
+        struct fjson_object *json = NULL;
+        rsRetVal iRet;
+
         if (!imbeats_seq_is_expected(sess->lastAckedSeq, idx, sess->batch.events[idx].seq)) {
             return RS_RET_INVALID_VALUE;
+        }
+        iRet = parseJsonEvent(&sess->batch.events[idx], &json);
+        if (json != NULL) {
+            fjson_object_put(json);
+        }
+        if (iRet != RS_RET_OK) {
+            if (iRet == RS_RET_INVALID_VALUE) {
+                STATSCOUNTER_INC(statsCounter.ctrJsonDecodeFailures, statsCounter.mutCtrJsonDecodeFailures);
+            }
+            STATSCOUNTER_INC(statsCounter.ctrEventsFailed, statsCounter.mutCtrEventsFailed);
+            return iRet;
         }
     }
     STATSCOUNTER_ADD(statsCounter.ctrEventsReceived, statsCounter.mutCtrEventsReceived, sess->batch.count);
@@ -611,6 +824,10 @@ static void sessionPrepareAck(session_t *const sess) {
     sess->ack[1] = LJ_FRAME_ACK;
     memcpy(sess->ack + 2, &netseq, sizeof(netseq));
     sess->ack_off = 0;
+    /* Start a fresh idle interval for the peer-controlled ACK write. This
+     * bounds clients that stop reading without charging local submission time
+     * against clients that remain responsive. */
+    sessionResumeTimeouts(sess);
     sess->state = IMBEATS_ST_SEND_ACK;
 }
 
@@ -623,6 +840,70 @@ static void sessionResetForNextBatch(session_t *const sess) {
     sess->payload_len = 0;
     sess->ack_off = 0;
     sess->state = IMBEATS_ST_READ_WINDOW_HDR;
+}
+
+static int sessionExpiredLocked(const session_t *const sess, const uint64_t now) {
+    const instanceConf_t *const inst = sess->inst;
+
+    if (sess->timedOut || now == 0) {
+        return sess->timedOut;
+    }
+    if (sess->timeoutsSuspended) {
+        return 0;
+    }
+    if (inst->idleTimeout != 0 && sess->lastProgressMs != 0 && now >= sess->lastProgressMs &&
+        now - sess->lastProgressMs >= (uint64_t)inst->idleTimeout * 1000u) {
+        return 1;
+    }
+    if (inst->frameTimeout != 0 && sess->readStartMs != 0 && now >= sess->readStartMs &&
+        now - sess->readStartMs >= (uint64_t)inst->frameTimeout * 1000u) {
+        return 1;
+    }
+    if (inst->windowTimeout != 0 && sess->windowStartMs != 0 && now >= sess->windowStartMs &&
+        now - sess->windowStartMs >= (uint64_t)inst->windowTimeout * 1000u) {
+        return 1;
+    }
+    return 0;
+}
+
+/* These deadlines bound peer-controlled network waits. Once a complete frame
+ * has arrived, maxCompressionRatio, maxDecompressedSize, maxInFlightBytes and
+ * starvationProtection.maxReads bound local work. windowTimeout ends when the
+ * complete batch enters submission. Expiring a batch while its events are
+ * being submitted would instead create an ambiguous partial-submit state
+ * without an ACK, so submission is intentionally not a timeout scope. A fresh
+ * idleTimeout interval begins before ACK transmission to bound peers that stop
+ * reading after their batch has been accepted. */
+
+static int sessionCheckTimeout(session_t *const sess) {
+    const uint64_t now = monotonicMs();
+    int expired;
+
+    pthread_mutex_lock(&sess->inst->mutSessions);
+    expired = sessionExpiredLocked(sess, now);
+    if (expired && !sess->timedOut) {
+        sess->timedOut = 1;
+        STATSCOUNTER_INC(statsCounter.ctrSessionsTimedOut, statsCounter.mutCtrSessionsTimedOut);
+    }
+    pthread_mutex_unlock(&sess->inst->mutSessions);
+    return expired;
+}
+
+static void shutdownExpiredSessions(instanceConf_t *const inst) {
+    const uint64_t now = monotonicMs();
+    session_t *sess;
+
+    pthread_mutex_lock(&inst->mutSessions);
+    for (sess = inst->sessions; sess != NULL; sess = sess->next) {
+        if (!sess->done && sess->awaitingNetwork && sessionExpiredLocked(sess, now)) {
+            if (!sess->timedOut) {
+                sess->timedOut = 1;
+                STATSCOUNTER_INC(statsCounter.ctrSessionsTimedOut, statsCounter.mutCtrSessionsTimedOut);
+            }
+            shutdownSessionSocket(sess);
+        }
+    }
+    pthread_mutex_unlock(&inst->mutSessions);
 }
 
 static rsRetVal sessionSendAckStep(session_t *const sess) {
@@ -653,6 +934,9 @@ static rsRetVal sessionProcess(session_t *const sess) {
     DEFiRet;
 
     assert(sess != NULL);
+    if (sessionCheckTimeout(sess)) {
+        ABORT_FINALIZE(RS_RET_CLOSED);
+    }
     while (glbl.GetGlobalInputTermState() == 0 && !instanceIsShuttingDown(sess->inst)) {
         if (sess->inst->starvationMaxReads != 0 && reads >= sess->inst->starvationMaxReads) {
             STATSCOUNTER_INC(statsCounter.ctrStarvationProtect, statsCounter.mutCtrStarvationProtect);
@@ -682,8 +966,11 @@ static rsRetVal sessionProcess(session_t *const sess) {
                     STATSCOUNTER_INC(statsCounter.ctrWindowsRejected, statsCounter.mutCtrWindowsRejected);
                     ABORT_FINALIZE(RS_RET_INVALID_VALUE);
                 }
-                CHKiRet(lj_batch_alloc(&sess->batch, net32, sess->inst->maxWindowSize, sess->inst->maxBatchBytes));
+                CHKiRet(lj_batch_alloc(&sess->batch, net32, sess->inst->maxWindowSize, sess->inst->maxBatchBytes,
+                                       reserveInstanceBytes, releaseInstanceBytes, sess->inst));
                 sess->batchActive = 1;
+                sessionRecordWindowStart(sess);
+                sessionRecordFrameComplete(sess);
                 STATSCOUNTER_INC(statsCounter.ctrBatchesReceived, statsCounter.mutCtrBatchesReceived);
                 sess->state = IMBEATS_ST_READ_FRAME_HDR;
                 break;
@@ -724,7 +1011,7 @@ static rsRetVal sessionProcess(session_t *const sess) {
                     STATSCOUNTER_INC(statsCounter.ctrFramesRejected, statsCounter.mutCtrFramesRejected);
                     ABORT_FINALIZE(RS_RET_INVALID_VALUE);
                 }
-                CHKmalloc(sess->payload = malloc(sess->payload_len));
+                CHKiRet(sessionAllocatePayload(sess, sess->payload_len));
                 sess->state = IMBEATS_ST_READ_JSON_PAYLOAD;
                 break;
             case IMBEATS_ST_READ_JSON_PAYLOAD:
@@ -732,17 +1019,24 @@ static rsRetVal sessionProcess(session_t *const sess) {
                 if (iRet == RS_RET_RETRY) return iRet;
                 CHKiRet(iRet);
                 ++reads;
-                iRet = lj_append_json_event(&sess->batch, sess->pendingSeq, sess->payload, sess->payload_len);
-                free(sess->payload);
-                sess->payload = NULL;
-                sess->payload_len = 0;
+                iRet = lj_append_json_event_owned(&sess->batch, sess->pendingSeq, sess->payload, sess->payload_len,
+                                                  sess->payload_alloc_len);
+                if (iRet == RS_RET_OK) {
+                    sess->payload = NULL;
+                    sess->payload_len = 0;
+                    sess->payload_alloc_len = 0;
+                }
                 if (iRet == RS_RET_INVALID_VALUE) {
                     STATSCOUNTER_INC(statsCounter.ctrFramesRejected, statsCounter.mutCtrFramesRejected);
                 }
                 CHKiRet(iRet);
+                sessionRecordFrameComplete(sess);
                 sess->state = (sess->batch.count == sess->batch.window_size) ? IMBEATS_ST_SUBMIT_EVENTS
                                                                              : IMBEATS_ST_READ_FRAME_HDR;
-                if (sess->state == IMBEATS_ST_SUBMIT_EVENTS) CHKiRet(sessionValidateBatch(sess));
+                if (sess->state == IMBEATS_ST_SUBMIT_EVENTS) {
+                    sessionRecordWindowComplete(sess);
+                    CHKiRet(sessionValidateBatch(sess));
+                }
                 break;
             case IMBEATS_ST_READ_COMP_LEN:
                 iRet = sessionReadStep(sess, sess->fixed, 4);
@@ -756,7 +1050,7 @@ static rsRetVal sessionProcess(session_t *const sess) {
                     STATSCOUNTER_INC(statsCounter.ctrCompressedRejected, statsCounter.mutCtrCompressedRejected);
                     ABORT_FINALIZE(RS_RET_INVALID_VALUE);
                 }
-                CHKmalloc(sess->payload = malloc(sess->payload_len));
+                CHKiRet(sessionAllocatePayload(sess, sess->payload_len));
                 sess->state = IMBEATS_ST_READ_COMP_PAYLOAD;
                 break;
             case IMBEATS_ST_READ_COMP_PAYLOAD:
@@ -764,18 +1058,21 @@ static rsRetVal sessionProcess(session_t *const sess) {
                 if (iRet == RS_RET_RETRY) return iRet;
                 CHKiRet(iRet);
                 ++reads;
-                iRet = lj_parse_compressed_frames(&sess->batch, sess->payload, sess->payload_len,
-                                                  sess->inst->maxFrameSize, sess->inst->maxDecompressedSize);
-                free(sess->payload);
-                sess->payload = NULL;
-                sess->payload_len = 0;
+                iRet =
+                    lj_parse_compressed_frames(&sess->batch, sess->payload, sess->payload_len, sess->inst->maxFrameSize,
+                                               sess->inst->maxDecompressedSize, sess->inst->maxCompressionRatio);
+                sessionFreePayload(sess);
                 if (iRet == RS_RET_INVALID_VALUE) {
                     STATSCOUNTER_INC(statsCounter.ctrCompressedRejected, statsCounter.mutCtrCompressedRejected);
                 }
                 CHKiRet(iRet);
+                sessionRecordFrameComplete(sess);
                 sess->state = (sess->batch.count == sess->batch.window_size) ? IMBEATS_ST_SUBMIT_EVENTS
                                                                              : IMBEATS_ST_READ_FRAME_HDR;
-                if (sess->state == IMBEATS_ST_SUBMIT_EVENTS) CHKiRet(sessionValidateBatch(sess));
+                if (sess->state == IMBEATS_ST_SUBMIT_EVENTS) {
+                    sessionRecordWindowComplete(sess);
+                    CHKiRet(sessionValidateBatch(sess));
+                }
                 break;
             case IMBEATS_ST_SUBMIT_EVENTS:
                 while (sess->submitIdx < sess->batch.count) {
@@ -838,12 +1135,20 @@ static void shutdownAllSessionSockets(instanceConf_t *const inst) {
 
 static void destroyAllSessions(instanceConf_t *const inst) {
     session_t *sess;
+    unsigned activeSessions;
 
     pthread_mutex_lock(&inst->mutSessions);
     sess = inst->sessions;
     inst->sessions = NULL;
+    activeSessions = inst->activeSessions;
     inst->activeSessions = 0;
     pthread_mutex_unlock(&inst->mutSessions);
+
+    while (activeSessions > 0) {
+        --activeSessions;
+        STATSCOUNTER_DEC(statsCounter.ctrConnectionsActive, statsCounter.mutCtrConnectionsActive);
+        STATSCOUNTER_INC(statsCounter.ctrConnectionsClosed, statsCounter.mutCtrConnectionsClosed);
+    }
 
     while (sess != NULL) {
         session_t *const next = sess->next;
@@ -858,7 +1163,7 @@ static void destroySession(session_t *sess) {
     if (sess == NULL) {
         return;
     }
-    free(sess->payload);
+    sessionFreePayload(sess);
     if (sess->batchActive) {
         lj_batch_free(&sess->batch);
     }
@@ -960,15 +1265,59 @@ static rsRetVal rearmSession(session_t *const sess) {
 #endif
 }
 
+static int sessionClaimAwaitingNetwork(session_t *const sess) {
+    int claimed = 0;
+
+    pthread_mutex_lock(&sess->inst->mutSessions);
+    if (!sess->done && sess->awaitingNetwork) {
+        sess->awaitingNetwork = 0;
+        claimed = 1;
+    }
+    pthread_mutex_unlock(&sess->inst->mutSessions);
+    return claimed;
+}
+
+static rsRetVal sessionRearmForNetwork(session_t *const sess) {
+    const uint64_t now = monotonicMs();
+    rsRetVal iRet = RS_RET_OK;
+
+    /* Publish readiness ownership only after epoll has been rearmed. The
+     * listener and timeout scanner use the same mutex to claim that ownership,
+     * so neither can close or enqueue this session while epoll_ctl still uses
+     * its socket. */
+    pthread_mutex_lock(&sess->inst->mutSessions);
+    if (sess->done || sess->inst->shuttingDown) {
+        iRet = RS_RET_CLOSED;
+    } else if (sessionExpiredLocked(sess, now)) {
+        if (!sess->timedOut) {
+            sess->timedOut = 1;
+            STATSCOUNTER_INC(statsCounter.ctrSessionsTimedOut, statsCounter.mutCtrSessionsTimedOut);
+        }
+        iRet = RS_RET_CLOSED;
+    } else {
+        iRet = rearmSession(sess);
+        if (iRet == RS_RET_OK) {
+            sess->awaitingNetwork = 1;
+        }
+    }
+    pthread_mutex_unlock(&sess->inst->mutSessions);
+    return iRet;
+}
+
 static void *workerThread(void *arg) {
     instanceConf_t *const inst = (instanceConf_t *)arg;
     session_t *sess;
 
     assert(inst != NULL);
     while ((sess = dequeueSession(inst)) != NULL) {
+        /* The poll fallback queues sessions without a readiness dispatcher.
+         * Clear its published network-wait ownership before processing so the
+         * timeout scanner cannot close a worker-owned session. On epoll builds
+         * the listener already made the same ownership transfer. */
+        (void)sessionClaimAwaitingNetwork(sess);
         const rsRetVal iRet = sessionProcess(sess);
         if (iRet == RS_RET_RETRY) {
-            if (rearmSession(sess) != RS_RET_OK) {
+            if (sessionRearmForNetwork(sess) != RS_RET_OK) {
                 closeSession(sess);
             }
         } else if (iRet == RS_RET_OK) {
@@ -1019,6 +1368,8 @@ static rsRetVal spawnSession(instanceConf_t *const inst, netstrm_t **const ppNew
     *ppNewStrm = NULL;
     sess->ioDirection = NSDSEL_RD;
     sess->state = IMBEATS_ST_READ_WINDOW_HDR;
+    sess->lastProgressMs = monotonicMs();
+    sess->awaitingNetwork = 1;
     CHKiRet(netstrm.GetSock(sess->pStrm, &sess->sock));
     if (inst->bKeepAlive) {
         CHKiRet(netstrm.SetKeepAliveProbes(sess->pStrm, inst->iKeepAliveProbes));
@@ -1237,13 +1588,16 @@ static void *listenerThread(void *arg) {
                     (void)rearmListener(inst, io->listener_idx);
                 }
             } else if (io->type == IMBEATS_IO_SESSION && io->sess != NULL) {
-                if ((events[n].events & (EPOLLERR | EPOLLHUP)) != 0) {
-                    closeSession(io->sess);
-                } else {
-                    enqueueSession(io->sess);
+                if (sessionClaimAwaitingNetwork(io->sess)) {
+                    if ((events[n].events & (EPOLLERR | EPOLLHUP)) != 0) {
+                        closeSession(io->sess);
+                    } else {
+                        enqueueSession(io->sess);
+                    }
                 }
             }
         }
+        shutdownExpiredSessions(inst);
     }
     /* Workers may still process session events queued before shutdown and call
      * epoll_ctl() from rearmSession()/closeSession(). Join them before closing
@@ -1270,6 +1624,7 @@ static void *listenerThread(void *arg) {
             }
         }
         free(pfds);
+        shutdownExpiredSessions(inst);
     }
 #endif
 #if !defined(IMBEATS_HAVE_EPOLL)
@@ -1321,6 +1676,11 @@ static rsRetVal createInstance(instanceConf_t **const pinst) {
     inst->maxFrameSize = IMBEATS_DEFAULT_MAX_FRAME_SIZE;
     inst->maxDecompressedSize = IMBEATS_DEFAULT_MAX_DECOMPRESSED_SIZE;
     inst->maxBatchBytes = IMBEATS_DEFAULT_MAX_BATCH_BYTES;
+    inst->maxInFlightBytes = IMBEATS_DEFAULT_MAX_IN_FLIGHT_BYTES;
+    inst->maxCompressionRatio = IMBEATS_DEFAULT_MAX_COMPRESSION_RATIO;
+    inst->idleTimeout = IMBEATS_DEFAULT_IDLE_TIMEOUT;
+    inst->frameTimeout = IMBEATS_DEFAULT_FRAME_TIMEOUT;
+    inst->windowTimeout = IMBEATS_DEFAULT_WINDOW_TIMEOUT;
     inst->maxSessions = IMBEATS_DEFAULT_MAX_SESSIONS;
     inst->workerThreads = IMBEATS_DEFAULT_WORKER_THREADS;
     inst->starvationMaxReads = IMBEATS_DEFAULT_STARVATION_MAX_READS;
@@ -1418,6 +1778,18 @@ BEGINnewInpInst
         } else if (!strcmp(inppblk.descr[i].name, "maxbatchbytes")) {
             CHKiRet(validateSizeLimit("maxBatchBytes", pvals[i].val.d.n, IMBEATS_MAX_BYTE_SIZE_LIMIT,
                                       &inst->maxBatchBytes));
+        } else if (!strcmp(inppblk.descr[i].name, "maxinflightbytes")) {
+            CHKiRet(validateSizeLimit("maxInFlightBytes", pvals[i].val.d.n, IMBEATS_MAX_IN_FLIGHT_BYTES_LIMIT,
+                                      &inst->maxInFlightBytes));
+        } else if (!strcmp(inppblk.descr[i].name, "maxcompressionratio")) {
+            CHKiRet(validateUInt32Limit("maxCompressionRatio", pvals[i].val.d.n, IMBEATS_MAX_COMPRESSION_RATIO_LIMIT,
+                                        &inst->maxCompressionRatio));
+        } else if (!strcmp(inppblk.descr[i].name, "idletimeout")) {
+            CHKiRet(validateTimeout("idleTimeout", pvals[i].val.d.n, &inst->idleTimeout));
+        } else if (!strcmp(inppblk.descr[i].name, "frametimeout")) {
+            CHKiRet(validateTimeout("frameTimeout", pvals[i].val.d.n, &inst->frameTimeout));
+        } else if (!strcmp(inppblk.descr[i].name, "windowtimeout")) {
+            CHKiRet(validateTimeout("windowTimeout", pvals[i].val.d.n, &inst->windowTimeout));
         } else if (!strcmp(inppblk.descr[i].name, "maxsessions")) {
             inst->maxSessions = normalizeMaxSessions(pvals[i].val.d.n);
         } else if (!strcmp(inppblk.descr[i].name, "workerthreads")) {
@@ -1620,6 +1992,9 @@ BEGINmodInit()
     STATSCOUNTER_INIT(statsCounter.ctrConnectionsActive, statsCounter.mutCtrConnectionsActive);
     STATSCOUNTER_INIT(statsCounter.ctrConnectionsRejected, statsCounter.mutCtrConnectionsRejected);
     STATSCOUNTER_INIT(statsCounter.ctrStarvationProtect, statsCounter.mutCtrStarvationProtect);
+    STATSCOUNTER_INIT(statsCounter.ctrResourceBytes, statsCounter.mutCtrResourceBytes);
+    STATSCOUNTER_INIT(statsCounter.ctrResourceRejected, statsCounter.mutCtrResourceRejected);
+    STATSCOUNTER_INIT(statsCounter.ctrSessionsTimedOut, statsCounter.mutCtrSessionsTimedOut);
     CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("connections.accepted"), ctrType_IntCtr,
                                 CTR_FLAG_RESETTABLE, &statsCounter.ctrConnectionsAccepted));
     CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("connections.closed"), ctrType_IntCtr,
@@ -1654,5 +2029,11 @@ BEGINmodInit()
                                 CTR_FLAG_RESETTABLE, &statsCounter.ctrConnectionsRejected));
     CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("starvation_protect"), ctrType_IntCtr,
                                 CTR_FLAG_RESETTABLE, &statsCounter.ctrStarvationProtect));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("resource_bytes"), ctrType_IntCtr, CTR_FLAG_NONE,
+                                &statsCounter.ctrResourceBytes));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("resource_rejected"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrResourceRejected));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("sessions.timed_out"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrSessionsTimedOut));
     CHKiRet(statsobj.ConstructFinalize(statsCounter.stats));
 ENDmodInit

--- a/plugins/imbeats/lj_parser.c
+++ b/plugins/imbeats/lj_parser.c
@@ -8,45 +8,123 @@
 #include "lj_parser.h"
 
 #include <arpa/inet.h>
+#include <limits.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <zlib.h>
 
-static rsRetVal append_event_owned(struct lj_batch_s *batch, uint32_t seq, unsigned char *payload, size_t payload_len) {
-    if (batch == NULL || batch->events == NULL) {
-        free(payload);
-        return RS_RET_PARAM_ERROR;
+static rsRetVal reserve_resource(struct lj_batch_s *batch, const size_t bytes) {
+    if (bytes == 0 || batch->reserve == NULL) {
+        return RS_RET_OK;
+    }
+    return batch->reserve(batch->resource_ctx, bytes);
+}
+
+static void release_resource(struct lj_batch_s *batch, const size_t bytes) {
+    if (bytes != 0 && batch->release != NULL) {
+        batch->release(batch->resource_ctx, bytes);
+    }
+}
+
+static rsRetVal ensure_event_capacity(struct lj_batch_s *batch) {
+    struct lj_event_s *events;
+    size_t new_capacity;
+    size_t new_alloc_len;
+    size_t additional_len;
+    rsRetVal iRet;
+
+    if (batch->count < batch->events_capacity) {
+        return RS_RET_OK;
     }
     if (batch->count >= batch->window_size) {
-        free(payload);
         return RS_RET_INVALID_VALUE;
+    }
+
+    new_capacity = (batch->events_capacity == 0) ? 8 : batch->events_capacity * 2;
+    if (new_capacity < batch->events_capacity || new_capacity > batch->window_size) {
+        new_capacity = batch->window_size;
+    }
+    if (new_capacity > SIZE_MAX / sizeof(*events)) {
+        return RS_RET_OUT_OF_MEMORY;
+    }
+    new_alloc_len = new_capacity * sizeof(*events);
+    additional_len = new_alloc_len - batch->events_alloc_len;
+    iRet = reserve_resource(batch, additional_len);
+    if (iRet != RS_RET_OK) {
+        return iRet;
+    }
+    events = realloc(batch->events, new_alloc_len);
+    if (events == NULL) {
+        release_resource(batch, additional_len);
+        return RS_RET_OUT_OF_MEMORY;
+    }
+    memset(events + batch->events_capacity, 0, (new_capacity - batch->events_capacity) * sizeof(*events));
+    batch->events = events;
+    batch->events_capacity = new_capacity;
+    batch->events_alloc_len = new_alloc_len;
+    return RS_RET_OK;
+}
+
+static rsRetVal validate_event(struct lj_batch_s *batch, const unsigned char *payload, const size_t payload_len) {
+    if (batch == NULL || payload == NULL || payload_len == 0) {
+        return RS_RET_PARAM_ERROR;
+    }
+    if (batch->count >= batch->window_size || payload_len > batch->max_payload_len ||
+        batch->total_payload_len > batch->max_payload_len - payload_len) {
+        return RS_RET_INVALID_VALUE;
+    }
+    return RS_RET_OK;
+}
+
+rsRetVal lj_append_json_event_owned(struct lj_batch_s *batch,
+                                    const uint32_t seq,
+                                    unsigned char *payload,
+                                    const size_t payload_len,
+                                    const size_t payload_alloc_len) {
+    rsRetVal iRet;
+
+    iRet = validate_event(batch, payload, payload_len);
+    if (iRet != RS_RET_OK) {
+        return iRet;
+    }
+    if (payload_alloc_len < payload_len) {
+        return RS_RET_PARAM_ERROR;
+    }
+    iRet = ensure_event_capacity(batch);
+    if (iRet != RS_RET_OK) {
+        return iRet;
     }
 
     batch->events[batch->count].seq = seq;
     batch->events[batch->count].payload = payload;
     batch->events[batch->count].payload_len = payload_len;
+    batch->events[batch->count].payload_alloc_len = payload_alloc_len;
     ++batch->count;
+    batch->total_payload_len += payload_len;
     return RS_RET_OK;
 }
 
 rsRetVal lj_batch_alloc(struct lj_batch_s *batch,
                         uint32_t window_size,
                         uint32_t max_window_size,
-                        size_t max_payload_len) {
+                        size_t max_payload_len,
+                        lj_resource_reserve_cb reserve,
+                        lj_resource_release_cb release,
+                        void *resource_ctx) {
     if (batch == NULL || window_size == 0 || window_size > max_window_size || max_payload_len == 0) {
         return RS_RET_PARAM_ERROR;
     }
-#if SIZE_MAX <= UINT32_MAX
-    if ((size_t)window_size > SIZE_MAX / sizeof(struct lj_event_s)) {
-        return RS_RET_OUT_OF_MEMORY;
+    if ((reserve == NULL) != (release == NULL)) {
+        return RS_RET_PARAM_ERROR;
     }
-#endif
     memset(batch, 0, sizeof(*batch));
     batch->window_size = window_size;
     batch->max_payload_len = max_payload_len;
-    batch->events = calloc(window_size, sizeof(struct lj_event_s));
-    return (batch->events == NULL) ? RS_RET_OUT_OF_MEMORY : RS_RET_OK;
+    batch->reserve = reserve;
+    batch->release = release;
+    batch->resource_ctx = resource_ctx;
+    return RS_RET_OK;
 }
 
 void lj_batch_free(struct lj_batch_s *batch) {
@@ -56,8 +134,10 @@ void lj_batch_free(struct lj_batch_s *batch) {
     }
     for (i = 0; i < batch->count; ++i) {
         free(batch->events[i].payload);
+        release_resource(batch, batch->events[i].payload_alloc_len);
     }
     free(batch->events);
+    release_resource(batch, batch->events_alloc_len);
     memset(batch, 0, sizeof(*batch));
 }
 
@@ -74,24 +154,27 @@ rsRetVal lj_append_json_event(struct lj_batch_s *batch,
                               size_t payload_len) {
     unsigned char *cpy;
     rsRetVal iRet;
-    if (batch == NULL || payload == NULL || payload_len == 0) {
-        return RS_RET_PARAM_ERROR;
-    }
-    if (payload_len > batch->max_payload_len || batch->total_payload_len > batch->max_payload_len - payload_len) {
-        return RS_RET_INVALID_VALUE;
-    }
+
+    iRet = validate_event(batch, payload, payload_len);
+    if (iRet != RS_RET_OK) return iRet;
     if (payload_len > SIZE_MAX - 1) {
         return RS_RET_OUT_OF_MEMORY;
     }
+    iRet = ensure_event_capacity(batch);
+    if (iRet != RS_RET_OK) return iRet;
+    iRet = reserve_resource(batch, payload_len + 1);
+    if (iRet != RS_RET_OK) return iRet;
     cpy = malloc(payload_len + 1);
     if (cpy == NULL) {
+        release_resource(batch, payload_len + 1);
         return RS_RET_OUT_OF_MEMORY;
     }
     memcpy(cpy, payload, payload_len);
     cpy[payload_len] = '\0';
-    iRet = append_event_owned(batch, seq, cpy, payload_len);
-    if (iRet == RS_RET_OK) {
-        batch->total_payload_len += payload_len;
+    iRet = lj_append_json_event_owned(batch, seq, cpy, payload_len, payload_len + 1);
+    if (iRet != RS_RET_OK) {
+        free(cpy);
+        release_resource(batch, payload_len + 1);
     }
     return iRet;
 }
@@ -102,7 +185,7 @@ static rsRetVal parse_frames_from_memory(struct lj_batch_s *batch,
                                          size_t max_frame_size) {
     size_t off = 0;
 
-    while (off + 2 <= len) {
+    while (len - off >= 2) {
         const unsigned char ver = buf[off++];
         const unsigned char type = buf[off++];
         uint32_t v1, v2;
@@ -114,7 +197,7 @@ static rsRetVal parse_frames_from_memory(struct lj_batch_s *batch,
 
         switch (type) {
             case LJ_FRAME_JSON:
-                if (off + 8 > len) {
+                if (len - off < 8) {
                     return RS_RET_INVALID_VALUE;
                 }
                 memcpy(&v1, buf + off, 4);
@@ -148,20 +231,33 @@ rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch,
                                     const unsigned char *payload,
                                     size_t payload_len,
                                     size_t max_frame_size,
-                                    size_t max_decompressed_size) {
+                                    size_t max_decompressed_size,
+                                    uint32_t max_compression_ratio) {
     z_stream zstrm;
     unsigned char *out = NULL;
     size_t out_cap = 0;
     size_t out_len = 0;
+    size_t expansion_limit;
     size_t old_count;
     int zrc;
     rsRetVal iRet = RS_RET_OK;
 
-    if (batch == NULL || payload == NULL || max_frame_size == 0 || max_decompressed_size == 0) {
+    if (batch == NULL || payload == NULL || max_frame_size == 0 || max_decompressed_size == 0 ||
+        max_compression_ratio == 0) {
         return RS_RET_PARAM_ERROR;
     }
     if (payload_len == 0 || payload_len > max_frame_size) {
         return RS_RET_INVALID_VALUE;
+    }
+#if SIZE_MAX > UINT_MAX
+    if (payload_len > UINT_MAX) {
+        return RS_RET_INVALID_VALUE;
+    }
+#endif
+    expansion_limit =
+        (payload_len > SIZE_MAX / max_compression_ratio) ? SIZE_MAX : payload_len * (size_t)max_compression_ratio;
+    if (expansion_limit > max_decompressed_size) {
+        expansion_limit = max_decompressed_size;
     }
     old_count = batch->count;
 
@@ -177,15 +273,40 @@ rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch,
     do {
         if (out_len == out_cap) {
             size_t new_cap = (out_cap == 0) ? 4096 : out_cap * 2;
-            if (out_cap >= max_decompressed_size) {
-                iRet = RS_RET_INVALID_VALUE;
-                goto finalize_it;
+            size_t additional_len;
+            rsRetVal reserveRet;
+
+            if (out_cap >= expansion_limit) {
+                unsigned char overflow_probe;
+                const uInt avail_in_before = zstrm.avail_in;
+
+                /* Give zlib one byte of unaccounted probe space so a stream
+                 * ending exactly at the configured limit can consume its
+                 * trailer. Producing that byte proves the limit was exceeded.
+                 * When inflate returns Z_STREAM_END without output, continue
+                 * evaluates the do-while condition and exits the loop. */
+                zstrm.next_out = &overflow_probe;
+                zstrm.avail_out = 1;
+                zrc = inflate(&zstrm, Z_NO_FLUSH);
+                if (zstrm.avail_out == 0 || (zrc != Z_OK && zrc != Z_STREAM_END) ||
+                    (zrc == Z_OK && zstrm.avail_in == avail_in_before)) {
+                    iRet = RS_RET_INVALID_VALUE;
+                    goto finalize_it;
+                }
+                continue;
             }
-            if (new_cap < out_cap || new_cap > max_decompressed_size) {
-                new_cap = max_decompressed_size;
+            if (new_cap < out_cap || new_cap > expansion_limit) {
+                new_cap = expansion_limit;
+            }
+            additional_len = new_cap - out_cap;
+            reserveRet = reserve_resource(batch, additional_len);
+            if (reserveRet != RS_RET_OK) {
+                iRet = reserveRet;
+                goto finalize_it;
             }
             unsigned char *tmp = realloc(out, new_cap);
             if (tmp == NULL) {
+                release_resource(batch, additional_len);
                 iRet = RS_RET_OUT_OF_MEMORY;
                 goto finalize_it;
             }
@@ -193,11 +314,24 @@ rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch,
             out_cap = new_cap;
         }
 
+        const size_t available = out_cap - out_len;
+#if SIZE_MAX > UINT_MAX
+        const uInt offered = (available > UINT_MAX) ? UINT_MAX : (uInt)available;
+#else
+        const uInt offered = (uInt)available;
+#endif
+        const uInt avail_in_before = zstrm.avail_in;
+        size_t produced;
         zstrm.next_out = out + out_len;
-        zstrm.avail_out = out_cap - out_len;
+        zstrm.avail_out = offered;
         zrc = inflate(&zstrm, Z_NO_FLUSH);
-        out_len = out_cap - zstrm.avail_out;
+        produced = offered - zstrm.avail_out;
+        out_len += produced;
         if (zrc != Z_OK && zrc != Z_STREAM_END) {
+            iRet = RS_RET_INVALID_VALUE;
+            goto finalize_it;
+        }
+        if (zrc == Z_OK && produced == 0 && zstrm.avail_in == avail_in_before) {
             iRet = RS_RET_INVALID_VALUE;
             goto finalize_it;
         }
@@ -225,5 +359,6 @@ rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch,
 finalize_it:
     inflateEnd(&zstrm);
     free(out);
+    release_resource(batch, out_cap);
     return iRet;
 }

--- a/plugins/imbeats/lj_parser.h
+++ b/plugins/imbeats/lj_parser.h
@@ -12,10 +12,14 @@
 #define LJ_FRAME_COMPRESSED ((unsigned char)'C')
 #define LJ_FRAME_ACK ((unsigned char)'A')
 
+typedef rsRetVal (*lj_resource_reserve_cb)(void *ctx, size_t bytes);
+typedef void (*lj_resource_release_cb)(void *ctx, size_t bytes);
+
 struct lj_event_s {
     uint32_t seq;
     unsigned char *payload;
     size_t payload_len;
+    size_t payload_alloc_len;
 };
 
 struct lj_batch_s {
@@ -24,19 +28,32 @@ struct lj_batch_s {
     size_t total_payload_len;
     size_t max_payload_len;
     struct lj_event_s *events;
+    size_t events_capacity;
+    size_t events_alloc_len;
+    lj_resource_reserve_cb reserve;
+    lj_resource_release_cb release;
+    void *resource_ctx;
 };
 
 rsRetVal lj_batch_alloc(struct lj_batch_s *batch,
                         uint32_t window_size,
                         uint32_t max_window_size,
-                        size_t max_payload_len);
+                        size_t max_payload_len,
+                        lj_resource_reserve_cb reserve,
+                        lj_resource_release_cb release,
+                        void *resource_ctx);
 void lj_batch_free(struct lj_batch_s *batch);
 rsRetVal lj_parse_window_header(const unsigned char hdr[2], uint32_t window_size);
 rsRetVal lj_append_json_event(struct lj_batch_s *batch, uint32_t seq, const unsigned char *payload, size_t payload_len);
+/* On success, ownership of a caller-reserved allocation transfers to the
+ * batch. On failure, the caller retains both the allocation and reservation. */
+rsRetVal lj_append_json_event_owned(
+    struct lj_batch_s *batch, uint32_t seq, unsigned char *payload, size_t payload_len, size_t payload_alloc_len);
 rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch,
                                     const unsigned char *payload,
                                     size_t payload_len,
                                     size_t max_frame_size,
-                                    size_t max_decompressed_size);
+                                    size_t max_decompressed_size,
+                                    uint32_t max_compression_ratio);
 
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -123,6 +123,7 @@ EXTRA_DIST += unit/impcap_arp_parser_test.c
 EXTRA_DIST += unit/imbeats_seq_test.c
 EXTRA_DIST += unit/segdisk_state_test.c
 EXTRA_DIST += unit/omazuredce_utils_test.c
+EXTRA_DIST += unit/imbeats_parser_test.c
 
 TESTS_IMPTCP_TABESCAPE = \
 	tabescape_dflt.sh \
@@ -1341,20 +1342,26 @@ TESTS_IMBEATS = \
 	imbeats-seq-cumulative-two-windows.sh \
 	imbeats-seq-cumulative-after-multi-event-window.sh \
 	imbeats-seq-reset-rejected.sh \
-	imbeats-compressed-window-overflow.sh \
-	imbeats-compressed-malformed.sh \
 	imbeats-metadata-collision.sh \
 	imbeats-elastic-agent-windows-fixture.sh \
 	imbeats-limits.sh \
-	imbeats-limits-impstats.sh \
 	imbeats-shutdown-open-session.sh \
 	imbeats-maxsessions.sh \
 	imbeats-maxsessions-cap-warning.sh \
 	imbeats-multiplex-idle-sessions.sh \
+	imbeats-submit-timeout.sh \
+	imbeats-json-trailing-data.sh \
 	imbeats-filebeat-docker.sh
 
+TESTS_IMBEATS_IMPSTATS = \
+	imbeats-compressed-window-overflow.sh \
+	imbeats-compressed-malformed.sh \
+	imbeats-limits-impstats.sh \
+	imbeats-resource-budget.sh
+
 TESTS_IMBEATS_YAML = \
-	yaml-imbeats-basic.sh
+	yaml-imbeats-basic.sh \
+	yaml-imbeats-session-timeouts.sh
 
 TESTS_IMBEATS_ELASTICSEARCH = \
 	imbeats-filebeat-omelasticsearch-docker.sh
@@ -2388,6 +2395,7 @@ EXTRA_DIST += $(TESTS_IMCZMQ)
 EXTRA_DIST += $(TESTS_IMHTTP)
 EXTRA_DIST += $(TESTS_IMHTTP_VALGRIND)
 EXTRA_DIST += $(TESTS_IMBEATS)
+EXTRA_DIST += $(TESTS_IMBEATS_IMPSTATS)
 EXTRA_DIST += $(TESTS_IMBEATS_YAML)
 EXTRA_DIST += $(TESTS_IMBEATS_ELASTICSEARCH)
 EXTRA_DIST += $(TESTS_OMRABBITMQ)
@@ -2570,8 +2578,8 @@ runtime_unit_gss_token_util_LDADD = $(PTHREADS_LIBS) $(SOL_LIBS)
 endif
 
 if ENABLE_IMBEATS
-check_PROGRAMS += runtime_unit_imbeats_seq
-TESTS += runtime_unit_imbeats_seq
+check_PROGRAMS += runtime_unit_imbeats_seq runtime_unit_imbeats_parser
+TESTS += runtime_unit_imbeats_seq runtime_unit_imbeats_parser
 
 runtime_unit_imbeats_seq_SOURCES = \
 	unit/imbeats_seq_test.c
@@ -2579,6 +2587,14 @@ runtime_unit_imbeats_seq_SOURCES = \
 runtime_unit_imbeats_seq_CPPFLAGS = \
 	$(runtime_unit_linkedlist_CPPFLAGS)
 runtime_unit_imbeats_seq_LDADD = $(PTHREADS_LIBS) $(SOL_LIBS)
+
+runtime_unit_imbeats_parser_SOURCES = \
+	unit/imbeats_parser_test.c
+
+runtime_unit_imbeats_parser_CPPFLAGS = \
+	$(runtime_unit_linkedlist_CPPFLAGS) \
+	$(ZLIB_CFLAGS)
+runtime_unit_imbeats_parser_LDADD = $(ZLIB_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
 endif
 
 runtime_unit_linkedlist_CPPFLAGS = \
@@ -3279,6 +3295,9 @@ endif # ENABLE_IMHTTP
 if ENABLE_IMBEATS
 if ENABLE_TESTBENCH
 TESTS += $(TESTS_IMBEATS)
+if ENABLE_IMPSTATS
+TESTS += $(TESTS_IMBEATS_IMPSTATS)
+endif # ENABLE_IMPSTATS
 if HAVE_LIBYAML
 TESTS += $(TESTS_IMBEATS_YAML)
 endif # HAVE_LIBYAML

--- a/tests/imbeats-basic.sh
+++ b/tests/imbeats-basic.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# Verify a basic JSON event is submitted with its Beats fields, reserved
+# metadata, and cumulative ACK intact.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
 
 generate_conf
 add_conf '
@@ -43,6 +44,7 @@ PY
 shutdown_when_empty
 wait_shutdown
 
+# shellcheck disable=SC2034
 EXPECTED='{"message":"hello","host":{"name":"web01"}}|hello|web01|lumberjack-v2|1'
 cmp_exact
 

--- a/tests/imbeats-compressed-malformed.sh
+++ b/tests/imbeats-compressed-malformed.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# Verify malformed compressed input is rejected without an ACK and is counted
+# by the imbeats failure statistics.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
-require_plugin impstats
 
 generate_conf
 add_conf '

--- a/tests/imbeats-compressed-window-overflow.sh
+++ b/tests/imbeats-compressed-window-overflow.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# Verify a compressed frame cannot expand into more events than its advertised
+# window and that impstats records the rejection.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
-require_plugin impstats
 
 generate_conf
 add_conf '

--- a/tests/imbeats-compressed.sh
+++ b/tests/imbeats-compressed.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# Verify a valid zlib-compressed Lumberjack window is decoded, submitted, and
+# acknowledged with the final sequence number.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
 
 generate_conf
 add_conf '
@@ -45,6 +46,7 @@ PY
 shutdown_when_empty
 wait_shutdown
 
+# shellcheck disable=SC2034
 EXPECTED='{"message":"compressed"}|compressed|1'
 cmp_exact
 

--- a/tests/imbeats-elastic-agent-windows-fixture.sh
+++ b/tests/imbeats-elastic-agent-windows-fixture.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# Verify an Elastic Agent Windows event preserves representative nested fields
+# and receives the expected cumulative ACK.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
 
 generate_conf
 add_conf '
@@ -95,6 +96,7 @@ PY
 shutdown_when_empty
 wait_shutdown
 
+# shellcheck disable=SC2034
 EXPECTED="$(cat "$RSYSLOG_DYNNAME.expected")"
 cmp_exact
 

--- a/tests/imbeats-filebeat-omelasticsearch-docker.sh
+++ b/tests/imbeats-filebeat-omelasticsearch-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# Verify real Filebeat traffic received by imbeats is delivered through
+# omelasticsearch and becomes queryable in Elasticsearch.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
-require_plugin omelasticsearch
 check_command_available docker
 
 if ! docker info >/dev/null 2>&1 ; then

--- a/tests/imbeats-json-trailing-data.sh
+++ b/tests/imbeats-json-trailing-data.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Regression coverage for strict JSON-frame consumption. A real imbeats
+# listener receives frames whose declared payload is a valid object followed
+# by either non-whitespace garbage or a second JSON value, plus non-object and
+# malformed controls. A two-event window with a valid first event and malformed
+# second event proves the entire batch is validated before any submission. The
+# peer closing without an ACK is the rejection oracle; a timeout is a failure
+# because it would leave the malformed session alive. A fresh, legitimate
+# object must then be submitted and cumulatively ACKed, proving strict rejection
+# did not damage normal Lumberjack v2 traffic.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string" string="%$!message%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+if ! $PYTHON - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+
+port = int(sys.argv[1])
+
+
+def wire(payload, seq=1):
+    return (
+        b"2W" + struct.pack(">I", 1)
+        + b"2J" + struct.pack(">I", seq)
+        + struct.pack(">I", len(payload)) + payload
+    )
+
+
+def batch_wire(payloads):
+    frames = [b"2W" + struct.pack(">I", len(payloads))]
+    for seq, payload in enumerate(payloads, 1):
+        frames.append(
+            b"2J" + struct.pack(">I", seq)
+            + struct.pack(">I", len(payload)) + payload
+        )
+    return b"".join(frames)
+
+
+def require_wire_rejected(frame):
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+        sock.settimeout(5)
+        sock.sendall(frame)
+        try:
+            data = sock.recv(6)
+        except (ConnectionResetError, BrokenPipeError):
+            return
+        except socket.timeout as exc:
+            raise SystemExit("malformed JSON session was not closed") from exc
+        if data:
+            raise SystemExit(f"unexpected ACK for malformed JSON: {data.hex()}")
+
+
+def require_rejected(payload):
+    require_wire_rejected(wire(payload))
+
+
+valid_prefix = b'{"message":"must-not-submit"}'
+require_rejected(valid_prefix + b"garbage")
+require_rejected(valid_prefix + b'{"message":"second-value"}')
+require_rejected(b"[]")
+require_rejected(b'"scalar"')
+require_rejected(b'{"message":')
+require_wire_rejected(batch_wire([b'{"message":"must-not-partially-submit"}', b'{"message":']))
+
+payload = b" \t" + json.dumps({"message": "strict-json-control"}, separators=(",", ":")).encode() + b"\r\n"
+with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+    sock.settimeout(5)
+    sock.sendall(wire(payload))
+    ack = sock.recv(6)
+    if ack != b"2A" + struct.pack(">I", 1):
+        raise SystemExit(f"unexpected control ACK: {ack.hex()}")
+    print(ack.hex())
+PY
+then
+	error_exit 1
+fi
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='strict-json-control'
+cmp_exact
+
+export EXPECTED='324100000001'
+cmp_exact "$RSYSLOG_DYNNAME.imbeats.ack"
+
+exit_test

--- a/tests/imbeats-limits.sh
+++ b/tests/imbeats-limits.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
+# Verify configured window, frame, decompression, and batch limits reject
+# oversized traffic while preserving valid boundary traffic.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
-if [ "$IMBEATS_LIMITS_CHECK_STATS" = "YES" ]; then
-	require_plugin impstats
-fi
 
 generate_conf
 if [ "$IMBEATS_LIMITS_CHECK_STATS" = "YES" ]; then
@@ -95,6 +93,7 @@ rst_msleep 1500
 shutdown_when_empty
 wait_shutdown
 
+# shellcheck disable=SC2034
 EXPECTED='{"message":"ok"}'
 cmp_exact
 

--- a/tests/imbeats-maxsessions-cap-warning.sh
+++ b/tests/imbeats-maxsessions-cap-warning.sh
@@ -3,7 +3,6 @@
 # during config load. The oracle is rsyslogd -N1 succeeding while emitting the
 # explicit cap warning, so the test avoids opening listeners or sending traffic.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
 
 generate_conf
 add_conf '

--- a/tests/imbeats-maxsessions.sh
+++ b/tests/imbeats-maxsessions.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# Verify maxSessions rejects excess peers and releases admission capacity after
+# an established session closes.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
 
 generate_conf
 add_conf '
@@ -81,6 +82,7 @@ fi
 shutdown_when_empty
 wait_shutdown
 
+# shellcheck disable=SC2034
 EXPECTED='{"message":"accepted-1"}
 {"message":"accepted-2"}'
 cmp_exact

--- a/tests/imbeats-metadata-collision.sh
+++ b/tests/imbeats-metadata-collision.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# Verify client JSON cannot overwrite the reserved imbeats protocol metadata
+# attached during message submission.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
 
 generate_conf
 add_conf '
@@ -54,6 +55,7 @@ PY
 shutdown_when_empty
 wait_shutdown
 
+# shellcheck disable=SC2034
 EXPECTED='{"message":"metadata collision","metadata":{"imbeats":{"protocol":"attacker","sequence":999,"tls_enabled":true}}}|lumberjack-v2|1|false'
 cmp_exact
 

--- a/tests/imbeats-multiplex-idle-sessions.sh
+++ b/tests/imbeats-multiplex-idle-sessions.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# Verify idle sessions do not prevent an active peer from being serviced and
+# cumulatively acknowledged by the shared worker pool.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
 
 generate_conf
 add_conf '
@@ -63,6 +64,7 @@ fi
 shutdown_when_empty
 wait_shutdown
 
+# shellcheck disable=SC2034
 EXPECTED='{"message":"active-after-idle"}'
 cmp_exact
 

--- a/tests/imbeats-resource-budget.sh
+++ b/tests/imbeats-resource-budget.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Exercise imbeats' listener-wide in-flight budget and compression-ratio cap.
+# One connection declares an incomplete 6144-byte JSON body under an 8192-byte
+# aggregate budget. Bounded retries wait until a second 4096-byte reservation is
+# rejected by peer close (never ACK); this avoids assuming when the worker has
+# consumed the first header. Closing the holder must release its reservation,
+# proven by a legitimate direct event receiving an ACK within the same bounded
+# retry window. A high-ratio compressed frame must also close without an ACK,
+# while a low-ratio compressed control remains accepted. Five seconds permits
+# loaded CI scheduling without turning silence/timeouts into a passing oracle.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/impstats/.libs/impstats" interval="1"
+       log.file="'$RSYSLOG_DYNNAME'.spool/imbeats-stats.log"
+       log.syslog="off" format="cee")
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main"
+      workerThreads="1"
+      maxInFlightBytes="8192"
+      maxCompressionRatio="4")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+if ! $PYTHON - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import select
+import socket
+import struct
+import sys
+import time
+import zlib
+
+port = int(sys.argv[1])
+ack1 = b"2A" + struct.pack(">I", 1)
+
+
+def window(frame):
+    return b"2W" + struct.pack(">I", 1) + frame
+
+
+def json_frame(payload, seq=1):
+    return b"2J" + struct.pack(">I", seq) + struct.pack(">I", len(payload)) + payload
+
+
+def declared_json(length, partial=b""):
+    return b"2J" + struct.pack(">I", 1) + struct.pack(">I", length) + partial
+
+
+def peer_closed(sock, timeout):
+    readable, _, _ = select.select([sock], [], [], timeout)
+    if not readable:
+        return False
+    try:
+        return sock.recv(6) == b""
+    except (ConnectionResetError, BrokenPipeError):
+        return True
+
+
+def retry_until_ack(frame, deadline):
+    last = b""
+    while time.monotonic() < deadline:
+        with socket.create_connection(("127.0.0.1", port), timeout=2) as sock:
+            sock.settimeout(1)
+            sock.sendall(window(frame))
+            try:
+                last = sock.recv(6)
+            except (ConnectionResetError, BrokenPipeError, socket.timeout):
+                last = b""
+            if last == ack1:
+                return last
+        select.select([], [], [], 0.05)
+    raise SystemExit(f"legitimate frame was not ACKed after budget release; last={last.hex()}")
+
+
+holder = socket.create_connection(("127.0.0.1", port), timeout=5)
+holder.settimeout(2)
+try:
+    holder.sendall(window(declared_json(6144, b"{")))
+
+    # Admission and parsing are asynchronous. Retry the competing reservation
+    # until the server's close proves the holder has been charged.
+    deadline = time.monotonic() + 5
+    rejected = False
+    while time.monotonic() < deadline and not rejected:
+        with socket.create_connection(("127.0.0.1", port), timeout=2) as contender:
+            contender.sendall(window(declared_json(4096, b"{")))
+            rejected = peer_closed(contender, 0.25)
+        if not rejected:
+            select.select([], [], [], 0.05)
+    if not rejected:
+        raise SystemExit("aggregate in-flight budget did not reject a competing reservation")
+finally:
+    holder.close()
+
+direct = json.dumps({"message": "budget-released"}, separators=(",", ":")).encode()
+direct_ack = retry_until_ack(json_frame(direct), time.monotonic() + 5)
+
+high = json_frame(json.dumps({"message": "x" * 400}, separators=(",", ":")).encode())
+high_compressed = zlib.compress(high)
+if len(high) <= 4 * len(high_compressed):
+    raise SystemExit("test bug: high-ratio fixture does not exceed configured ratio")
+with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+    sock.sendall(window(b"2C" + struct.pack(">I", len(high_compressed)) + high_compressed))
+    if not peer_closed(sock, 5):
+        raise SystemExit("high-ratio compressed frame was not rejected by peer close")
+
+normal = json_frame(
+    json.dumps({"message": "compressed-control-0123456789abcdef"}, separators=(",", ":")).encode()
+)
+normal_compressed = zlib.compress(normal)
+if len(normal) > 4 * len(normal_compressed):
+    raise SystemExit("test bug: normal compressed fixture exceeds configured ratio")
+compressed_ack = retry_until_ack(
+    b"2C" + struct.pack(">I", len(normal_compressed)) + normal_compressed,
+    time.monotonic() + 5,
+)
+
+print(direct_ack.hex())
+print(compressed_ack.hex())
+PY
+then
+	error_exit 1
+fi
+
+rst_msleep 1500
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"budget-released"}
+{"message":"compressed-control-0123456789abcdef"}'
+cmp_exact
+
+EXPECTED_ACK='324100000001
+324100000001'
+export EXPECTED="$EXPECTED_ACK"
+cmp_exact "$RSYSLOG_DYNNAME.imbeats.ack"
+
+if ! $PYTHON - "$RSYSLOG_DYNNAME.spool/imbeats-stats.log" <<'PY'
+import json
+import sys
+
+stats = {}
+with open(sys.argv[1], encoding="utf-8") as fh:
+    for line in fh:
+        if "@cee: " in line:
+            data = json.loads(line.split("@cee: ", 1)[1])
+            if data.get("name") == "imbeats":
+                stats = data
+
+if stats.get("resource_bytes") != 0:
+    raise SystemExit(f"resource accounting did not return to zero: {stats}")
+if stats.get("resource_rejected", 0) < 1:
+    raise SystemExit(f"resource rejection counter did not advance: {stats}")
+if stats.get("protocol_errors") != 1:
+    raise SystemExit(f"resource rejection was misclassified as a protocol error: {stats}")
+PY
+then
+	error_exit 1
+fi
+
+exit_test

--- a/tests/imbeats-seq-cumulative-after-multi-event-window.sh
+++ b/tests/imbeats-seq-cumulative-after-multi-event-window.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# Verify the next window continues after a multi-event cumulative ACK instead
+# of resetting sequence state.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
 
 generate_conf
 add_conf '
@@ -48,6 +49,7 @@ PY
 shutdown_when_empty
 wait_shutdown
 
+# shellcheck disable=SC2034
 EXPECTED='{"message":"one"}|1
 {"message":"two"}|2
 {"message":"three"}|3'

--- a/tests/imbeats-seq-cumulative-two-windows.sh
+++ b/tests/imbeats-seq-cumulative-two-windows.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# Verify cumulative sequence tracking and ACKs across two Lumberjack windows
+# on one connection.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
 
 generate_conf
 add_conf '
@@ -47,6 +48,7 @@ PY
 shutdown_when_empty
 wait_shutdown
 
+# shellcheck disable=SC2034
 EXPECTED='{"message":"first"}|1
 {"message":"second"}|2'
 cmp_exact

--- a/tests/imbeats-seq-reset-rejected.sh
+++ b/tests/imbeats-seq-reset-rejected.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# Verify a sequence reset on an established connection is rejected without
+# submitting or acknowledging the invalid event.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
 
 generate_conf
 add_conf '
@@ -52,6 +53,7 @@ PY
 shutdown_when_empty
 wait_shutdown
 
+# shellcheck disable=SC2034
 EXPECTED='{"message":"first"}|1'
 cmp_exact
 

--- a/tests/imbeats-shutdown-open-session.sh
+++ b/tests/imbeats-shutdown-open-session.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
 
 # This checks that imbeats shutdown closes client sessions that are already
 # accepted and left open in idle or partial-frame protocol states. The client

--- a/tests/imbeats-submit-timeout.sh
+++ b/tests/imbeats-submit-timeout.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Regression test for imbeats timeout ownership while a complete batch is
+# submitted. A direct ruleset deliberately spends longer than idleTimeout on
+# each event, and starvation protection yields between the two submissions.
+# The cumulative ACK and both output lines prove that neither the timeout
+# scanner nor worker re-entry expired the session during local submission.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+module(load="../plugins/omtesting/.libs/omtesting")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+ruleset(name="main" queue.type="Direct") {
+  :omtesting:sleep 1 100000
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main"
+      idleTimeout="1"
+      workerThreads="1"
+      starvationProtection.maxReads="1")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+if ! $PYTHON - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+
+port = int(sys.argv[1])
+events = []
+
+
+def recv_exactly(sock, length):
+    data = b""
+    while len(data) < length:
+        chunk = sock.recv(length - len(data))
+        if not chunk:
+            raise ConnectionError("connection closed before cumulative ACK")
+        data += chunk
+    return data
+
+
+for sequence in (1, 2):
+    payload = json.dumps({"message": "submit-timeout-%d" % sequence}, separators=(",", ":")).encode()
+    events.append(b"2J" + struct.pack(">I", sequence) + struct.pack(">I", len(payload)) + payload)
+
+with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+    sock.settimeout(10)
+    sock.sendall(b"2W" + struct.pack(">I", len(events)) + b"".join(events))
+    print(recv_exactly(sock, 6).hex())
+PY
+then
+	error_exit 1
+fi
+
+shutdown_when_empty
+wait_shutdown
+
+# diag.sh's cmp_exact consumes this conventionally named variable.
+# shellcheck disable=SC2034
+EXPECTED='{"message":"submit-timeout-1"}
+{"message":"submit-timeout-2"}'
+cmp_exact
+
+# shellcheck disable=SC2034
+EXPECTED='324100000002'
+cmp_exact "$RSYSLOG_DYNNAME.imbeats.ack"
+
+exit_test

--- a/tests/unit/imbeats_parser_test.c
+++ b/tests/unit/imbeats_parser_test.c
@@ -1,0 +1,309 @@
+/*
+ * Exercise imbeats' transport-independent Lumberjack parser resource and
+ * framing invariants. The deterministic oracle is the parser return code,
+ * parsed event content, and an exact reserve/release balance after batch
+ * cleanup; no timing or live listener behavior is involved.
+ */
+#include "config.h"
+
+#include <arpa/inet.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <zlib.h>
+
+#include "rsyslog.h"
+#include "plugins/imbeats/lj_parser.h"
+
+/* Compile the parser into this test translation unit. Keeping all test
+ * sources below tests/ avoids Automake dependency-file paths that are not
+ * portable to older make versions, while still exercising production code. */
+#include "../../plugins/imbeats/lj_parser.c"
+
+#define CHECK(cond)                                                                  \
+    do {                                                                             \
+        if (!(cond)) {                                                               \
+            fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__, #cond); \
+            return 1;                                                                \
+        }                                                                            \
+    } while (0)
+
+struct resource_account_s {
+    size_t current;
+    size_t peak;
+    size_t reserved;
+    size_t released;
+    size_t limit;
+};
+
+static rsRetVal reserve_bytes(void *const ctx, const size_t bytes) {
+    struct resource_account_s *const account = ctx;
+
+    if (bytes > account->limit - account->current) {
+        return RS_RET_OUT_OF_MEMORY;
+    }
+    account->current += bytes;
+    account->reserved += bytes;
+    if (account->current > account->peak) account->peak = account->current;
+    return RS_RET_OK;
+}
+
+static void release_bytes(void *const ctx, const size_t bytes) {
+    struct resource_account_s *const account = ctx;
+
+    if (bytes > account->current) {
+        fprintf(stderr, "resource accounting underflow: current=%zu release=%zu\n", account->current, bytes);
+        abort();
+    }
+    account->current -= bytes;
+    account->released += bytes;
+}
+
+static rsRetVal init_batch(struct lj_batch_s *const batch,
+                           struct resource_account_s *const account,
+                           const uint32_t window_size,
+                           const size_t max_payload_len) {
+    memset(account, 0, sizeof(*account));
+    account->limit = SIZE_MAX;
+    return lj_batch_alloc(batch, window_size, window_size, max_payload_len, reserve_bytes, release_bytes, account);
+}
+
+static size_t put_json_frame(unsigned char *const dst,
+                             const uint32_t seq,
+                             const unsigned char *const payload,
+                             const size_t payload_len) {
+    const uint32_t net_seq = htonl(seq);
+    const uint32_t net_len = htonl((uint32_t)payload_len);
+
+    dst[0] = LJ_VERSION_V2;
+    dst[1] = LJ_FRAME_JSON;
+    memcpy(dst + 2, &net_seq, sizeof(net_seq));
+    memcpy(dst + 6, &net_len, sizeof(net_len));
+    memcpy(dst + 10, payload, payload_len);
+    return 10 + payload_len;
+}
+
+static int compress_bytes(const unsigned char *const input,
+                          const size_t input_len,
+                          unsigned char **const output,
+                          size_t *const output_len) {
+    uLongf compressed_len = compressBound(input_len);
+
+    *output = malloc(compressed_len);
+    if (*output == NULL) return 1;
+    if (compress2(*output, &compressed_len, input, input_len, Z_BEST_COMPRESSION) != Z_OK) {
+        free(*output);
+        *output = NULL;
+        return 1;
+    }
+    *output_len = compressed_len;
+    return 0;
+}
+
+static int test_lazy_allocation_and_cleanup(void) {
+    struct lj_batch_s batch;
+    struct resource_account_s account;
+    static const unsigned char payload[] = "one";
+    const size_t descriptor_bytes = 3 * sizeof(struct lj_event_s);
+
+    CHECK(init_batch(&batch, &account, 3, 64) == RS_RET_OK);
+    CHECK(batch.events == NULL);
+    CHECK(account.current == 0);
+    CHECK(lj_append_json_event(&batch, 1, payload, sizeof(payload) - 1) == RS_RET_OK);
+    CHECK(batch.events_capacity == 3);
+    CHECK(batch.events_alloc_len == descriptor_bytes);
+    CHECK(batch.events[0].payload_alloc_len == sizeof(payload));
+    CHECK(account.current == descriptor_bytes + sizeof(payload));
+    lj_batch_free(&batch);
+    CHECK(account.current == 0);
+    CHECK(account.reserved == account.released);
+    return 0;
+}
+
+static int test_budget_rejection_is_balanced(void) {
+    struct lj_batch_s batch;
+    struct resource_account_s account;
+    static const unsigned char payload[] = "budget";
+    const size_t descriptor_bytes = sizeof(struct lj_event_s);
+
+    CHECK(init_batch(&batch, &account, 1, 64) == RS_RET_OK);
+    account.limit = descriptor_bytes + sizeof(payload) - 1;
+    CHECK(lj_append_json_event(&batch, 1, payload, sizeof(payload) - 1) == RS_RET_OUT_OF_MEMORY);
+    CHECK(batch.count == 0);
+    CHECK(account.current == descriptor_bytes);
+    lj_batch_free(&batch);
+    CHECK(account.current == 0);
+    CHECK(account.reserved == account.released);
+    return 0;
+}
+
+static int test_owned_transfer_and_failure_contract(void) {
+    struct lj_batch_s batch;
+    struct resource_account_s account;
+    unsigned char *owned;
+    unsigned char *rejected;
+    const size_t alloc_len = 6;
+
+    CHECK(init_batch(&batch, &account, 1, 64) == RS_RET_OK);
+    CHECK(reserve_bytes(&account, alloc_len) == RS_RET_OK);
+    owned = malloc(alloc_len);
+    CHECK(owned != NULL);
+    memcpy(owned, "owned", alloc_len);
+    CHECK(lj_append_json_event_owned(&batch, 9, owned, 5, alloc_len) == RS_RET_OK);
+    CHECK(batch.events[0].payload == owned);
+    CHECK(batch.events[0].payload_alloc_len == alloc_len);
+
+    CHECK(reserve_bytes(&account, 2) == RS_RET_OK);
+    rejected = malloc(2);
+    CHECK(rejected != NULL);
+    memcpy(rejected, "x", 2);
+    CHECK(lj_append_json_event_owned(&batch, 10, rejected, 1, 2) == RS_RET_INVALID_VALUE);
+    /* Failure retains caller ownership, so this free is required and is also
+     * the oracle that the parser did not consume the second allocation. */
+    free(rejected);
+    release_bytes(&account, 2);
+
+    lj_batch_free(&batch);
+    CHECK(account.current == 0);
+    CHECK(account.reserved == account.released);
+    return 0;
+}
+
+static int test_valid_compressed_batch(void) {
+    struct lj_batch_s batch;
+    struct resource_account_s account;
+    unsigned char frames[128];
+    unsigned char *compressed = NULL;
+    size_t frames_len = 0;
+    size_t compressed_len = 0;
+
+    frames_len += put_json_frame(frames + frames_len, 1, (const unsigned char *)"{\"a\":1}", 7);
+    frames_len += put_json_frame(frames + frames_len, 2, (const unsigned char *)"{\"b\":2}", 7);
+    CHECK(compress_bytes(frames, frames_len, &compressed, &compressed_len) == 0);
+    CHECK(init_batch(&batch, &account, 2, 128) == RS_RET_OK);
+    CHECK(lj_parse_compressed_frames(&batch, compressed, compressed_len, 128, 4096, 64) == RS_RET_OK);
+    CHECK(batch.count == 2);
+    CHECK(batch.events[0].seq == 1 && batch.events[1].seq == 2);
+    CHECK(memcmp(batch.events[0].payload, "{\"a\":1}", 7) == 0);
+    lj_batch_free(&batch);
+    CHECK(account.current == 0);
+    CHECK(account.reserved == account.released);
+
+    /* A stream ending at the exact decompressed-size limit must consume its
+     * zlib trailer and terminate. Success is the oracle against a boundary
+     * spin or an off-by-one rejection. */
+    CHECK(init_batch(&batch, &account, 2, 128) == RS_RET_OK);
+    CHECK(lj_parse_compressed_frames(&batch, compressed, compressed_len, 128, frames_len, 64) == RS_RET_OK);
+    CHECK(batch.count == 2);
+    lj_batch_free(&batch);
+    CHECK(account.current == 0);
+    CHECK(account.reserved == account.released);
+
+    CHECK(init_batch(&batch, &account, 2, 128) == RS_RET_OK);
+    compressed = realloc(compressed, compressed_len + 1);
+    CHECK(compressed != NULL);
+    compressed[compressed_len++] = 0;
+    CHECK(lj_parse_compressed_frames(&batch, compressed, compressed_len, 128, 4096, 64) == RS_RET_INVALID_VALUE);
+    free(compressed);
+    lj_batch_free(&batch);
+    CHECK(account.current == 0);
+    CHECK(account.reserved == account.released);
+    return 0;
+}
+
+static int test_high_ratio_and_scratch_budget_rejection(void) {
+    struct lj_batch_s batch;
+    struct resource_account_s account;
+    unsigned char *frames;
+    unsigned char *compressed = NULL;
+    unsigned char payload[8192];
+    size_t compressed_len = 0;
+    const size_t frames_len = sizeof(payload) + 10;
+
+    memset(payload, 'A', sizeof(payload));
+    frames = malloc(frames_len);
+    CHECK(frames != NULL);
+    CHECK(put_json_frame(frames, 1, payload, sizeof(payload)) == frames_len);
+    CHECK(compress_bytes(frames, frames_len, &compressed, &compressed_len) == 0);
+    free(frames);
+    CHECK(frames_len > compressed_len * 2);
+
+    CHECK(init_batch(&batch, &account, 1, 16384) == RS_RET_OK);
+    CHECK(lj_parse_compressed_frames(&batch, compressed, compressed_len, 16384, 16384, 2) == RS_RET_INVALID_VALUE);
+    CHECK(batch.count == 0);
+    CHECK(account.current == 0);
+    lj_batch_free(&batch);
+
+    CHECK(init_batch(&batch, &account, 1, 16384) == RS_RET_OK);
+    account.limit = 32;
+    CHECK(lj_parse_compressed_frames(&batch, compressed, compressed_len, 16384, 16384, 1000) == RS_RET_OUT_OF_MEMORY);
+    CHECK(batch.count == 0);
+    CHECK(account.current == 0);
+    free(compressed);
+    lj_batch_free(&batch);
+    CHECK(account.reserved == account.released);
+    return 0;
+}
+
+static int expect_invalid_compressed(const unsigned char *const frames, const size_t frames_len) {
+    struct lj_batch_s batch;
+    struct resource_account_s account;
+    unsigned char *compressed = NULL;
+    size_t compressed_len = 0;
+
+    CHECK(compress_bytes(frames, frames_len, &compressed, &compressed_len) == 0);
+    CHECK(init_batch(&batch, &account, 2, 128) == RS_RET_OK);
+    CHECK(lj_parse_compressed_frames(&batch, compressed, compressed_len, 128, 4096, 128) == RS_RET_INVALID_VALUE);
+    free(compressed);
+    lj_batch_free(&batch);
+    CHECK(account.current == 0);
+    CHECK(account.reserved == account.released);
+    return 0;
+}
+
+static int test_truncation_and_invalid_framing(void) {
+    static const unsigned char invalid_version[] = {'1', LJ_FRAME_JSON};
+    static const unsigned char nested[] = {LJ_VERSION_V2, LJ_FRAME_COMPRESSED};
+    unsigned char valid[32];
+    unsigned char valid_with_trailing[32];
+    size_t valid_len;
+    size_t prefix_len;
+
+    valid_len = put_json_frame(valid, 1, (const unsigned char *)"{}", 2);
+    /* Every strict prefix is a distinct truncated-frame boundary. Each must
+     * fail, while test_valid_compressed_batch supplies the positive control. */
+    for (prefix_len = 0; prefix_len < valid_len; ++prefix_len) {
+        CHECK(expect_invalid_compressed(valid, prefix_len) == 0);
+    }
+    CHECK(expect_invalid_compressed(invalid_version, sizeof(invalid_version)) == 0);
+    CHECK(expect_invalid_compressed(nested, sizeof(nested)) == 0);
+    valid_len = put_json_frame(valid_with_trailing, 1, (const unsigned char *)"{}", 2);
+    valid_with_trailing[valid_len++] = LJ_VERSION_V2;
+    CHECK(expect_invalid_compressed(valid_with_trailing, valid_len) == 0);
+    return 0;
+}
+
+int main(void) {
+    struct {
+        const char *name;
+        int (*fn)(void);
+    } tests[] = {
+        {"lazy_allocation_and_cleanup", test_lazy_allocation_and_cleanup},
+        {"budget_rejection_is_balanced", test_budget_rejection_is_balanced},
+        {"owned_transfer_and_failure_contract", test_owned_transfer_and_failure_contract},
+        {"valid_compressed_batch", test_valid_compressed_batch},
+        {"high_ratio_and_scratch_budget_rejection", test_high_ratio_and_scratch_budget_rejection},
+        {"truncation_and_invalid_framing", test_truncation_and_invalid_framing},
+    };
+    size_t i;
+
+    for (i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {
+        if (tests[i].fn() != 0) {
+            fprintf(stderr, "FAILED: %s\n", tests[i].name);
+            return 1;
+        }
+    }
+    printf("imbeats parser tests passed (%zu cases)\n", sizeof(tests) / sizeof(tests[0]));
+    return 0;
+}

--- a/tests/yaml-imbeats-basic.sh
+++ b/tests/yaml-imbeats-basic.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# Verify YAML configuration accepts a basic imbeats event and preserves JSON
+# fields, reserved metadata, and the cumulative ACK.
 . ${srcdir:=.}/diag.sh init
-require_plugin imbeats
 require_yaml_support
 
 generate_conf --yaml-only
@@ -48,6 +49,7 @@ PY
 shutdown_when_empty
 wait_shutdown
 
+# shellcheck disable=SC2034
 EXPECTED='{"message":"yaml"}|yaml|1'
 cmp_exact
 

--- a/tests/yaml-imbeats-session-timeouts.sh
+++ b/tests/yaml-imbeats-session-timeouts.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Verify YAML wiring and enforcement for all imbeats session deadlines. Three
+# listeners isolate the invariants: idleTimeout closes an entirely idle peer,
+# frameTimeout closes a partial body despite byte progress, and windowTimeout
+# closes an incomplete advertised window despite receiving a complete event.
+# Each listener has maxSessions=1. A peer close is the timeout oracle, and an
+# ACKed valid client on that same listener proves its sole admission slot was
+# reclaimed. The configured two-second limits are observed through bounded
+# select/poll loops with a ten-second outer deadline, allowing loaded CI runners
+# several timer sweeps without fixed sleeps or accepting mere silence as success.
+. ${srcdir:=.}/diag.sh init
+require_yaml_support
+
+generate_conf --yaml-only
+add_yaml_conf 'modules:'
+add_yaml_conf '  - load: "../plugins/imbeats/.libs/imbeats"'
+add_yaml_conf ''
+add_yaml_conf 'templates:'
+add_yaml_conf '  - name: outfmt'
+add_yaml_conf '    type: string'
+add_yaml_conf '    string: "%msg%\n"'
+add_yaml_conf ''
+add_yaml_conf 'inputs:'
+add_yaml_conf '  - type: imbeats'
+add_yaml_conf '    port: "0"'
+add_yaml_conf "    listenPortFileName: \"${RSYSLOG_DYNNAME}.imbeats-idle.port\""
+add_yaml_conf '    ruleset: main'
+add_yaml_conf '    maxSessions: 1'
+add_yaml_conf '    idleTimeout: 2'
+add_yaml_conf '    frameTimeout: 0'
+add_yaml_conf '  - type: imbeats'
+add_yaml_conf '    port: "0"'
+add_yaml_conf "    listenPortFileName: \"${RSYSLOG_DYNNAME}.imbeats-frame.port\""
+add_yaml_conf '    ruleset: main'
+add_yaml_conf '    maxSessions: 1'
+add_yaml_conf '    idleTimeout: 0'
+add_yaml_conf '    frameTimeout: 2'
+add_yaml_conf '  - type: imbeats'
+add_yaml_conf '    port: "0"'
+add_yaml_conf "    listenPortFileName: \"${RSYSLOG_DYNNAME}.imbeats-window.port\""
+add_yaml_conf '    ruleset: main'
+add_yaml_conf '    maxSessions: 1'
+add_yaml_conf '    idleTimeout: 0'
+add_yaml_conf '    frameTimeout: 0'
+add_yaml_conf '    windowTimeout: 2'
+add_yaml_conf ''
+add_yaml_conf 'rulesets:'
+add_yaml_conf '  - name: main'
+add_yaml_conf '    script: |'
+add_yaml_conf "      action(type=\"omfile\" file=\"${RSYSLOG_OUT_LOG}\" template=\"outfmt\")"
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats-idle.port"
+IDLE_PORT="$RS_PORT"
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats-frame.port"
+FRAME_PORT="$RS_PORT"
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats-window.port"
+WINDOW_PORT="$RS_PORT"
+
+if ! $PYTHON - "$IDLE_PORT" "$FRAME_PORT" "$WINDOW_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import select
+import socket
+import struct
+import sys
+import time
+
+idle_port = int(sys.argv[1])
+frame_port = int(sys.argv[2])
+window_port = int(sys.argv[3])
+expected_ack = b"2A" + struct.pack(">I", 1)
+
+
+def event(message):
+    payload = json.dumps({"message": message}, separators=(",", ":")).encode()
+    return (
+        b"2W" + struct.pack(">I", 1)
+        + b"2J" + struct.pack(">I", 1)
+        + struct.pack(">I", len(payload)) + payload
+    )
+
+
+def wait_for_close(sock, description):
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        readable, _, _ = select.select([sock], [], [], min(0.25, deadline - time.monotonic()))
+        if not readable:
+            continue
+        try:
+            data = sock.recv(6)
+        except (ConnectionResetError, BrokenPipeError):
+            return
+        if data == b"":
+            return
+        raise SystemExit(f"{description} unexpectedly received data: {data.hex()}")
+    raise SystemExit(f"{description} was not closed within bounded timeout")
+
+
+def recv_exactly(sock, size):
+    data = b""
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        if chunk == b"":
+            break
+        data += chunk
+    return data
+
+
+def wait_for_control(port, message):
+    deadline = time.monotonic() + 10
+    last = b""
+    while time.monotonic() < deadline:
+        with socket.create_connection(("127.0.0.1", port), timeout=2) as sock:
+            sock.settimeout(1)
+            sock.sendall(event(message))
+            try:
+                last = recv_exactly(sock, 6)
+            except (ConnectionResetError, BrokenPipeError, socket.timeout):
+                last = b""
+            if last == expected_ack:
+                return last
+        select.select([], [], [], 0.05)
+    raise SystemExit(f"valid client did not regain admission; last={last.hex()}")
+
+
+idle = socket.create_connection(("127.0.0.1", idle_port), timeout=5)
+try:
+    wait_for_close(idle, "idle holder")
+finally:
+    idle.close()
+idle_ack = wait_for_control(idle_port, "after-idle-timeout")
+
+partial = socket.create_connection(("127.0.0.1", frame_port), timeout=5)
+try:
+    # A declared frame with a partial body starts frameTimeout while remaining
+    # incomplete and therefore must never be submitted or ACKed.
+    partial.sendall(
+        b"2W" + struct.pack(">I", 1)
+        + b"2J" + struct.pack(">I", 1)
+        + struct.pack(">I", 128) + b"{"
+    )
+    wait_for_close(partial, "partial-body holder")
+finally:
+    partial.close()
+frame_ack = wait_for_control(frame_port, "after-frame-timeout")
+
+window = socket.create_connection(("127.0.0.1", window_port), timeout=5)
+try:
+    payload = json.dumps({"message": "must-not-submit"}, separators=(",", ":")).encode()
+    # Complete one event in a two-event window. Byte and frame progress cannot
+    # extend the absolute window deadline; the incomplete batch is never ACKed.
+    window.sendall(
+        b"2W" + struct.pack(">I", 2)
+        + b"2J" + struct.pack(">I", 1)
+        + struct.pack(">I", len(payload)) + payload
+    )
+    wait_for_close(window, "incomplete-window holder")
+finally:
+    window.close()
+window_ack = wait_for_control(window_port, "after-window-timeout")
+
+print(idle_ack.hex())
+print(frame_ack.hex())
+print(window_ack.hex())
+PY
+then
+	error_exit 1
+fi
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"after-idle-timeout"}
+{"message":"after-frame-timeout"}
+{"message":"after-window-timeout"}'
+cmp_exact
+
+EXPECTED_ACK='324100000001
+324100000001
+324100000001'
+export EXPECTED="$EXPECTED_ACK"
+cmp_exact "$RSYSLOG_DYNNAME.imbeats.ack"
+
+exit_test


### PR DESCRIPTION
## Summary

This change strengthens `imbeats` handling of malformed, incomplete, and
resource-intensive Lumberjack v2 traffic.

It adds:

- instance-wide accounting for parser and session memory
- configurable compression expansion limits
- idle, frame, and incomplete-window timeouts
- strict whole-batch JSON object validation before submission
- lazy allocation of window event descriptors
- safer synchronization between timeout handling and socket rearming
- additional statistics, documentation, and configuration coverage

Valid Filebeat and Elastic Agent traffic, existing configuration syntax,
cumulative acknowledgements, and Lumberjack v2 `W`, `J`, and `C` flows remain
compatible.

## Why

Frame sizes, compressed payloads, advertised windows, and connection timing
are supplied by peers. Applying aggregate limits and explicit deadlines makes
resource use predictable and ensures incomplete or malformed batches fail
consistently without changing legitimate delivery behavior.

## New input parameters

- `maxInFlightBytes`
- `maxCompressionRatio`
- `idleTimeout`
- `frameTimeout`
- `windowTimeout`

A value of `0` disables the corresponding timeout.

## New statistics

- `resource_bytes`
- `resource_rejected`
- `sessions.timed_out`

## Validation

- complete registered `imbeats` suite: 22/22 passed
- Ubuntu 26.04 PR-ready container run: 1,281 passed, 34 expected skips,
  0 failures
- focused ASan/UBSan and TSan coverage passed
- clang-21 no-debug and GCC 15 GNU23 builds passed
- clang static analyzer reported no findings
- mock distcheck and rendered documentation build passed
- clang-format, shellcheck, and test-antipattern checks passed
- real Filebeat Docker interoperability test passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

