### PR TITLE
queue: add segmented disk-assisted queue support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,13 @@
 --------------------------------------------------------------------------------------
 Scheduled Release 8.2608.0 (aka 2026.08) 2026-08-??
 
+- 2026-07-14: queue: add segmented disk-assisted storage
+  FixedArray and LinkedList disk-assisted queues now use the segmented disk
+  engine by default for new stores while automatically retaining existing
+  classic disk backlogs. New selectors can pin either engine or permit a
+  clean classic store to upgrade on restart. Empty segmented children can
+  remove their store and final worker after a configurable idle interval,
+  then recreate both transparently on the next spill.
 - 2026-07-08: omawslogshlc: add CloudWatch Logs HLC output module
   The new omawslogshlc output module sends events to Amazon CloudWatch Logs
   through the HTTP Log Collector endpoint using bearer-token authentication.

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -3,10 +3,19 @@
 # directory as `MODULE_METADATA.yaml`; update both the metadata file and this map
 # when concurrency guidance changes.
 runtime_queue:
-  paths: ["runtime/queue.c", "runtime/queue.h"]
+  paths:
+    - "runtime/queue.c"
+    - "runtime/queue.h"
+    - "runtime/queue_da.c"
+    - "runtime/queue_da.h"
+    - "runtime/segdisk_store.c"
+    - "runtime/segdisk_store.h"
   requires_serialization: true
   notes:
     - Disk-assisted mode is an in-memory parent plus a first-class disk child; disk queue semantics apply to the child.
+    - The queue mutex is shared by a disk-assisted parent and child; segmented store operations and idle dematerialization callbacks run under that lock.
+    - queue_da resolves the durable disk-child engine at startup and atomically publishes its marker before first persistent data; engines never switch while a process is running.
+    - The segmented store is lazy only for a disk-assisted child, and dematerialization requires an empty store with no recovery, batch, retry, or completion work pending.
 
 runtime_ratelimit:
   paths: ["runtime/ratelimit.c", "runtime/ratelimit.h"]

--- a/doc/source/concepts/queues.rst
+++ b/doc/source/concepts/queues.rst
@@ -220,11 +220,26 @@ and requests offline recovery instead of delaying daemon startup with a full
 scan. Version 1 of this unmerged experimental format is intentionally rejected;
 there is no migration guarantee for experimental queue data.
 
-This mode is opt-in and currently only available as a pure-disk queue
-type. Disk-assisted queues continue to use the classic disk child queue.
-Do not point ``segmentedDisk`` at an existing classic disk queue prefix. The
-queue refuses to start when the matching legacy ``.qi`` file exists. Queue
-encryption providers are not supported by this first implementation.
+The segmented store is also the default disk child for new disk-assisted
+``FixedArray`` and ``LinkedList`` queues. Their memory tier remains primary and
+the segmented child stays unmaterialized until the first spill. The
+``queue.diskQueueType`` selector can pin the classic or segmented engine. Its
+default ``auto`` preserves existing classic backlogs, with a warning, and uses
+a durable ``.da-engine`` marker to keep the choice stable. It never converts
+records or mixes the two formats. Queue encryption providers and classic-only
+corruption modes make ``auto`` select the classic engine.
+
+For a fresh segmented disk-assisted child, neither the marker nor the
+``.segq`` store exists before the first spill. The marker is made durable
+before the store is materialized. Idle cleanup removes the store but retains
+the marker so the same engine is selected when a later spill recreates it.
+
+After a segmented disk-assisted child drains, ``queue.diskQueueIdleTimeout``
+can remove its empty ``.segq`` directory and terminate the last child worker.
+The default grace period is 60 seconds; ``0`` requests immediate cleanup and
+``-1`` keeps the materialized child. New producer activity restarts the full
+grace period, and recovery, retries, or in-flight batches prevent cleanup. The
+small engine marker remains so a later spill can recreate the store safely.
 
 Storage operations are serialized under the queue lock. Multiple generic
 queue workers may consume batches concurrently, and their completions may be
@@ -255,7 +270,10 @@ Queue statistics add ``disk.usage``, ``segments``, ``checkpoints``,
 ``replayed``, ``corruption.events``, ``corruption.bytes``,
 ``corruption.records``, ``corruption.segments``, ``retry.overage.bytes``,
 ``retry.overage.maxbytes``, state-write/recovery counters, and the startup
-payload-byte and segment-probe counters for this backend.
+payload-byte and segment-probe counters for this backend. Segmented
+disk-assisted children additionally expose ``store.materializations``,
+``store.idleDematerializations``, ``store.idleCleanupFailures``, and
+``workers.current`` for lifecycle observability.
 
 If you happen to lose or otherwise need the housekeeping structures and
 have all your queue chunks you can use the ``recover_qi.pl`` script

--- a/doc/source/concepts/queues.rst
+++ b/doc/source/concepts/queues.rst
@@ -226,8 +226,10 @@ the segmented child stays unmaterialized until the first spill. The
 ``queue.diskQueueType`` selector can pin the classic or segmented engine. Its
 default ``auto`` preserves existing classic backlogs, with a warning, and uses
 a durable ``.da-engine`` marker to keep the choice stable. It never converts
-records or mixes the two formats. Queue encryption providers and classic-only
-corruption modes make ``auto`` select the classic engine.
+records or mixes the two formats. For a fresh selection, queue encryption
+providers and classic-only corruption modes make ``auto`` select the classic
+engine. If segmented state already exists, those unsupported options make
+initialization fail instead of converting or falling back to another engine.
 
 For a fresh segmented disk-assisted child, neither the marker nor the
 ``.segq`` store exists before the first spill. The marker is made durable

--- a/doc/source/rainerscript/queue_parameters.rst
+++ b/doc/source/rainerscript/queue_parameters.rst
@@ -1,3 +1,7 @@
+.. meta::
+   :description: Reference for rsyslog queue parameters, including memory, disk, and disk-assisted queue behavior.
+   :keywords: rsyslog, queue parameters, disk queue, segmented disk, disk assisted, RainerScript, YAML
+
 ************************
 General Queue Parameters
 ************************
@@ -23,6 +27,13 @@ set up by default.
 
 To fully understand queue parameters and how they interact, be sure to
 read the :doc:`queues <../concepts/queues>` documentation.
+
+.. summary-start
+
+Queue parameters configure main, ruleset, and action queue capacity,
+concurrency, persistence, disk-assisted behavior, and shutdown policy.
+
+.. summary-end
 
 
 Configuration Parameters
@@ -57,6 +68,84 @@ files.
 
 For the experimental ``segmentedDisk`` queue type, ``queue.filename`` is
 required. Configuration fails if it is omitted.
+
+
+queue.diskQueueType
+-------------------
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "word", "auto", "no", "none"
+
+Selects the disk engine used by a disk-assisted ``FixedArray`` or
+``LinkedList`` queue. It does not change the memory-first behavior: no disk
+store is created until the queue spills past its high watermark.
+
+Accepted values are:
+
+* ``auto``: use ``segmentedDisk`` for a fresh queue. Existing classic ``.qi``
+  or numeric queue files select ``Disk`` and emit a warning. Existing
+  segmented state selects ``segmentedDisk``.
+* ``disk``: require the classic disk queue engine.
+* ``segmentedDisk``: require the segmented engine.
+
+The selection is recorded in a small versioned
+``<queue.filename>.da-engine`` file. Malformed markers, mixed classic and
+segmented stores, and an explicit engine that conflicts with existing data
+fail queue initialization. ``auto`` selects classic ``Disk`` when encryption
+or a classic-only corruption mode is configured. Explicit ``segmentedDisk``
+rejects those unsupported options.
+
+For a fresh segmented selection, neither the marker nor the ``.segq`` store is
+created until the first spill. The marker is made durable before the store is
+materialized. Idle cleanup removes the store but retains that marker.
+
+This parameter has no legacy directive alias. Outside a disk-assisted memory
+queue it is reported as dirty configuration and ignored.
+
+
+queue.diskQueueAutoUpgrade
+--------------------------
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "none"
+
+Applies only when ``queue.diskQueueType="auto"``. With the default ``off``, an
+automatically selected classic engine remains sticky after its backlog drains.
+With ``on``, the next clean restart after that drain selects an unmaterialized
+segmented child. Records are never converted and engines never switch while a
+process is running.
+
+
+queue.diskQueueIdleTimeout
+--------------------------
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "integer", "60000", "no", "none"
+
+Controls how long, in milliseconds, an empty segmented disk-assisted child
+remains materialized. After the complete interval passes without new producer
+or disk-transfer activity, rsyslog durably removes the empty segmented store
+and lets its final disk-consumer worker terminate. The engine marker remains.
+A later spill recreates both the store and workers transparently.
+
+``0`` requests cleanup immediately after a safe drain. ``-1`` disables runtime
+dematerialization. Recovery work, in-flight batches, retries, or uncertain
+cleanup state postpone cleanup. This timeout is independent of
+``queue.timeoutWorkerThreadShutdown`` and applies only to an effective
+segmented disk-assisted child. A nondefault value with explicit classic
+``disk`` is dirty configuration and is ignored.
 
 
 queue.spoolDirectory

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -77,6 +77,8 @@ librsyslog_la_SOURCES = \
 	wti.h \
 	queue.c \
 	queue.h \
+	queue_da.c \
+	queue_da.h \
 	segdisk_codec.c \
 	segdisk_codec.h \
 	segdisk_crc.c \

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -720,6 +720,7 @@ static rsRetVal qqueueChkIsDA(qqueue_t *pThis) {
 static rsRetVal StartDA(qqueue_t *pThis) {
     DEFiRet;
     uchar pszDAQName[128];
+    sbool permit_classic_inmemory_fallback = 0;
 
     ISOBJ_TYPE_assert(pThis, qqueue);
 
@@ -762,6 +763,7 @@ static rsRetVal StartDA(qqueue_t *pThis) {
 
     const queueType_t child_type =
         engine_result.effective == QDA_ENGINE_SEGMENTED_DISK ? QUEUETYPE_SEGMENTED_DISK : QUEUETYPE_DISK;
+    permit_classic_inmemory_fallback = child_type == QUEUETYPE_DISK;
     /* create message queue */
     CHKiRet(qqueueConstruct(&pThis->pqDA, child_type, pThis->iNumWorkerThreads, 0, pThis->pConsumer));
 
@@ -828,11 +830,18 @@ static rsRetVal StartDA(qqueue_t *pThis) {
 
 finalize_it:
     if (iRet != RS_RET_OK) {
+        const rsRetVal startup_error = iRet;
         if (pThis->pqDA != NULL) {
             qqueueDestruct(&pThis->pqDA);
         }
-        LogError(0, iRet, "%s: error creating disk queue - giving up.", obj.GetName((obj_t *)pThis));
         pThis->bIsDA = 0;
+        if (permit_classic_inmemory_fallback) {
+            LogError(0, startup_error, "%s: error creating classic disk queue; continuing in pure in-memory mode",
+                     obj.GetName((obj_t *)pThis));
+            iRet = RS_RET_OK;
+        } else {
+            LogError(0, startup_error, "%s: error creating disk queue - giving up.", obj.GetName((obj_t *)pThis));
+        }
     }
 
     RETiRet;

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -755,6 +755,9 @@ static rsRetVal StartDA(qqueue_t *pThis) {
                    "to use segmentedDisk after the classic backlog drains",
                    obj.GetName((obj_t *)pThis), pThis->pszFilePrefix);
     }
+    /* A marker mismatch is the intentional auto-upgrade case.  The resolver
+     * permits it only after proving that the old classic store is empty, so
+     * publish the new selection durably at this restart boundary. */
     if (engine_result.classic_data || engine_result.segmented_data ||
         (engine_result.marker_present && engine_result.marker_engine != engine_result.effective)) {
         CHKiRet(qdaEngineWriteMarker((const char *)pThis->pszSpoolDir, (const char *)pThis->pszFilePrefix,

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -3873,6 +3873,13 @@ rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis) /* this is the Construction
         CHKiRet(wtpSetbAllowFirstWorkerToTimeout(pThis->pWtpReg, 1));
         CHKiRet(wtpSetpfIdleTimeout(pThis->pWtpReg, (rsRetVal(*)(void *pUsr))qqueueSegDiskIdleTimeout));
         CHKiRet(wtpSettoWrkShutdown(pThis->pWtpReg, pThis->diskQueueIdleTimeout));
+    } else if (pThis->segdiskDAChild) {
+        /* An idle timeout of -1 disables dematerialization without disabling
+         * the normal shutdown timeout for additional workers.  Explicitly
+         * keep slot zero non-timeout-capable: wtpStartWrkr() consequently
+         * marks that slot always-running, so the generic worker timeout can
+         * never terminate the segmented DA child's final worker. */
+        CHKiRet(wtpSetbAllowFirstWorkerToTimeout(pThis->pWtpReg, 0));
     }
     CHKiRet(wtpSetpUsr(pThis->pWtpReg, pThis));
     CHKiRet(wtpConstructFinalize(pThis->pWtpReg));

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -720,7 +720,7 @@ static rsRetVal qqueueChkIsDA(qqueue_t *pThis) {
 static rsRetVal StartDA(qqueue_t *pThis) {
     DEFiRet;
     uchar pszDAQName[128];
-    sbool permit_classic_inmemory_fallback = 0;
+    sbool permit_classic_startup_fallback = 0;
 
     ISOBJ_TYPE_assert(pThis, qqueue);
 
@@ -763,7 +763,6 @@ static rsRetVal StartDA(qqueue_t *pThis) {
 
     const queueType_t child_type =
         engine_result.effective == QDA_ENGINE_SEGMENTED_DISK ? QUEUETYPE_SEGMENTED_DISK : QUEUETYPE_DISK;
-    permit_classic_inmemory_fallback = child_type == QUEUETYPE_DISK;
     /* create message queue */
     CHKiRet(qqueueConstruct(&pThis->pqDA, child_type, pThis->iNumWorkerThreads, 0, pThis->pConsumer));
 
@@ -817,6 +816,12 @@ static rsRetVal StartDA(qqueue_t *pThis) {
         pThis->cryprovNameFull = NULL;
     }
 
+    /* Preserve the classic queue's long-standing invalid-.qi behavior only
+     * for errors returned while opening that fully configured child.  Engine
+     * resolution, marker publication, construction, and property setup must
+     * still fail the parent queue: treating those failures as an in-memory
+     * fallback could silently discard persistence guarantees. */
+    permit_classic_startup_fallback = child_type == QUEUETYPE_DISK;
     iRet = qqueueStart(runConf, pThis->pqDA);
     /* file not found is expected, that means it is no previous QIF available */
     if (iRet != RS_RET_OK && iRet != RS_RET_FILE_NOT_FOUND) {
@@ -835,7 +840,7 @@ finalize_it:
             qqueueDestruct(&pThis->pqDA);
         }
         pThis->bIsDA = 0;
-        if (permit_classic_inmemory_fallback) {
+        if (permit_classic_startup_fallback) {
             LogError(0, startup_error, "%s: error creating classic disk queue; continuing in pure in-memory mode",
                      obj.GetName((obj_t *)pThis));
             iRet = RS_RET_OK;

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -887,6 +887,7 @@ static rsRetVal ATTR_NONNULL() InitDA(qqueue_t *const pThis, const int bLockMute
     }
 
 finalize_it:
+    if (iRet != RS_RET_OK) pThis->bIsDA = 0;
     if (bLockMutex == LOCK_MUTEX) {
         d_pthread_mutex_unlock(pThis->mut);
     }

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -2453,6 +2453,7 @@ static rsRetVal tryShutdownWorkersWithinActionTimeout(qqueue_t *pThis) {
  */
 static rsRetVal cancelWorkers(qqueue_t *pThis) {
     rsRetVal iRetLocal;
+    struct timespec tTimeout;
     DEFiRet;
 
     assert(pThis->qType != QUEUETYPE_DIRECT);
@@ -2470,6 +2471,11 @@ static rsRetVal cancelWorkers(qqueue_t *pThis) {
                   "threads, continuing, but results are unpredictable\n",
                   iRetLocal);
     }
+    timeoutComp(&tTimeout, QUEUE_TIMEOUT_ETERNAL);
+    iRetLocal = wtpShutdownAll(pThis->pWtpReg, wtpState_SHUTDOWN_IMMEDIATE, &tTimeout);
+    if (iRetLocal != RS_RET_OK) {
+        DBGOPRINT((obj_t *)pThis, "unexpected state %d joining cancelled primary workers\n", iRetLocal);
+    }
 
     /* ... and now the DA queue, if it exists (should always be after the primary one) */
     if (pThis->pqDA != NULL) {
@@ -2484,6 +2490,11 @@ static rsRetVal cancelWorkers(qqueue_t *pThis) {
                       "threads, continuing, but results are unpredictable\n",
                       iRetLocal);
         }
+        timeoutComp(&tTimeout, QUEUE_TIMEOUT_ETERNAL);
+        iRetLocal = wtpShutdownAll(pThis->pqDA->pWtpReg, wtpState_SHUTDOWN_IMMEDIATE, &tTimeout);
+        if (iRetLocal != RS_RET_OK) {
+            DBGOPRINT((obj_t *)pThis, "unexpected state %d joining cancelled DA child workers\n", iRetLocal);
+        }
 
         /* finally, we cancel the main queue's DA worker pool, if it still is running. It may be
          * restarted later to persist the queue. But we stop it, because otherwise we get into
@@ -2493,6 +2504,11 @@ static rsRetVal cancelWorkers(qqueue_t *pThis) {
         DBGOPRINT((obj_t *)pThis, "checking to see if main queue DA worker pool needs to be cancelled\n");
         wtpCancelAll(pThis->pWtpDA, objGetName((obj_t *)pThis));
         /* returns immediately if all threads already have terminated */
+        timeoutComp(&tTimeout, QUEUE_TIMEOUT_ETERNAL);
+        iRetLocal = wtpShutdownAll(pThis->pWtpDA, wtpState_SHUTDOWN_IMMEDIATE, &tTimeout);
+        if (iRetLocal != RS_RET_OK) {
+            DBGOPRINT((obj_t *)pThis, "unexpected state %d joining cancelled DA transfer workers\n", iRetLocal);
+        }
     }
 
     RETiRet;
@@ -2540,10 +2556,8 @@ rsRetVal ATTR_NONNULL(1) qqueueShutdownWorkers(qqueue_t *const pThis) {
 
     CHKiRet(cancelWorkers(pThis));
 
-    /* ... finally ... all worker threads have terminated :-)
-     * Well, more precisely, they *are in termination*. Some cancel cleanup handlers
-     * may still be running. Note that the main queue's DA worker may still be running.
-     */
+    /* All worker threads have terminated and been joined. This stable point is
+     * required before save-on-shutdown may restart the DA transfer pool. */
     DBGOPRINT((obj_t *)pThis, "worker threads terminated, remaining queue size log %d, phys %d.\n",
               getLogicalQueueSize(pThis), getPhysicalQueueSize(pThis));
 
@@ -4202,6 +4216,13 @@ BEGINobjDestruct(qqueue) /* be sure to specify the object type also in END and C
         if (pThis->qType != QUEUETYPE_DIRECT && !pThis->bEnqOnly && pThis->pqParent == NULL && pThis->pWtpReg != NULL)
             qqueueShutdownWorkers(pThis);
 
+        /* Destroy the now-joined regular pool before inspecting the remaining
+         * size or starting save-on-shutdown. It is no longer needed, and this
+         * keeps the persistence phase's worker ownership explicit. */
+        if (pThis->qType != QUEUETYPE_DIRECT && pThis->pWtpReg != NULL) {
+            wtpDestruct(&pThis->pWtpReg);
+        }
+
         if (pThis->bIsDA && getPhysicalQueueSize(pThis) > 0) {
             if (pThis->bSaveOnShutdown) {
                 LogMsg(0, RS_RET_TIMED_OUT, LOG_INFO,
@@ -4224,15 +4245,10 @@ BEGINobjDestruct(qqueue) /* be sure to specify the object type also in END and C
          * about this condition here ;)
          * rgerhards, 2008-01-25
          */
-        if (pThis->qType != QUEUETYPE_DIRECT && pThis->pWtpReg != NULL) {
-            wtpDestruct(&pThis->pWtpReg);
-        }
-
         /* Now check if we actually have a DA queue and, if so, destruct it.
-         * Note that the wtp must be destructed first, it may be in cancel cleanup handler
-         * *right now* and actually *need* to access the queue object to persist some final
-         * data (re-queueing case). So we need to destruct the wtp first, which will make
-         * sure all workers have terminated. Please note that this also generates a situation
+         * The wtp must be destructed before the child queue. Shutdown has already
+         * joined its workers, so destruction now releases only pool resources.
+         * Please note that this also generates a situation
          * where it is possible that the DA queue has a parent pointer but the parent has
          * no WtpDA associated with it - which is perfectly legal thanks to this code here.
          */
@@ -5086,6 +5102,16 @@ finalize_it:
 
 /* return 1 if the content of two qqueue_t structs equal */
 int queuesEqual(qqueue_t *pOld, qqueue_t *pNew) {
+    const qda_lifecycle_config_t old_da = {
+        .engine = pOld->diskQueueType,
+        .auto_upgrade = pOld->diskQueueAutoUpgrade,
+        .idle_timeout = pOld->diskQueueIdleTimeout,
+    };
+    const qda_lifecycle_config_t new_da = {
+        .engine = pNew->diskQueueType,
+        .auto_upgrade = pNew->diskQueueAutoUpgrade,
+        .idle_timeout = pNew->diskQueueIdleTimeout,
+    };
     return (NUM_EQUALS(qType) && NUM_EQUALS(iMaxQueueSize) && NUM_EQUALS(iDeqBatchSize) &&
             NUM_EQUALS(iMinDeqBatchSize) && NUM_EQUALS(toMinDeqBatchSize) && NUM_EQUALS(sizeOnDiskMax) &&
             NUM_EQUALS(iHighWtrMrk) && NUM_EQUALS(iLowWtrMrk) && NUM_EQUALS(iFullDlyMrk) && NUM_EQUALS(iLightDlyMrk) &&
@@ -5094,9 +5120,8 @@ int queuesEqual(qqueue_t *pOld, qqueue_t *pNew) {
             NUM_EQUALS(toActShutdown) && NUM_EQUALS(toEnq) && NUM_EQUALS(toWrkShutdown) &&
             NUM_EQUALS(iMinMsgsPerWrkr) && NUM_EQUALS(iMaxFileSize) && NUM_EQUALS(bSaveOnShutdown) &&
             NUM_EQUALS(iDeqSlowdown) && NUM_EQUALS(iDeqtWinFromHr) && NUM_EQUALS(iDeqtWinToHr) &&
-            NUM_EQUALS(iSmpInterval) && NUM_EQUALS(takeFlowCtlFromMsg) && NUM_EQUALS(diskQueueType) &&
-            NUM_EQUALS(diskQueueAutoUpgrade) && NUM_EQUALS(diskQueueIdleTimeout) && USTR_EQUALS(pszFilePrefix) &&
-            USTR_EQUALS(cryprovName));
+            NUM_EQUALS(iSmpInterval) && NUM_EQUALS(takeFlowCtlFromMsg) && qdaLifecycleConfigEqual(&old_da, &new_da) &&
+            USTR_EQUALS(pszFilePrefix) && USTR_EQUALS(cryprovName));
 }
 
 

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -292,6 +292,9 @@ static struct cnfparamdescr cnfpdescr[] = {{"queue.filename", eCmdHdlrGetWord, 0
                                            {"queue.checkpointinterval", eCmdHdlrInt, 0},
                                            {"queue.syncqueuefiles", eCmdHdlrBinary, 0},
                                            {"queue.type", eCmdHdlrQueueType, 0},
+                                           {"queue.diskqueuetype", eCmdHdlrGetWord, 0},
+                                           {"queue.diskqueueautoupgrade", eCmdHdlrBinary, 0},
+                                           {"queue.diskqueueidletimeout", eCmdHdlrInt, 0},
                                            {"queue.workerthreads", eCmdHdlrPositiveInt, 0},
                                            {"queue.timeoutshutdown", eCmdHdlrInt, 0},
                                            {"queue.timeoutactioncompletion", eCmdHdlrInt, 0},
@@ -562,27 +565,52 @@ static void qqueueUpdateSegDiskStats(qqueue_t *pThis) {
     pThis->segdiskStartupSegmentFilesProbed = segdiskStatsInt(stats.startup_segment_files_probed);
     pThis->segdiskRecoveryPending = segdiskStatsInt(stats.recovery_pending);
     pThis->segdiskCorruptionSegments = segdiskStatsInt(stats.corruption_segments);
+    pThis->segdiskMaterializations = segdiskStatsInt(stats.materializations);
+    pThis->segdiskDematerializations = segdiskStatsInt(stats.dematerializations);
+    pThis->segdiskIdleCleanupFailures = segdiskStatsInt(stats.idle_cleanup_failures);
+}
+
+static rsRetVal qqueueSegDiskIdleTimeout(qqueue_t *pThis) {
+    if (!pThis->segdiskDAChild || pThis->qType != QUEUETYPE_SEGMENTED_DISK || pThis->tVars.segdisk == NULL)
+        return RS_RET_RETRY;
+    if (getLogicalQueueSize(pThis) != 0 || getPhysicalQueueSize(pThis) != 0 ||
+        !segdiskStoreCanDematerialize(pThis->tVars.segdisk))
+        return RS_RET_RETRY;
+    if (pThis->segdiskIdleObservedActivity != pThis->pqParent->daActivityGeneration) {
+        pThis->segdiskIdleObservedActivity = pThis->pqParent->daActivityGeneration;
+        return RS_RET_RETRY;
+    }
+    const rsRetVal r = segdiskStoreDematerialize(pThis->tVars.segdisk);
+    qqueueUpdateSegDiskStats(pThis);
+    if (r != RS_RET_OK) {
+        LogError(0, r, "%s: segmented disk-assisted idle store cleanup failed; will retry",
+                 obj.GetName((obj_t *)pThis));
+        return RS_RET_RETRY;
+    }
+    return RS_RET_OK;
 }
 
 #ifdef ENABLE_IMDIAG
 rsRetVal qqueueSetSegDiskTestFault(qqueue_t *pThis, const char *point, unsigned int hit_count) {
     if (pThis == NULL || point == NULL || hit_count == 0) return RS_RET_PARAM_ERROR;
-    d_pthread_mutex_lock(pThis->mut);
-    const rsRetVal r = pThis->qType == QUEUETYPE_SEGMENTED_DISK && pThis->tVars.segdisk != NULL
-                           ? segdiskStoreSetTestFault(pThis->tVars.segdisk, point, hit_count)
-                           : RS_RET_INVALID_VALUE;
-    d_pthread_mutex_unlock(pThis->mut);
+    qqueue_t *target = pThis->qType == QUEUETYPE_SEGMENTED_DISK ? pThis : pThis->pqDA;
+    if (target == NULL || target->qType != QUEUETYPE_SEGMENTED_DISK || target->tVars.segdisk == NULL)
+        return RS_RET_INVALID_VALUE;
+    d_pthread_mutex_lock(target->mut);
+    const rsRetVal r = segdiskStoreSetTestFault(target->tVars.segdisk, point, hit_count);
+    d_pthread_mutex_unlock(target->mut);
     return r;
 }
 
 rsRetVal qqueueClearSegDiskTestFault(qqueue_t *pThis) {
     if (pThis == NULL) return RS_RET_PARAM_ERROR;
-    d_pthread_mutex_lock(pThis->mut);
-    const rsRetVal r =
-        pThis->qType == QUEUETYPE_SEGMENTED_DISK && pThis->tVars.segdisk != NULL ? RS_RET_OK : RS_RET_INVALID_VALUE;
-    if (r == RS_RET_OK) segdiskStoreClearTestFault(pThis->tVars.segdisk);
-    d_pthread_mutex_unlock(pThis->mut);
-    return r;
+    qqueue_t *target = pThis->qType == QUEUETYPE_SEGMENTED_DISK ? pThis : pThis->pqDA;
+    if (target == NULL || target->qType != QUEUETYPE_SEGMENTED_DISK || target->tVars.segdisk == NULL)
+        return RS_RET_INVALID_VALUE;
+    d_pthread_mutex_lock(target->mut);
+    segdiskStoreClearTestFault(target->tVars.segdisk);
+    d_pthread_mutex_unlock(target->mut);
+    return RS_RET_OK;
 }
 #endif
 
@@ -695,8 +723,47 @@ static rsRetVal StartDA(qqueue_t *pThis) {
 
     ISOBJ_TYPE_assert(pThis, qqueue);
 
+    const qda_engine_config_t engine_config = {
+        .spool_dir = (const char *)pThis->pszSpoolDir,
+        .file_prefix = (const char *)pThis->pszFilePrefix,
+        .requested = pThis->diskQueueType,
+        .auto_upgrade = pThis->diskQueueAutoUpgrade,
+        .requires_classic_features = pThis->useCryprov || pThis->onCorruption != QUEUE_ON_CORRUPTION_SAFE_MODE,
+    };
+    qda_engine_result_t engine_result;
+    iRet = qdaEngineResolve(&engine_config, &engine_result);
+    if (iRet != RS_RET_OK) {
+        LogError(0, iRet,
+                 "%s: cannot select disk-assisted queue engine for prefix '%s'; classic and segmented data, "
+                 "an explicit engine conflict, a malformed engine marker, or unsupported segmented options "
+                 "require operator intervention",
+                 obj.GetName((obj_t *)pThis), pThis->pszFilePrefix);
+        FINALIZE;
+    }
+    pThis->effectiveDiskQueueType = engine_result.effective;
+    if (pThis->diskQueueType == QDA_ENGINE_AUTO && engine_result.effective == QDA_ENGINE_DISK) {
+        if (engine_result.reason == QDA_REASON_CLASSIC_FEATURE)
+            LogMsg(0, RS_RET_OK_WARN, LOG_WARNING,
+                   "%s: disk-assisted queue automatically selected the classic disk engine for prefix '%s' "
+                   "because classic-only queue options are configured",
+                   obj.GetName((obj_t *)pThis), pThis->pszFilePrefix);
+        else
+            LogMsg(0, RS_RET_OK_WARN, LOG_WARNING,
+                   "%s: disk-assisted queue automatically selected the classic disk engine for prefix '%s' "
+                   "because classic queue state is present or retained; set queue.diskQueueAutoUpgrade=\"on\" "
+                   "to use segmentedDisk after the classic backlog drains",
+                   obj.GetName((obj_t *)pThis), pThis->pszFilePrefix);
+    }
+    if (engine_result.effective == QDA_ENGINE_DISK || engine_result.segmented_data ||
+        (engine_result.marker_present && engine_result.marker_engine != engine_result.effective)) {
+        CHKiRet(qdaEngineWriteMarker((const char *)pThis->pszSpoolDir, (const char *)pThis->pszFilePrefix,
+                                     engine_result.effective));
+    }
+
+    const queueType_t child_type =
+        engine_result.effective == QDA_ENGINE_SEGMENTED_DISK ? QUEUETYPE_SEGMENTED_DISK : QUEUETYPE_DISK;
     /* create message queue */
-    CHKiRet(qqueueConstruct(&pThis->pqDA, QUEUETYPE_DISK, pThis->iNumWorkerThreads, 0, pThis->pConsumer));
+    CHKiRet(qqueueConstruct(&pThis->pqDA, child_type, pThis->iNumWorkerThreads, 0, pThis->pConsumer));
 
     /* give it a name */
     snprintf((char *)pszDAQName, sizeof(pszDAQName), "%s[DA]", obj.GetName((obj_t *)pThis));
@@ -706,6 +773,10 @@ static rsRetVal StartDA(qqueue_t *pThis) {
      * liberty to access its properties directly.
      */
     pThis->pqDA->pqParent = pThis;
+    pThis->pqDA->segdiskDAChild = child_type == QUEUETYPE_SEGMENTED_DISK;
+    pThis->pqDA->segdiskLazyCreate = pThis->pqDA->segdiskDAChild && !engine_result.segmented_data;
+    pThis->pqDA->segdiskMarkerPending = pThis->pqDA->segdiskLazyCreate && !engine_result.marker_present;
+    pThis->pqDA->diskQueueIdleTimeout = pThis->diskQueueIdleTimeout;
 
     CHKiRet(qqueueSetpAction(pThis->pqDA, pThis->pAction));
     CHKiRet(qqueueSetsizeOnDiskMax(pThis->pqDA, pThis->sizeOnDiskMax));
@@ -727,7 +798,7 @@ static rsRetVal StartDA(qqueue_t *pThis) {
     pThis->pqDA->iMinMsgsPerWrkr = pThis->iMinMsgsPerWrkr;
     pThis->pqDA->iLowWtrMrk = pThis->iLowWtrMrk;
     pThis->pqDA->onCorruption = pThis->onCorruption;
-    if (pThis->useCryprov) {
+    if (pThis->useCryprov && child_type == QUEUETYPE_DISK) {
         /* hand over cryprov to DA queue - in-mem queue does no longer need it
          * and DA queue will be kept active from now on until termination.
          */
@@ -1091,6 +1162,7 @@ static rsRetVal qConstructSegDisk(qqueue_t *pThis) {
         .max_disk_space = pThis->sizeOnDiskMax,
         .checkpoint_interval = (unsigned int)pThis->iPersistUpdCnt,
         .sync_files = pThis->bSyncQueueFiles,
+        .lazy_create = pThis->segdiskLazyCreate,
     };
     int recovered = 0;
     DEFiRet;
@@ -1112,7 +1184,13 @@ static rsRetVal qDestructSegDisk(qqueue_t *pThis) {
 
 static rsRetVal qAddSegDisk(qqueue_t *pThis, smsg_t *pMsg) {
     DEFiRet;
+    if (pThis->segdiskMarkerPending) {
+        CHKiRet(qdaEngineWriteMarker((const char *)pThis->pszSpoolDir, (const char *)pThis->pszFilePrefix,
+                                     QDA_ENGINE_SEGMENTED_DISK));
+        pThis->segdiskMarkerPending = 0;
+    }
     CHKiRet(segdiskStoreAppend(pThis->tVars.segdisk, pMsg, 0, NULL));
+    if (pThis->segdiskDAChild) ++pThis->pqParent->daActivityGeneration;
     qqueueUpdateSegDiskStats(pThis);
 finalize_it:
     /* The store serializes synchronously and never retains the message. The
@@ -1134,6 +1212,8 @@ static rsRetVal qDeqBatchSegDisk(qqueue_t *pThis, batch_t *batch, int max, int *
 
 static rsRetVal qCompleteBatchSegDisk(qqueue_t *pThis, batch_t *batch, int *committed, int *retried) {
     const rsRetVal r = segdiskStoreCompleteBatch(pThis->tVars.segdisk, batch, committed, retried);
+    if (r == RS_RET_OK && pThis->segdiskDAChild && segdiskStoreCanDematerialize(pThis->tVars.segdisk))
+        pThis->segdiskIdleObservedActivity = pThis->pqParent->daActivityGeneration;
     qqueueUpdateSegDiskStats(pThis);
     return r;
 }
@@ -2145,6 +2225,14 @@ static rsRetVal qqueueAdd(qqueue_t *pThis, smsg_t *pMsg) {
 
     CHKiRet(pThis->qAdd(pThis, pMsg));
 
+    if (pThis->bIsDA && pThis->pqDA != NULL && pThis->pqDA->segdiskDAChild) {
+        /* Parent and DA child intentionally share this queue mutex. The idle
+         * callback therefore observes this activity generation atomically
+         * with both producer enqueue and child store operations. */
+        ++pThis->daActivityGeneration;
+        if (pThis->pqDA->pWtpReg != NULL) wtpWakeupAllWrkr(pThis->pqDA->pWtpReg);
+    }
+
     if (pThis->qType != QUEUETYPE_DIRECT) {
         ATOMIC_INC(&pThis->iQueueSize, &pThis->mutQueueSize);
 #ifdef ENABLE_IMDIAG
@@ -2468,6 +2556,9 @@ rsRetVal qqueueConstruct(qqueue_t **ppThis,
     pThis->iMinDeqBatchSize = 0; /* conservative default, should still provide good performance */
     pThis->isRunning = 0;
     pThis->onCorruption = QUEUE_ON_CORRUPTION_SAFE_MODE;
+    pThis->diskQueueType = QDA_ENGINE_AUTO;
+    pThis->effectiveDiskQueueType = QDA_ENGINE_AUTO;
+    pThis->diskQueueIdleTimeout = 60000;
 
     pThis->pszFilePrefix = NULL;
     pThis->qType = qType;
@@ -3507,6 +3598,15 @@ static rsRetVal ConsumerDA(qqueue_t *pThis, wti_t *pWti) {
                           "ConsumerDA:qqueueEnqMsg item (%d) returned "
                           "with error state: '%d'\n",
                           i, iRet);
+                if (pThis->pqDA->qType == QUEUETYPE_SEGMENTED_DISK) {
+                    /* The segmented child may fail before the event becomes
+                     * durable (for example while publishing its engine marker
+                     * or materializing the store). Leave this and the
+                     * remaining batch elements uncommitted so normal parent
+                     * retry handling preserves them. Classic DA behavior is
+                     * intentionally unchanged. */
+                    break;
+                }
             }
         }
         pWti->batch.eltState[i] = BATCH_STATE_COMM; /* commited to other queue! */
@@ -3760,6 +3860,11 @@ rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis) /* this is the Construction
     CHKiRet(wtpSetpmutUsr(pThis->pWtpReg, pThis->mut));
     CHKiRet(wtpSetiNumWorkerThreads(pThis->pWtpReg, pThis->iNumWorkerThreads));
     CHKiRet(wtpSettoWrkShutdown(pThis->pWtpReg, pThis->toWrkShutdown));
+    if (pThis->segdiskDAChild && pThis->diskQueueIdleTimeout != -1) {
+        CHKiRet(wtpSetbAllowFirstWorkerToTimeout(pThis->pWtpReg, 1));
+        CHKiRet(wtpSetpfIdleTimeout(pThis->pWtpReg, (rsRetVal(*)(void *pUsr))qqueueSegDiskIdleTimeout));
+        CHKiRet(wtpSettoWrkShutdown(pThis->pWtpReg, pThis->diskQueueIdleTimeout));
+    }
     CHKiRet(wtpSetpUsr(pThis->pWtpReg, pThis));
     CHKiRet(wtpConstructFinalize(pThis->pWtpReg));
 
@@ -3775,7 +3880,7 @@ rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis) /* this is the Construction
         }
     }
     /* set up DA system if we have a disk-assisted queue */
-    if (pThis->bIsDA) InitDA(pThis, LOCK_MUTEX); /* initiate DA mode */
+    if (pThis->bIsDA) CHKiRet(InitDA(pThis, LOCK_MUTEX)); /* initiate DA mode */
 
     DBGOPRINT((obj_t *)pThis, "queue finished initialization\n");
 
@@ -3852,6 +3957,14 @@ rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis) /* this is the Construction
                                     CTR_FLAG_NONE, &pThis->segdiskStartupPayloadBytes));
         CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("startup.segmentFilesProbed"), ctrType_Int,
                                     CTR_FLAG_NONE, &pThis->segdiskStartupSegmentFilesProbed));
+        CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("store.materializations"), ctrType_Int,
+                                    CTR_FLAG_NONE, &pThis->segdiskMaterializations));
+        CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("store.idleDematerializations"), ctrType_Int,
+                                    CTR_FLAG_NONE, &pThis->segdiskDematerializations));
+        CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("store.idleCleanupFailures"), ctrType_Int,
+                                    CTR_FLAG_NONE, &pThis->segdiskIdleCleanupFailures));
+        CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("workers.current"), ctrType_Int, CTR_FLAG_NONE,
+                                    &pThis->pWtpReg->iCurNumWrkThrd));
     }
 
     CHKiRet(statsobj.ConstructFinalize(pThis->statsobj));
@@ -4771,6 +4884,31 @@ rsRetVal qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst) {
                  */
                 n_params_set--;
             }
+        } else if (!strcmp(pblk.descr[i].name, "queue.diskqueuetype")) {
+            char *mode;
+            CHKmalloc(mode = es_str2cstr(pvals[i].val.d.estr, NULL));
+            pThis->diskQueueTypeSet = 1;
+            if (!strcasecmp(mode, "auto"))
+                pThis->diskQueueType = QDA_ENGINE_AUTO;
+            else if (!strcasecmp(mode, "disk"))
+                pThis->diskQueueType = QDA_ENGINE_DISK;
+            else if (!strcasecmp(mode, "segmentedDisk"))
+                pThis->diskQueueType = QDA_ENGINE_SEGMENTED_DISK;
+            else {
+                parser_errmsg("queue.diskQueueType: invalid value '%s'; using 'auto'", mode);
+                pThis->diskQueueType = QDA_ENGINE_AUTO;
+            }
+            free(mode);
+        } else if (!strcmp(pblk.descr[i].name, "queue.diskqueueautoupgrade")) {
+            pThis->diskQueueAutoUpgrade = pvals[i].val.d.n;
+            pThis->diskQueueAutoUpgradeSet = 1;
+        } else if (!strcmp(pblk.descr[i].name, "queue.diskqueueidletimeout")) {
+            pThis->diskQueueIdleTimeout = pvals[i].val.d.n;
+            pThis->diskQueueIdleTimeoutSet = 1;
+            if (pThis->diskQueueIdleTimeout < -1) {
+                parser_errmsg("queue.diskQueueIdleTimeout must be -1 or greater; using 60000");
+                pThis->diskQueueIdleTimeout = 60000;
+            }
         } else if (!strcmp(pblk.descr[i].name, "queue.workerthreads")) {
             CHKiRet(qqueueSetiNumWorkerThreads(pThis, pvals[i].val.d.n));
         } else if (!strcmp(pblk.descr[i].name, "queue.timeoutshutdown")) {
@@ -4817,6 +4955,27 @@ rsRetVal qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst) {
                 "param '%s'\n",
                 pblk.descr[i].name);
         }
+    }
+
+    const sbool is_da_memory_queue =
+        (pThis->qType == QUEUETYPE_FIXED_ARRAY || pThis->qType == QUEUETYPE_LINKEDLIST) && pThis->pszFilePrefix != NULL;
+    if ((pThis->diskQueueTypeSet || pThis->diskQueueAutoUpgradeSet || pThis->diskQueueIdleTimeoutSet) &&
+        !is_da_memory_queue) {
+        parser_errmsg(
+            "queue.diskQueueType, queue.diskQueueAutoUpgrade, and queue.diskQueueIdleTimeout apply only to "
+            "FixedArray or LinkedList disk-assisted queues; ignoring these parameters");
+        pThis->diskQueueType = QDA_ENGINE_AUTO;
+        pThis->diskQueueAutoUpgrade = 0;
+        pThis->diskQueueIdleTimeout = 60000;
+    }
+    if (is_da_memory_queue && pThis->diskQueueAutoUpgradeSet && pThis->diskQueueType != QDA_ENGINE_AUTO) {
+        parser_errmsg("queue.diskQueueAutoUpgrade applies only when queue.diskQueueType='auto'; ignoring it");
+        pThis->diskQueueAutoUpgrade = 0;
+    }
+    if (is_da_memory_queue && pThis->diskQueueType == QDA_ENGINE_DISK && pThis->diskQueueIdleTimeoutSet &&
+        pThis->diskQueueIdleTimeout != 60000) {
+        parser_errmsg("queue.diskQueueIdleTimeout does not apply to the classic disk engine; using 60000");
+        pThis->diskQueueIdleTimeout = 60000;
     }
 
     checkUniqueDiskFile(pThis);
@@ -4887,7 +5046,8 @@ int queuesEqual(qqueue_t *pOld, qqueue_t *pNew) {
             NUM_EQUALS(toActShutdown) && NUM_EQUALS(toEnq) && NUM_EQUALS(toWrkShutdown) &&
             NUM_EQUALS(iMinMsgsPerWrkr) && NUM_EQUALS(iMaxFileSize) && NUM_EQUALS(bSaveOnShutdown) &&
             NUM_EQUALS(iDeqSlowdown) && NUM_EQUALS(iDeqtWinFromHr) && NUM_EQUALS(iDeqtWinToHr) &&
-            NUM_EQUALS(iSmpInterval) && NUM_EQUALS(takeFlowCtlFromMsg) && USTR_EQUALS(pszFilePrefix) &&
+            NUM_EQUALS(iSmpInterval) && NUM_EQUALS(takeFlowCtlFromMsg) && NUM_EQUALS(diskQueueType) &&
+            NUM_EQUALS(diskQueueAutoUpgrade) && NUM_EQUALS(diskQueueIdleTimeout) && USTR_EQUALS(pszFilePrefix) &&
             USTR_EQUALS(cryprovName));
 }
 

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -720,7 +720,6 @@ static rsRetVal qqueueChkIsDA(qqueue_t *pThis) {
 static rsRetVal StartDA(qqueue_t *pThis) {
     DEFiRet;
     uchar pszDAQName[128];
-    sbool permit_classic_startup_fallback = 0;
 
     ISOBJ_TYPE_assert(pThis, qqueue);
 
@@ -820,12 +819,6 @@ static rsRetVal StartDA(qqueue_t *pThis) {
         pThis->cryprovNameFull = NULL;
     }
 
-    /* Preserve the classic queue's long-standing invalid-.qi behavior only
-     * for errors returned while opening that fully configured child.  Engine
-     * resolution, marker publication, construction, and property setup must
-     * still fail the parent queue: treating those failures as an in-memory
-     * fallback could silently discard persistence guarantees. */
-    permit_classic_startup_fallback = child_type == QUEUETYPE_DISK;
     iRet = qqueueStart(runConf, pThis->pqDA);
     /* file not found is expected, that means it is no previous QIF available */
     if (iRet != RS_RET_OK && iRet != RS_RET_FILE_NOT_FOUND) {
@@ -844,13 +837,7 @@ finalize_it:
             qqueueDestruct(&pThis->pqDA);
         }
         pThis->bIsDA = 0;
-        if (permit_classic_startup_fallback) {
-            LogError(0, startup_error, "%s: error creating classic disk queue; continuing in pure in-memory mode",
-                     obj.GetName((obj_t *)pThis));
-            iRet = RS_RET_OK;
-        } else {
-            LogError(0, startup_error, "%s: error creating disk queue - giving up.", obj.GetName((obj_t *)pThis));
-        }
+        LogError(0, startup_error, "%s: error creating disk queue - giving up.", obj.GetName((obj_t *)pThis));
     }
 
     RETiRet;
@@ -1460,6 +1447,17 @@ static rsRetVal qqueueVerifyAndRecover(qqueue_t *pThis, rsRetVal loadRet) {
             corruptionDetected = 1;
             LogError(0, RS_RET_ERR, "queue corruption: .qi file missing or inaccessible but %d segment files exist",
                      nFiles);
+        } else if (loadRet != RS_RET_FILE_NOT_FOUND) {
+            /* A readable path that failed deserialization is corrupt even
+             * without segment files.  Route it through normal safe-mode
+             * quarantine so a fresh classic child can start.  If stat fails
+             * (permissions or another I/O error), retain loadRet and fail
+             * startup instead of silently dropping persistence. */
+            struct stat qi_st;
+            if (stat((char *)pThis->pszQIFNam, &qi_st) == 0) {
+                corruptionDetected = 1;
+                LogError(0, RS_RET_ERR, "queue corruption: .qi file is invalid and contains no usable queue state");
+            }
         }
     }
 

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -1190,6 +1190,10 @@ static rsRetVal qDestructSegDisk(qqueue_t *pThis) {
 static rsRetVal qAddSegDisk(qqueue_t *pThis, smsg_t *pMsg) {
     DEFiRet;
     if (pThis->daEngineMarkerPending) {
+        /* The marker lives in workDirectory beside <prefix>.segq, not inside
+         * that lazy store directory.  StartDA has already validated the
+         * parent spool directory, so publishing the engine choice here can
+         * and must precede segdiskStoreAppend() materializing .segq. */
         CHKiRet(qdaEngineWriteMarker((const char *)pThis->pszSpoolDir, (const char *)pThis->pszFilePrefix,
                                      QDA_ENGINE_SEGMENTED_DISK));
         pThis->daEngineMarkerPending = 0;

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -3886,7 +3886,7 @@ rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis) /* this is the Construction
     if (pThis->segdiskDAChild && pThis->diskQueueIdleTimeout != -1) {
         CHKiRet(wtpSetbAllowFirstWorkerToTimeout(pThis->pWtpReg, 1));
         CHKiRet(wtpSetpfIdleTimeout(pThis->pWtpReg, (rsRetVal(*)(void *pUsr))qqueueSegDiskIdleTimeout));
-        CHKiRet(wtpSettoWrkShutdown(pThis->pWtpReg, pThis->diskQueueIdleTimeout));
+        CHKiRet(wtpSettoFirstWrkShutdown(pThis->pWtpReg, pThis->diskQueueIdleTimeout));
     } else if (pThis->segdiskDAChild) {
         /* An idle timeout of -1 disables dematerialization without disabling
          * the normal shutdown timeout for additional workers.  Explicitly

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -1272,6 +1272,11 @@ static sbool fileEntryExistsByNumber(const fileEntry_t *files, int nFiles, int n
 }
 
 static sbool qqueueLoadRetIsStructuralCorruption(rsRetVal loadRet) {
+    /* This classifier is used only by qConstructDisk() after parsing classic
+     * .qi state. Segmented state and DA engine markers have separate fail-fast
+     * validation paths and never reach it. Do not classify the generic
+     * RS_RET_INVALID_VALUE here: it is not a classic deserializer framing
+     * result and may represent a non-corruption startup/configuration error. */
     static const rsRetVal structural_errors[] = {
         RS_RET_FILE_TRUNCATED,      RS_RET_EOF,
         RS_RET_INVALID_OID,         RS_RET_INVALID_HEADER,

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -4989,6 +4989,10 @@ rsRetVal qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst) {
 
     const sbool is_da_memory_queue =
         (pThis->qType == QUEUETYPE_FIXED_ARRAY || pThis->qType == QUEUETYPE_LINKEDLIST) && pThis->pszFilePrefix != NULL;
+    /* These are deliberately parser_errmsg(), not advisory warnings:
+     * parser_errmsg marks the configuration dirty.  Permissive startup keeps
+     * running after the unusable value is ignored, while
+     * abortOnUncleanConfig="on" rejects the same configuration. */
     if ((pThis->diskQueueTypeSet || pThis->diskQueueAutoUpgradeSet || pThis->diskQueueIdleTimeoutSet) &&
         !is_da_memory_queue) {
         parser_errmsg(

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -3917,6 +3917,10 @@ rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis) /* this is the Construction
     CHKiRet(wtpSetpmutUsr(pThis->pWtpReg, pThis->mut));
     CHKiRet(wtpSetiNumWorkerThreads(pThis->pWtpReg, pThis->iNumWorkerThreads));
     CHKiRet(wtpSettoWrkShutdown(pThis->pWtpReg, pThis->toWrkShutdown));
+    /* This callback implements runtime idle dematerialization only.  Process
+     * shutdown deliberately stops and joins the workers without waiting for
+     * this timer; qDestructSegDisk() then closes the store and, when empty,
+     * removes its segments, state file, and directory synchronously. */
     if (pThis->segdiskDAChild && pThis->diskQueueIdleTimeout != -1) {
         CHKiRet(wtpSetbAllowFirstWorkerToTimeout(pThis->pWtpReg, 1));
         CHKiRet(wtpSetpfIdleTimeout(pThis->pWtpReg, (rsRetVal(*)(void *pUsr))qqueueSegDiskIdleTimeout));

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -1267,6 +1267,22 @@ static sbool fileEntryExistsByNumber(const fileEntry_t *files, int nFiles, int n
     return bsearch(&key, files, (size_t)nFiles, sizeof(fileEntry_t), fileEntryCmpByNumber) != NULL;
 }
 
+static sbool qqueueLoadRetIsStructuralCorruption(rsRetVal loadRet) {
+    static const rsRetVal structural_errors[] = {
+        RS_RET_FILE_TRUNCATED,      RS_RET_EOF,
+        RS_RET_INVALID_OID,         RS_RET_INVALID_HEADER,
+        RS_RET_INVALID_HEADER_VERS, RS_RET_INVALID_DELIMITER,
+        RS_RET_INVALID_PROPFRAME,   RS_RET_NO_PROPLINE,
+        RS_RET_INVALID_TRAILER,     RS_RET_INVALID_HEADER_RECTYPE,
+        RS_RET_QTYPE_MISMATCH,      RS_RET_SYNTAX_ERROR,
+        RS_RET_DS_PROP_SEQ_ERR,     RS_RET_INVLD_PROP,
+    };
+    for (size_t i = 0; i < sizeof(structural_errors) / sizeof(structural_errors[0]); ++i) {
+        if (loadRet == structural_errors[i]) return 1;
+    }
+    return 0;
+}
+
 static rsRetVal qqueueVerifyAndRecover(qqueue_t *pThis, rsRetVal loadRet) {
     DEFiRet;
     DIR *d = NULL;
@@ -1447,17 +1463,13 @@ static rsRetVal qqueueVerifyAndRecover(qqueue_t *pThis, rsRetVal loadRet) {
             corruptionDetected = 1;
             LogError(0, RS_RET_ERR, "queue corruption: .qi file missing or inaccessible but %d segment files exist",
                      nFiles);
-        } else if (loadRet != RS_RET_FILE_NOT_FOUND) {
-            /* A readable path that failed deserialization is corrupt even
-             * without segment files.  Route it through normal safe-mode
-             * quarantine so a fresh classic child can start.  If stat fails
-             * (permissions or another I/O error), retain loadRet and fail
-             * startup instead of silently dropping persistence. */
-            struct stat qi_st;
-            if (stat((char *)pThis->pszQIFNam, &qi_st) == 0) {
-                corruptionDetected = 1;
-                LogError(0, RS_RET_ERR, "queue corruption: .qi file is invalid and contains no usable queue state");
-            }
+        } else if (qqueueLoadRetIsStructuralCorruption(loadRet)) {
+            /* Only deterministic parser/framing failures prove that the .qi
+             * contents are corrupt.  I/O, access, allocation, and other
+             * operational failures retain loadRet and fail startup so a
+             * transient storage problem can never quarantine healthy state. */
+            corruptionDetected = 1;
+            LogError(0, RS_RET_ERR, "queue corruption: .qi file is invalid and contains no usable queue state");
         }
     }
 

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -755,7 +755,7 @@ static rsRetVal StartDA(qqueue_t *pThis) {
                    "to use segmentedDisk after the classic backlog drains",
                    obj.GetName((obj_t *)pThis), pThis->pszFilePrefix);
     }
-    if (engine_result.effective == QDA_ENGINE_DISK || engine_result.segmented_data ||
+    if (engine_result.classic_data || engine_result.segmented_data ||
         (engine_result.marker_present && engine_result.marker_engine != engine_result.effective)) {
         CHKiRet(qdaEngineWriteMarker((const char *)pThis->pszSpoolDir, (const char *)pThis->pszFilePrefix,
                                      engine_result.effective));
@@ -776,7 +776,8 @@ static rsRetVal StartDA(qqueue_t *pThis) {
     pThis->pqDA->pqParent = pThis;
     pThis->pqDA->segdiskDAChild = child_type == QUEUETYPE_SEGMENTED_DISK;
     pThis->pqDA->segdiskLazyCreate = pThis->pqDA->segdiskDAChild && !engine_result.segmented_data;
-    pThis->pqDA->segdiskMarkerPending = pThis->pqDA->segdiskLazyCreate && !engine_result.marker_present;
+    pThis->pqDA->daEngineMarkerPending =
+        !engine_result.marker_present && !engine_result.classic_data && !engine_result.segmented_data;
     pThis->pqDA->diskQueueIdleTimeout = pThis->diskQueueIdleTimeout;
 
     CHKiRet(qqueueSetpAction(pThis->pqDA, pThis->pAction));
@@ -1198,10 +1199,10 @@ static rsRetVal qDestructSegDisk(qqueue_t *pThis) {
 
 static rsRetVal qAddSegDisk(qqueue_t *pThis, smsg_t *pMsg) {
     DEFiRet;
-    if (pThis->segdiskMarkerPending) {
+    if (pThis->daEngineMarkerPending) {
         CHKiRet(qdaEngineWriteMarker((const char *)pThis->pszSpoolDir, (const char *)pThis->pszFilePrefix,
                                      QDA_ENGINE_SEGMENTED_DISK));
-        pThis->segdiskMarkerPending = 0;
+        pThis->daEngineMarkerPending = 0;
     }
     CHKiRet(segdiskStoreAppend(pThis->tVars.segdisk, pMsg, 0, NULL));
     if (pThis->segdiskDAChild) ++pThis->pqParent->daActivityGeneration;
@@ -2025,6 +2026,11 @@ static rsRetVal ATTR_NONNULL(1, 2) qAddDisk(qqueue_t *const pThis, smsg_t *pMsg)
     DEFiRet;
     ISOBJ_TYPE_assert(pThis, qqueue);
     ISOBJ_TYPE_assert(pMsg, msg);
+    if (pThis->daEngineMarkerPending) {
+        CHKiRet(qdaEngineWriteMarker((const char *)pThis->pszSpoolDir, (const char *)pThis->pszFilePrefix,
+                                     QDA_ENGINE_DISK));
+        pThis->daEngineMarkerPending = 0;
+    }
     number_t nWriteCount;
     const int oldfile = strmGetCurrFileNum(pThis->tVars.disk.pWrite);
 

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -48,6 +48,7 @@
 #include "stream.h"
 #include "statsobj.h"
 #include "cryprov.h"
+#include "queue_da.h"
 #include "segdisk_store.h"
 
 /* support for the toDelete list */
@@ -185,6 +186,18 @@ struct queue_s {
         qDeqID deqIDAdd; /* next dequeue ID to use during add to queue store */
         qDeqID deqIDDel; /* queue store delete position */
         int bIsDA; /* is this queue disk assisted? */
+        qda_engine_mode_t diskQueueType; /* configured DA disk child selection */
+        qda_engine_mode_t effectiveDiskQueueType; /* selected DA disk child engine */
+        sbool diskQueueAutoUpgrade; /* move a drained auto-selected classic child to segmented */
+        int diskQueueIdleTimeout; /* segmented DA child idle dematerialization timeout */
+        sbool diskQueueTypeSet;
+        sbool diskQueueAutoUpgradeSet;
+        sbool diskQueueIdleTimeoutSet;
+        sbool segdiskLazyCreate; /* create a fresh segmented store on first append */
+        sbool segdiskDAChild; /* segmented child of an in-memory DA parent */
+        sbool segdiskMarkerPending; /* publish the DA engine marker before first append */
+        uint64_t daActivityGeneration; /* parent enqueue generation for the idle grace period */
+        uint64_t segdiskIdleObservedActivity;
         struct queue_s *pqDA; /* queue for disk-assisted modes */
         struct queue_s *pqParent; /* pointer to the parent (if this is a child queue) */
         int bDAEnqOnly; /* EnqOnly setting for DA queue */
@@ -246,6 +259,9 @@ struct queue_s {
         int segdiskStartupPayloadBytes;
         int segdiskStartupSegmentFilesProbed;
         int segdiskCorruptionSegments;
+        int segdiskMaterializations;
+        int segdiskDematerializations;
+        int segdiskIdleCleanupFailures;
         int iSmpInterval; /* line interval of sampling logs */
         int isRunning;
 };

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -195,7 +195,7 @@ struct queue_s {
         sbool diskQueueIdleTimeoutSet;
         sbool segdiskLazyCreate; /* create a fresh segmented store on first append */
         sbool segdiskDAChild; /* segmented child of an in-memory DA parent */
-        sbool segdiskMarkerPending; /* publish the DA engine marker before first append */
+        sbool daEngineMarkerPending; /* publish the selected DA engine before first append */
         uint64_t daActivityGeneration; /* parent enqueue generation for the idle grace period */
         uint64_t segdiskIdleObservedActivity;
         struct queue_s *pqDA; /* queue for disk-assisted modes */

--- a/runtime/queue_da.c
+++ b/runtime/queue_da.c
@@ -179,6 +179,11 @@ rsRetVal qdaEngineResolve(const qda_engine_config_t *config, qda_engine_result_t
         result->effective = QDA_ENGINE_DISK;
         result->reason = QDA_REASON_MARKER;
     } else if (result->marker_present && result->marker_engine == QDA_ENGINE_DISK && config->auto_upgrade) {
+        /* This is the requested upgrade boundary: the durable marker proves
+         * that the previous engine was classic, while the absence of .qi and
+         * numeric segments proves that it drained.  Selection changes only
+         * during this restart; StartDA atomically replaces the marker before
+         * constructing the new child, and no records are converted. */
         result->effective = QDA_ENGINE_SEGMENTED_DISK;
         result->reason = QDA_REASON_AUTO_UPGRADE;
     } else if (result->marker_present) {

--- a/runtime/queue_da.c
+++ b/runtime/queue_da.c
@@ -1,0 +1,252 @@
+/* Disk-assisted queue engine selection and durable marker handling. */
+#include "config.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "queue_da.h"
+
+#define QDA_MARKER_MAGIC "RSYSLOG-DA-ENGINE-V1 "
+
+static rsRetVal make_path(char **path, const char *dir, const char *prefix, const char *suffix) {
+    if (asprintf(path, "%s/%s%s", dir, prefix, suffix) < 0) {
+        *path = NULL;
+        return RS_RET_OUT_OF_MEMORY;
+    }
+    return RS_RET_OK;
+}
+
+static rsRetVal path_exists(const char *path, sbool *exists) {
+    struct stat st;
+    if (lstat(path, &st) == 0) {
+        *exists = 1;
+        return RS_RET_OK;
+    }
+    if (errno == ENOENT) {
+        *exists = 0;
+        return RS_RET_OK;
+    }
+    return RS_RET_IO_ERROR;
+}
+
+static sbool is_classic_segment_name(const char *name, const char *prefix) {
+    const size_t prefix_len = strlen(prefix);
+    if (strncmp(name, prefix, prefix_len) != 0 || name[prefix_len] != '.') return 0;
+    const char *p = name + prefix_len + 1;
+    if (*p == '\0') return 0;
+    for (; *p != '\0'; ++p) {
+        if (*p < '0' || *p > '9') return 0;
+    }
+    return 1;
+}
+
+static rsRetVal find_classic_segments(const char *dir, const char *prefix, sbool *found) {
+    DIR *d = opendir(dir);
+    if (d == NULL) return errno == ENOENT ? RS_RET_FILE_NOT_FOUND : RS_RET_IO_ERROR;
+    *found = 0;
+    errno = 0;
+    struct dirent *entry;
+    while ((entry = readdir(d)) != NULL) {
+        if (is_classic_segment_name(entry->d_name, prefix)) {
+            *found = 1;
+            break;
+        }
+    }
+    const int saved_errno = errno;
+    closedir(d);
+    if (!*found && saved_errno != 0) return RS_RET_IO_ERROR;
+    return RS_RET_OK;
+}
+
+const char *qdaEngineName(qda_engine_mode_t engine) {
+    switch (engine) {
+        case QDA_ENGINE_AUTO:
+            return "auto";
+        case QDA_ENGINE_DISK:
+            return "disk";
+        case QDA_ENGINE_SEGMENTED_DISK:
+            return "segmentedDisk";
+        default:
+            return "invalid";
+    }
+}
+
+static rsRetVal read_marker(const char *path, sbool *present, qda_engine_mode_t *engine) {
+    char buf[64];
+    *present = 0;
+    const int fd = open(path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+    if (fd < 0) return errno == ENOENT ? RS_RET_OK : RS_RET_IO_ERROR;
+    struct stat st;
+    if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) || st.st_size <= 0 || st.st_size >= (off_t)sizeof(buf)) {
+        close(fd);
+        return RS_RET_INVALID_VALUE;
+    }
+    size_t off = 0;
+    while (off < (size_t)st.st_size) {
+        const ssize_t n = read(fd, buf + off, (size_t)st.st_size - off);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            close(fd);
+            return RS_RET_IO_ERROR;
+        }
+        if (n == 0) break;
+        off += (size_t)n;
+    }
+    close(fd);
+    if (off != (size_t)st.st_size) return RS_RET_IO_ERROR;
+    buf[off] = '\0';
+    const char *value = buf + sizeof(QDA_MARKER_MAGIC) - 1;
+    if (strncmp(buf, QDA_MARKER_MAGIC, sizeof(QDA_MARKER_MAGIC) - 1) != 0) return RS_RET_INVALID_VALUE;
+    if (!strcmp(value, "disk\n"))
+        *engine = QDA_ENGINE_DISK;
+    else if (!strcmp(value, "segmentedDisk\n"))
+        *engine = QDA_ENGINE_SEGMENTED_DISK;
+    else
+        return RS_RET_INVALID_VALUE;
+    *present = 1;
+    return RS_RET_OK;
+}
+
+rsRetVal qdaEngineResolve(const qda_engine_config_t *config, qda_engine_result_t *result) {
+    if (config == NULL || result == NULL || config->spool_dir == NULL || config->file_prefix == NULL)
+        return RS_RET_PARAM_ERROR;
+    memset(result, 0, sizeof(*result));
+    char *qi_path = NULL;
+    char *seg_path = NULL;
+    char *marker_path = NULL;
+    rsRetVal r = make_path(&qi_path, config->spool_dir, config->file_prefix, ".qi");
+    if (r == RS_RET_OK) r = make_path(&seg_path, config->spool_dir, config->file_prefix, ".segq");
+    if (r == RS_RET_OK) r = make_path(&marker_path, config->spool_dir, config->file_prefix, ".da-engine");
+    if (r != RS_RET_OK) goto done;
+    r = path_exists(qi_path, &result->classic_data);
+    if (r == RS_RET_OK) r = path_exists(seg_path, &result->segmented_data);
+    if (r == RS_RET_OK) r = read_marker(marker_path, &result->marker_present, &result->marker_engine);
+    if (r != RS_RET_OK) goto done;
+
+    sbool numeric_segments = 0;
+    r = find_classic_segments(config->spool_dir, config->file_prefix, &numeric_segments);
+    if (r == RS_RET_FILE_NOT_FOUND) r = RS_RET_OK;
+    if (r != RS_RET_OK) goto done;
+    result->classic_data = result->classic_data || numeric_segments;
+    if (result->classic_data && result->segmented_data) {
+        r = RS_RET_INVALID_VALUE;
+        goto done;
+    }
+    if (result->marker_present && ((result->classic_data && result->marker_engine == QDA_ENGINE_SEGMENTED_DISK) ||
+                                   (result->segmented_data && result->marker_engine == QDA_ENGINE_DISK))) {
+        r = RS_RET_INVALID_VALUE;
+        goto done;
+    }
+
+    if (config->requested == QDA_ENGINE_DISK) {
+        if (result->segmented_data) {
+            r = RS_RET_INVALID_VALUE;
+            goto done;
+        }
+        result->effective = QDA_ENGINE_DISK;
+        result->reason = QDA_REASON_CONFIGURED;
+    } else if (config->requested == QDA_ENGINE_SEGMENTED_DISK) {
+        if (result->classic_data || config->requires_classic_features) {
+            r = RS_RET_INVALID_VALUE;
+            goto done;
+        }
+        result->effective = QDA_ENGINE_SEGMENTED_DISK;
+        result->reason = QDA_REASON_CONFIGURED;
+    } else if (config->requested != QDA_ENGINE_AUTO) {
+        r = RS_RET_INVALID_VALUE;
+        goto done;
+    } else if (result->classic_data) {
+        result->effective = QDA_ENGINE_DISK;
+        result->reason = QDA_REASON_CLASSIC_DATA;
+    } else if (result->segmented_data) {
+        if (config->requires_classic_features) {
+            r = RS_RET_INVALID_VALUE;
+            goto done;
+        }
+        result->effective = QDA_ENGINE_SEGMENTED_DISK;
+        result->reason = QDA_REASON_SEGMENTED_DATA;
+    } else if (config->requires_classic_features) {
+        result->effective = QDA_ENGINE_DISK;
+        result->reason = QDA_REASON_CLASSIC_FEATURE;
+    } else if (result->marker_present && result->marker_engine == QDA_ENGINE_DISK && !config->auto_upgrade) {
+        result->effective = QDA_ENGINE_DISK;
+        result->reason = QDA_REASON_MARKER;
+    } else if (result->marker_present && result->marker_engine == QDA_ENGINE_DISK && config->auto_upgrade) {
+        result->effective = QDA_ENGINE_SEGMENTED_DISK;
+        result->reason = QDA_REASON_AUTO_UPGRADE;
+    } else if (result->marker_present) {
+        result->effective = result->marker_engine;
+        result->reason = QDA_REASON_MARKER;
+    } else {
+        result->effective = QDA_ENGINE_SEGMENTED_DISK;
+        result->reason = QDA_REASON_FRESH_DEFAULT;
+    }
+
+done:
+    free(qi_path);
+    free(seg_path);
+    free(marker_path);
+    return r;
+}
+
+static rsRetVal write_all(int fd, const char *buf, size_t len) {
+    size_t off = 0;
+    while (off < len) {
+        const ssize_t n = write(fd, buf + off, len - off);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return RS_RET_IO_ERROR;
+        }
+        off += (size_t)n;
+    }
+    return RS_RET_OK;
+}
+
+rsRetVal qdaEngineWriteMarker(const char *spool_dir, const char *file_prefix, qda_engine_mode_t engine) {
+    if (spool_dir == NULL || file_prefix == NULL || engine == QDA_ENGINE_AUTO) return RS_RET_PARAM_ERROR;
+    char *path = NULL;
+    char *tmp = NULL;
+    rsRetVal r = make_path(&path, spool_dir, file_prefix, ".da-engine");
+    if (r != RS_RET_OK) return r;
+    const char *name = qdaEngineName(engine);
+    char content[64];
+    const int content_len = snprintf(content, sizeof(content), "%s%s\n", QDA_MARKER_MAGIC, name);
+    if (content_len < 0 || content_len >= (int)sizeof(content)) {
+        free(path);
+        return RS_RET_INTERNAL_ERROR;
+    }
+    if (asprintf(&tmp, "%s.tmp.%ld", path, (long)getpid()) < 0) {
+        free(path);
+        return RS_RET_OUT_OF_MEMORY;
+    }
+    int fd = open(tmp, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW, 0600);
+    if (fd < 0) {
+        if (errno == EEXIST && unlink(tmp) == 0)
+            fd = open(tmp, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW, 0600);
+    }
+    if (fd < 0) {
+        r = RS_RET_IO_ERROR;
+        goto done;
+    }
+    r = write_all(fd, content, (size_t)content_len);
+    if (r == RS_RET_OK && fdatasync(fd) != 0) r = RS_RET_IO_ERROR;
+    if (close(fd) != 0 && r == RS_RET_OK) r = RS_RET_IO_ERROR;
+    if (r == RS_RET_OK && rename(tmp, path) != 0) r = RS_RET_IO_ERROR;
+    if (r == RS_RET_OK) {
+        const int dirfd = open(spool_dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+        if (dirfd < 0 || fsync(dirfd) != 0) r = RS_RET_IO_ERROR;
+        if (dirfd >= 0) close(dirfd);
+    }
+    if (r != RS_RET_OK) unlink(tmp);
+done:
+    free(tmp);
+    free(path);
+    return r;
+}

--- a/runtime/queue_da.c
+++ b/runtime/queue_da.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright 2008-2026 Rainer Gerhards and Adiscon GmbH.
+ *
+ * This file is part of the rsyslog runtime library.
+ *
+ * The rsyslog runtime library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The rsyslog runtime library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the rsyslog runtime library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * A copy of the GPL can be found in the file "COPYING" in this distribution.
+ * A copy of the LGPL can be found in the file "COPYING.LESSER" in this distribution.
+ */
+
 /* Disk-assisted queue engine selection and durable marker handling. */
 #include "config.h"
 
@@ -107,8 +129,9 @@ static rsRetVal read_marker(const char *path, sbool *present, qda_engine_mode_t 
     close(fd);
     if (off != (size_t)st.st_size) return RS_RET_IO_ERROR;
     buf[off] = '\0';
-    const char *value = buf + sizeof(QDA_MARKER_MAGIC) - 1;
-    if (strncmp(buf, QDA_MARKER_MAGIC, sizeof(QDA_MARKER_MAGIC) - 1) != 0) return RS_RET_INVALID_VALUE;
+    const size_t magic_len = sizeof(QDA_MARKER_MAGIC) - 1;
+    if (off <= magic_len || memcmp(buf, QDA_MARKER_MAGIC, magic_len) != 0) return RS_RET_INVALID_VALUE;
+    const char *value = buf + magic_len;
     if (!strcmp(value, "disk\n"))
         *engine = QDA_ENGINE_DISK;
     else if (!strcmp(value, "segmentedDisk\n"))

--- a/runtime/queue_da.c
+++ b/runtime/queue_da.c
@@ -145,6 +145,12 @@ rsRetVal qdaEngineResolve(const qda_engine_config_t *config, qda_engine_result_t
         goto done;
     }
 
+    /* An explicit selector may replace an opposite marker only after the
+     * probes above proved that the old engine has no state or segments.  The
+     * marker is intentionally not data: it is retained after a clean drain so
+     * auto mode stays sticky, while an operator can explicitly choose the
+     * engine for the next materialization.  Opposite-engine data remains a
+     * hard conflict in both branches. */
     if (config->requested == QDA_ENGINE_DISK) {
         if (result->segmented_data) {
             r = RS_RET_INVALID_VALUE;

--- a/runtime/queue_da.c
+++ b/runtime/queue_da.c
@@ -82,7 +82,11 @@ static rsRetVal find_classic_segments(const char *dir, const char *prefix, sbool
         }
     }
     const int saved_errno = errno;
-    closedir(d);
+    /* A close failure means the directory probe did not complete reliably,
+     * even if a matching name was observed.  Engine selection must fail
+     * closed here: treating a partial/invalid probe as authoritative could
+     * select an engine that conflicts with persistent data. */
+    if (closedir(d) != 0) return RS_RET_IO_ERROR;
     if (!*found && saved_errno != 0) return RS_RET_IO_ERROR;
     return RS_RET_OK;
 }
@@ -207,6 +211,10 @@ rsRetVal qdaEngineResolve(const qda_engine_config_t *config, qda_engine_result_t
         result->effective = QDA_ENGINE_SEGMENTED_DISK;
         result->reason = QDA_REASON_SEGMENTED_DATA;
     } else if (config->requires_classic_features) {
+        /* Unsupported segmented features take precedence over an empty
+         * segmented marker in auto mode.  The data probes above proved that
+         * changing the marker cannot strand records, and auto is required to
+         * select the classic engine for these features. */
         result->effective = QDA_ENGINE_DISK;
         result->reason = QDA_REASON_CLASSIC_FEATURE;
     } else if (result->marker_present && result->marker_engine == QDA_ENGINE_DISK && !config->auto_upgrade) {

--- a/runtime/queue_da.c
+++ b/runtime/queue_da.c
@@ -78,6 +78,11 @@ const char *qdaEngineName(qda_engine_mode_t engine) {
     }
 }
 
+sbool qdaLifecycleConfigEqual(const qda_lifecycle_config_t *left, const qda_lifecycle_config_t *right) {
+    return left != NULL && right != NULL && left->engine == right->engine &&
+           left->auto_upgrade == right->auto_upgrade && left->idle_timeout == right->idle_timeout;
+}
+
 static rsRetVal read_marker(const char *path, sbool *present, qda_engine_mode_t *engine) {
     char buf[64];
     *present = 0;
@@ -215,13 +220,15 @@ static rsRetVal write_all(int fd, const char *buf, size_t len) {
             if (errno == EINTR) continue;
             return RS_RET_IO_ERROR;
         }
+        if (n == 0) return RS_RET_IO_ERROR;
         off += (size_t)n;
     }
     return RS_RET_OK;
 }
 
 rsRetVal qdaEngineWriteMarker(const char *spool_dir, const char *file_prefix, qda_engine_mode_t engine) {
-    if (spool_dir == NULL || file_prefix == NULL || engine == QDA_ENGINE_AUTO) return RS_RET_PARAM_ERROR;
+    if (spool_dir == NULL || file_prefix == NULL || (engine != QDA_ENGINE_DISK && engine != QDA_ENGINE_SEGMENTED_DISK))
+        return RS_RET_PARAM_ERROR;
     char *path = NULL;
     char *tmp = NULL;
     rsRetVal r = make_path(&path, spool_dir, file_prefix, ".da-engine");

--- a/runtime/queue_da.c
+++ b/runtime/queue_da.c
@@ -249,6 +249,18 @@ static rsRetVal write_all(int fd, const char *buf, size_t len) {
     return RS_RET_OK;
 }
 
+static int sync_file_data(const int fd) {
+#if defined(HAVE_FDATASYNC) && !defined(__APPLE__)
+    return fdatasync(fd);
+#else
+    return fsync(fd);
+#endif
+}
+
+static rsRetVal sync_directory(const int fd) {
+    return fsync(fd) == 0 || errno == EINVAL || errno == ENOTSUP ? RS_RET_OK : RS_RET_IO_ERROR;
+}
+
 rsRetVal qdaEngineWriteMarker(const char *spool_dir, const char *file_prefix, qda_engine_mode_t engine) {
     if (spool_dir == NULL || file_prefix == NULL || (engine != QDA_ENGINE_DISK && engine != QDA_ENGINE_SEGMENTED_DISK))
         return RS_RET_PARAM_ERROR;
@@ -277,12 +289,12 @@ rsRetVal qdaEngineWriteMarker(const char *spool_dir, const char *file_prefix, qd
         goto done;
     }
     r = write_all(fd, content, (size_t)content_len);
-    if (r == RS_RET_OK && fdatasync(fd) != 0) r = RS_RET_IO_ERROR;
+    if (r == RS_RET_OK && sync_file_data(fd) != 0) r = RS_RET_IO_ERROR;
     if (close(fd) != 0 && r == RS_RET_OK) r = RS_RET_IO_ERROR;
     if (r == RS_RET_OK && rename(tmp, path) != 0) r = RS_RET_IO_ERROR;
     if (r == RS_RET_OK) {
         const int dirfd = open(spool_dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
-        if (dirfd < 0 || fsync(dirfd) != 0) r = RS_RET_IO_ERROR;
+        if (dirfd < 0 || sync_directory(dirfd) != RS_RET_OK) r = RS_RET_IO_ERROR;
         if (dirfd >= 0) close(dirfd);
     }
     if (r != RS_RET_OK) unlink(tmp);

--- a/runtime/queue_da.h
+++ b/runtime/queue_da.h
@@ -33,8 +33,17 @@ typedef struct qda_engine_result_s {
     qda_engine_mode_t marker_engine;
 } qda_engine_result_t;
 
+/* Fields which determine whether a disk-assisted queue can retain its
+ * existing child across a configuration reload. */
+typedef struct qda_lifecycle_config_s {
+    qda_engine_mode_t engine;
+    sbool auto_upgrade;
+    int idle_timeout;
+} qda_lifecycle_config_t;
+
 rsRetVal qdaEngineResolve(const qda_engine_config_t *config, qda_engine_result_t *result);
 rsRetVal qdaEngineWriteMarker(const char *spool_dir, const char *file_prefix, qda_engine_mode_t engine);
 const char *qdaEngineName(qda_engine_mode_t engine);
+sbool qdaLifecycleConfigEqual(const qda_lifecycle_config_t *left, const qda_lifecycle_config_t *right);
 
 #endif

--- a/runtime/queue_da.h
+++ b/runtime/queue_da.h
@@ -1,0 +1,40 @@
+/* Internal disk-assisted queue engine selection helpers. */
+#ifndef INCLUDED_QUEUE_DA_H
+#define INCLUDED_QUEUE_DA_H
+
+#include "rsyslog.h"
+
+typedef enum qda_engine_mode_e { QDA_ENGINE_AUTO = 0, QDA_ENGINE_DISK, QDA_ENGINE_SEGMENTED_DISK } qda_engine_mode_t;
+
+typedef enum qda_selection_reason_e {
+    QDA_REASON_CONFIGURED = 0,
+    QDA_REASON_FRESH_DEFAULT,
+    QDA_REASON_MARKER,
+    QDA_REASON_CLASSIC_DATA,
+    QDA_REASON_SEGMENTED_DATA,
+    QDA_REASON_CLASSIC_FEATURE,
+    QDA_REASON_AUTO_UPGRADE
+} qda_selection_reason_t;
+
+typedef struct qda_engine_config_s {
+    const char *spool_dir;
+    const char *file_prefix;
+    qda_engine_mode_t requested;
+    sbool auto_upgrade;
+    sbool requires_classic_features;
+} qda_engine_config_t;
+
+typedef struct qda_engine_result_s {
+    qda_engine_mode_t effective;
+    qda_selection_reason_t reason;
+    sbool classic_data;
+    sbool segmented_data;
+    sbool marker_present;
+    qda_engine_mode_t marker_engine;
+} qda_engine_result_t;
+
+rsRetVal qdaEngineResolve(const qda_engine_config_t *config, qda_engine_result_t *result);
+rsRetVal qdaEngineWriteMarker(const char *spool_dir, const char *file_prefix, qda_engine_mode_t engine);
+const char *qdaEngineName(qda_engine_mode_t engine);
+
+#endif

--- a/runtime/queue_da.h
+++ b/runtime/queue_da.h
@@ -1,3 +1,25 @@
+/*
+ * Copyright 2008-2026 Rainer Gerhards and Adiscon GmbH.
+ *
+ * This file is part of the rsyslog runtime library.
+ *
+ * The rsyslog runtime library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The rsyslog runtime library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the rsyslog runtime library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * A copy of the GPL can be found in the file "COPYING" in this distribution.
+ * A copy of the LGPL can be found in the file "COPYING.LESSER" in this distribution.
+ */
+
 /* Internal disk-assisted queue engine selection helpers. */
 #ifndef INCLUDED_QUEUE_DA_H
 #define INCLUDED_QUEUE_DA_H

--- a/runtime/segdisk_store.c
+++ b/runtime/segdisk_store.c
@@ -1215,6 +1215,12 @@ rsRetVal segdiskStoreOpen(segdisk_store_t **out, const segdisk_store_config_t *c
     if (asprintf(&legacy_qi, "%s/%s.qi", cfg->work_dir, cfg->file_prefix) < 0) goto oom;
     struct stat legacy_st;
     if (lstat(legacy_qi, &legacy_st) == 0) {
+        /* DA engine resolution happens before this constructor.  Auto mode
+         * sends any existing .qi to the classic child, and an explicit
+         * segmented selector is rejected as a data conflict.  Keep this
+         * store-level guard for pure segmentedDisk queues and races: a .qi is
+         * persistent classic state even if it describes zero records, so it
+         * must be drained/removed before auto-upgrade can select segmented. */
         LogError(0, RS_RET_INVALID_VALUE, "%s: segmentedDisk refuses legacy queue state '%s'", s->queue_name,
                  legacy_qi);
         free(legacy_qi);

--- a/runtime/segdisk_store.c
+++ b/runtime/segdisk_store.c
@@ -1515,6 +1515,21 @@ static rsRetVal restore_empty_materialized(segdisk_store_t *s, uint64_t next_seg
     } else if (random_uuid(s->uuid) != RS_RET_OK) {
         return RS_RET_IO_ERROR;
     }
+    if (!state_present) {
+        /* Publish a valid cleanup-in-progress slot before rebuilding the
+         * active segment.  If reconstruction fails or the process crashes,
+         * startup can finish the empty cleanup instead of finding a newly
+         * created state file with two invalid slots. */
+        s->dematerializing = 1;
+        const rsRetVal state_ret = write_state(s, 1, 1);
+        s->dematerializing = 0;
+        if (state_ret != RS_RET_OK) {
+            close(s->state_fd);
+            s->state_fd = -1;
+            unlinkat(s->dir_fd, "state", 0);
+            return state_ret;
+        }
+    }
     rsRetVal r = create_active(s);
     if (r == RS_RET_OK) r = sync_dir(s);
     return r;

--- a/runtime/segdisk_store.c
+++ b/runtime/segdisk_store.c
@@ -1582,7 +1582,16 @@ rsRetVal segdiskStoreDematerialize(segdisk_store_t *s) {
     const uint64_t restore_next_segment = s->next_segment;
     s->dematerializing = 1;
     rsRetVal r = write_state(s, 1, 1);
-    if (r == RS_RET_OK) test_fault(s, SEGDISK_TEST_FAULT_IDLE_EMPTY_PUBLISHED);
+    if (r != RS_RET_OK) {
+        /* No destructive step is permitted until the cleanup intent is
+         * durable.  The previous normal state and the still-open active
+         * segment therefore remain a complete recoverable store when state
+         * publication itself fails. */
+        s->dematerializing = 0;
+        ++s->stats.idle_cleanup_failures;
+        return r;
+    }
+    test_fault(s, SEGDISK_TEST_FAULT_IDLE_EMPTY_PUBLISHED);
     if (s->active_fd >= 0) {
         if (close(s->active_fd) != 0 && r == RS_RET_OK) r = RS_RET_IO_ERROR;
         s->active_fd = -1;
@@ -1606,9 +1615,15 @@ rsRetVal segdiskStoreDematerialize(segdisk_store_t *s) {
     } else {
         ++s->stats.idle_cleanup_failures;
         const rsRetVal restore_ret = restore_empty_materialized(s, restore_next_segment);
-        if (restore_ret != RS_RET_OK)
+        if (restore_ret != RS_RET_OK) {
+            /* r is already a hard failure returned to the queue callback.  A
+             * failed repair does not soften it: the durable
+             * cleanup-in-progress state (or a state-free empty directory
+             * after segment removal) makes restart complete deletion, while
+             * the live worker retries cleanup in this process. */
             LogError(0, restore_ret, "%s: failed to restore an empty segmentedDisk store after idle cleanup error",
                      s->queue_name);
+        }
     }
     return r;
 }

--- a/runtime/segdisk_store.c
+++ b/runtime/segdisk_store.c
@@ -41,6 +41,8 @@
 #define FOOT_LEN 48u
 #define MAX_RECORD_SIZE (128u * 1024u * 1024u)
 #define RECOVERY_SCAN_BUDGET (1024u * 1024u)
+#define STATE_FLAG_RECOVERY 1u
+#define STATE_FLAG_DEMATERIALIZING 2u
 
 typedef struct segdisk_segment_s {
     uint64_t id;
@@ -106,6 +108,7 @@ struct segdisk_store_s {
     uint64_t next_batch_sequence;
     uint64_t known_queue_size;
     unsigned int updates_since_checkpoint;
+    sbool dematerializing;
     segdisk_store_stats_t stats;
 #ifdef ENABLE_IMDIAG
     segdisk_test_fault_point_t test_fault_point;
@@ -128,6 +131,10 @@ static const segdisk_test_fault_name_t test_fault_names[] = {
     {"commit-published", SEGDISK_TEST_FAULT_COMMIT_PUBLISHED},
     {"predelete-published", SEGDISK_TEST_FAULT_PREDELETE_PUBLISHED},
     {"segment-unlinked", SEGDISK_TEST_FAULT_SEGMENT_UNLINKED},
+    {"idle-empty-published", SEGDISK_TEST_FAULT_IDLE_EMPTY_PUBLISHED},
+    {"idle-segments-unlinked", SEGDISK_TEST_FAULT_IDLE_SEGMENTS_UNLINKED},
+    {"idle-state-unlinked", SEGDISK_TEST_FAULT_IDLE_STATE_UNLINKED},
+    {"idle-directory-removed", SEGDISK_TEST_FAULT_IDLE_DIRECTORY_REMOVED},
 };
 
 static void test_fault(segdisk_store_t *s, const segdisk_test_fault_point_t point) {
@@ -294,7 +301,8 @@ static void capture_state_image(const segdisk_store_t *s, segdisk_state_image_t 
     memset(state, 0, sizeof(*state));
     memcpy(state->uuid, s->uuid, sizeof(state->uuid));
     state->generation = s->generation;
-    state->flags = s->recovery_first != 0 ? 1u : 0u;
+    state->flags =
+        (s->recovery_first != 0 ? STATE_FLAG_RECOVERY : 0u) | (s->dematerializing ? STATE_FLAG_DEMATERIALIZING : 0u);
     state->committed_segment = s->committed_segment;
     state->committed_offset = s->committed_offset;
     state->committed_record_sequence = s->committed_record_sequence;
@@ -320,6 +328,7 @@ static void capture_state_image(const segdisk_store_t *s, segdisk_state_image_t 
 static void apply_state_image(segdisk_store_t *s, const segdisk_state_image_t *state) {
     memcpy(s->uuid, state->uuid, sizeof(s->uuid));
     s->generation = state->generation;
+    s->dematerializing = (state->flags & STATE_FLAG_DEMATERIALIZING) != 0;
     s->committed_segment = state->committed_segment;
     s->committed_offset = state->committed_offset;
     s->committed_record_sequence = state->committed_record_sequence;
@@ -368,7 +377,8 @@ static rsRetVal read_state(segdisk_store_t *s) {
     segdisk_state_image_t state;
     const rsRetVal r = segdiskStateSelect(slots[0], r0 == RS_RET_OK, slots[1], r1 == RS_RET_OK, &state, NULL);
     if (r == RS_RET_OK &&
-        ((state.delete_first == 0) != (state.delete_last == 0) ||
+        ((state.flags & ~(STATE_FLAG_RECOVERY | STATE_FLAG_DEMATERIALIZING)) != 0 ||
+         (state.delete_first == 0) != (state.delete_last == 0) ||
          (state.delete_first != 0 && state.delete_first > state.delete_last) || state.delete_bytes < 0))
         return RS_RET_INVALID_VALUE;
     if (r == RS_RET_OK) apply_state_image(s, &state);
@@ -577,6 +587,38 @@ static rsRetVal create_active(segdisk_store_t *s) {
     return RS_RET_OK;
 }
 
+static rsRetVal materialize_empty(segdisk_store_t *s) {
+    if (s->dir_fd >= 0) return RS_RET_OK;
+    rsRetVal r = RS_RET_OK;
+    if (mkdir(s->dir, 0700) != 0 && errno != EEXIST) return RS_RET_IO_ERROR;
+    s->dir_fd = open(s->dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (s->dir_fd < 0) return RS_RET_IO_ERROR;
+    s->state_fd = openat(s->dir_fd, "state", O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW, 0600);
+    if (s->state_fd < 0 || ftruncate(s->state_fd, STATE_FILE_LEN) != 0 || random_uuid(s->uuid) != RS_RET_OK)
+        r = RS_RET_IO_ERROR;
+    s->committed_offset = SEG_HDR_LEN;
+    s->persisted_writer_end = SEG_HDR_LEN;
+    s->next_segment = 1;
+    if (r == RS_RET_OK) r = create_active(s);
+    if (r == RS_RET_OK) r = sync_dir(s);
+    if (r == RS_RET_OK) {
+        ++s->stats.materializations;
+        return RS_RET_OK;
+    }
+    if (s->active_fd >= 0) close(s->active_fd);
+    s->active_fd = -1;
+    free_segment(&s->active);
+    if (s->dir_fd >= 0) {
+        remove_remaining_segments(s);
+        unlinkat(s->dir_fd, "state", 0);
+    }
+    if (s->state_fd >= 0) close(s->state_fd);
+    if (s->dir_fd >= 0) close(s->dir_fd);
+    s->state_fd = s->dir_fd = -1;
+    rmdir(s->dir);
+    return r;
+}
+
 static void restore_active_after_seal_failure(segdisk_store_t *s) {
     const int fd = open(s->active->path, O_RDWR | O_APPEND | O_CLOEXEC | O_NOFOLLOW);
     if (fd < 0) return;
@@ -683,6 +725,10 @@ static void update_retry_overage(segdisk_store_t *s) {
 }
 
 static rsRetVal append_record(segdisk_store_t *s, smsg_t *msg, sbool internal, int64_t *written) {
+    if (s->dir_fd < 0) {
+        const rsRetVal materialize_ret = materialize_empty(s);
+        if (materialize_ret != RS_RET_OK) return materialize_ret;
+    }
     if (s->active == NULL) {
         rsRetVal r = create_active(s);
         if (r != RS_RET_OK) return r;
@@ -1107,6 +1153,23 @@ static rsRetVal adopt_reserved_segment(segdisk_store_t *s) {
     return RS_RET_OK;
 }
 
+static void reset_after_dematerialize(segdisk_store_t *s);
+
+static rsRetVal finish_interrupted_dematerialization(segdisk_store_t *s) {
+    rsRetVal r = remove_remaining_segments(s);
+    if (r == RS_RET_OK) r = sync_dir(s);
+    if (r == RS_RET_OK && unlinkat(s->dir_fd, "state", 0) != 0 && errno != ENOENT) r = RS_RET_IO_ERROR;
+    if (r == RS_RET_OK) r = sync_dir(s);
+    if (r == RS_RET_OK && rmdir(s->dir) != 0 && errno != ENOENT) r = RS_RET_IO_ERROR;
+    if (r != RS_RET_OK) return r;
+    if (s->state_fd >= 0) close(s->state_fd);
+    if (s->dir_fd >= 0) close(s->dir_fd);
+    s->state_fd = s->dir_fd = -1;
+    reset_after_dematerialize(s);
+    ++s->stats.dematerializations;
+    return RS_RET_OK;
+}
+
 rsRetVal segdiskStoreOpen(segdisk_store_t **out, const segdisk_store_config_t *cfg, int *queue_size) {
     if (out == NULL || cfg == NULL || cfg->work_dir == NULL || cfg->file_prefix == NULL || queue_size == NULL)
         return RS_RET_PARAM_ERROR;
@@ -1133,6 +1196,14 @@ rsRetVal segdiskStoreOpen(segdisk_store_t **out, const segdisk_store_config_t *c
         goto invalid;
     }
     free(legacy_qi);
+    if (cfg->lazy_create) {
+        struct stat dir_st;
+        if (lstat(s->dir, &dir_st) != 0 && errno == ENOENT) {
+            *queue_size = 0;
+            *out = s;
+            return RS_RET_OK;
+        }
+    }
     sbool directory_created = 0;
     if (mkdir(s->dir, 0700) == 0)
         directory_created = 1;
@@ -1160,6 +1231,18 @@ rsRetVal segdiskStoreOpen(segdisk_store_t **out, const segdisk_store_config_t *c
                      s->queue_name);
             goto invalid;
         }
+        if (cfg->lazy_create && !directory_created) {
+            /* A crash after durable state removal but before rmdir leaves an
+             * empty directory. For a DA child this is the final, unambiguous
+             * cleanup residue, so finish dematerialization instead of
+             * creating a fresh empty store during startup. */
+            close(s->dir_fd);
+            s->dir_fd = -1;
+            if (rmdir(s->dir) != 0 && errno != ENOENT) goto ioerr;
+            *queue_size = 0;
+            *out = s;
+            return RS_RET_OK;
+        }
         s->state_fd = openat(s->dir_fd, "state", O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW, 0600);
         if (s->state_fd < 0 || ftruncate(s->state_fd, STATE_FILE_LEN) != 0 || random_uuid(s->uuid) != RS_RET_OK)
             goto ioerr;
@@ -1173,11 +1256,24 @@ rsRetVal segdiskStoreOpen(segdisk_store_t **out, const segdisk_store_config_t *c
                      s->queue_name);
             goto invalid;
         }
+        if (s->dematerializing) {
+            if (finish_interrupted_dematerialization(s) != RS_RET_OK) goto ioerr;
+            if (cfg->lazy_create) {
+                *queue_size = 0;
+                *out = s;
+                return RS_RET_OK;
+            }
+            if (materialize_empty(s) != RS_RET_OK) goto ioerr;
+            *queue_size = 0;
+            *out = s;
+            return RS_RET_OK;
+        }
         if (prepare_existing_active(s) != RS_RET_OK) goto ioerr;
         if (adopt_reserved_segment(s) != RS_RET_OK) goto ioerr;
         s->discovery_through_segment = s->last_data_segment;
         if (create_active(s) != RS_RET_OK) goto ioerr;
     }
+    ++s->stats.materializations;
     s->known_queue_size = 0;
     *queue_size = 0;
     s->stats.replayed = s->persisted_queue_size;
@@ -1220,7 +1316,17 @@ sbool segdiskStoreMayHaveData(const segdisk_store_t *s) {
            (s->read_segment_id < s->active->id || s->read_offset < s->active->data_end);
 }
 
+sbool segdiskStoreIsMaterialized(const segdisk_store_t *s) {
+    return s != NULL && s->dir_fd >= 0;
+}
+
+sbool segdiskStoreCanDematerialize(const segdisk_store_t *s) {
+    return s != NULL && s->dir_fd >= 0 && s->known_queue_size == 0 && s->pending_head == NULL && s->delete_first == 0 &&
+           !segdiskStoreMayHaveData(s);
+}
+
 rsRetVal segdiskStoreDequeueBatch(segdisk_store_t *s, batch_t *batch, int max, int *skipped, int *discovered) {
+    if (s->dir_fd < 0) return RS_RET_NO_DATA;
     if (batch->storeData != NULL) return RS_RET_INTERNAL_ERROR;
     if (s->delete_first != 0) {
         if (cleanup_one_pending_delete(s) != RS_RET_OK)
@@ -1348,9 +1454,107 @@ rsRetVal segdiskStoreCompleteBatch(segdisk_store_t *s, batch_t *batch, int *comm
 }
 
 rsRetVal segdiskStoreCheckpoint(segdisk_store_t *s, sbool force_sync) {
+    if (s->dir_fd < 0) return RS_RET_OK;
     capture_writer(s);
     const rsRetVal r = write_state(s, force_sync, force_sync);
     if (r == RS_RET_OK) test_fault(s, SEGDISK_TEST_FAULT_CHECKPOINT_PUBLISHED);
+    return r;
+}
+
+static void reset_after_dematerialize(segdisk_store_t *s) {
+    memset(s->uuid, 0, sizeof(s->uuid));
+    s->generation = 0;
+    s->committed_segment = 0;
+    s->committed_record_sequence = 0;
+    s->committed_offset = SEG_HDR_LEN;
+    s->first_live_segment = 0;
+    s->last_data_segment = 0;
+    s->active_segment = 0;
+    s->recovery_first = 0;
+    s->recovery_last = 0;
+    s->next_segment = 1;
+    s->persisted_queue_size = 0;
+    s->persisted_writer_segment = 0;
+    s->persisted_writer_end = SEG_HDR_LEN;
+    s->persisted_writer_sequence = 0;
+    s->persisted_writer_count = 0;
+    s->delete_first = 0;
+    s->delete_last = 0;
+    s->delete_bytes = 0;
+    s->delete_segments = 0;
+    s->discovery_through_segment = 0;
+    s->read_segment_id = 0;
+    s->read_offset = SEG_HDR_LEN;
+    s->next_batch_sequence = 0;
+    s->known_queue_size = 0;
+    s->updates_since_checkpoint = 0;
+    s->dematerializing = 0;
+    s->stats.bytes = 0;
+    s->stats.segments = 0;
+}
+
+static rsRetVal restore_empty_materialized(segdisk_store_t *s, uint64_t next_segment) {
+    unsigned char old_uuid[sizeof(s->uuid)];
+    memcpy(old_uuid, s->uuid, sizeof(old_uuid));
+    const uint64_t old_generation = s->generation;
+    if (s->dir_fd < 0) {
+        s->dir_fd = open(s->dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+        if (s->dir_fd < 0) return RS_RET_IO_ERROR;
+    }
+    const sbool state_present = faccessat(s->dir_fd, "state", F_OK, 0) == 0;
+    if (!state_present) {
+        if (s->state_fd >= 0) close(s->state_fd);
+        s->state_fd = openat(s->dir_fd, "state", O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW, 0600);
+        if (s->state_fd < 0 || ftruncate(s->state_fd, STATE_FILE_LEN) != 0) return RS_RET_IO_ERROR;
+    }
+    reset_after_dematerialize(s);
+    s->next_segment = next_segment == 0 ? 1 : next_segment;
+    if (state_present) {
+        memcpy(s->uuid, old_uuid, sizeof(s->uuid));
+        s->generation = old_generation;
+    } else if (random_uuid(s->uuid) != RS_RET_OK) {
+        return RS_RET_IO_ERROR;
+    }
+    rsRetVal r = create_active(s);
+    if (r == RS_RET_OK) r = sync_dir(s);
+    return r;
+}
+
+rsRetVal segdiskStoreDematerialize(segdisk_store_t *s) {
+    if (s == NULL) return RS_RET_PARAM_ERROR;
+    if (s->dir_fd < 0) return RS_RET_OK;
+    if (!segdiskStoreCanDematerialize(s)) return RS_RET_RETRY;
+    const uint64_t restore_next_segment = s->next_segment;
+    s->dematerializing = 1;
+    rsRetVal r = write_state(s, 1, 1);
+    if (r == RS_RET_OK) test_fault(s, SEGDISK_TEST_FAULT_IDLE_EMPTY_PUBLISHED);
+    if (s->active_fd >= 0) {
+        if (close(s->active_fd) != 0 && r == RS_RET_OK) r = RS_RET_IO_ERROR;
+        s->active_fd = -1;
+    }
+    if (r == RS_RET_OK) r = remove_remaining_segments(s);
+    if (r == RS_RET_OK) r = sync_dir(s);
+    if (r == RS_RET_OK) test_fault(s, SEGDISK_TEST_FAULT_IDLE_SEGMENTS_UNLINKED);
+    if (r == RS_RET_OK && unlinkat(s->dir_fd, "state", 0) != 0 && errno != ENOENT) r = RS_RET_IO_ERROR;
+    if (r == RS_RET_OK) test_fault(s, SEGDISK_TEST_FAULT_IDLE_STATE_UNLINKED);
+    if (r == RS_RET_OK) r = sync_dir(s);
+    free_segment(&s->active);
+    free_segment(&s->read_segment);
+    if (r == RS_RET_OK && rmdir(s->dir) != 0 && errno != ENOENT) r = RS_RET_IO_ERROR;
+    if (r == RS_RET_OK) test_fault(s, SEGDISK_TEST_FAULT_IDLE_DIRECTORY_REMOVED);
+    if (r == RS_RET_OK) {
+        if (s->state_fd >= 0) close(s->state_fd);
+        if (s->dir_fd >= 0) close(s->dir_fd);
+        s->state_fd = s->dir_fd = -1;
+        reset_after_dematerialize(s);
+        ++s->stats.dematerializations;
+    } else {
+        ++s->stats.idle_cleanup_failures;
+        const rsRetVal restore_ret = restore_empty_materialized(s, restore_next_segment);
+        if (restore_ret != RS_RET_OK)
+            LogError(0, restore_ret, "%s: failed to restore an empty segmentedDisk store after idle cleanup error",
+                     s->queue_name);
+    }
     return r;
 }
 
@@ -1378,6 +1582,13 @@ rsRetVal segdiskStoreClose(segdisk_store_t **ps, sbool empty) {
     if (ps == NULL || *ps == NULL) return RS_RET_OK;
     segdisk_store_t *s = *ps;
     rsRetVal r = RS_RET_OK;
+    if (s->dir_fd < 0) {
+        free(s->dir);
+        free(s->queue_name);
+        free(s);
+        *ps = NULL;
+        return RS_RET_OK;
+    }
     if (s->active_fd >= 0) {
         if (!empty && s->active != NULL && s->active->record_count != 0)
             r = seal_active(s);

--- a/runtime/segdisk_store.c
+++ b/runtime/segdisk_store.c
@@ -402,7 +402,13 @@ static rsRetVal remove_remaining_segments(segdisk_store_t *s) {
     }
     rsRetVal r = RS_RET_OK;
     struct dirent *de;
-    while ((de = readdir(dir)) != NULL) {
+    while (1) {
+        errno = 0;
+        de = readdir(dir);
+        if (de == NULL) {
+            if (errno != 0) r = RS_RET_IO_ERROR;
+            break;
+        }
         if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, "..") || !strcmp(de->d_name, "state")) continue;
         if (!segment_name(de->d_name)) {
             r = RS_RET_IO_ERROR;
@@ -418,7 +424,7 @@ static rsRetVal remove_remaining_segments(segdisk_store_t *s) {
             continue;
         }
     }
-    closedir(dir);
+    if (closedir(dir) != 0) r = RS_RET_IO_ERROR;
     return r;
 }
 
@@ -432,14 +438,16 @@ static rsRetVal directory_has_segments(segdisk_store_t *s, sbool *has_segments) 
     }
     *has_segments = 0;
     struct dirent *de;
+    errno = 0;
     while ((de = readdir(dir)) != NULL) {
         if (segment_name(de->d_name)) {
             *has_segments = 1;
             break;
         }
     }
-    closedir(dir);
-    return RS_RET_OK;
+    const int scan_errno = errno;
+    if (closedir(dir) != 0) return RS_RET_IO_ERROR;
+    return !*has_segments && scan_errno != 0 ? RS_RET_IO_ERROR : RS_RET_OK;
 }
 
 static rsRetVal write_segment_header(segdisk_store_t *s, int fd, uint64_t id) {
@@ -1347,11 +1355,11 @@ sbool segdiskStoreMayHaveData(const segdisk_store_t *s) {
            (s->read_segment_id < s->active->id || s->read_offset < s->active->data_end);
 }
 
-sbool segdiskStoreIsMaterialized(const segdisk_store_t *s) {
-    return s != NULL && s->dir_fd >= 0;
-}
-
 sbool segdiskStoreCanDematerialize(const segdisk_store_t *s) {
+    /* recovery_first is durable topology, not an undiscovered-work flag: it
+     * may still name the final, fully inspected recovery segment until the
+     * commit frontier enters a later segment.  segdiskStoreMayHaveData() uses
+     * the live read cursor and is the authoritative recovery-work check. */
     return s != NULL && s->dir_fd >= 0 && s->known_queue_size == 0 && s->pending_head == NULL && s->delete_first == 0 &&
            !segdiskStoreMayHaveData(s);
 }

--- a/runtime/segdisk_store.c
+++ b/runtime/segdisk_store.c
@@ -1359,9 +1359,11 @@ sbool segdiskStoreCanDematerialize(const segdisk_store_t *s) {
     /* recovery_first is durable topology, not an undiscovered-work flag: it
      * may still name the final, fully inspected recovery segment until the
      * commit frontier enters a later segment.  segdiskStoreMayHaveData() uses
-     * the live read cursor and is the authoritative recovery-work check. */
+     * the live read cursor and is the authoritative recovery-work check. A
+     * durable cleanup already in progress is also eligible: failed repair may
+     * retain stale cursors, but cleanup intent proves the store was empty. */
     return s != NULL && s->dir_fd >= 0 && s->known_queue_size == 0 && s->pending_head == NULL && s->delete_first == 0 &&
-           !segdiskStoreMayHaveData(s);
+           (s->dematerializing || !segdiskStoreMayHaveData(s));
 }
 
 rsRetVal segdiskStoreDequeueBatch(segdisk_store_t *s, batch_t *batch, int max, int *skipped, int *discovered) {
@@ -1530,6 +1532,7 @@ static void reset_after_dematerialize(segdisk_store_t *s) {
     s->dematerializing = 0;
     s->stats.bytes = 0;
     s->stats.segments = 0;
+    s->stats.retry_overage_bytes = 0;
 }
 
 static rsRetVal restore_empty_materialized(segdisk_store_t *s, uint64_t next_segment) {

--- a/runtime/segdisk_store.c
+++ b/runtime/segdisk_store.c
@@ -406,15 +406,40 @@ static rsRetVal remove_remaining_segments(segdisk_store_t *s) {
         if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, "..") || !strcmp(de->d_name, "state")) continue;
         if (!segment_name(de->d_name)) {
             r = RS_RET_IO_ERROR;
-            break;
+            /* A foreign entry prevents rmdir(), but it must not prevent us
+             * from removing the queue's own segments.  Continuing here is
+             * important for cleanup-error recovery: the replacement empty
+             * state may only exclude the old segment IDs after every old
+             * segment has actually gone. */
+            continue;
         }
         if (unlinkat(s->dir_fd, de->d_name, 0) != 0 && errno != ENOENT) {
             r = RS_RET_IO_ERROR;
-            break;
+            continue;
         }
     }
     closedir(dir);
     return r;
+}
+
+static rsRetVal directory_has_segments(segdisk_store_t *s, sbool *has_segments) {
+    const int scan_fd = openat(s->dir_fd, ".", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (scan_fd < 0) return RS_RET_IO_ERROR;
+    DIR *dir = fdopendir(scan_fd);
+    if (dir == NULL) {
+        close(scan_fd);
+        return RS_RET_IO_ERROR;
+    }
+    *has_segments = 0;
+    struct dirent *de;
+    while ((de = readdir(dir)) != NULL) {
+        if (segment_name(de->d_name)) {
+            *has_segments = 1;
+            break;
+        }
+    }
+    closedir(dir);
+    return RS_RET_OK;
 }
 
 static rsRetVal write_segment_header(segdisk_store_t *s, int fd, uint64_t id) {
@@ -1501,6 +1526,18 @@ static rsRetVal restore_empty_materialized(segdisk_store_t *s, uint64_t next_seg
         s->dir_fd = open(s->dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
         if (s->dir_fd < 0) return RS_RET_IO_ERROR;
     }
+    /* The failed cleanup can have stopped after unlinking only part of the
+     * old topology.  Make a best effort to finish removing queue-owned files,
+     * then prove none remain before publishing a fresh empty topology.  A
+     * foreign file may still make remove_remaining_segments() report failure;
+     * that is harmless here because it is deliberately excluded from the
+     * segment-only verification and will make the next rmdir retry fail.
+     * Conversely, an undeletable segment leaves the cleanup-in-progress state
+     * authoritative and prevents stale records from being hidden by a new
+     * normal state. */
+    (void)remove_remaining_segments(s);
+    sbool has_segments;
+    if (directory_has_segments(s, &has_segments) != RS_RET_OK || has_segments) return RS_RET_IO_ERROR;
     const sbool state_present = faccessat(s->dir_fd, "state", F_OK, 0) == 0;
     if (!state_present) {
         if (s->state_fd >= 0) close(s->state_fd);
@@ -1515,14 +1552,12 @@ static rsRetVal restore_empty_materialized(segdisk_store_t *s, uint64_t next_seg
     } else if (random_uuid(s->uuid) != RS_RET_OK) {
         return RS_RET_IO_ERROR;
     }
+    /* Keep every state publication in cleanup-in-progress form until the new
+     * active segment is durable.  Thus a crash during reconstruction finishes
+     * deletion on restart instead of accepting a partially rebuilt store. */
+    s->dematerializing = 1;
     if (!state_present) {
-        /* Publish a valid cleanup-in-progress slot before rebuilding the
-         * active segment.  If reconstruction fails or the process crashes,
-         * startup can finish the empty cleanup instead of finding a newly
-         * created state file with two invalid slots. */
-        s->dematerializing = 1;
         const rsRetVal state_ret = write_state(s, 1, 1);
-        s->dematerializing = 0;
         if (state_ret != RS_RET_OK) {
             close(s->state_fd);
             s->state_fd = -1;
@@ -1531,6 +1566,11 @@ static rsRetVal restore_empty_materialized(segdisk_store_t *s, uint64_t next_seg
         }
     }
     rsRetVal r = create_active(s);
+    if (r == RS_RET_OK) {
+        s->dematerializing = 0;
+        r = write_state(s, 1, 1);
+        if (r != RS_RET_OK) s->dematerializing = 1;
+    }
     if (r == RS_RET_OK) r = sync_dir(s);
     return r;
 }

--- a/runtime/segdisk_store.h
+++ b/runtime/segdisk_store.h
@@ -70,7 +70,6 @@ rsRetVal segdiskStoreDematerialize(segdisk_store_t *store);
 rsRetVal segdiskStoreClose(segdisk_store_t **store, sbool empty);
 void segdiskStoreGetStats(const segdisk_store_t *store, segdisk_store_stats_t *stats);
 sbool segdiskStoreMayHaveData(const segdisk_store_t *store);
-sbool segdiskStoreIsMaterialized(const segdisk_store_t *store);
 sbool segdiskStoreCanDematerialize(const segdisk_store_t *store);
 #ifdef ENABLE_IMDIAG
 rsRetVal segdiskStoreSetTestFault(segdisk_store_t *store, const char *point, unsigned int hit_count);

--- a/runtime/segdisk_store.h
+++ b/runtime/segdisk_store.h
@@ -17,6 +17,7 @@ typedef struct segdisk_store_config_s {
     int64_t max_disk_space;
     unsigned int checkpoint_interval;
     sbool sync_files;
+    sbool lazy_create;
 } segdisk_store_config_t;
 
 typedef struct segdisk_store_stats_s {
@@ -37,6 +38,9 @@ typedef struct segdisk_store_stats_s {
     uint64_t startup_segment_files_probed;
     uint64_t recovery_pending;
     uint64_t corruption_segments;
+    uint64_t materializations;
+    uint64_t dematerializations;
+    uint64_t idle_cleanup_failures;
 } segdisk_store_stats_t;
 
 #ifdef ENABLE_IMDIAG
@@ -50,6 +54,10 @@ typedef enum segdisk_test_fault_point_e {
     SEGDISK_TEST_FAULT_COMMIT_PUBLISHED,
     SEGDISK_TEST_FAULT_PREDELETE_PUBLISHED,
     SEGDISK_TEST_FAULT_SEGMENT_UNLINKED,
+    SEGDISK_TEST_FAULT_IDLE_EMPTY_PUBLISHED,
+    SEGDISK_TEST_FAULT_IDLE_SEGMENTS_UNLINKED,
+    SEGDISK_TEST_FAULT_IDLE_STATE_UNLINKED,
+    SEGDISK_TEST_FAULT_IDLE_DIRECTORY_REMOVED,
 } segdisk_test_fault_point_t;
 #endif
 
@@ -58,9 +66,12 @@ rsRetVal segdiskStoreAppend(segdisk_store_t *store, smsg_t *msg, sbool internal_
 rsRetVal segdiskStoreDequeueBatch(segdisk_store_t *store, batch_t *batch, int max, int *skipped, int *discovered);
 rsRetVal segdiskStoreCompleteBatch(segdisk_store_t *store, batch_t *batch, int *committed, int *retried);
 rsRetVal segdiskStoreCheckpoint(segdisk_store_t *store, sbool force_sync);
+rsRetVal segdiskStoreDematerialize(segdisk_store_t *store);
 rsRetVal segdiskStoreClose(segdisk_store_t **store, sbool empty);
 void segdiskStoreGetStats(const segdisk_store_t *store, segdisk_store_stats_t *stats);
 sbool segdiskStoreMayHaveData(const segdisk_store_t *store);
+sbool segdiskStoreIsMaterialized(const segdisk_store_t *store);
+sbool segdiskStoreCanDematerialize(const segdisk_store_t *store);
 #ifdef ENABLE_IMDIAG
 rsRetVal segdiskStoreSetTestFault(segdisk_store_t *store, const char *point, unsigned int hit_count);
 void segdiskStoreClearTestFault(segdisk_store_t *store);

--- a/runtime/segdisk_store.h
+++ b/runtime/segdisk_store.h
@@ -7,8 +7,14 @@
 #include "rsyslog.h"
 #include "batch.h"
 
+/** Opaque segmented queue store. All access is serialized by its queue lock. */
 typedef struct segdisk_store_s segdisk_store_t;
 
+/** Configuration captured when a segmented store object is constructed.
+ *
+ * lazy_create keeps a DA child unmaterialized until its first append. It does
+ * not change the eager lifecycle of a pure segmentedDisk queue.
+ */
 typedef struct segdisk_store_config_s {
     const char *work_dir;
     const char *file_prefix;
@@ -20,6 +26,12 @@ typedef struct segdisk_store_config_s {
     sbool lazy_create;
 } segdisk_store_config_t;
 
+/** Monotonic operation counters and current physical store gauges.
+ *
+ * bytes and segments describe the current topology. The remaining fields are
+ * cumulative counters, including lazy materialization and idle-cleanup
+ * outcomes; startup_payload_bytes_read is expected to remain zero.
+ */
 typedef struct segdisk_store_stats_s {
     int64_t bytes;
     int segments;
@@ -61,6 +73,22 @@ typedef enum segdisk_test_fault_point_e {
 } segdisk_test_fault_point_t;
 #endif
 
+/**
+ * Concurrency & Locking
+ * ---------------------
+ * Every function below is called with the owning queue mutex held. The same
+ * mutex is shared by a DA parent and its child, so no store function acquires
+ * an independent lifecycle lock. Append serializes synchronously and retains
+ * no message reference. A dequeued batch retains internal completion state
+ * until CompleteBatch commits or retry-appends every element.
+ *
+ * Dematerialize is destructive and succeeds only when CanDematerialize proves
+ * there is no known data, undiscovered recovery work, pending batch, retry,
+ * completion, or deletion. Failure leaves a materialized recoverable store.
+ * Close destroys the object; Dematerialize resets the same object for a later
+ * lazy append. GetStats and test-fault operations are safe before lazy
+ * materialization.
+ */
 rsRetVal segdiskStoreOpen(segdisk_store_t **store, const segdisk_store_config_t *config, int *queue_size);
 rsRetVal segdiskStoreAppend(segdisk_store_t *store, smsg_t *msg, sbool internal_retry, int64_t *written);
 rsRetVal segdiskStoreDequeueBatch(segdisk_store_t *store, batch_t *batch, int max, int *skipped, int *discovered);

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -380,7 +380,9 @@ static void ATTR_NONNULL() doIdleProcessing(wti_t *const pThis, wtp_t *const pWt
         /* never shut down any started worker */
         d_pthread_cond_wait(&pThis->pcondBusy, pWtp->pmutUsr);
     } else {
-        timeoutComp(&t, pWtp->toWrkShutdown); /* get absolute timeout */
+        const int timeout =
+            pThis->workerIndex == 0 && pWtp->toFirstWrkShutdown != -2 ? pWtp->toFirstWrkShutdown : pWtp->toWrkShutdown;
+        timeoutComp(&t, timeout); /* get absolute timeout */
         if (d_pthread_cond_timedwait(&pThis->pcondBusy, pWtp->pmutUsr, &t) != 0) {
             DBGPRINTF("%s: inactivity timeout, worker terminating...\n", wtiGetDbgHdr(pThis));
             *pbInactivityTOOccurred = 1; /* indicate we had a timeout */

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -456,6 +456,11 @@ PRAGMA_IGNORE_Wempty_body rsRetVal wtiWorker(wti_t *__restrict__ const pThis) {
             break; /* end of loop */
         } else if (localRet == RS_RET_IDLE) {
             if (terminateRet == RS_RET_TERMINATE_WHEN_IDLE || bInactivityTOOccurred) {
+                if (bInactivityTOOccurred && pWtp->pfIdleTimeout != NULL && pWtp->pWrkr[0] == pThis &&
+                    pWtp->pfIdleTimeout(pWtp->pUsr) == RS_RET_RETRY) {
+                    bInactivityTOOccurred = 0;
+                    continue;
+                }
                 DBGOPRINT((obj_t *)pThis,
                           "terminating worker terminateRet=%d, "
                           "bInactivityTOOccurred=%d\n",

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -74,6 +74,7 @@ struct wti_s {
         pthread_t thrdID; /* thread ID */
         int bIsRunning; /* is this thread currently running? (must be int for atomic op!) */
         sbool bAlwaysRunning; /* should this thread always run? */
+        int workerIndex; /* stable slot in the owning worker pool */
         int *pbShutdownImmediate; /* end processing of this batch immediately if set to 1 */
         DEF_ATOMIC_HELPER_MUT(*pmutShutdownImmediate); /* fallback mutex for atomic access */
         wtp_t *pWtp; /* my worker thread pool (important if only the work thread instance is passed! */

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -499,7 +499,10 @@ static rsRetVal ATTR_NONNULL() wtpStartWrkr(wtp_t *const pThis, const int permit
 
     if (i == pThis->iNumWorkerThreads) ABORT_FINALIZE(RS_RET_NO_MORE_THREADS);
 
-    if ((i == 0 && !pThis->bAllowFirstWorkerToTimeout) || pThis->toWrkShutdown == -1) {
+    const sbool first_worker_runs_forever =
+        i == 0 && (!pThis->bAllowFirstWorkerToTimeout || pThis->toFirstWrkShutdown == -1 ||
+                   (pThis->toFirstWrkShutdown == -2 && pThis->toWrkShutdown == -1));
+    if (first_worker_runs_forever || (i != 0 && pThis->toWrkShutdown == -1)) {
         wtiSetAlwaysRunning(pThis->pWrkr[i]);
     }
 

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -91,6 +91,7 @@ static rsRetVal NotImplementedDummy_voidp_wti_tp(__attribute__((unused)) void *p
 /* Standard-Constructor for the wtp object
  */
 BEGINobjConstruct(wtp) /* be sure to specify the object type also in END macro! */
+    pThis->toFirstWrkShutdown = -2;
     pthread_mutex_init(&pThis->mutWtp, NULL);
     pthread_cond_init(&pThis->condThrdInitDone, NULL);
     pthread_cond_init(&pThis->condThrdTrm, NULL);
@@ -146,6 +147,7 @@ rsRetVal wtpConstructFinalize(wtp_t *pThis) {
         }
         CHKiRet(wtiSetDbgHdr(pWti, pszBuf, lenBuf));
         CHKiRet(wtiSetpWtp(pWti, pThis));
+        pWti->workerIndex = i;
         CHKiRet(wtiConstructFinalize(pWti));
     }
 
@@ -609,6 +611,7 @@ rsRetVal wtpWakeupAllWrkr(wtp_t *pThis) {
  * reformatted by clang-format;
  */
 DEFpropSetMeth(wtp, toWrkShutdown, long);
+DEFpropSetMeth(wtp, toFirstWrkShutdown, long);
 DEFpropSetMeth(wtp, wtpState, wtpState_t);
 DEFpropSetMeth(wtp, iNumWorkerThreads, int);
 DEFpropSetMeth(wtp, pUsr, void *);

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -497,7 +497,7 @@ static rsRetVal ATTR_NONNULL() wtpStartWrkr(wtp_t *const pThis, const int permit
 
     if (i == pThis->iNumWorkerThreads) ABORT_FINALIZE(RS_RET_NO_MORE_THREADS);
 
-    if (i == 0 || pThis->toWrkShutdown == -1) {
+    if ((i == 0 && !pThis->bAllowFirstWorkerToTimeout) || pThis->toWrkShutdown == -1) {
         wtiSetAlwaysRunning(pThis->pWrkr[i]);
     }
 
@@ -590,6 +590,17 @@ finalize_it:
 }
 
 
+rsRetVal wtpWakeupAllWrkr(wtp_t *pThis) {
+    if (pThis == NULL) return RS_RET_PARAM_ERROR;
+    d_pthread_mutex_lock(&pThis->mutWtp);
+    for (int i = 0; i < pThis->iNumWorkerThreads; ++i) {
+        if (wtiGetState(pThis->pWrkr[i]) != WRKTHRD_STOPPED) pthread_cond_signal(&pThis->pWrkr[i]->pcondBusy);
+    }
+    d_pthread_mutex_unlock(&pThis->mutWtp);
+    return RS_RET_OK;
+}
+
+
 /* some simple object access methods
  * Note: the semicolons behind the macros are actually empty declarations. This is
  * a work-around for clang-format's missing understanding of generative macros.
@@ -607,6 +618,8 @@ DEFpropSetMethFP(wtp, pfRateLimiter, rsRetVal (*pVal)(void *));
 DEFpropSetMethFP(wtp, pfGetDeqBatchSize, rsRetVal (*pVal)(void *, int *));
 DEFpropSetMethFP(wtp, pfDoWork, rsRetVal (*pVal)(void *, void *));
 DEFpropSetMethFP(wtp, pfObjProcessed, rsRetVal (*pVal)(void *, wti_t *));
+DEFpropSetMethFP(wtp, pfIdleTimeout, rsRetVal (*pVal)(void *));
+DEFpropSetMeth(wtp, bAllowFirstWorkerToTimeout, sbool);
 
 
 /* set the debug header message

--- a/runtime/wtp.h
+++ b/runtime/wtp.h
@@ -68,6 +68,8 @@ struct wtp_s {
         rsRetVal (*pfObjProcessed)(void *pUsr, wti_t *pWti); /* indicate user object is processed */
         rsRetVal (*pfRateLimiter)(void *pUsr);
         rsRetVal (*pfDoWork)(void *pUsr, void *pWti);
+        rsRetVal (*pfIdleTimeout)(void *pUsr);
+        sbool bAllowFirstWorkerToTimeout;
         /* end user objects */
         uchar *pszDbgHdr; /* header string for debug messages */
         DEF_ATOMIC_HELPER_MUT(mutCurNumWrkThrd);
@@ -99,6 +101,8 @@ PROTOTYPEpropSetMethFP(wtp, pfRateLimiter, rsRetVal (*pVal)(void *));
 PROTOTYPEpropSetMethFP(wtp, pfGetDeqBatchSize, rsRetVal (*pVal)(void *, int *));
 PROTOTYPEpropSetMethFP(wtp, pfDoWork, rsRetVal (*pVal)(void *, void *));
 PROTOTYPEpropSetMethFP(wtp, pfObjProcessed, rsRetVal (*pVal)(void *, wti_t *));
+PROTOTYPEpropSetMethFP(wtp, pfIdleTimeout, rsRetVal (*pVal)(void *));
+PROTOTYPEpropSetMeth(wtp, bAllowFirstWorkerToTimeout, sbool);
 PROTOTYPEpropSetMeth(wtp, toWrkShutdown, long);
 PROTOTYPEpropSetMeth(wtp, wtpState, wtpState_t);
 PROTOTYPEpropSetMeth(wtp, iMaxWorkerThreads, int);

--- a/runtime/wtp.h
+++ b/runtime/wtp.h
@@ -91,6 +91,12 @@ rsRetVal wtpAdviseMaxWorkers(wtp_t *pThis, int nMaxWrkr, const int permit_during
 rsRetVal wtpProcessThrdChanges(wtp_t *pThis);
 rsRetVal wtpChkStopWrkr(wtp_t *pThis, int bLockUsrMutex);
 rsRetVal wtpSetState(wtp_t *pThis, wtpState_t iNewState);
+/** Wake every existing worker without creating a stopped worker.
+ *
+ * The caller must hold the pool's pmutUsr mutex so the queue predicate and
+ * pthread condition signal cannot race. The helper serializes only the worker
+ * table walk with mutWtp; it does not acquire pmutUsr itself.
+ */
 rsRetVal wtpWakeupAllWrkr(wtp_t *pThis);
 rsRetVal wtpCancelAll(wtp_t *pThis, const uchar *const cancelobj);
 rsRetVal wtpSetDbgHdr(wtp_t *pThis, uchar *pszMsg, size_t lenMsg);

--- a/runtime/wtp.h
+++ b/runtime/wtp.h
@@ -53,6 +53,7 @@ struct wtp_s {
         int iCurNumWrkThrd; /* current number of active worker threads */
         struct wti_s **pWrkr; /* array with control structure for the worker thread(s) associated with this wtp */
         int toWrkShutdown; /* timeout for idle workers in ms, -1 means indefinite (0 is immediate) */
+        int toFirstWrkShutdown; /* slot-zero override, -2 means use toWrkShutdown */
         rsRetVal (*pConsumer)(void *); /* user-supplied consumer function for dewtpd messages */
         /* synchronization variables */
         pthread_mutex_t mutWtp; /* mutex for the wtp's thread management */
@@ -104,6 +105,7 @@ PROTOTYPEpropSetMethFP(wtp, pfObjProcessed, rsRetVal (*pVal)(void *, wti_t *));
 PROTOTYPEpropSetMethFP(wtp, pfIdleTimeout, rsRetVal (*pVal)(void *));
 PROTOTYPEpropSetMeth(wtp, bAllowFirstWorkerToTimeout, sbool);
 PROTOTYPEpropSetMeth(wtp, toWrkShutdown, long);
+PROTOTYPEpropSetMeth(wtp, toFirstWrkShutdown, long);
 PROTOTYPEpropSetMeth(wtp, wtpState, wtpState_t);
 PROTOTYPEpropSetMeth(wtp, iMaxWorkerThreads, int);
 PROTOTYPEpropSetMeth(wtp, pUsr, void *);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -68,13 +68,31 @@ TESTS_SEGMENTED_DISK_QUEUE = \
 	segmented-diskqueue-crash-checkpoint-repeat.sh \
 	segmented-diskqueue-crash-commit.sh \
 	segmented-diskqueue-crash-predelete.sh \
-	segmented-diskqueue-crash-unlink.sh
-TESTS_SEGMENTED_DISK_QUEUE_LIBYAML = yaml-segmented-diskqueue.sh
+	segmented-diskqueue-crash-unlink.sh \
+	segmented-da-idle-dematerialize.sh \
+	segmented-da-idle-timeout-values.sh \
+	segmented-da-config-errors.sh \
+	segmented-da-engine-transition.sh \
+	segmented-da-event-properties.sh \
+	segmented-da-behavior.sh \
+	classic-da-behavior.sh \
+	segmented-da-multiworker-frontier.sh \
+	segmented-da-maxdiskspace.sh \
+	segmented-da-recovery-budget.sh \
+	segmented-da-idle-retry.sh \
+	segmented-da-idle-crash-state.sh \
+	segmented-da-idle-crash-segments.sh \
+	segmented-da-idle-crash-state-unlink.sh \
+	segmented-da-idle-crash-directory.sh \
+	segmented-da-idle-cleanup-failure.sh
+TESTS_SEGMENTED_DISK_QUEUE_LIBYAML = yaml-segmented-diskqueue.sh yaml-segmented-da-config.sh
 TESTS_SEGMENTED_DISK_QUEUE_IMPSTATS = segmented-diskqueue-startup-bounded.sh
 EXTRA_DIST += $(TESTS_SEGMENTED_DISK_QUEUE) $(TESTS_SEGMENTED_DISK_QUEUE_LIBYAML) \
 	$(TESTS_SEGMENTED_DISK_QUEUE_IMPSTATS) segdisk-inspect.py \
 	testsuites/segmented-diskqueue-checkpoint-driver.sh \
 	testsuites/segmented-diskqueue-crash-driver.sh \
+	testsuites/segmented-da-idle-crash-driver.sh \
+	testsuites/da-engine-behavior-driver.sh \
 	testsuites/segmented-diskqueue-invalid-state-driver.sh \
 	testsuites/pure-disk-queue-scope-driver.sh
 
@@ -2449,9 +2467,9 @@ check_LTLIBRARIES =
 
 # TODO: reenable TESTRUNS = rt_init rscript
 check_PROGRAMS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace \
-	runtime_unit_ommongodb_date runtime_unit_segdisk_state
+	runtime_unit_ommongodb_date runtime_unit_segdisk_state runtime_unit_queue_da
 TESTS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace \
-	runtime_unit_ommongodb_date runtime_unit_segdisk_state
+	runtime_unit_ommongodb_date runtime_unit_segdisk_state runtime_unit_queue_da
 
 runtime_unit_linkedlist_SOURCES = \
 	unit/linkedlist_test.c
@@ -2470,6 +2488,9 @@ runtime_unit_ommongodb_date_SOURCES = \
 
 runtime_unit_segdisk_state_SOURCES = \
 	unit/segdisk_state_test.c
+
+runtime_unit_queue_da_SOURCES = \
+	unit/queue_da_test.c
 
 if ENABLE_IMPCAP
 check_PROGRAMS += runtime_unit_impcap_arp_parser
@@ -2533,6 +2554,8 @@ runtime_unit_ommongodb_date_CPPFLAGS = \
 	-I$(top_srcdir)/plugins/ommongodb
 runtime_unit_segdisk_state_CPPFLAGS = \
 	$(runtime_unit_linkedlist_CPPFLAGS)
+runtime_unit_queue_da_CPPFLAGS = \
+	$(runtime_unit_linkedlist_CPPFLAGS)
 
 runtime_unit_linkedlist_LDADD = $(RSRT_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
 runtime_unit_stringbuf_LDADD = $(LIBESTR_LIBS) $(LIBFASTJSON_LIBS) $(LIBSYSTEMD_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
@@ -2540,6 +2563,7 @@ runtime_unit_parser_pri_LDADD = $(LIBESTR_LIBS) $(LIBFASTJSON_LIBS) $(LIBSYSTEMD
 runtime_unit_msg_replace_LDADD = $(runtime_unit_linkedlist_LDADD)
 runtime_unit_ommongodb_date_LDADD = $(runtime_unit_linkedlist_LDADD)
 runtime_unit_segdisk_state_LDADD =
+runtime_unit_queue_da_LDADD =
 
 if ENABLE_LIBLOGGING_STDLOG
 runtime_unit_linkedlist_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -69,30 +69,39 @@ TESTS_SEGMENTED_DISK_QUEUE = \
 	segmented-diskqueue-crash-commit.sh \
 	segmented-diskqueue-crash-predelete.sh \
 	segmented-diskqueue-crash-unlink.sh \
-	segmented-da-idle-dematerialize.sh \
-	segmented-da-idle-timeout-values.sh \
 	segmented-da-config-errors.sh \
 	segmented-da-engine-transition.sh \
 	segmented-da-event-properties.sh \
+	segmented-da-event-properties-fixedarray.sh \
 	segmented-da-behavior.sh \
 	classic-da-behavior.sh \
+	segmented-da-persist.sh \
+	classic-da-persist.sh \
+	segmented-da-retry-restart.sh \
+	classic-da-retry-restart.sh \
 	segmented-da-multiworker-frontier.sh \
-	segmented-da-maxdiskspace.sh \
 	segmented-da-recovery-budget.sh \
 	segmented-da-idle-retry.sh \
 	segmented-da-idle-crash-state.sh \
 	segmented-da-idle-crash-segments.sh \
 	segmented-da-idle-crash-state-unlink.sh \
-	segmented-da-idle-crash-directory.sh \
-	segmented-da-idle-cleanup-failure.sh
-TESTS_SEGMENTED_DISK_QUEUE_LIBYAML = yaml-segmented-diskqueue.sh yaml-segmented-da-config.sh
-TESTS_SEGMENTED_DISK_QUEUE_IMPSTATS = segmented-diskqueue-startup-bounded.sh
+	segmented-da-idle-crash-directory.sh
+TESTS_SEGMENTED_DISK_QUEUE_LIBYAML = yaml-segmented-diskqueue.sh yaml-segmented-da-config.sh \
+	yaml-segmented-da-config-errors.sh
+TESTS_SEGMENTED_DISK_QUEUE_IMPSTATS = segmented-diskqueue-startup-bounded.sh \
+	segmented-da-idle-dematerialize.sh \
+	segmented-da-idle-timeout-values.sh \
+	segmented-da-idle-cleanup-failure.sh \
+	segmented-da-maxdiskspace.sh \
+	segmented-da-maxdiskspace-fixedarray.sh
 EXTRA_DIST += $(TESTS_SEGMENTED_DISK_QUEUE) $(TESTS_SEGMENTED_DISK_QUEUE_LIBYAML) \
 	$(TESTS_SEGMENTED_DISK_QUEUE_IMPSTATS) segdisk-inspect.py \
 	testsuites/segmented-diskqueue-checkpoint-driver.sh \
 	testsuites/segmented-diskqueue-crash-driver.sh \
 	testsuites/segmented-da-idle-crash-driver.sh \
 	testsuites/da-engine-behavior-driver.sh \
+	testsuites/da-engine-persist-driver.sh \
+	testsuites/da-engine-retry-restart-driver.sh \
 	testsuites/segmented-diskqueue-invalid-state-driver.sh \
 	testsuites/pure-disk-queue-scope-driver.sh
 

--- a/tests/badqi.sh
+++ b/tests/badqi.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 # Test startup fallback with a bad classic .qi file. The daemon must survive,
-# process messages in memory, and shut down cleanly. The static fixture now
-# receives a durable classic-engine marker during selection, so the test
-# removes that generated marker after the daemon has stopped.
+# quarantine the corrupt control file, create a fresh classic DA child, process
+# messages, and shut down cleanly. A per-test copy keeps the source fixture
+# immutable while exercising the real safe-mode recovery path.
 # added 2009-10-21 by RGerhards
 # This file is part of the rsyslog project, released  under GPLv3
 # uncomment for debugging support:
 echo ===============================================================================
 echo \[badqi.sh\]: test startup with invalid .qi file
 . ${srcdir:=.}/diag.sh init
-rm -f bad_qi/dbq.da-engine
+SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
+mkdir -p "$SPOOL_DIR"
+cp "$srcdir/bad_qi/dbq.qi" "$SPOOL_DIR/dbq.qi"
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
@@ -19,7 +21,7 @@ input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="'$RSYSLOG_DY
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!
 # instruct to use bad .qi file
-$WorkDirectory bad_qi
+$WorkDirectory '"$SPOOL_DIR"'
 $ActionQueueType LinkedList
 $ActionQueueFileName dbq
 :msg, contains, "msgnum:" ?dynfile;outfmt
@@ -29,6 +31,5 @@ startup
 tcpflood -m20
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown  # wait for process to terminate
-rm -f bad_qi/dbq.da-engine
 seq_check 0 19
 exit_test

--- a/tests/badqi.sh
+++ b/tests/badqi.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
-# Test for a startup with a bad qi file. This tests simply tests
-# if the rsyslog engine survives (we had segfaults in this situation
-# in the past).
+# Test startup fallback with a bad classic .qi file. The daemon must survive,
+# process messages in memory, and shut down cleanly. The static fixture now
+# receives a durable classic-engine marker during selection, so the test
+# removes that generated marker after the daemon has stopped.
 # added 2009-10-21 by RGerhards
 # This file is part of the rsyslog project, released  under GPLv3
 # uncomment for debugging support:
 echo ===============================================================================
 echo \[badqi.sh\]: test startup with invalid .qi file
 . ${srcdir:=.}/diag.sh init
+rm -f bad_qi/dbq.da-engine
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
@@ -27,5 +29,6 @@ startup
 tcpflood -m20
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown  # wait for process to terminate
+rm -f bad_qi/dbq.da-engine
 seq_check 0 19
 exit_test

--- a/tests/classic-da-behavior.sh
+++ b/tests/classic-da-behavior.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# Run the shared DA main/ruleset/action spill oracle with the classic engine
-# explicitly pinned, proving that compatibility mode remains available.
-for DA_SCOPE in main ruleset action; do
-	export DA_SCOPE DA_ENGINE=disk
-	"${srcdir:=.}/testsuites/da-engine-behavior-driver.sh" || exit $?
+# Run the shared LinkedList/FixedArray and main/ruleset/action spill oracle with
+# classic disk explicitly pinned, proving compatibility mode remains available.
+for DA_QUEUE_TYPE in LinkedList FixedArray; do
+	for DA_SCOPE in main ruleset action; do
+		export DA_SCOPE DA_QUEUE_TYPE DA_ENGINE=disk
+		"${srcdir:=.}/testsuites/da-engine-behavior-driver.sh" || exit $?
+	done
 done

--- a/tests/classic-da-behavior.sh
+++ b/tests/classic-da-behavior.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Run the shared DA main/ruleset/action spill oracle with the classic engine
+# explicitly pinned, proving that compatibility mode remains available.
+for DA_SCOPE in main ruleset action; do
+	export DA_SCOPE DA_ENGINE=disk
+	"${srcdir:=.}/testsuites/da-engine-behavior-driver.sh" || exit $?
+done

--- a/tests/classic-da-behavior.sh
+++ b/tests/classic-da-behavior.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Run the shared LinkedList/FixedArray and main/ruleset/action spill oracle with
 # classic disk explicitly pinned, proving compatibility mode remains available.
+# This matrix wrapper deliberately leaves diag.sh initialization to each driver
+# invocation; sourcing it here would initialize one shared test instance six
+# times instead of giving every scenario its own harness lifecycle.
 for DA_QUEUE_TYPE in LinkedList FixedArray; do
 	for DA_SCOPE in main ruleset action; do
 		export DA_SCOPE DA_QUEUE_TYPE DA_ENGINE=disk

--- a/tests/classic-da-persist.sh
+++ b/tests/classic-da-persist.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Run the shared save-on-shutdown/restart oracle for both DA memory queue types
+# with classic disk explicitly pinned.
+for DA_QUEUE_TYPE in LinkedList FixedArray; do
+	export DA_QUEUE_TYPE DA_ENGINE=disk
+	"${srcdir:=.}/testsuites/da-engine-persist-driver.sh" || exit $?
+done

--- a/tests/classic-da-retry-restart.sh
+++ b/tests/classic-da-retry-restart.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Exercise the shared suspended-action restart oracle for both DA memory queue
+# types with the classic disk engine explicitly pinned.
+for DA_QUEUE_TYPE in LinkedList FixedArray; do
+	export DA_QUEUE_TYPE DA_ENGINE=disk
+	"${srcdir:=.}/testsuites/da-engine-retry-restart-driver.sh" || exit $?
+done

--- a/tests/da-queue-persist.sh
+++ b/tests/da-queue-persist.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Test for DA queue data persisting at shutdown. The
-# plan is to start an instance, emit some data, do a relatively
-# fast shutdown and then re-start the engine to process the 
-# remaining data.
+# Test for classic DA queue data persisting at shutdown. This test deliberately
+# inspects the classic .qi file, so it pins diskQueueType="disk". A fast
+# shutdown must save the remaining messages and restart must drain them, with
+# duplicates allowed because the shutdown can interrupt an in-flight batch.
 # added 2019-05-08 by Rgerhards
 # This file is part of the rsyslog project, released  under ASL 2.0
 . ${srcdir:=.}/diag.sh init
@@ -11,7 +11,8 @@ generate_conf
 add_conf '
 global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
 main_queue(queue.type="linkedList" queue.filename="mainq"
-	queue.timeoutShutdown="1" queue.saveonshutdown="on")
+	queue.timeoutShutdown="1" queue.saveonshutdown="on"
+	queue.diskQueueType="disk")
 
 module(load="../plugins/omtesting/.libs/omtesting")
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")

--- a/tests/daqueue-dirty-shutdown-recovery.sh
+++ b/tests/daqueue-dirty-shutdown-recovery.sh
@@ -6,7 +6,8 @@
 # spool directory. Modern queue handling can also quarantine damaged queue
 # state into mainq.bad.* when queue.onCorruption="safe" detects an
 # inconsistent on-disk state. Both outcomes are valid as long as restart
-# succeeds and no live mainq.* state is left behind.
+# succeeds and no live queue payload or state remains. The durable DA engine
+# marker is intentionally retained and is not live queue data.
 # added 2016-12-01 by Rainer Gerhards
 # rewritten 2026-03-30 to match current queue corruption semantics
 # released under ASL 2.0
@@ -25,6 +26,7 @@ module(load="../plugins/omtesting/.libs/omtesting")
 global(workDirectory="'"$SPOOL_DIR"'")
 main_queue(
 	queue.filename="mainq"
+	queue.diskQueueType="disk"
 	queue.saveOnShutdown="on"
 	queue.timeoutShutdown="1"
 	queue.maxFileSize="1m"
@@ -44,6 +46,7 @@ module(load="../plugins/omtesting/.libs/omtesting")
 global(workDirectory="'"$SPOOL_DIR"'")
 main_queue(
 	queue.filename="mainq"
+	queue.diskQueueType="disk"
 	queue.saveOnShutdown="on"
 	queue.maxFileSize="1m"
 	queue.timeoutWorkerThreadShutdown="500"
@@ -68,7 +71,7 @@ check_no_live_mainq_files() {
 	local live_files
 
 	live_files="$(find "$SPOOL_DIR" -maxdepth 1 -mindepth 1 \
-		\( -type f -o -type l \) -name 'mainq*' -printf '%f\n')"
+		\( -type f -o -type l \) -name 'mainq*' ! -name 'mainq.da-engine' -printf '%f\n')"
 	if [ -n "$live_files" ]; then
 		echo "FAIL: live mainq files remain after restart recovery"
 		printf '%s\n' "$live_files"

--- a/tests/daqueue-invld-qi.sh
+++ b/tests/daqueue-invld-qi.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Exercise classic DA recovery from a deliberately mangled .qi file. This test
+# inspects classic state directly, so the modern queue configuration pins the
+# classic engine; restart must recover the full sequence, allowing duplicates.
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 skip_platform "SunOS"  "This test currently does not work on all flavors of Solaris."
@@ -6,16 +9,16 @@ skip_platform "SunOS"  "This test currently does not work on all flavors of Sola
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$MainMsgQueueTimeoutShutdown 1
-$MainMsgQueueSaveOnShutdown on
 input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 $ModLoad ../plugins/omtesting/.libs/omtesting
 
-# Configure a disk-assisted main queue.
-$WorkDirectory '$RSYSLOG_DYNNAME'.spool
-$MainMsgQueueType LinkedList
-$MainMsgQueueFilename mainq
+# Configure a classic disk-assisted main queue. Keep this fully in the modern
+# frontend because diskQueueType intentionally has no legacy directive alias.
+global(workDirectory="'$RSYSLOG_DYNNAME'.spool")
+main_queue(queue.type="LinkedList" queue.filename="mainq"
+	queue.timeoutShutdown="1" queue.saveOnShutdown="on"
+	queue.diskQueueType="disk")
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/daqueue-truncated-segment-startup.sh
+++ b/tests/daqueue-truncated-segment-startup.sh
@@ -5,7 +5,8 @@
 # restart phase, where rsyslog must process the valid prefix, quarantine the
 # unread tail into mainq.bad.*, and leave no stale live queue files behind. A
 # fresh mainq.00000001/mainq.qi pair is acceptable because resetting the DA disk
-# child constructs a new live head.
+# child constructs a new live head. The classic DA engine marker is also
+# intentionally retained and contains no queue records.
 # added 2026-04-25 by Codex, released under ASL 2.0
 
 export TEST_MAX_RUNTIME=${TEST_MAX_RUNTIME:-420}
@@ -37,6 +38,7 @@ global(workDirectory="'"$SPOOL_DIR"'")
 main_queue(
 	queue.type="LinkedList"
 	queue.filename="mainq"
+	queue.diskQueueType="disk"
 	queue.maxFileSize="16k"
 	queue.saveOnShutdown="on"
 	queue.timeoutShutdown="1"
@@ -61,6 +63,7 @@ global(workDirectory="'"$SPOOL_DIR"'")
 main_queue(
 	queue.type="LinkedList"
 	queue.filename="mainq"
+	queue.diskQueueType="disk"
 	queue.maxFileSize="16k"
 	queue.saveOnShutdown="off"
 	queue.onCorruption="safe"
@@ -187,7 +190,7 @@ check_clean_live_mainq_state() {
 		return 0
 	fi
 
-	if ! grep -Evqx 'mainq\.00000001|mainq\.qi' "$live_list"; then
+	if ! grep -Evqx 'mainq\.00000001|mainq\.qi|mainq\.da-engine' "$live_list"; then
 		rm -f "$live_list"
 		return 0
 	fi

--- a/tests/daqueue-truncated-segment-startup.sh
+++ b/tests/daqueue-truncated-segment-startup.sh
@@ -310,7 +310,7 @@ wait_for_recovery_outcome() {
 	deadline=$(( start_ts + RECOVERY_WAIT_TIMEOUT ))
 	next_progress=$start_ts
 
-	while [ $(date +%s) -le "$deadline" ]; do
+	while [ "$(date +%s)" -le "$deadline" ]; do
 		now=$(date +%s)
 		bad_after=$(count_bad_dirs)
 		if [ "$bad_after" -gt "$bad_before" ]; then

--- a/tests/queue-encryption-da.sh
+++ b/tests/queue-encryption-da.sh
@@ -7,6 +7,7 @@ module(load="../plugins/omtesting/.libs/omtesting")
 global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
 main_queue(queue.filename="mainq"
 	queue.type="linkedList"
+	queue.diskQueueType="disk"
 	queue.maxDiskSpace="4m"
 	queue.maxfilesize="1m"
 	queue.timeoutenqueue="300000"

--- a/tests/queue-persist-drvr.sh
+++ b/tests/queue-persist-drvr.sh
@@ -1,25 +1,30 @@
 #!/bin/bash
-# Test for queue data persisting at shutdown. The
-# plan is to start an instance, emit some data, do a relatively
-# fast shutdown and then re-start the engine to process the 
-# remaining data.
+# Test for queue data persisting at shutdown. LinkedList and FixedArray cases
+# inspect the classic .qi format, so their modern queue configuration pins the
+# classic DA engine. A fast shutdown must persist the remainder and restart
+# must recover the complete sequence, with in-flight duplicates permitted.
 # added 2009-05-27 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
 # uncomment for debugging support:
 echo testing memory queue persisting to disk, mode $1
+disk_selector=
+if [ "$1" != Disk ]; then
+	# shellcheck disable=SC2089 # This is RainerScript text, expanded into add_conf below.
+	disk_selector='queue.diskQueueType="disk"'
+fi
 generate_conf
+# shellcheck disable=SC2090 # RainerScript quotes are intentionally retained.
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$MainMsgQueueTimeoutShutdown 1
-$MainMsgQueueSaveOnShutdown on
 $InputTCPServerRun '$TCPFLOOD_PORT'
 
 $ModLoad ../plugins/omtesting/.libs/omtesting
 
-# set spool locations and switch queue to disk-only mode
-$WorkDirectory '$RSYSLOG_DYNNAME'.spool
-$MainMsgQueueFilename mainq
-$IncludeConfig '${RSYSLOG_DYNNAME}'work-queuemode.conf
+# Configure either a classic DA memory queue or the pure classic disk queue.
+global(workDirectory="'$RSYSLOG_DYNNAME'.spool")
+main_queue(queue.type="'$1'" queue.filename="mainq"
+	queue.timeoutShutdown="1" queue.saveOnShutdown="on"
+	'$disk_selector')
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!
@@ -28,7 +33,6 @@ template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to
 $IncludeConfig '${RSYSLOG_DYNNAME}'work-delay.conf
 '
 # prepare config
-echo \$MainMsgQueueType $1 > ${RSYSLOG_DYNNAME}work-queuemode.conf
 echo "*.*     :omtesting:sleep 0 1000" > ${RSYSLOG_DYNNAME}work-delay.conf
 
 # inject 5000 msgs, so that we do not hit the high watermark

--- a/tests/rcvr_fail_restore.sh
+++ b/tests/rcvr_fail_restore.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Verify classic DA reactivation across receiver outages. The filesystem oracle
+# compares the classic numeric segment before and after drain, so the sender
+# pins diskQueueType="disk" through the modern main-queue frontend.
 # Copyright (C) 2011 by Rainer Gerhards
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
@@ -23,6 +26,8 @@ wait_sender_queues_outage_data() {
 	initial_segment_size="$1"
 	echo "waiting for sender queue and DA segment growth from $initial_segment_size bytes"
 	i=0
+	# Use the standard startup bound so a loaded CI host has time to append;
+	# queue-size plus segment growth is the deterministic readiness oracle.
 	while [ $i -le $TB_TIMEOUT_STARTSTOP ]; do
 		qsize="$(sender_mainqueuesize)"
 		segment_size="$(mainq_segment_size)"
@@ -65,14 +70,11 @@ export PORT_RCVR="$TCPFLOOD_PORT"
 echo starting sender
 generate_conf 2
 add_conf '
-$WorkDirectory '$RSYSLOG_DYNNAME'.spool
-$MainMsgQueueSize 2000
-$MainMsgQueueLowWaterMark 800
-$MainMsgQueueHighWaterMark 1000
-$MainMsgQueueDequeueBatchSize 1
-$MainMsgQueueMaxFileSize 1g
-$MainMsgQueueWorkerThreads 1
-$MainMsgQueueFileName mainq
+global(workDirectory="'$RSYSLOG_DYNNAME'.spool")
+main_queue(queue.type="LinkedList" queue.filename="mainq"
+	queue.size="2000" queue.lowWatermark="800" queue.highWatermark="1000"
+	queue.dequeueBatchSize="1" queue.maxFileSize="1g"
+	queue.workerThreads="1" queue.diskQueueType="disk")
 
 # we use the shortest resume interval a) to let the test not run too long 
 # and b) make sure some retries happen before the reconnect
@@ -145,7 +147,7 @@ ls -l ${RSYSLOG_DYNNAME}.spool
 NEWFILESIZE=$(stat -c%s ${RSYSLOG_DYNNAME}.spool/mainq.00000001)
 if [ $NEWFILESIZE != $OLDFILESIZE ]
 then
-   echo file sizes do not match, expected $OLDFILESIZE, actual $NEWFILESIZE
+   echo "file sizes do not match, expected $OLDFILESIZE, actual $NEWFILESIZE"
    echo this means that data has been written to the queue file where it
    echo no longer should be written.
    # abort will happen below, because we must ensure proper system shutdown

--- a/tests/segmented-da-behavior.sh
+++ b/tests/segmented-da-behavior.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Run the shared DA main/ruleset/action spill oracle with the automatic default,
+# which must resolve a fresh queue to the segmented disk engine.
+for DA_SCOPE in main ruleset action; do
+	export DA_SCOPE DA_ENGINE=auto
+	"${srcdir:=.}/testsuites/da-engine-behavior-driver.sh" || exit $?
+done

--- a/tests/segmented-da-behavior.sh
+++ b/tests/segmented-da-behavior.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Run the shared LinkedList/FixedArray and main/ruleset/action spill oracle with
 # the automatic default, which must resolve fresh queues to segmented disk.
+# This matrix wrapper deliberately leaves diag.sh initialization to each driver
+# invocation; sourcing it here would initialize one shared test instance six
+# times instead of giving every scenario its own harness lifecycle.
 for DA_QUEUE_TYPE in LinkedList FixedArray; do
 	for DA_SCOPE in main ruleset action; do
 		export DA_SCOPE DA_QUEUE_TYPE DA_ENGINE=auto

--- a/tests/segmented-da-behavior.sh
+++ b/tests/segmented-da-behavior.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# Run the shared DA main/ruleset/action spill oracle with the automatic default,
-# which must resolve a fresh queue to the segmented disk engine.
-for DA_SCOPE in main ruleset action; do
-	export DA_SCOPE DA_ENGINE=auto
-	"${srcdir:=.}/testsuites/da-engine-behavior-driver.sh" || exit $?
+# Run the shared LinkedList/FixedArray and main/ruleset/action spill oracle with
+# the automatic default, which must resolve fresh queues to segmented disk.
+for DA_QUEUE_TYPE in LinkedList FixedArray; do
+	for DA_SCOPE in main ruleset action; do
+		export DA_SCOPE DA_QUEUE_TYPE DA_ENGINE=auto
+		"${srcdir:=.}/testsuites/da-engine-behavior-driver.sh" || exit $?
+	done
 done

--- a/tests/segmented-da-config-errors.sh
+++ b/tests/segmented-da-config-errors.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Queue DA engine parameters are intentionally limited to FixedArray and
+# LinkedList queues with a filename. The permissive oracle is a successful -N1
+# validation plus the dirty-configuration diagnostic; the strict oracle is a
+# failed validation when abortOnUncleanConfig is enabled.
+. ${srcdir:=.}/diag.sh init
+
+assert_contains() {
+	grep -Fq "$2" "$1" || {
+		cat "$1"
+		error_exit 1 "missing expected diagnostic: $2"
+	}
+}
+
+check_permissive_invalid_context() {
+	generate_conf
+	add_conf '
+global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+main_queue(queue.type="segmentedDisk" queue.filename="mainq"
+	queue.diskQueueType="disk" queue.diskQueueAutoUpgrade="on"
+	queue.diskQueueIdleTimeout="25")
+'
+	local out="${RSYSLOG_DYNNAME}.permissive.log"
+	export RS_REDIR=">\"$out\" 2>&1"
+	startup
+	shutdown_when_empty
+	wait_shutdown
+	unset RS_REDIR
+	assert_contains "$out" 'apply only to FixedArray or LinkedList disk-assisted queues'
+}
+
+check_strict_invalid_context() {
+	generate_conf
+	add_conf '
+global(abortOnUncleanConfig="on" workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+main_queue(queue.type="segmentedDisk" queue.filename="mainq"
+	queue.diskQueueType="disk")
+'
+	local out="${RSYSLOG_DYNNAME}.strict.log"
+	if ../tools/rsyslogd -C -N1 -f"${TESTCONF_NM}.conf" -M../runtime/.libs:../.libs >"$out" 2>&1; then
+		error_exit 1 "strict invalid-context configuration unexpectedly passed"
+	fi
+	assert_contains "$out" 'apply only to FixedArray or LinkedList disk-assisted queues'
+}
+
+check_strict_meaningless_options() {
+	generate_conf
+	add_conf '
+global(abortOnUncleanConfig="on" workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+main_queue(queue.type="LinkedList" queue.filename="mainq"
+	queue.diskQueueType="disk" queue.diskQueueAutoUpgrade="on"
+	queue.diskQueueIdleTimeout="25")
+'
+	local out="${RSYSLOG_DYNNAME}.meaningless.log"
+	if ../tools/rsyslogd -C -N1 -f"${TESTCONF_NM}.conf" -M../runtime/.libs:../.libs >"$out" 2>&1; then
+		error_exit 1 "strict meaningless DA options unexpectedly passed"
+	fi
+	assert_contains "$out" 'queue.diskQueueAutoUpgrade applies only'
+	assert_contains "$out" 'queue.diskQueueIdleTimeout does not apply'
+}
+
+check_strict_invalid_values() {
+	generate_conf
+	add_conf '
+global(abortOnUncleanConfig="on" workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+main_queue(queue.type="LinkedList" queue.filename="mainq"
+	queue.diskQueueType="unknown" queue.diskQueueIdleTimeout="-2")
+'
+	local out="${RSYSLOG_DYNNAME}.invalid-values.log"
+	if ../tools/rsyslogd -C -N1 -f"${TESTCONF_NM}.conf" -M../runtime/.libs:../.libs >"$out" 2>&1; then
+		error_exit 1 "strict invalid DA values unexpectedly passed"
+	fi
+	assert_contains "$out" "queue.diskQueueType: invalid value 'unknown'"
+	assert_contains "$out" 'queue.diskQueueIdleTimeout must be -1 or greater'
+}
+
+check_permissive_invalid_context
+check_strict_invalid_context
+check_strict_meaningless_options
+check_strict_invalid_values
+exit_test

--- a/tests/segmented-da-engine-transition.sh
+++ b/tests/segmented-da-engine-transition.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 # Build a real classic disk-assisted action backlog, then restart with the auto
-# selector. The marker, warning, and exact drain prove sticky classic
+# selector. The marker, warning, and complete drain prove sticky classic
 # compatibility. A final clean restart with auto-upgrade enabled must replace
-# only the drained marker and select an unmaterialized segmented child.
+# only the drained marker and select an unmaterialized segmented child. The
+# seed uses checkpointInterval=1; an interrupted in-flight batch may replay,
+# so duplicates are accepted but every sequence number must be present.
 . ${srcdir:=.}/diag.sh init
 
 export NUMMESSAGES=3000
@@ -10,35 +12,47 @@ SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
 MARKER="$SPOOL_DIR/transition.da-engine"
 
 write_conf() {
-	local selector="$1" upgrade="$2" slowdown="$3"
-	local delay_rule=
+	local selector="$1" upgrade="$2"
 	local upgrade_config=
-	[ "$slowdown" = 0 ] || delay_rule=":omtesting:sleep 0 $slowdown"
 	[ "$selector" != auto ] || upgrade_config="queue.diskQueueAutoUpgrade=\"$upgrade\""
 	generate_conf
 	add_conf '
-module(load="../plugins/omtesting/.libs/omtesting")
 global(workDirectory="'"$SPOOL_DIR"'")
 main_queue(queue.type="LinkedList" queue.filename="transition"
 	queue.diskQueueType="'"$selector"'" '"$upgrade_config"'
 	queue.size="50" queue.highWatermark="10" queue.lowWatermark="5"
 	queue.checkpointInterval="1" queue.saveOnShutdown="on"
-	queue.timeoutShutdown="1")
+	queue.timeoutShutdown="10000")
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
-'"$delay_rule"'
 :msg, contains, "msgnum:" action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
 '
 }
 
-write_conf disk off 5000
+write_seed_conf() {
+	generate_conf
+	add_conf '
+module(load="../plugins/omtesting/.libs/omtesting")
+global(workDirectory="'"$SPOOL_DIR"'")
+main_queue(queue.type="Disk" queue.filename="transition"
+	queue.checkpointInterval="1" queue.saveOnShutdown="on"
+	queue.timeoutShutdown="1")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:omtesting:sleep 0 5000
+:msg, contains, "msgnum:" action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
+'
+}
+
+# Seed the spool through the classic pure-disk path. Every accepted message is
+# durable before injectmsg returns, avoiding a shutdown race in the DA transfer
+# layer while producing the exact legacy artifacts that auto-detection sees.
+write_seed_conf
 startup
 injectmsg
 shutdown_immediate
 wait_shutdown
-[ "$(cat "$MARKER")" = "RSYSLOG-DA-ENGINE-V1 disk" ] || error_exit 1 "classic marker missing"
-[ -f "$SPOOL_DIR/transition.qi" ] || error_exit 1 "classic DA backlog was not persisted"
+[ -f "$SPOOL_DIR/transition.qi" ] || error_exit 1 "classic backlog was not persisted"
 
-write_conf auto off 0
+write_conf auto off
 AUTO_LOG="${RSYSLOG_DYNNAME}.auto.log"
 export RS_REDIR=">\"$AUTO_LOG\" 2>&1"
 startup
@@ -49,11 +63,11 @@ grep -Fq 'automatically selected the classic disk engine' "${RSYSLOG_DYNNAME}.st
 	cat "${RSYSLOG_DYNNAME}.started"
 	error_exit 1 "automatic classic selection warning missing"
 }
-seq_check 0 $((NUMMESSAGES - 1))
+seq_check 0 $((NUMMESSAGES - 1)) -d
 [ "$(cat "$MARKER")" = "RSYSLOG-DA-ENGINE-V1 disk" ] || error_exit 1 "classic marker was not sticky"
 [ ! -f "$SPOOL_DIR/transition.qi" ] || error_exit 1 "classic state remained after a clean drain"
 
-write_conf auto on 0
+write_conf auto on
 startup
 [ "$(cat "$MARKER")" = "RSYSLOG-DA-ENGINE-V1 segmentedDisk" ] ||
 	error_exit 1 "auto-upgrade did not select segmentedDisk after classic drain"

--- a/tests/segmented-da-engine-transition.sh
+++ b/tests/segmented-da-engine-transition.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Build a real classic disk-assisted action backlog, then restart with the auto
+# selector. The marker, warning, and exact drain prove sticky classic
+# compatibility. A final clean restart with auto-upgrade enabled must replace
+# only the drained marker and select an unmaterialized segmented child.
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=3000
+SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
+MARKER="$SPOOL_DIR/transition.da-engine"
+
+write_conf() {
+	local selector="$1" upgrade="$2" slowdown="$3"
+	local delay_rule=
+	local upgrade_config=
+	[ "$slowdown" = 0 ] || delay_rule=":omtesting:sleep 0 $slowdown"
+	[ "$selector" != auto ] || upgrade_config="queue.diskQueueAutoUpgrade=\"$upgrade\""
+	generate_conf
+	add_conf '
+module(load="../plugins/omtesting/.libs/omtesting")
+global(workDirectory="'"$SPOOL_DIR"'")
+main_queue(queue.type="LinkedList" queue.filename="transition"
+	queue.diskQueueType="'"$selector"'" '"$upgrade_config"'
+	queue.size="50" queue.highWatermark="10" queue.lowWatermark="5"
+	queue.checkpointInterval="1" queue.saveOnShutdown="on"
+	queue.timeoutShutdown="1")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+'"$delay_rule"'
+:msg, contains, "msgnum:" action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
+'
+}
+
+write_conf disk off 5000
+startup
+injectmsg
+shutdown_immediate
+wait_shutdown
+[ "$(cat "$MARKER")" = "RSYSLOG-DA-ENGINE-V1 disk" ] || error_exit 1 "classic marker missing"
+[ -f "$SPOOL_DIR/transition.qi" ] || error_exit 1 "classic DA backlog was not persisted"
+
+write_conf auto off 0
+AUTO_LOG="${RSYSLOG_DYNNAME}.auto.log"
+export RS_REDIR=">\"$AUTO_LOG\" 2>&1"
+startup
+shutdown_when_empty
+wait_shutdown
+unset RS_REDIR
+grep -Fq 'automatically selected the classic disk engine' "${RSYSLOG_DYNNAME}.started" || {
+	cat "${RSYSLOG_DYNNAME}.started"
+	error_exit 1 "automatic classic selection warning missing"
+}
+seq_check 0 $((NUMMESSAGES - 1))
+[ "$(cat "$MARKER")" = "RSYSLOG-DA-ENGINE-V1 disk" ] || error_exit 1 "classic marker was not sticky"
+[ ! -f "$SPOOL_DIR/transition.qi" ] || error_exit 1 "classic state remained after a clean drain"
+
+write_conf auto on 0
+startup
+[ "$(cat "$MARKER")" = "RSYSLOG-DA-ENGINE-V1 segmentedDisk" ] ||
+	error_exit 1 "auto-upgrade did not select segmentedDisk after classic drain"
+[ ! -e "$SPOOL_DIR/transition.segq" ] || error_exit 1 "auto-upgraded child materialized without a spill"
+shutdown_when_empty
+wait_shutdown
+exit_test

--- a/tests/segmented-da-engine-transition.sh
+++ b/tests/segmented-da-engine-transition.sh
@@ -59,18 +59,16 @@ startup
 shutdown_when_empty
 wait_shutdown
 unset RS_REDIR
-grep -Fq 'automatically selected the classic disk engine' "${RSYSLOG_DYNNAME}.started" || {
-	cat "${RSYSLOG_DYNNAME}.started"
-	error_exit 1 "automatic classic selection warning missing"
-}
+content_check 'automatically selected the classic disk engine' "${RSYSLOG_DYNNAME}.started"
 seq_check 0 $((NUMMESSAGES - 1)) -d
-[ "$(cat "$MARKER")" = "RSYSLOG-DA-ENGINE-V1 disk" ] || error_exit 1 "classic marker was not sticky"
+printf '%s\n' 'RSYSLOG-DA-ENGINE-V1 disk' | cmp - "$MARKER" \
+	|| error_exit 1 "classic marker was not sticky"
 [ ! -f "$SPOOL_DIR/transition.qi" ] || error_exit 1 "classic state remained after a clean drain"
 
 write_conf auto on
 startup
-[ "$(cat "$MARKER")" = "RSYSLOG-DA-ENGINE-V1 segmentedDisk" ] ||
-	error_exit 1 "auto-upgrade did not select segmentedDisk after classic drain"
+printf '%s\n' 'RSYSLOG-DA-ENGINE-V1 segmentedDisk' | cmp - "$MARKER" \
+	|| error_exit 1 "auto-upgrade did not select segmentedDisk after classic drain"
 [ ! -e "$SPOOL_DIR/transition.segq" ] || error_exit 1 "auto-upgraded child materialized without a spill"
 shutdown_when_empty
 wait_shutdown

--- a/tests/segmented-da-event-properties-fixedarray.sh
+++ b/tests/segmented-da-event-properties-fixedarray.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Run the complete-event persistence oracle through a FixedArray segmented DA
+# child, complementing the LinkedList wrapper with identical typed JSON,
+# message-variable, local-variable, and RFC5424 field comparisons.
+export SEGDISK_EVENT_DA=1
+export SEGDISK_DA_QUEUE_TYPE=FixedArray
+. ${srcdir:=.}/segmented-diskqueue-event-properties.sh

--- a/tests/segmented-da-event-properties.sh
+++ b/tests/segmented-da-event-properties.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Run the complete-event persistence oracle through a segmented DA child.
+export SEGDISK_EVENT_DA=1
+. ${srcdir:=.}/segmented-diskqueue-event-properties.sh

--- a/tests/segmented-da-idle-cleanup-failure.sh
+++ b/tests/segmented-da-idle-cleanup-failure.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 # Force idle cleanup to encounter an unexpected file in the private store
 # directory. The first cleanup must fail visibly while restoring a valid empty
-# materialized store and keeping its worker alive. Removing the blocker must
-# allow the next complete idle interval to dematerialize normally.
+# materialized store and keeping its worker alive. The restored state must
+# reference one newly created active segment, proving partially removed old
+# topology cannot be stranded beside the replacement state. Removing the
+# blocker must allow the next complete idle interval to dematerialize normally.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=1000
 SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
@@ -42,6 +44,9 @@ wait_content 'store.idleCleanupFailures=1' "$STATS_FILE"
 [ -f "$SEG_DIR/state" ] || error_exit 1 "cleanup failure did not restore durable state"
 find "$SEG_DIR" -maxdepth 1 -name '*.open' -print -quit | grep -q . ||
 	error_exit 1 "cleanup failure did not restore an active segment"
+segment_count=$(find "$SEG_DIR" -maxdepth 1 -type f -name 'segment-*' -print | wc -l)
+[ "$segment_count" -eq 1 ] ||
+	error_exit 1 "cleanup failure retained $segment_count segments instead of one replacement active segment"
 rm -f "$SEG_DIR/blocker"
 wait_path absent "$SEG_DIR"
 wait_content 'store.idleDematerializations=1' "$STATS_FILE"

--- a/tests/segmented-da-idle-cleanup-failure.sh
+++ b/tests/segmented-da-idle-cleanup-failure.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Force idle cleanup to encounter an unexpected file in the private store
+# directory. The first cleanup must fail visibly while restoring a valid empty
+# materialized store and keeping its worker alive. Removing the blocker must
+# allow the next complete idle interval to dematerialize normally.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1000
+SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
+SEG_DIR="$SPOOL_DIR/cleanup-failure.segq"
+STATS_FILE="${RSYSLOG_DYNNAME}.stats"
+
+wait_path() {
+	local mode="$1" path="$2" timeoutend=$((SECONDS + 30))
+	while true; do
+		[ "$mode" = present ] && [ -e "$path" ] && return
+		[ "$mode" = absent ] && [ ! -e "$path" ] && return
+		[ "$SECONDS" -ge "$timeoutend" ] && error_exit 1 "path did not become $mode: $path"
+		./msleep 50
+	done
+}
+
+generate_conf
+add_conf '
+global(workDirectory="'"$SPOOL_DIR"'")
+module(load="../plugins/impstats/.libs/impstats"
+	interval="1" log.syslog="off" log.file="'"$STATS_FILE"'")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" name="cleanup-failure"
+	file="'"$RSYSLOG_OUT_LOG"'" template="outfmt"
+	queue.type="LinkedList" queue.filename="cleanup-failure"
+	queue.size="50" queue.highWatermark="10" queue.lowWatermark="5"
+	queue.dequeueBatchSize="1" queue.dequeueSlowdown="5"
+	queue.diskQueueType="segmentedDisk" queue.diskQueueIdleTimeout="200")
+'
+
+startup
+injectmsg
+wait_path present "$SEG_DIR"
+touch "$SEG_DIR/blocker"
+wait_file_lines "$RSYSLOG_OUT_LOG" "$NUMMESSAGES" 300
+wait_content 'store.idleCleanupFailures=1' "$STATS_FILE"
+[ -f "$SEG_DIR/state" ] || error_exit 1 "cleanup failure did not restore durable state"
+find "$SEG_DIR" -maxdepth 1 -name '*.open' -print -quit | grep -q . ||
+	error_exit 1 "cleanup failure did not restore an active segment"
+rm -f "$SEG_DIR/blocker"
+wait_path absent "$SEG_DIR"
+wait_content 'store.idleDematerializations=1' "$STATS_FILE"
+
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test

--- a/tests/segmented-da-idle-crash-directory.sh
+++ b/tests/segmented-da-idle-crash-directory.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Crash after the empty segmented store directory has been removed.
+export SEGDISK_IDLE_FAULT_POINT=idle-directory-removed
+. ${srcdir:=.}/testsuites/segmented-da-idle-crash-driver.sh

--- a/tests/segmented-da-idle-crash-segments.sh
+++ b/tests/segmented-da-idle-crash-segments.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
-# Crash after all segment deletions have been synchronized.
+# Crash after all segment deletions have been synchronized in two consecutive
+# materialization cycles; final exact drain proves repeated cleanup recovery.
 export SEGDISK_IDLE_FAULT_POINT=idle-segments-unlinked
+export SEGDISK_IDLE_FAULT_REPEATS=2
 . ${srcdir:=.}/testsuites/segmented-da-idle-crash-driver.sh

--- a/tests/segmented-da-idle-crash-segments.sh
+++ b/tests/segmented-da-idle-crash-segments.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Crash after all segment deletions have been synchronized.
+export SEGDISK_IDLE_FAULT_POINT=idle-segments-unlinked
+. ${srcdir:=.}/testsuites/segmented-da-idle-crash-driver.sh

--- a/tests/segmented-da-idle-crash-state-unlink.sh
+++ b/tests/segmented-da-idle-crash-state-unlink.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Crash after state unlink, when the queue directory is empty.
+export SEGDISK_IDLE_FAULT_POINT=idle-state-unlinked
+. ${srcdir:=.}/testsuites/segmented-da-idle-crash-driver.sh

--- a/tests/segmented-da-idle-crash-state.sh
+++ b/tests/segmented-da-idle-crash-state.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Crash immediately after the durable empty-state publication.
+export SEGDISK_IDLE_FAULT_POINT=idle-empty-published
+. ${srcdir:=.}/testsuites/segmented-da-idle-crash-driver.sh

--- a/tests/segmented-da-idle-dematerialize.sh
+++ b/tests/segmented-da-idle-dematerialize.sh
@@ -4,6 +4,9 @@
 # filesystem oracle proves lazy creation, grace-period dematerialization, and
 # transparent rematerialization; exact sequence output proves no loss or
 # reordering. The impstats oracle proves the final child worker terminated.
+# The reset probe uses a 3-second timeout, injects after 1 second, and checks
+# 2.25 seconds later: the check is past the original deadline but still 750 ms
+# before the reset deadline, leaving a substantial scheduler margin under SAN.
 . ${srcdir:=.}/diag.sh init
 
 export NUMMESSAGES=4000
@@ -52,7 +55,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 	queue.dequeueBatchSize="1"
 	queue.dequeueSlowdown="2"
 	queue.diskQueueType="segmentedDisk"
-	queue.diskQueueIdleTimeout="500"
+	queue.diskQueueIdleTimeout="3000"
 )
 '
 
@@ -67,10 +70,10 @@ wait_file_lines "$RSYSLOG_OUT_LOG" 2000 300
 
 # A memory-tier-only enqueue during the grace period must wake the child and
 # restart the full timeout even though it does not itself spill to disk.
-./msleep 250
+./msleep 1000
 injectmsg 2000 1
 wait_file_lines "$RSYSLOG_OUT_LOG" 2001 300
-./msleep 300
+./msleep 2250
 [ -d "$SEG_DIR" ] || error_exit 1 "new traffic did not reset the segmented DA idle grace period"
 wait_path_state absent "$SEG_DIR"
 

--- a/tests/segmented-da-idle-dematerialize.sh
+++ b/tests/segmented-da-idle-dematerialize.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Exercise the complete segmented DA idle lifecycle on an action queue. A
+# deliberately slow, tiny memory tier makes each 2000-message burst spill. The
+# filesystem oracle proves lazy creation, grace-period dematerialization, and
+# transparent rematerialization; exact sequence output proves no loss or
+# reordering. The impstats oracle proves the final child worker terminated.
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=4000
+SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
+SEG_DIR="$SPOOL_DIR/idle-action.segq"
+MARKER="$SPOOL_DIR/idle-action.da-engine"
+STATS_FILE="${RSYSLOG_DYNNAME}.stats"
+
+wait_path_state() {
+	local mode="$1"
+	local path="$2"
+	local timeoutend=$((SECONDS + 30))
+	while true; do
+		if [ "$mode" = present ] && [ -e "$path" ]; then
+			return
+		fi
+		if [ "$mode" = absent ] && [ ! -e "$path" ]; then
+			return
+		fi
+		if [ "$SECONDS" -ge "$timeoutend" ]; then
+			echo "FAIL: path did not become $mode: $path"
+			find "$SPOOL_DIR" -maxdepth 2 -print 2>/dev/null || true
+			error_exit 1
+		fi
+		./msleep 50
+	done
+}
+
+generate_conf
+add_conf '
+global(workDirectory="'"$SPOOL_DIR"'")
+module(load="../plugins/impstats/.libs/impstats"
+	interval="1" log.syslog="off" log.file="'"$STATS_FILE"'")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(
+	type="omfile"
+	name="idle-action"
+	file="'"$RSYSLOG_OUT_LOG"'"
+	template="outfmt"
+	queue.type="LinkedList"
+	queue.filename="idle-action"
+	queue.size="50"
+	queue.highWatermark="10"
+	queue.lowWatermark="5"
+	queue.dequeueBatchSize="1"
+	queue.dequeueSlowdown="2"
+	queue.diskQueueType="segmentedDisk"
+	queue.diskQueueIdleTimeout="500"
+)
+'
+
+startup
+[ ! -e "$SEG_DIR" ] || error_exit 1 "segmented DA store materialized before the first spill"
+[ ! -e "$MARKER" ] || error_exit 1 "segmented DA engine marker was created before the first spill"
+
+injectmsg 0 2000
+wait_path_state present "$SEG_DIR"
+[ -f "$MARKER" ] || error_exit 1 "segmented DA engine marker was not created with the first spill"
+wait_file_lines "$RSYSLOG_OUT_LOG" 2000 300
+
+# A memory-tier-only enqueue during the grace period must wake the child and
+# restart the full timeout even though it does not itself spill to disk.
+./msleep 250
+injectmsg 2000 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 2001 300
+./msleep 300
+[ -d "$SEG_DIR" ] || error_exit 1 "new traffic did not reset the segmented DA idle grace period"
+wait_path_state absent "$SEG_DIR"
+
+# A second burst must recreate the same child store and run through the same
+# lifecycle, proving that worker and store teardown are both reversible.
+injectmsg 2001 1999
+wait_path_state present "$SEG_DIR"
+wait_file_lines "$RSYSLOG_OUT_LOG" 4000 300
+wait_path_state absent "$SEG_DIR"
+
+wait_content 'store.idleDematerializations=2' "$STATS_FILE"
+wait_content 'workers.current=0' "$STATS_FILE"
+[ "$(cat "$MARKER")" = "RSYSLOG-DA-ENGINE-V1 segmentedDisk" ] ||
+	error_exit 1 "segmented DA marker changed during idle cleanup"
+
+shutdown_when_empty
+wait_shutdown
+seq_check 0 3999
+exit_test

--- a/tests/segmented-da-idle-retry.sh
+++ b/tests/segmented-da-idle-retry.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Keep a segmented DA action in retry state for longer than its 100 ms idle
+# timeout. The store must remain materialized while retry-before-commit owns
+# records; after the output directory appears, exact drain plus store removal
+# proves cleanup begins only after the retry batch is durably completed.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1000
+SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
+SEG_DIR="$SPOOL_DIR/retryq.segq"
+OUTPUT_DIR="$PWD/${RSYSLOG_DYNNAME}.missing"
+OUTPUT_FILE="$OUTPUT_DIR/output.log"
+
+wait_path_state() {
+	local mode="$1" path="$2" deadline=$((SECONDS + 30))
+	while true; do
+		[ "$mode" = present ] && [ -e "$path" ] && return
+		[ "$mode" = absent ] && [ ! -e "$path" ] && return
+		[ "$SECONDS" -lt "$deadline" ] || error_exit 1 "path did not become $mode: $path"
+		./msleep 25
+	done
+}
+
+generate_conf
+add_conf '
+global(workDirectory="'"$SPOOL_DIR"'")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" file="'"$OUTPUT_FILE"'" template="outfmt"
+	createDirs="off" action.resumeRetryCount="-1" action.resumeInterval="1"
+	queue.type="LinkedList" queue.filename="retryq"
+	queue.size="50" queue.highWatermark="10" queue.lowWatermark="5"
+	queue.dequeueBatchSize="1" queue.diskQueueType="segmentedDisk"
+	queue.diskQueueIdleTimeout="100")
+'
+
+startup
+injectmsg
+wait_path_state present "$SEG_DIR"
+./msleep 500
+[ -d "$SEG_DIR" ] || error_exit 1 "idle cleanup removed a store with retry records"
+mkdir "$OUTPUT_DIR"
+wait_file_lines "$OUTPUT_FILE" "$NUMMESSAGES" 300
+wait_path_state absent "$SEG_DIR"
+shutdown_when_empty
+wait_shutdown
+RSYSLOG_OUT_LOG="$OUTPUT_FILE" seq_check
+exit_test

--- a/tests/segmented-da-idle-timeout-values.sh
+++ b/tests/segmented-da-idle-timeout-values.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Verify the two boundary values of queue.diskQueueIdleTimeout. Identical slow
+# action queues force a spill; timeout 0 must remove its store immediately,
+# while -1 must retain its drained store and final worker until shutdown. Exact
+# output sequences prove both children drained without loss.
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=1500
+SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
+ZERO_OUT="${RSYSLOG_DYNNAME}.zero.log"
+DISABLED_OUT="${RSYSLOG_DYNNAME}.disabled.log"
+STATS_FILE="${RSYSLOG_DYNNAME}.stats"
+
+wait_path_state() {
+	local mode="$1" path="$2" timeoutend=$((SECONDS + 30))
+	while true; do
+		[ "$mode" = present ] && [ -e "$path" ] && return
+		[ "$mode" = absent ] && [ ! -e "$path" ] && return
+		[ "$SECONDS" -ge "$timeoutend" ] && error_exit 1 "path did not become $mode: $path"
+		./msleep 25
+	done
+}
+
+generate_conf
+add_conf '
+global(workDirectory="'"$SPOOL_DIR"'")
+module(load="../plugins/impstats/.libs/impstats"
+	interval="1" log.syslog="off" log.file="'"$STATS_FILE"'")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+:msg, contains, "msgnum:" {
+	action(type="omfile" name="idle-zero" file="'"$ZERO_OUT"'" template="outfmt"
+		queue.type="LinkedList" queue.filename="idle-zero" queue.size="50"
+		queue.highWatermark="10" queue.lowWatermark="5"
+		queue.dequeueBatchSize="1" queue.dequeueSlowdown="10"
+		queue.diskQueueType="segmentedDisk" queue.diskQueueIdleTimeout="0")
+	action(type="omfile" name="idle-disabled" file="'"$DISABLED_OUT"'" template="outfmt"
+		queue.type="LinkedList" queue.filename="idle-disabled" queue.size="50"
+		queue.highWatermark="10" queue.lowWatermark="5"
+		queue.dequeueBatchSize="1" queue.dequeueSlowdown="10"
+		queue.diskQueueType="segmentedDisk" queue.diskQueueIdleTimeout="-1")
+}
+'
+
+startup
+injectmsg
+wait_path_state present "$SPOOL_DIR/idle-disabled.segq"
+wait_file_lines "$ZERO_OUT" "$NUMMESSAGES" 300
+wait_file_lines "$DISABLED_OUT" "$NUMMESSAGES" 300
+wait_path_state absent "$SPOOL_DIR/idle-zero.segq"
+./msleep 1000
+[ -d "$SPOOL_DIR/idle-disabled.segq" ] || error_exit 1 "idle timeout -1 removed the store"
+wait_content 'store.idleDematerializations=1' "$STATS_FILE"
+
+shutdown_when_empty
+wait_shutdown
+RSYSLOG_OUT_LOG="$ZERO_OUT" seq_check 0 $((NUMMESSAGES - 1))
+RSYSLOG_OUT_LOG="$DISABLED_OUT" seq_check 0 $((NUMMESSAGES - 1))
+exit_test

--- a/tests/segmented-da-idle-timeout-values.sh
+++ b/tests/segmented-da-idle-timeout-values.sh
@@ -38,6 +38,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 		queue.type="LinkedList" queue.filename="idle-disabled" queue.size="50"
 		queue.highWatermark="10" queue.lowWatermark="5"
 		queue.dequeueBatchSize="1" queue.dequeueSlowdown="10"
+		queue.timeoutWorkerThreadShutdown="100"
 		queue.diskQueueType="segmentedDisk" queue.diskQueueIdleTimeout="-1")
 }
 '
@@ -51,6 +52,10 @@ wait_path_state absent "$SPOOL_DIR/idle-zero.segq"
 ./msleep 1000
 [ -d "$SPOOL_DIR/idle-disabled.segq" ] || error_exit 1 "idle timeout -1 removed the store"
 wait_content 'store.idleDematerializations=1' "$STATS_FILE"
+# The 100ms generic worker timeout has elapsed several times by now.  A live
+# worker proves that -1 protects slot zero while still leaving the generic
+# timeout available for any additional workers.
+content_check --regex 'idle-disabled queue\[DA\].*workers.current=1' "$STATS_FILE"
 
 shutdown_when_empty
 wait_shutdown

--- a/tests/segmented-da-idle-timeout-values.sh
+++ b/tests/segmented-da-idle-timeout-values.sh
@@ -38,6 +38,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 		queue.type="LinkedList" queue.filename="idle-disabled" queue.size="50"
 		queue.highWatermark="10" queue.lowWatermark="5"
 		queue.dequeueBatchSize="1" queue.dequeueSlowdown="10"
+		queue.workerThreads="3" queue.workerThreadMinimumMessages="1"
 		queue.timeoutWorkerThreadShutdown="100"
 		queue.diskQueueType="segmentedDisk" queue.diskQueueIdleTimeout="-1")
 }

--- a/tests/segmented-da-idle-timeout-values.sh
+++ b/tests/segmented-da-idle-timeout-values.sh
@@ -52,7 +52,15 @@ wait_file_lines "$DISABLED_OUT" "$NUMMESSAGES" 300
 wait_path_state absent "$SPOOL_DIR/idle-zero.segq"
 ./msleep 1000
 [ -d "$SPOOL_DIR/idle-disabled.segq" ] || error_exit 1 "idle timeout -1 removed the store"
-wait_content 'store.idleDematerializations=1' "$STATS_FILE"
+# With a zero grace period, a producer scheduling gap may permit more than one
+# drain/rematerialize cycle during the burst. At least one completed cleanup,
+# an absent store, and zero child workers are the deterministic immediacy
+# oracle; requiring exactly one cleanup would make scheduler timing observable.
+wait_content 'store.idleDematerializations=' "$STATS_FILE"
+zero_dematerializations=$(grep 'idle-zero queue\[DA\]' "$STATS_FILE" |
+	sed -E 's/.*store\.idleDematerializations=([0-9]+).*/\1/' | sort -n | tail -n 1)
+[ "${zero_dematerializations:-0}" -ge 1 ] || error_exit 1 "idle timeout 0 did not dematerialize its store"
+content_check --regex 'idle-zero queue\[DA\].*workers.current=0' "$STATS_FILE"
 # The 100ms generic worker timeout has elapsed several times by now.  A live
 # worker proves that -1 protects slot zero while still leaving the generic
 # timeout available for any additional workers.

--- a/tests/segmented-da-maxdiskspace-fixedarray.sh
+++ b/tests/segmented-da-maxdiskspace-fixedarray.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Run the segmented DA disk-space backpressure and reclamation oracle with the
+# FixedArray memory tier; the base test retains LinkedList as its default.
+export DA_QUEUE_TYPE=FixedArray
+. ${srcdir:=.}/segmented-da-maxdiskspace.sh

--- a/tests/segmented-da-maxdiskspace.sh
+++ b/tests/segmented-da-maxdiskspace.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Fill a 64 KiB segmented DA child while a slow consumer keeps the 50-record
+# memory tier above its high watermark, drain it, and repeat. Exact delivery
+# proves producer backpressure without loss and reuse after segment reclamation;
+# impstats permits only the current-record/topology overshoot used by the pure
+# segmented store test.
+. ${srcdir:=.}/diag.sh init
+require_plugin impstats
+export NUMMESSAGES=2000
+STATS_FILE="$PWD/${RSYSLOG_DYNNAME}.stats.log"
+
+generate_conf
+add_conf '
+module(load="../plugins/omtesting/.libs/omtesting")
+module(load="../plugins/impstats/.libs/impstats" log.file="'"$STATS_FILE"'" interval="1")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" address="127.0.0.1" port="0"
+	listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+main_queue(queue.type="LinkedList" queue.filename="mainq"
+	queue.size="50" queue.highWatermark="10" queue.lowWatermark="5"
+	queue.maxDiskSpace="64k" queue.maxFileSize="8k"
+	queue.timeoutEnqueue="300000" queue.dequeueBatchSize="16"
+	queue.diskQueueType="auto" queue.diskQueueIdleTimeout="-1")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" :omtesting:sleep 0 1000
+if ($msg contains "msgnum:") then
+	action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
+'
+
+startup
+tcpflood -p"$TCPFLOOD_PORT" -m1000 -i0
+wait_file_lines "$RSYSLOG_OUT_LOG" 1000
+tcpflood -p"$TCPFLOOD_PORT" -m1000 -i1000
+wait_file_lines "$RSYSLOG_OUT_LOG" "$NUMMESSAGES"
+shutdown_when_empty
+wait_shutdown
+seq_check
+max_usage=$(grep 'disk.usage=' "$STATS_FILE" | sed -E 's/.*disk\.usage=([0-9]+).*/\1/' |
+	sort -n | tail -n 1)
+if [ "${max_usage:-0}" -gt 66560 ]; then
+	printf 'FAIL: segmented DA sampled usage %s exceeds the 64 KiB limit plus one record\n' "$max_usage"
+	cat "$STATS_FILE"
+	error_exit 1
+fi
+rm -rf "${RSYSLOG_DYNNAME}.spool"
+exit_test

--- a/tests/segmented-da-maxdiskspace.sh
+++ b/tests/segmented-da-maxdiskspace.sh
@@ -7,6 +7,7 @@
 . ${srcdir:=.}/diag.sh init
 require_plugin impstats
 export NUMMESSAGES=2000
+DA_QUEUE_TYPE=${DA_QUEUE_TYPE:-LinkedList}
 STATS_FILE="$PWD/${RSYSLOG_DYNNAME}.stats.log"
 
 generate_conf
@@ -17,7 +18,7 @@ module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" address="127.0.0.1" port="0"
 	listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
 global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
-main_queue(queue.type="LinkedList" queue.filename="mainq"
+main_queue(queue.type="'"$DA_QUEUE_TYPE"'" queue.filename="mainq"
 	queue.size="50" queue.highWatermark="10" queue.lowWatermark="5"
 	queue.maxDiskSpace="64k" queue.maxFileSize="8k"
 	queue.timeoutEnqueue="300000" queue.dequeueBatchSize="16"

--- a/tests/segmented-da-multiworker-frontier.sh
+++ b/tests/segmented-da-multiworker-frontier.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Seed a pure segmented queue, crash it with twelve uncommitted events, then
+# reopen that store as an automatic segmented DA child with three one-record
+# workers. Workers 1 and 2 hold events 0 and 1 for five and two seconds, so
+# worker 3 must emit event 2. State inspection proves the durable frontier stays
+# behind the held batch and then crosses the already completed suffix. Sorted
+# exact output is the loss/duplicate oracle because worker output order is not
+# otherwise constrained.
+. ${srcdir:=.}/diag.sh init
+check_command_available python3
+export NUMMESSAGES=12
+SPOOL_DIR="$PWD/${RSYSLOG_DYNNAME}.spool"
+BLOCKED_FILE="$PWD/${RSYSLOG_DYNNAME}.missing/output.log"
+
+write_seed_conf() {
+	generate_conf
+	add_conf '
+global(workDirectory="'"$SPOOL_DIR"'")
+main_queue(queue.type="segmentedDisk" queue.filename="mainq"
+	queue.dequeueBatchSize="1" queue.saveOnShutdown="on")
+:msg, contains, "msgnum:" action(type="omfile" file="'"$BLOCKED_FILE"'"
+	createDirs="off" action.resumeRetryCount="-1")
+'
+}
+
+write_da_conf() {
+	generate_conf
+	add_conf '
+module(load="../plugins/omtesting/.libs/omtesting")
+global(workDirectory="'"$SPOOL_DIR"'")
+main_queue(queue.type="LinkedList" queue.filename="mainq"
+	queue.size="50" queue.highWatermark="10" queue.lowWatermark="5"
+	queue.dequeueBatchSize="1" queue.workerThreads="3"
+	queue.workerThreadMinimumMessages="1" queue.checkpointInterval="1"
+	queue.diskQueueType="auto" queue.diskQueueIdleTimeout="-1")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:00000000:" :omtesting:sleep 5 0
+:msg, contains, "msgnum:00000001:" :omtesting:sleep 2 0
+if ($msg contains "msgnum:") then
+	action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
+'
+}
+
+write_seed_conf
+startup
+injectmsg
+state_deadline=$((SECONDS + 30))
+while [ ! -s "$SPOOL_DIR/mainq.segq/state" ]; do
+	[ "$SECONDS" -lt "$state_deadline" ] || error_exit 1 "seed segmented state was not created"
+	./msleep 25
+done
+wait_rsyslog_instance_pid ""
+. "$srcdir/diag.sh" kill-immediate
+wait_shutdown
+
+python3 "$srcdir/segdisk-inspect.py" "$SPOOL_DIR/mainq.segq" >"${RSYSLOG_DYNNAME}.frontier-baseline.json"
+baseline_sequence=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(max(s["committed_sequence"] for s in d["state_slots"] if s["valid"]))' \
+	"${RSYSLOG_DYNNAME}.frontier-baseline.json")
+held_sequence=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(min(r["local_sequence"] for s in d["segments"] for r in s["records"] if r["message_number"] == 0))' \
+	"${RSYSLOG_DYNNAME}.frontier-baseline.json")
+
+write_da_conf
+startup
+wait_content '00000002' "$RSYSLOG_OUT_LOG"
+check_not_present '00000000' "$RSYSLOG_OUT_LOG"
+python3 "$srcdir/segdisk-inspect.py" "$SPOOL_DIR/mainq.segq" >"${RSYSLOG_DYNNAME}.frontier-blocked.json"
+blocked_sequence=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(max(s["committed_sequence"] for s in d["state_slots"] if s["valid"]))' \
+	"${RSYSLOG_DYNNAME}.frontier-blocked.json")
+if [ "$blocked_sequence" -ne $((held_sequence - 1)) ]; then
+	printf 'FAIL: DA durable frontier crossed delayed first batch: sequence=%s held=%s baseline=%s\n' \
+		"$blocked_sequence" "$held_sequence" "$baseline_sequence"
+	error_exit 1
+fi
+
+wait_file_lines "$RSYSLOG_OUT_LOG" "$NUMMESSAGES"
+python3 "$srcdir/segdisk-inspect.py" "$SPOOL_DIR/mainq.segq" >"${RSYSLOG_DYNNAME}.frontier-complete.json"
+complete_sequence=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(max(s["committed_sequence"] for s in d["state_slots"] if s["valid"]))' \
+	"${RSYSLOG_DYNNAME}.frontier-complete.json")
+if [ "$complete_sequence" -lt $((held_sequence + NUMMESSAGES - 1)) ]; then
+	printf 'FAIL: DA durable frontier did not cross completed suffix: sequence=%s held=%s\n' \
+		"$complete_sequence" "$held_sequence"
+	error_exit 1
+fi
+
+shutdown_when_empty
+wait_shutdown
+$RS_SORTCMD "$RSYSLOG_OUT_LOG" >"${RSYSLOG_DYNNAME}.sorted"
+seq -f '%08g' 0 11 >"${RSYSLOG_DYNNAME}.expected"
+cmp_exact_file "${RSYSLOG_DYNNAME}.expected" "${RSYSLOG_DYNNAME}.sorted"
+rm -rf "$SPOOL_DIR"
+exit_test

--- a/tests/segmented-da-multiworker-frontier.sh
+++ b/tests/segmented-da-multiworker-frontier.sh
@@ -3,9 +3,10 @@
 # reopen that store as an automatic segmented DA child with three one-record
 # workers. Workers 1 and 2 hold events 0 and 1 for five and two seconds, so
 # worker 3 must emit event 2. State inspection proves the durable frontier stays
-# behind the held batch and then crosses the already completed suffix. Sorted
-# exact output is the loss/duplicate oracle because worker output order is not
-# otherwise constrained.
+# behind the held batch and then crosses the already completed suffix. A 750 ms
+# wait beyond the 500 ms idle timeout proves an in-flight batch prevents store
+# cleanup. Sorted exact output is the loss/duplicate oracle because worker
+# output order is not otherwise constrained.
 . ${srcdir:=.}/diag.sh init
 check_command_available python3
 export NUMMESSAGES=12
@@ -32,7 +33,7 @@ main_queue(queue.type="LinkedList" queue.filename="mainq"
 	queue.size="50" queue.highWatermark="10" queue.lowWatermark="5"
 	queue.dequeueBatchSize="1" queue.workerThreads="3"
 	queue.workerThreadMinimumMessages="1" queue.checkpointInterval="1"
-	queue.diskQueueType="auto" queue.diskQueueIdleTimeout="-1")
+	queue.diskQueueType="auto" queue.diskQueueIdleTimeout="500")
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:00000000:" :omtesting:sleep 5 0
 :msg, contains, "msgnum:00000001:" :omtesting:sleep 2 0
@@ -63,6 +64,9 @@ write_da_conf
 startup
 wait_content '00000002' "$RSYSLOG_OUT_LOG"
 check_not_present '00000000' "$RSYSLOG_OUT_LOG"
+./msleep 750
+[ -d "$SPOOL_DIR/mainq.segq" ] ||
+	error_exit 1 "idle cleanup removed the store while the first batch was in flight"
 python3 "$srcdir/segdisk-inspect.py" "$SPOOL_DIR/mainq.segq" >"${RSYSLOG_DYNNAME}.frontier-blocked.json"
 blocked_sequence=$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(max(s["committed_sequence"] for s in d["state_slots"] if s["valid"]))' \
 	"${RSYSLOG_DYNNAME}.frontier-blocked.json")
@@ -82,6 +86,12 @@ if [ "$complete_sequence" -lt $((held_sequence + NUMMESSAGES - 1)) ]; then
 	error_exit 1
 fi
 
+cleanup_deadline=$((SECONDS + 30))
+while [ -e "$SPOOL_DIR/mainq.segq" ]; do
+	[ "$SECONDS" -lt "$cleanup_deadline" ] ||
+		error_exit 1 "idle cleanup did not dematerialize the drained DA store"
+	./msleep 25
+done
 shutdown_when_empty
 wait_shutdown
 $RS_SORTCMD "$RSYSLOG_OUT_LOG" >"${RSYSLOG_DYNNAME}.sorted"

--- a/tests/segmented-da-persist.sh
+++ b/tests/segmented-da-persist.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Run the shared save-on-shutdown/restart oracle for both DA memory queue types
+# with automatic segmented storage.
+for DA_QUEUE_TYPE in LinkedList FixedArray; do
+	export DA_QUEUE_TYPE DA_ENGINE=auto
+	"${srcdir:=.}/testsuites/da-engine-persist-driver.sh" || exit $?
+done

--- a/tests/segmented-da-recovery-budget.sh
+++ b/tests/segmented-da-recovery-budget.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Run the bounded lazy-recovery oracle through an automatic segmented DA child;
+# the shared driver verifies recovery-pending rescheduling, counters, and later
+# producer delivery while the child owns an undiscovered corrupt range.
+export SEGDISK_RECOVERY_DA=1
+. ${srcdir:=.}/segmented-diskqueue-recovery-budget.sh

--- a/tests/segmented-da-retry-restart.sh
+++ b/tests/segmented-da-retry-restart.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Exercise the shared suspended-action restart oracle for both DA memory queue
+# types with the automatic segmented engine selection.
+for DA_QUEUE_TYPE in LinkedList FixedArray; do
+	export DA_QUEUE_TYPE DA_ENGINE=auto
+	"${srcdir:=.}/testsuites/da-engine-retry-restart-driver.sh" || exit $?
+done

--- a/tests/segmented-diskqueue-corruption.sh
+++ b/tests/segmented-diskqueue-corruption.sh
@@ -36,6 +36,12 @@ shutdown_immediate
 . "$srcdir/diag.sh" kill-immediate
 wait_shutdown
 
+# The crash helper can interrupt the artificial sleep after the action has
+# already appended the in-flight record. Discard phase-one output so the
+# salvage oracle counts only the restarted queue; the uncommitted record must
+# replay, while the deliberately damaged record must be the sole omission.
+rm -f "$RSYSLOG_OUT_LOG"
+
 case "$CORRUPTION_KIND" in
 payload) mutation=--corrupt-message-number ;;
 framing) mutation=--corrupt-record-framing ;;

--- a/tests/segmented-diskqueue-event-properties.sh
+++ b/tests/segmented-diskqueue-event-properties.sh
@@ -15,7 +15,8 @@ RECOVERED_FILE="$PWD/${RSYSLOG_DYNNAME}.recovered.log"
 BLOCKED_FILE="$PWD/${RSYSLOG_DYNNAME}.missing/output.log"
 
 if [ "${SEGDISK_EVENT_DA:-0}" = 1 ]; then
-	QUEUE_CONFIG='queue.type="LinkedList"
+	SEGDISK_DA_QUEUE_TYPE=${SEGDISK_DA_QUEUE_TYPE:-LinkedList}
+	QUEUE_CONFIG='queue.type="'"$SEGDISK_DA_QUEUE_TYPE"'"
 	queue.filename="eventq"
 	queue.diskQueueType="segmentedDisk"
 	queue.size="20"

--- a/tests/segmented-diskqueue-event-properties.sh
+++ b/tests/segmented-diskqueue-event-properties.sh
@@ -14,6 +14,18 @@ REFERENCE_FILE="$PWD/${RSYSLOG_DYNNAME}.reference.log"
 RECOVERED_FILE="$PWD/${RSYSLOG_DYNNAME}.recovered.log"
 BLOCKED_FILE="$PWD/${RSYSLOG_DYNNAME}.missing/output.log"
 
+if [ "${SEGDISK_EVENT_DA:-0}" = 1 ]; then
+	QUEUE_CONFIG='queue.type="LinkedList"
+	queue.filename="eventq"
+	queue.diskQueueType="segmentedDisk"
+	queue.size="20"
+	queue.highWatermark="5"
+	queue.lowWatermark="2"'
+else
+	QUEUE_CONFIG='queue.type="segmentedDisk"
+	queue.filename="eventq"'
+fi
+
 write_conf() {
 	generate_conf
 	add_conf '
@@ -21,6 +33,7 @@ global(workDirectory="'"$SPOOL_DIR"'")
 
 template(name="eventSnapshot" type="list") {
 	constant(value="{")
+	property(format="jsonf" name="msg" field.number="2" field.delimiter="58" outname="sequence") constant(value=",")
 	property(format="jsonf" name="protocol-version" outname="protocol_version") constant(value=",")
 	property(format="jsonf" name="syslogseverity" outname="severity") constant(value=",")
 	property(format="jsonf" name="syslogfacility" outname="facility") constant(value=",")
@@ -53,15 +66,16 @@ set $.parse_result = parse_json(
 	"{\"text\":\"local-value\",\"integer\":7,\"boolean\":false}", "\$.local");
 unset $.parse_result;
 
-action(type="omfile" file="'"$REFERENCE_FILE"'" template="eventSnapshot")
-action(type="omfile" file="'"$1"'" template="eventSnapshot"
-	createDirs="off"
-	action.resumeRetryCount="-1"
-	queue.type="segmentedDisk"
-	queue.filename="eventq"
-	queue.maxFileSize="4k"
-	queue.dequeueBatchSize="8"
-	queue.saveOnShutdown="on")
+if $msg contains "msgnum:" then {
+	action(type="omfile" file="'"$REFERENCE_FILE"'" template="eventSnapshot")
+	action(type="omfile" file="'"$1"'" template="eventSnapshot"
+		createDirs="off"
+		action.resumeRetryCount="-1"
+'"$QUEUE_CONFIG"'
+		queue.maxFileSize="4k"
+		queue.dequeueBatchSize="8"
+		queue.saveOnShutdown="on")
+}
 '
 }
 
@@ -70,7 +84,9 @@ startup
 injectmsg 0 "$NUMMESSAGES"
 wait_file_lines "$REFERENCE_FILE" "$NUMMESSAGES"
 shutdown_immediate
-. "$srcdir/diag.sh" kill-immediate
+if [ "${SEGDISK_EVENT_DA:-0}" != 1 ]; then
+	. "$srcdir/diag.sh" kill-immediate
+fi
 wait_shutdown
 if [ "$(wc -c < "$SPOOL_DIR/eventq.segq/state")" -ne 512 ]; then
 	echo "FAIL: segmented action queue was not persisted"
@@ -82,6 +98,16 @@ startup
 wait_file_lines "$RECOVERED_FILE" "$NUMMESSAGES"
 shutdown_when_empty
 wait_shutdown
-cmp_exact_file "$REFERENCE_FILE" "$RECOVERED_FILE"
+if [ "${SEGDISK_EVENT_DA:-0}" = 1 ]; then
+	# The DA shutdown path may append the final in-memory records after records
+	# already spilled to disk. Sorting by the fixed-width leading sequence key
+	# keeps this test focused on lossless full-event persistence, not on shutdown
+	# transfer ordering, which is covered separately by the DA ordering tests.
+	sort "$REFERENCE_FILE" > "${REFERENCE_FILE}.sorted"
+	sort "$RECOVERED_FILE" > "${RECOVERED_FILE}.sorted"
+	cmp_exact_file "${REFERENCE_FILE}.sorted" "${RECOVERED_FILE}.sorted"
+else
+	cmp_exact_file "$REFERENCE_FILE" "$RECOVERED_FILE"
+fi
 rm -rf "${RSYSLOG_DYNNAME}.spool"
 exit_test

--- a/tests/segmented-diskqueue-recovery-budget.sh
+++ b/tests/segmented-diskqueue-recovery-budget.sh
@@ -11,13 +11,20 @@ SPOOL_DIR="$PWD/${RSYSLOG_DYNNAME}.spool"
 STATS_FILE="$PWD/${RSYSLOG_DYNNAME}.stats.log"
 
 write_conf() {
+	local queue_config='main_queue(queue.type="segmentedDisk" queue.filename="mainq"
+	queue.maxFileSize="1200k" queue.dequeueBatchSize="32" queue.saveOnShutdown="on")'
+	if [ "${SEGDISK_RECOVERY_DA:-0}" = 1 ] && [ "$2" = recovery ]; then
+		queue_config='main_queue(queue.type="LinkedList" queue.filename="mainq"
+		queue.size="50" queue.highWatermark="10" queue.lowWatermark="5"
+		queue.maxFileSize="1200k" queue.dequeueBatchSize="32" queue.saveOnShutdown="on"
+		queue.diskQueueType="auto" queue.diskQueueIdleTimeout="-1")'
+	fi
 	generate_conf
 	add_conf '
 module(load="../plugins/omtesting/.libs/omtesting")
 module(load="../plugins/impstats/.libs/impstats" log.file="'$STATS_FILE'" interval="1")
 global(workDirectory="'$SPOOL_DIR'")
-main_queue(queue.type="segmentedDisk" queue.filename="mainq"
-	queue.maxFileSize="1200k" queue.dequeueBatchSize="32" queue.saveOnShutdown="on")
+'"$queue_config"'
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 '"$1"'
 if ($msg contains "msgnum:") then
@@ -25,7 +32,7 @@ if ($msg contains "msgnum:") then
 '
 }
 
-write_conf ':omtesting:sleep 10 0'
+write_conf ':omtesting:sleep 10 0' seed
 startup
 wait_rsyslog_instance_pid
 injectmsg
@@ -40,7 +47,7 @@ python3 "$srcdir/segdisk-inspect.py" "$SPOOL_DIR/mainq.segq" --corrupt-segment-f
 	>"${RSYSLOG_DYNNAME}.budget-corrupt.json"
 
 : >"$STATS_FILE"
-write_conf '# no delay during bounded recovery'
+write_conf '# no delay during bounded recovery' recovery
 startup
 injectmsg 10000 1
 export NUMMESSAGES=$((10001 - target_records))

--- a/tests/testsuites/da-engine-behavior-driver.sh
+++ b/tests/testsuites/da-engine-behavior-driver.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Shared pure disk-assisted queue behavior driver. The wrapper selects one
+# engine and this driver runs one queue placement (main, ruleset, or action).
+# A tiny queue with single-record, slowed dequeue must spill a 2000-message
+# burst. The engine-specific filesystem object proves the child was used; the
+# exact 0..1999 output sequence proves lossless ordered spill and drain.
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=2000
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
+DA_SCOPE=${DA_SCOPE:?DA_SCOPE must be main, ruleset, or action}
+DA_ENGINE=${DA_ENGINE:?DA_ENGINE must be auto or disk}
+SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
+
+wait_for_path() {
+	local path="$1"
+	local deadline=$((SECONDS + 30))
+	while [ ! -e "$path" ]; do
+		if [ "$SECONDS" -ge "$deadline" ]; then
+			find "$SPOOL_DIR" -maxdepth 2 -print 2>/dev/null || true
+			error_exit 1 "$DA_SCOPE DA child did not create $path"
+		fi
+		./msleep 25
+	done
+}
+
+wait_for_classic_segment() {
+	local deadline=$((SECONDS + 30))
+	while ! compgen -G "$SPOOL_DIR/scopeq.[0-9]*" >/dev/null; do
+		if [ "$SECONDS" -ge "$deadline" ]; then
+			find "$SPOOL_DIR" -maxdepth 1 -print 2>/dev/null || true
+			error_exit 1 "$DA_SCOPE classic DA child did not create a numeric segment"
+		fi
+		./msleep 25
+	done
+}
+
+if [ "$DA_ENGINE" = auto ]; then
+	ENGINE_CONFIG='queue.diskQueueType="auto"
+	queue.diskQueueIdleTimeout="-1"'
+	EXPECTED_ENGINE=segmentedDisk
+else
+	ENGINE_CONFIG='queue.diskQueueType="disk"'
+	EXPECTED_ENGINE=disk
+fi
+
+QUEUE_CONFIG='queue.type="LinkedList"
+	queue.filename="scopeq"
+	queue.size="50"
+	queue.highWatermark="10"
+	queue.lowWatermark="5"
+	queue.dequeueBatchSize="1"
+	queue.dequeueSlowdown="2"
+	'"$ENGINE_CONFIG"
+
+generate_conf
+case "$DA_SCOPE" in
+main)
+	add_conf '
+global(workDirectory="'"$SPOOL_DIR"'")
+main_queue(
+'"$QUEUE_CONFIG"'
+)
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
+'
+	;;
+ruleset)
+	add_conf '
+global(workDirectory="'"$SPOOL_DIR"'")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+ruleset(name="queued"
+'"$QUEUE_CONFIG"'
+) {
+	action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
+}
+:msg, contains, "msgnum:" call queued
+'
+	;;
+action)
+	add_conf '
+global(workDirectory="'"$SPOOL_DIR"'")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(
+	type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt"
+'"$QUEUE_CONFIG"'
+)
+'
+	;;
+*)
+	error_exit 1 "unknown DA_SCOPE: $DA_SCOPE"
+	;;
+esac
+
+startup
+injectmsg
+
+MARKER="$SPOOL_DIR/scopeq.da-engine"
+wait_for_path "$MARKER"
+[ "$(cat "$MARKER")" = "RSYSLOG-DA-ENGINE-V1 $EXPECTED_ENGINE" ] ||
+	error_exit 1 "$DA_SCOPE DA engine marker selected the wrong engine"
+if [ "$DA_ENGINE" = auto ]; then
+	wait_for_path "$SPOOL_DIR/scopeq.segq"
+else
+	wait_for_classic_segment
+fi
+
+wait_file_lines "$RSYSLOG_OUT_LOG" "$NUMMESSAGES" 300
+shutdown_when_empty
+wait_shutdown
+seq_check 0 1999
+exit_test

--- a/tests/testsuites/da-engine-behavior-driver.sh
+++ b/tests/testsuites/da-engine-behavior-driver.sh
@@ -7,7 +7,6 @@
 . ${srcdir:=.}/diag.sh init
 
 export NUMMESSAGES=2000
-export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 DA_SCOPE=${DA_SCOPE:?DA_SCOPE must be main, ruleset, or action}
 DA_ENGINE=${DA_ENGINE:?DA_ENGINE must be auto or disk}
 SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"

--- a/tests/testsuites/da-engine-behavior-driver.sh
+++ b/tests/testsuites/da-engine-behavior-driver.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Shared pure disk-assisted queue behavior driver. The wrapper selects one
-# engine and this driver runs one queue placement (main, ruleset, or action).
+# engine, memory queue type, and placement (main, ruleset, or action).
 # A tiny queue with single-record, slowed dequeue must spill a 2000-message
 # burst. The engine-specific filesystem object proves the child was used; the
 # exact 0..1999 output sequence proves lossless ordered spill and drain.
@@ -9,6 +9,7 @@
 export NUMMESSAGES=2000
 DA_SCOPE=${DA_SCOPE:?DA_SCOPE must be main, ruleset, or action}
 DA_ENGINE=${DA_ENGINE:?DA_ENGINE must be auto or disk}
+DA_QUEUE_TYPE=${DA_QUEUE_TYPE:?DA_QUEUE_TYPE must be LinkedList or FixedArray}
 SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
 
 wait_for_path() {
@@ -43,7 +44,7 @@ else
 	EXPECTED_ENGINE=disk
 fi
 
-QUEUE_CONFIG='queue.type="LinkedList"
+QUEUE_CONFIG='queue.type="'"$DA_QUEUE_TYPE"'"
 	queue.filename="scopeq"
 	queue.size="50"
 	queue.highWatermark="10"

--- a/tests/testsuites/da-engine-persist-driver.sh
+++ b/tests/testsuites/da-engine-persist-driver.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Shared DA save-on-shutdown/restart driver. The wrapper selects the memory
+# queue and disk engine. Single-record, deliberately slowed dequeue leaves a
+# durable spill at immediate shutdown; restart must recover every sequence.
+# Duplicates are accepted because an interrupted in-flight batch is replayable.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=2000
+DA_ENGINE=${DA_ENGINE:?DA_ENGINE must be auto or disk}
+DA_QUEUE_TYPE=${DA_QUEUE_TYPE:?DA_QUEUE_TYPE must be LinkedList or FixedArray}
+SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
+idle_config=
+if [ "$DA_ENGINE" = auto ]; then
+	idle_config='queue.diskQueueIdleTimeout="-1"'
+fi
+
+generate_conf
+# shellcheck disable=SC2090 # RainerScript quotes are intentionally retained.
+add_conf '
+global(workDirectory="'"$SPOOL_DIR"'")
+main_queue(queue.type="'"$DA_QUEUE_TYPE"'" queue.filename="mainq"
+	queue.size="6000" queue.highWatermark="10" queue.lowWatermark="5"
+	queue.dequeueBatchSize="1" queue.dequeueSlowdown="10000"
+	queue.timeoutShutdown="1000"
+	queue.saveOnShutdown="on"
+	queue.diskQueueType="'"$DA_ENGINE"'" '"$idle_config"')
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
+'
+
+startup
+injectmsg
+shutdown_immediate
+wait_shutdown
+if [ "$DA_ENGINE" = auto ]; then
+	[ -s "$SPOOL_DIR/mainq.segq/state" ] ||
+		error_exit 1 "segmented DA save-on-shutdown did not persist state"
+	content_check "RSYSLOG-DA-ENGINE-V1 segmentedDisk" "$SPOOL_DIR/mainq.da-engine"
+else
+	check_mainq_spool
+fi
+startup
+# Main-queue emptiness may be observed while the DA child is still draining.
+# Sequence completion is therefore the phase-two oracle and shutdown barrier.
+wait_seq_check 0 $((NUMMESSAGES - 1)) -d
+shutdown_when_empty
+wait_shutdown
+seq_check 0 $((NUMMESSAGES - 1)) -d
+exit_test

--- a/tests/testsuites/da-engine-retry-restart-driver.sh
+++ b/tests/testsuites/da-engine-retry-restart-driver.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Shared DA retry/restart driver. The wrapper selects the memory queue and disk
+# engine. A deliberately suspended omfile action must spill, survive an
+# immediate restart, and preserve retry-before-commit semantics. Exact sequence
+# coverage after the destination becomes writable proves no loss; duplicates
+# are accepted because a shutdown may replay an in-flight action batch.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1000
+DA_ENGINE=${DA_ENGINE:?DA_ENGINE must be auto or disk}
+DA_QUEUE_TYPE=${DA_QUEUE_TYPE:?DA_QUEUE_TYPE must be LinkedList or FixedArray}
+SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
+OUTPUT_DIR="$PWD/${RSYSLOG_DYNNAME}.missing"
+OUTPUT_FILE="$OUTPUT_DIR/output.log"
+
+wait_for_store() {
+	local deadline=$((SECONDS + 30))
+	while true; do
+		if [ "$DA_ENGINE" = auto ]; then
+			[ -s "$SPOOL_DIR/retryq.segq/state" ] && return
+		else
+			[ -s "$SPOOL_DIR/retryq.00000001" ] && return
+		fi
+		[ "$SECONDS" -lt "$deadline" ] ||
+			error_exit 1 "$DA_ENGINE DA store was not materialized"
+		./msleep 25
+	done
+}
+
+idle_config=
+if [ "$DA_ENGINE" = auto ]; then
+	idle_config='queue.diskQueueIdleTimeout="-1"'
+fi
+
+generate_conf
+# shellcheck disable=SC2090 # RainerScript quotes are intentionally retained.
+add_conf '
+global(workDirectory="'"$SPOOL_DIR"'")
+main_queue(queue.type="Direct")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" file="'"$OUTPUT_FILE"'" template="outfmt"
+	createDirs="off" action.resumeRetryCount="-1" action.resumeInterval="1"
+	queue.type="'"$DA_QUEUE_TYPE"'" queue.filename="retryq"
+	queue.size="2000" queue.highWatermark="10" queue.lowWatermark="5"
+	queue.dequeueBatchSize="1" queue.timeoutShutdown="10000" queue.saveOnShutdown="on"
+	queue.diskQueueType="'"$DA_ENGINE"'" '"$idle_config"')
+'
+
+startup
+injectmsg
+# The direct main queue makes completion of injectmsg the barrier proving that
+# every event reached the suspended action queue before immediate shutdown.
+wait_for_store
+shutdown_immediate
+wait_shutdown
+
+mkdir "$OUTPUT_DIR"
+startup
+wait_file_lines "$OUTPUT_FILE" "$NUMMESSAGES" 300
+shutdown_when_empty
+wait_shutdown
+RSYSLOG_OUT_LOG="$OUTPUT_FILE" seq_check 0 $((NUMMESSAGES - 1)) -d
+exit_test

--- a/tests/testsuites/segmented-da-idle-crash-driver.sh
+++ b/tests/testsuites/segmented-da-idle-crash-driver.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Shared idle-cleanup crash driver for a segmented disk-assisted main queue.
+# A small, slow memory tier guarantees a spill. The configured imdiag hook must
+# SIGKILL rsyslog during empty-store cleanup; restart must accept the surviving
+# marker/state combination and preserve the exact acknowledged sequence.
+. ${srcdir:=.}/diag.sh init
+: "${SEGDISK_IDLE_FAULT_POINT:?SEGDISK_IDLE_FAULT_POINT is required}"
+export NUMMESSAGES=1000
+export RSTB_IMDIAG_INJECT_DELAY_MODE=none
+SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
+
+write_conf() {
+	generate_conf
+	add_conf '
+global(workDirectory="'"$SPOOL_DIR"'")
+main_queue(queue.type="LinkedList" queue.filename="mainq"
+	queue.diskQueueType="segmentedDisk" queue.diskQueueIdleTimeout="0"
+	queue.size="50" queue.highWatermark="10" queue.lowWatermark="5"
+	queue.dequeueBatchSize="1" queue.dequeueSlowdown="2"
+	queue.checkpointInterval="1" queue.saveOnShutdown="on")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
+'
+}
+
+write_conf
+startup
+set_segmented_disk_fault "$SEGDISK_IDLE_FAULT_POINT"
+export RSTB_EXPECT_NO_PROPER_TERMINATION=YES
+crashed_pid=$(getpid)
+injectmsg 0 "$NUMMESSAGES" || true
+for _ in {1..600}; do
+	kill -0 "$crashed_pid" 2>/dev/null || break
+	./msleep 100
+done
+if kill -0 "$crashed_pid" 2>/dev/null; then
+	error_exit 1 "idle fault point did not terminate rsyslogd: $SEGDISK_IDLE_FAULT_POINT"
+fi
+wait "$crashed_pid" 2>/dev/null || true
+rm -f "$RSYSLOG_PIDBASE.pid"
+unset RSTB_EXPECT_NO_PROPER_TERMINATION
+
+write_conf
+startup
+shutdown_when_empty
+wait_shutdown
+seq_check 0 $((NUMMESSAGES - 1))
+[ -f "$SPOOL_DIR/mainq.da-engine" ] || error_exit 1 "engine marker missing after cleanup crash"
+exit_test

--- a/tests/testsuites/segmented-da-idle-crash-driver.sh
+++ b/tests/testsuites/segmented-da-idle-crash-driver.sh
@@ -39,7 +39,8 @@ for ((cycle = 0; cycle < SEGDISK_IDLE_FAULT_REPEATS; ++cycle)); do
 		./msleep 100
 	done
 	if kill -0 "$crashed_pid" 2>/dev/null; then
-		error_exit 1 "idle fault point did not terminate rsyslogd: $SEGDISK_IDLE_FAULT_POINT"
+		printf 'FAIL: idle fault point did not terminate rsyslogd: %s\n' "$SEGDISK_IDLE_FAULT_POINT"
+		error_exit 1
 	fi
 	wait "$crashed_pid" 2>/dev/null || true
 	rm -f "$RSYSLOG_PIDBASE.pid"
@@ -51,5 +52,8 @@ startup
 shutdown_when_empty
 wait_shutdown
 seq_check 0 $((NUMMESSAGES - 1))
-[ -f "$SPOOL_DIR/mainq.da-engine" ] || error_exit 1 "engine marker missing after cleanup crash"
+if [ ! -f "$SPOOL_DIR/mainq.da-engine" ]; then
+	printf 'FAIL: engine marker missing after cleanup crash\n'
+	error_exit 1
+fi
 exit_test

--- a/tests/testsuites/segmented-da-idle-crash-driver.sh
+++ b/tests/testsuites/segmented-da-idle-crash-driver.sh
@@ -5,7 +5,8 @@
 # marker/state combination and preserve the exact acknowledged sequence.
 . ${srcdir:=.}/diag.sh init
 : "${SEGDISK_IDLE_FAULT_POINT:?SEGDISK_IDLE_FAULT_POINT is required}"
-export NUMMESSAGES=1000
+SEGDISK_IDLE_FAULT_REPEATS=${SEGDISK_IDLE_FAULT_REPEATS:-1}
+export NUMMESSAGES=$((1000 * SEGDISK_IDLE_FAULT_REPEATS))
 export RSTB_IMDIAG_INJECT_DELAY_MODE=none
 SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
 
@@ -23,22 +24,27 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 '
 }
 
-write_conf
-startup
-set_segmented_disk_fault "$SEGDISK_IDLE_FAULT_POINT"
-export RSTB_EXPECT_NO_PROPER_TERMINATION=YES
-crashed_pid=$(getpid)
-injectmsg 0 "$NUMMESSAGES" || true
-for _ in {1..600}; do
-	kill -0 "$crashed_pid" 2>/dev/null || break
-	./msleep 100
+for ((cycle = 0; cycle < SEGDISK_IDLE_FAULT_REPEATS; ++cycle)); do
+	write_conf
+	startup
+	set_segmented_disk_fault "$SEGDISK_IDLE_FAULT_POINT"
+	export RSTB_EXPECT_NO_PROPER_TERMINATION=YES
+	crashed_pid=$(getpid)
+	# Every cycle appends a distinct range. This rematerializes the store if an
+	# earlier interrupted cleanup completed during restart and proves the armed
+	# fault state survives the unmaterialized child representation.
+	injectmsg $((cycle * 1000)) 1000 || true
+	for _ in {1..600}; do
+		kill -0 "$crashed_pid" 2>/dev/null || break
+		./msleep 100
+	done
+	if kill -0 "$crashed_pid" 2>/dev/null; then
+		error_exit 1 "idle fault point did not terminate rsyslogd: $SEGDISK_IDLE_FAULT_POINT"
+	fi
+	wait "$crashed_pid" 2>/dev/null || true
+	rm -f "$RSYSLOG_PIDBASE.pid"
+	unset RSTB_EXPECT_NO_PROPER_TERMINATION
 done
-if kill -0 "$crashed_pid" 2>/dev/null; then
-	error_exit 1 "idle fault point did not terminate rsyslogd: $SEGDISK_IDLE_FAULT_POINT"
-fi
-wait "$crashed_pid" 2>/dev/null || true
-rm -f "$RSYSLOG_PIDBASE.pid"
-unset RSTB_EXPECT_NO_PROPER_TERMINATION
 
 write_conf
 startup

--- a/tests/unit/queue_da_test.c
+++ b/tests/unit/queue_da_test.c
@@ -1,0 +1,105 @@
+/*
+ * Unit coverage for disk-assisted engine selection and its durable marker.
+ * Each case builds an exact temporary spool layout; the oracle is the chosen
+ * engine or an explicit rejection, so no daemon timing is involved.
+ */
+#include "config.h"
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include "queue_da.h"
+
+/* Keep this internal helper unit-testable without linking the queue runtime. */
+#include "../../runtime/queue_da.c"
+
+#define CHECK(condition)                                                                    \
+    do {                                                                                    \
+        if (!(condition)) {                                                                 \
+            fprintf(stderr, "CHECK failed at %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+            exit(1);                                                                        \
+        }                                                                                   \
+    } while (0)
+
+static void touch_file(const char *dir, const char *name, const char *contents) {
+    char path[512];
+    CHECK(snprintf(path, sizeof(path), "%s/%s", dir, name) < (int)sizeof(path));
+    const int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    CHECK(fd >= 0);
+    if (contents != NULL) CHECK(write(fd, contents, strlen(contents)) == (ssize_t)strlen(contents));
+    CHECK(close(fd) == 0);
+}
+
+static qda_engine_result_t resolve(
+    const char *dir, qda_engine_mode_t requested, sbool auto_upgrade, sbool classic_features, rsRetVal expected) {
+    const qda_engine_config_t config = {
+        .spool_dir = dir,
+        .file_prefix = "queue",
+        .requested = requested,
+        .auto_upgrade = auto_upgrade,
+        .requires_classic_features = classic_features,
+    };
+    qda_engine_result_t result;
+    CHECK(qdaEngineResolve(&config, &result) == expected);
+    return result;
+}
+
+int main(void) {
+    char root[] = "/tmp/rsyslog-qda-unit-XXXXXX";
+    CHECK(mkdtemp(root) != NULL);
+
+    qda_engine_result_t result = resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_OK);
+    CHECK(result.effective == QDA_ENGINE_SEGMENTED_DISK);
+    CHECK(result.reason == QDA_REASON_FRESH_DEFAULT);
+
+    result = resolve(root, QDA_ENGINE_AUTO, 0, 1, RS_RET_OK);
+    CHECK(result.effective == QDA_ENGINE_DISK);
+    CHECK(result.reason == QDA_REASON_CLASSIC_FEATURE);
+    resolve(root, QDA_ENGINE_SEGMENTED_DISK, 0, 1, RS_RET_INVALID_VALUE);
+
+    touch_file(root, "queue.qi", "classic");
+    result = resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_OK);
+    CHECK(result.effective == QDA_ENGINE_DISK && result.classic_data);
+    CHECK(resolve(root, QDA_ENGINE_SEGMENTED_DISK, 0, 0, RS_RET_INVALID_VALUE).classic_data);
+    char path[512];
+    CHECK(snprintf(path, sizeof(path), "%s/queue.qi", root) < (int)sizeof(path));
+    CHECK(unlink(path) == 0);
+
+    touch_file(root, "queue.0000001", "classic segment");
+    result = resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_OK);
+    CHECK(result.effective == QDA_ENGINE_DISK && result.classic_data);
+    CHECK(snprintf(path, sizeof(path), "%s/queue.0000001", root) < (int)sizeof(path));
+    CHECK(unlink(path) == 0);
+
+    CHECK(qdaEngineWriteMarker(root, "queue", QDA_ENGINE_DISK) == RS_RET_OK);
+    result = resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_OK);
+    CHECK(result.effective == QDA_ENGINE_DISK && result.reason == QDA_REASON_MARKER);
+    result = resolve(root, QDA_ENGINE_AUTO, 1, 0, RS_RET_OK);
+    CHECK(result.effective == QDA_ENGINE_SEGMENTED_DISK && result.reason == QDA_REASON_AUTO_UPGRADE);
+    CHECK(qdaEngineWriteMarker(root, "queue", QDA_ENGINE_SEGMENTED_DISK) == RS_RET_OK);
+    result = resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_OK);
+    CHECK(result.effective == QDA_ENGINE_SEGMENTED_DISK && result.marker_present);
+
+    CHECK(snprintf(path, sizeof(path), "%s/queue.segq", root) < (int)sizeof(path));
+    CHECK(mkdir(path, 0700) == 0);
+    result = resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_OK);
+    CHECK(result.effective == QDA_ENGINE_SEGMENTED_DISK && result.segmented_data);
+    resolve(root, QDA_ENGINE_DISK, 0, 0, RS_RET_INVALID_VALUE);
+    touch_file(root, "queue.1", "classic segment");
+    resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_INVALID_VALUE);
+    CHECK(snprintf(path, sizeof(path), "%s/queue.1", root) < (int)sizeof(path));
+    CHECK(unlink(path) == 0);
+    CHECK(snprintf(path, sizeof(path), "%s/queue.segq", root) < (int)sizeof(path));
+    CHECK(rmdir(path) == 0);
+
+    touch_file(root, "queue.da-engine", "bad marker\n");
+    resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_INVALID_VALUE);
+    CHECK(snprintf(path, sizeof(path), "%s/queue.da-engine", root) < (int)sizeof(path));
+    CHECK(unlink(path) == 0);
+    CHECK(rmdir(root) == 0);
+
+    puts("disk-assisted engine resolver tests passed");
+    return 0;
+}

--- a/tests/unit/queue_da_test.c
+++ b/tests/unit/queue_da_test.c
@@ -32,6 +32,19 @@ static void touch_file(const char *dir, const char *name, const char *contents) 
     CHECK(close(fd) == 0);
 }
 
+static void check_file_contents(const char *dir, const char *name, const char *expected) {
+    char path[512];
+    char contents[128];
+    CHECK(snprintf(path, sizeof(path), "%s/%s", dir, name) < (int)sizeof(path));
+    const int fd = open(path, O_RDONLY);
+    CHECK(fd >= 0);
+    const ssize_t len = read(fd, contents, sizeof(contents) - 1);
+    CHECK(len >= 0);
+    contents[len] = '\0';
+    CHECK(close(fd) == 0);
+    CHECK(strcmp(contents, expected) == 0);
+}
+
 static qda_engine_result_t resolve(
     const char *dir, qda_engine_mode_t requested, sbool auto_upgrade, sbool classic_features, rsRetVal expected) {
     const qda_engine_config_t config = {
@@ -49,6 +62,23 @@ static qda_engine_result_t resolve(
 int main(void) {
     char root[] = "/tmp/rsyslog-qda-unit-XXXXXX";
     CHECK(mkdtemp(root) != NULL);
+
+    const qda_lifecycle_config_t lifecycle = {
+        .engine = QDA_ENGINE_AUTO,
+        .auto_upgrade = 0,
+        .idle_timeout = 60000,
+    };
+    qda_lifecycle_config_t changed = lifecycle;
+    CHECK(qdaLifecycleConfigEqual(&lifecycle, &changed));
+    changed.engine = QDA_ENGINE_DISK;
+    CHECK(!qdaLifecycleConfigEqual(&lifecycle, &changed));
+    changed = lifecycle;
+    changed.auto_upgrade = 1;
+    CHECK(!qdaLifecycleConfigEqual(&lifecycle, &changed));
+    changed = lifecycle;
+    changed.idle_timeout = -1;
+    CHECK(!qdaLifecycleConfigEqual(&lifecycle, &changed));
+    CHECK(!qdaLifecycleConfigEqual(NULL, &changed));
 
     qda_engine_result_t result = resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_OK);
     CHECK(result.effective == QDA_ENGINE_SEGMENTED_DISK);
@@ -74,6 +104,8 @@ int main(void) {
     CHECK(unlink(path) == 0);
 
     CHECK(qdaEngineWriteMarker(root, "queue", QDA_ENGINE_DISK) == RS_RET_OK);
+    CHECK(qdaEngineWriteMarker(root, "queue", QDA_ENGINE_AUTO) == RS_RET_PARAM_ERROR);
+    CHECK(qdaEngineWriteMarker(root, "queue", (qda_engine_mode_t)99) == RS_RET_PARAM_ERROR);
     result = resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_OK);
     CHECK(result.effective == QDA_ENGINE_DISK && result.reason == QDA_REASON_MARKER);
     /* A marker without state or segments records an empty former engine, not
@@ -83,7 +115,17 @@ int main(void) {
     CHECK(result.effective == QDA_ENGINE_SEGMENTED_DISK && result.reason == QDA_REASON_CONFIGURED);
     result = resolve(root, QDA_ENGINE_AUTO, 1, 0, RS_RET_OK);
     CHECK(result.effective == QDA_ENGINE_SEGMENTED_DISK && result.reason == QDA_REASON_AUTO_UPGRADE);
+
+    /* Model a crash-left temporary marker from this process. The atomic
+     * replacement helper must remove it, durably replace the live marker, and
+     * leave no temporary name that could confuse a later restart. */
+    char tmp_name[128];
+    CHECK(snprintf(tmp_name, sizeof(tmp_name), "queue.da-engine.tmp.%ld", (long)getpid()) < (int)sizeof(tmp_name));
+    touch_file(root, tmp_name, "incomplete marker");
     CHECK(qdaEngineWriteMarker(root, "queue", QDA_ENGINE_SEGMENTED_DISK) == RS_RET_OK);
+    check_file_contents(root, "queue.da-engine", "RSYSLOG-DA-ENGINE-V1 segmentedDisk\n");
+    CHECK(snprintf(path, sizeof(path), "%s/%s", root, tmp_name) < (int)sizeof(path));
+    CHECK(access(path, F_OK) != 0);
     result = resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_OK);
     CHECK(result.effective == QDA_ENGINE_SEGMENTED_DISK && result.marker_present);
     result = resolve(root, QDA_ENGINE_DISK, 0, 0, RS_RET_OK);

--- a/tests/unit/queue_da_test.c
+++ b/tests/unit/queue_da_test.c
@@ -76,11 +76,18 @@ int main(void) {
     CHECK(qdaEngineWriteMarker(root, "queue", QDA_ENGINE_DISK) == RS_RET_OK);
     result = resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_OK);
     CHECK(result.effective == QDA_ENGINE_DISK && result.reason == QDA_REASON_MARKER);
+    /* A marker without state or segments records an empty former engine, not
+     * a backlog. An explicit selector may therefore replace it for the next
+     * materialization; the data-conflict cases above and below must reject. */
+    result = resolve(root, QDA_ENGINE_SEGMENTED_DISK, 0, 0, RS_RET_OK);
+    CHECK(result.effective == QDA_ENGINE_SEGMENTED_DISK && result.reason == QDA_REASON_CONFIGURED);
     result = resolve(root, QDA_ENGINE_AUTO, 1, 0, RS_RET_OK);
     CHECK(result.effective == QDA_ENGINE_SEGMENTED_DISK && result.reason == QDA_REASON_AUTO_UPGRADE);
     CHECK(qdaEngineWriteMarker(root, "queue", QDA_ENGINE_SEGMENTED_DISK) == RS_RET_OK);
     result = resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_OK);
     CHECK(result.effective == QDA_ENGINE_SEGMENTED_DISK && result.marker_present);
+    result = resolve(root, QDA_ENGINE_DISK, 0, 0, RS_RET_OK);
+    CHECK(result.effective == QDA_ENGINE_DISK && result.reason == QDA_REASON_CONFIGURED);
 
     CHECK(snprintf(path, sizeof(path), "%s/queue.segq", root) < (int)sizeof(path));
     CHECK(mkdir(path, 0700) == 0);

--- a/tests/unit/queue_da_test.c
+++ b/tests/unit/queue_da_test.c
@@ -55,6 +55,8 @@ static qda_engine_result_t resolve(
         .requires_classic_features = classic_features,
     };
     qda_engine_result_t result;
+    /* Callers may ignore the returned result for rejection cases because this
+     * helper itself makes the return-code expectation a fatal test oracle. */
     CHECK(qdaEngineResolve(&config, &result) == expected);
     return result;
 }
@@ -128,6 +130,8 @@ int main(void) {
     CHECK(access(path, F_OK) != 0);
     result = resolve(root, QDA_ENGINE_AUTO, 0, 0, RS_RET_OK);
     CHECK(result.effective == QDA_ENGINE_SEGMENTED_DISK && result.marker_present);
+    result = resolve(root, QDA_ENGINE_AUTO, 0, 1, RS_RET_OK);
+    CHECK(result.effective == QDA_ENGINE_DISK && result.reason == QDA_REASON_CLASSIC_FEATURE);
     result = resolve(root, QDA_ENGINE_DISK, 0, 0, RS_RET_OK);
     CHECK(result.effective == QDA_ENGINE_DISK && result.reason == QDA_REASON_CONFIGURED);
 

--- a/tests/yaml-segmented-da-config-errors.sh
+++ b/tests/yaml-segmented-da-config-errors.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Verify YAML uses the same DA parameter validation as RainerScript. A
+# segmented-only queue is an invalid context: permissive validation must retain
+# startup compatibility while reporting the dirty configuration, and strict
+# validation must reject it. Explicit classic options that have no effect are
+# likewise rejected in strict mode.
+. ${srcdir:=.}/diag.sh init
+
+assert_contains() {
+	grep -Fq "$2" "$1" || {
+		cat "$1"
+		error_exit 1 "missing expected YAML diagnostic: $2"
+	}
+}
+
+write_loader() {
+	generate_conf
+	add_conf 'include(file="'${TESTCONF_NM}'.yaml")'
+	rm -f "${TESTCONF_NM}.yaml"
+}
+
+validate_permissive_context() {
+	write_loader
+	add_yaml_conf 'global:'
+	add_yaml_conf '  workDirectory: "'${RSYSLOG_DYNNAME}'.spool"'
+	add_yaml_conf 'mainqueue:'
+	add_yaml_conf '  queue.type: segmentedDisk'
+	add_yaml_conf '  queue.filename: mainq'
+	add_yaml_conf '  queue.diskQueueType: disk'
+	add_yaml_conf '  queue.diskQueueAutoUpgrade: on'
+	add_yaml_conf '  queue.diskQueueIdleTimeout: 25'
+	local out="${RSYSLOG_DYNNAME}.yaml-permissive.log"
+	export RS_REDIR=">\"$out\" 2>&1"
+	startup
+	shutdown_when_empty
+	wait_shutdown
+	unset RS_REDIR
+	assert_contains "$out" 'apply only to FixedArray or LinkedList disk-assisted queues'
+}
+
+validate_strict_options() {
+	write_loader
+	add_yaml_conf 'global:'
+	add_yaml_conf '  abortOnUncleanConfig: on'
+	add_yaml_conf '  workDirectory: "'${RSYSLOG_DYNNAME}'.spool"'
+	add_yaml_conf 'mainqueue:'
+	add_yaml_conf '  queue.type: FixedArray'
+	add_yaml_conf '  queue.filename: mainq'
+	add_yaml_conf '  queue.diskQueueType: disk'
+	add_yaml_conf '  queue.diskQueueAutoUpgrade: on'
+	add_yaml_conf '  queue.diskQueueIdleTimeout: 25'
+	local out="${RSYSLOG_DYNNAME}.yaml-strict.log"
+	if ../tools/rsyslogd -C -N1 -f"${TESTCONF_NM}.conf" -M../runtime/.libs:../.libs >"$out" 2>&1; then
+		error_exit 1 "strict meaningless YAML DA options unexpectedly passed"
+	fi
+	assert_contains "$out" 'queue.diskQueueAutoUpgrade applies only'
+	assert_contains "$out" 'queue.diskQueueIdleTimeout does not apply'
+}
+
+validate_permissive_context
+validate_strict_options
+exit_test

--- a/tests/yaml-segmented-da-config.sh
+++ b/tests/yaml-segmented-da-config.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Verify YAML reaches the shared DA queue parameter backend. A fresh LinkedList
+# main queue selects the fresh auto default with idle cleanup disabled. The
+# absence of both marker and .segq proves selection remained fully
+# unmaterialized before any spill; exact output proves memory-first operation.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=20
+
+generate_conf
+add_conf '
+include(file="'${TESTCONF_NM}'.yaml")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt" file="'${RSYSLOG_OUT_LOG}'")
+'
+rm -f "${TESTCONF_NM}.yaml"
+add_yaml_conf 'global:'
+add_yaml_conf '  workDirectory: "'${RSYSLOG_DYNNAME}'.spool"'
+add_yaml_conf 'mainqueue:'
+add_yaml_conf '  queue.type: LinkedList'
+add_yaml_conf '  queue.filename: mainq'
+add_yaml_conf '  queue.diskQueueType: auto'
+add_yaml_conf '  queue.diskQueueAutoUpgrade: off'
+add_yaml_conf '  queue.diskQueueIdleTimeout: -1'
+
+startup
+injectmsg
+wait_file_lines "$RSYSLOG_OUT_LOG" "$NUMMESSAGES"
+[ ! -e "${RSYSLOG_DYNNAME}.spool/mainq.da-engine" ] || error_exit 1 "YAML DA marker created without a spill"
+[ ! -e "${RSYSLOG_DYNNAME}.spool/mainq.segq" ] || error_exit 1 "YAML DA queue materialized without a spill"
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test


### PR DESCRIPTION
## Summary

This is an interim draft for segmented disk-assisted queue support.

It makes the segmented store the default disk engine for fresh FixedArray and
LinkedList disk-assisted queues while preserving existing classic disk
backlogs. The selected engine is recorded in a durable `.da-engine` marker,
and explicit classic or segmented selection remains available.

Segmented DA children are created lazily on first spill. Once drained, they can
remove their empty store and terminate the final disk worker after the
configured idle interval; a later spill recreates both transparently.

## Main changes

- Add `queue.diskQueueType="auto|disk|segmentedDisk"`.
- Add `queue.diskQueueAutoUpgrade="off|on"`.
- Add `queue.diskQueueIdleTimeout`, defaulting to 60000 ms.
- Detect classic `.qi` and numeric segment backlogs and select classic disk in
  auto mode with a warning.
- Reject malformed markers, mixed stores, and explicit engine/data conflicts.
- Keep fresh segmented DA children unmaterialized until their first spill.
- Add crash-safe segmented idle dematerialization and later rematerialization.
- Give the final segmented DA worker an independent idle lifetime without
  changing generic worker shutdown semantics.
- Route imdiag segmented fault commands from a DA parent to its disk child.
- Add impstats counters for materialization and idle cleanup outcomes.
- Document both RainerScript and YAML configuration behavior.

## Compatibility and safety

No records are converted between engines. Existing classic state remains
sticky in auto mode. Auto-upgrade can select segmented storage only on a later
restart after the classic store has drained cleanly.

Idle cleanup publishes durable cleanup intent before deleting anything,
removes segments before state, and remains restart-recoverable at every tested
crash point. Operational `.qi` read failures are not treated as corruption;
only deterministic structural errors enter safe-mode quarantine.

## Validation

- RSYSLOG_LOCAL_BUILD_JOBS=60
- RSYSLOG_LOCAL_CHECK_JOBS=60
- focused and repeated segmented/classic DA behavior, transition, event,
  recovery, crash, idle, max-disk-space, and multi-worker tests
- complete DA matrix repeated at concurrency 60
- code formatting, Python style, shell, and test-antipattern checks
- mock distcheck and strict documentation build
- final change-gated Ubuntu 26.04 container run: 1486 passed, 29 expected
  skips, 0 failures out of 1515 tests
- SAN run: 1287 passed, 31 skipped, 0 failed out of 1318 tests
- TSAN run: 1205 passed, 46 skipped, 0 failed out of 1251 tests
- static analyzer: no bugs found
- memory, concurrency, and test prompt audits completed
- local Cubic review: no issues found

The complete planned implementation and coverage are present. The PR remains
in draft only while the refreshed hosted checks finish.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

