### PR TITLE
queue: document DA engine internals

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -714,8 +714,20 @@ static rsRetVal qqueueChkIsDA(qqueue_t *pThis) {
 }
 
 
-/* Start disk-assisted queue mode.
- * rgerhards, 2008-01-15
+/**
+ * @brief Construct and configure the persistent child of a memory-first DA queue.
+ *
+ * Disk-assisted queues have an in-memory parent and a separate child that
+ * receives overflow. The resolver chooses the child's concrete store before
+ * construction, preserving legacy backlogs and rejecting mixed stores rather
+ * than attempting in-place conversion. For a fresh segmented child, this
+ * routine deliberately leaves the store unmaterialized: the marker, .segq
+ * directory, state file, and disk worker are created only on the first spill.
+ *
+ * The durable marker is published before opening existing data or replacing a
+ * drained classic selection. A fresh child instead carries marker-pending
+ * state until its first append, which keeps normal memory-only operation free
+ * of disk artifacts while still preventing a later engine ambiguity.
  */
 static rsRetVal StartDA(qqueue_t *pThis) {
     DEFiRet;
@@ -1159,6 +1171,15 @@ static void qqueueAddPhysicalQueueSize(qqueue_t *pThis, const int nElem) {
 #endif
 }
 
+/**
+ * @brief Open the segmented store backing a pure or disk-assisted queue.
+ *
+ * The same store implementation backs eager pure segmentedDisk queues and
+ * lazy DA children. For the latter, lazy_create allows open to succeed without
+ * creating files; qAddSegDisk() materializes them when overflow actually
+ * occurs. Recovered logical count is reflected in both child and overall queue
+ * accounting before workers are advised.
+ */
 static rsRetVal qConstructSegDisk(qqueue_t *pThis) {
     segdisk_store_config_t cfg = {
         .work_dir = (const char *)pThis->pszSpoolDir,
@@ -1188,6 +1209,16 @@ static rsRetVal qDestructSegDisk(qqueue_t *pThis) {
     return segdiskStoreClose(&pThis->tVars.segdisk, getPhysicalQueueSize(pThis) == 0);
 }
 
+/**
+ * @brief Serialize one message into a segmented store and account for DA activity.
+ *
+ * A lazy DA child must durably claim segmentedDisk before its first append can
+ * create .segq. The marker write therefore precedes serialization and remains
+ * pending after a failure. A successful DA append increments the parent
+ * activity generation, invalidating any in-progress idle-dematerialization
+ * grace period. The store consumes no message reference, so this function
+ * always destroys the queue-owned reference before returning.
+ */
 static rsRetVal qAddSegDisk(qqueue_t *pThis, smsg_t *pMsg) {
     DEFiRet;
     if (pThis->daEngineMarkerPending) {

--- a/runtime/queue_da.c
+++ b/runtime/queue_da.c
@@ -1,26 +1,24 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /*
- * Copyright 2008-2026 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2026 Rainer Gerhards and Adiscon GmbH.
  *
- * This file is part of the rsyslog runtime library.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The rsyslog runtime library is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * The rsyslog runtime library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with the rsyslog runtime library. If not, see <http://www.gnu.org/licenses/>.
- *
- * A copy of the GPL can be found in the file "COPYING" in this distribution.
- * A copy of the LGPL can be found in the file "COPYING.LESSER" in this distribution.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-/* Disk-assisted queue engine selection and durable marker handling. */
+/**
+ * @file queue_da.c
+ * @brief Resolves disk-assisted child engines and maintains their durable markers.
+ *
+ * This internal implementation selects the classic or segmented disk child for
+ * a disk-assisted queue from its configuration, marker, and existing spool
+ * contents. It also provides the crash-safe marker operations that preserve
+ * the selected engine across restarts.
+ */
 #include "config.h"
 
 #include <dirent.h>
@@ -35,8 +33,18 @@
 
 #include "queue_da.h"
 
+/* The marker format is intentionally independent of either queue payload
+ * format. Its version identifies only the selection record, allowing future
+ * engine-policy changes to reject rather than misinterpret an old marker. */
 #define QDA_MARKER_MAGIC "RSYSLOG-DA-ENGINE-V1 "
 
+/**
+ * @brief Allocate a path in a queue's persistent namespace.
+ *
+ * The caller owns *path on success and must free it. Keeping path assembly in
+ * one helper makes all engine probes use the exact same prefix and suffix
+ * convention.
+ */
 static rsRetVal make_path(char **path, const char *dir, const char *prefix, const char *suffix) {
     if (asprintf(path, "%s/%s%s", dir, prefix, suffix) < 0) {
         *path = NULL;
@@ -45,6 +53,7 @@ static rsRetVal make_path(char **path, const char *dir, const char *prefix, cons
     return RS_RET_OK;
 }
 
+/** @brief Test whether a named path exists without following a queue policy. */
 static rsRetVal path_exists(const char *path, sbool *exists) {
     struct stat st;
     if (lstat(path, &st) == 0) {
@@ -58,6 +67,12 @@ static rsRetVal path_exists(const char *path, sbool *exists) {
     return RS_RET_IO_ERROR;
 }
 
+/**
+ * @brief Recognize only legacy numeric segment names for the supplied prefix.
+ *
+ * A numeric segment is classic-engine evidence even when the .qi index is
+ * gone. Non-numeric lookalikes must not make AUTO select classic.
+ */
 static sbool is_classic_segment_name(const char *name, const char *prefix) {
     const size_t prefix_len = strlen(prefix);
     if (strncmp(name, prefix, prefix_len) != 0 || name[prefix_len] != '.') return 0;
@@ -69,6 +84,13 @@ static sbool is_classic_segment_name(const char *name, const char *prefix) {
     return 1;
 }
 
+/**
+ * @brief Probe for classic numeric segments and fail closed on an incomplete scan.
+ *
+ * This is the one namespace enumeration in engine selection. A close or
+ * readdir error is treated as an I/O failure rather than as an empty store:
+ * choosing the wrong engine could otherwise strand persistent records.
+ */
 static rsRetVal find_classic_segments(const char *dir, const char *prefix, sbool *found) {
     DIR *d = opendir(dir);
     if (d == NULL) return errno == ENOENT ? RS_RET_FILE_NOT_FOUND : RS_RET_IO_ERROR;
@@ -109,6 +131,14 @@ sbool qdaLifecycleConfigEqual(const qda_lifecycle_config_t *left, const qda_life
            left->auto_upgrade == right->auto_upgrade && left->idle_timeout == right->idle_timeout;
 }
 
+/**
+ * @brief Read and validate a durable engine marker without following symlinks.
+ *
+ * Markers are deliberately tiny regular files with an exact versioned payload.
+ * A malformed, truncated, oversized, or unsafe marker is rejected instead of
+ * silently reverting to automatic detection, because it represents an
+ * ambiguous persistent-engine decision.
+ */
 static rsRetVal read_marker(const char *path, sbool *present, qda_engine_mode_t *engine) {
     char buf[64];
     *present = 0;
@@ -243,6 +273,7 @@ done:
     return r;
 }
 
+/** @brief Write a complete marker payload, retrying only interrupted writes. */
 static rsRetVal write_all(int fd, const char *buf, size_t len) {
     size_t off = 0;
     while (off < len) {
@@ -257,6 +288,13 @@ static rsRetVal write_all(int fd, const char *buf, size_t len) {
     return RS_RET_OK;
 }
 
+/**
+ * @brief Synchronize marker content before its atomic rename.
+ *
+ * fdatasync is sufficient where it is available because the marker's inode
+ * metadata is established by the following rename and directory sync. macOS
+ * falls back to fsync for portability.
+ */
 static int sync_file_data(const int fd) {
 #if defined(HAVE_FDATASYNC) && !defined(__APPLE__)
     return fdatasync(fd);
@@ -265,6 +303,13 @@ static int sync_file_data(const int fd) {
 #endif
 }
 
+/**
+ * @brief Synchronize a marker rename while tolerating unsupported directory fsync.
+ *
+ * Some supported filesystems report EINVAL or ENOTSUP for directory fsync.
+ * Treating only those responses as success preserves the strongest available
+ * durability guarantee without making otherwise usable spool filesystems fail.
+ */
 static rsRetVal sync_directory(const int fd) {
     return fsync(fd) == 0 || errno == EINVAL || errno == ENOTSUP ? RS_RET_OK : RS_RET_IO_ERROR;
 }

--- a/runtime/queue_da.h
+++ b/runtime/queue_da.h
@@ -1,71 +1,155 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /*
- * Copyright 2008-2026 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2026 Rainer Gerhards and Adiscon GmbH.
  *
- * This file is part of the rsyslog runtime library.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The rsyslog runtime library is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * The rsyslog runtime library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with the rsyslog runtime library. If not, see <http://www.gnu.org/licenses/>.
- *
- * A copy of the GPL can be found in the file "COPYING" in this distribution.
- * A copy of the LGPL can be found in the file "COPYING.LESSER" in this distribution.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-/* Internal disk-assisted queue engine selection helpers. */
+/**
+ * @file queue_da.h
+ * @brief Internal API for disk-assisted queue engine selection and markers.
+ *
+ * These declarations encapsulate automatic classic-versus-segmented selection,
+ * the persistent engine marker, and reload-lifecycle comparison for
+ * disk-assisted child queues.
+ */
 #ifndef INCLUDED_QUEUE_DA_H
 #define INCLUDED_QUEUE_DA_H
 
 #include "rsyslog.h"
 
-typedef enum qda_engine_mode_e { QDA_ENGINE_AUTO = 0, QDA_ENGINE_DISK, QDA_ENGINE_SEGMENTED_DISK } qda_engine_mode_t;
+/**
+ * @brief Configurable disk-store engine choices for a disk-assisted child.
+ *
+ * AUTO is a policy, not a persistent engine: qdaEngineResolve() maps it to
+ * either DISK or SEGMENTED_DISK using existing spool data, the durable marker,
+ * and features unsupported by the segmented store. Only the two concrete
+ * values may be persisted in a marker.
+ */
+typedef enum qda_engine_mode_e {
+    QDA_ENGINE_AUTO = 0, /**< Select a compatible concrete engine at startup. */
+    QDA_ENGINE_DISK, /**< Use the established .qi and numeric-segment store. */
+    QDA_ENGINE_SEGMENTED_DISK /**< Use the segmented .segq store. */
+} qda_engine_mode_t;
 
+/**
+ * @brief Evidence that determined the selected effective engine.
+ *
+ * The reason is retained for diagnostics and warning policy. It records the
+ * decisive input, not every probe performed while resolving the engine.
+ */
 typedef enum qda_selection_reason_e {
-    QDA_REASON_CONFIGURED = 0,
-    QDA_REASON_FRESH_DEFAULT,
-    QDA_REASON_MARKER,
-    QDA_REASON_CLASSIC_DATA,
-    QDA_REASON_SEGMENTED_DATA,
-    QDA_REASON_CLASSIC_FEATURE,
-    QDA_REASON_AUTO_UPGRADE
+    QDA_REASON_CONFIGURED = 0, /**< An explicit concrete selector chose it. */
+    QDA_REASON_FRESH_DEFAULT, /**< No prior store exists; choose segmented. */
+    QDA_REASON_MARKER, /**< A retained marker keeps the empty queue sticky. */
+    QDA_REASON_CLASSIC_DATA, /**< Classic state or numeric segments exist. */
+    QDA_REASON_SEGMENTED_DATA, /**< Segmented state directory exists. */
+    QDA_REASON_CLASSIC_FEATURE, /**< Requested options require the classic store. */
+    QDA_REASON_AUTO_UPGRADE /**< A clean classic marker permits a restart upgrade. */
 } qda_selection_reason_t;
 
+/**
+ * @brief Inputs used to choose a disk-assisted child engine.
+ *
+ * spool_dir and file_prefix identify the parent queue's persistent namespace.
+ * The resolver examines only this namespace; it never creates, modifies, or
+ * migrates a store. requires_classic_features is true for settings that the
+ * segmented store intentionally does not implement (currently encryption or
+ * an unsafe corruption policy).
+ */
 typedef struct qda_engine_config_s {
-    const char *spool_dir;
-    const char *file_prefix;
-    qda_engine_mode_t requested;
-    sbool auto_upgrade;
-    sbool requires_classic_features;
+    const char *spool_dir; /**< Existing workDirectory; not owned by this object. */
+    const char *file_prefix; /**< Queue filename prefix within spool_dir; not owned. */
+    qda_engine_mode_t requested; /**< AUTO or an explicit concrete engine. */
+    sbool auto_upgrade; /**< Permit a drained classic AUTO queue to switch at restart. */
+    sbool requires_classic_features; /**< Force classic in AUTO; reject explicit segmented. */
 } qda_engine_config_t;
 
+/**
+ * @brief Result and probe observations returned by qdaEngineResolve().
+ *
+ * The data-presence fields deliberately distinguish compatibility evidence
+ * from the chosen engine. Callers use them to decide when a marker must be
+ * replaced before a child is materialized. The structure is initialized by
+ * qdaEngineResolve() and is meaningful only when that function succeeds.
+ */
 typedef struct qda_engine_result_s {
-    qda_engine_mode_t effective;
-    qda_selection_reason_t reason;
-    sbool classic_data;
-    sbool segmented_data;
-    sbool marker_present;
-    qda_engine_mode_t marker_engine;
+    qda_engine_mode_t effective; /**< Concrete engine to instantiate. */
+    qda_selection_reason_t reason; /**< Decisive selection evidence. */
+    sbool classic_data; /**< .qi or numeric classic segments were found. */
+    sbool segmented_data; /**< .segq directory was found. */
+    sbool marker_present; /**< A valid .da-engine marker was read. */
+    qda_engine_mode_t marker_engine; /**< Concrete engine recorded in that marker. */
 } qda_engine_result_t;
 
-/* Fields which determine whether a disk-assisted queue can retain its
- * existing child across a configuration reload. */
+/**
+ * @brief Configuration that controls a disk-assisted child's identity.
+ *
+ * Changing any field requires rebuilding the child on reload. These values
+ * are deliberately separate from generic queue settings: they determine
+ * persistent-store compatibility and idle dematerialization semantics.
+ */
 typedef struct qda_lifecycle_config_s {
-    qda_engine_mode_t engine;
-    sbool auto_upgrade;
-    int idle_timeout;
+    qda_engine_mode_t engine; /**< Configured selector, including AUTO. */
+    sbool auto_upgrade; /**< AUTO-only clean-drain upgrade policy. */
+    int idle_timeout; /**< Segmented child idle lifetime in milliseconds. */
 } qda_lifecycle_config_t;
 
+/**
+ * @brief Resolve the concrete engine for a disk-assisted child without writing.
+ *
+ * Precedence is intentionally data-first: mixed stores and malformed markers
+ * fail, existing classic or segmented data keeps its compatible engine, then
+ * unsupported segmented features force classic in AUTO mode. A valid marker
+ * makes an otherwise empty queue sticky, except when AUTO upgrade is enabled
+ * and the old classic store has demonstrably drained. A fresh AUTO queue
+ * resolves to segmentedDisk.
+ *
+ * @param config Non-NULL selection inputs and spool namespace.
+ * @param result Non-NULL output, zeroed and populated by this call.
+ * @return RS_RET_OK on a concrete selection; RS_RET_PARAM_ERROR for missing
+ *         required parameters; RS_RET_INVALID_VALUE for mixed, malformed, or
+ *         explicitly incompatible state; another error for I/O or allocation
+ *         failure. The function never creates or changes files.
+ */
 rsRetVal qdaEngineResolve(const qda_engine_config_t *config, qda_engine_result_t *result);
+
+/**
+ * @brief Atomically publish the concrete engine marker for a queue namespace.
+ *
+ * The marker is a small versioned compatibility record, not queue data or
+ * metadata. The helper writes a private temporary file, synchronizes it,
+ * renames it over the marker, and synchronizes the containing directory. This
+ * makes an engine selection durable before its first persistent records exist
+ * and allows an empty dematerialized segmented child to remain sticky.
+ *
+ * @param spool_dir Existing parent workDirectory.
+ * @param file_prefix Parent queue filename prefix.
+ * @param engine Concrete DISK or SEGMENTED_DISK engine to publish; AUTO is invalid.
+ * @return RS_RET_OK or an allocation, parameter, or I/O error.
+ */
 rsRetVal qdaEngineWriteMarker(const char *spool_dir, const char *file_prefix, qda_engine_mode_t engine);
+
+/**
+ * @brief Return the configuration/marker spelling for an engine value.
+ *
+ * The returned static string is never NULL and must not be freed. Invalid
+ * values return "invalid" for diagnostics; callers must still validate values
+ * before attempting to persist them.
+ */
 const char *qdaEngineName(qda_engine_mode_t engine);
+
+/**
+ * @brief Compare all settings that require DA child replacement on reload.
+ *
+ * NULL inputs are unequal. This function compares values only; it does not
+ * inspect the spool or determine whether a replacement can safely occur.
+ */
 sbool qdaLifecycleConfigEqual(const qda_lifecycle_config_t *left, const qda_lifecycle_config_t *right);
 
 #endif

--- a/tests/classic-da-behavior.sh
+++ b/tests/classic-da-behavior.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Run the shared LinkedList/FixedArray and main/ruleset/action spill oracle with
 # classic disk explicitly pinned, proving compatibility mode remains available.
 # This matrix wrapper deliberately leaves diag.sh initialization to each driver

--- a/tests/classic-da-persist.sh
+++ b/tests/classic-da-persist.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Run the shared save-on-shutdown/restart oracle for both DA memory queue types
 # with classic disk explicitly pinned.
 for DA_QUEUE_TYPE in LinkedList FixedArray; do

--- a/tests/classic-da-retry-restart.sh
+++ b/tests/classic-da-retry-restart.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Exercise the shared suspended-action restart oracle for both DA memory queue
 # types with the classic disk engine explicitly pinned.
 for DA_QUEUE_TYPE in LinkedList FixedArray; do

--- a/tests/segmented-da-behavior.sh
+++ b/tests/segmented-da-behavior.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Run the shared LinkedList/FixedArray and main/ruleset/action spill oracle with
 # the automatic default, which must resolve fresh queues to segmented disk.
 # This matrix wrapper deliberately leaves diag.sh initialization to each driver

--- a/tests/segmented-da-config-errors.sh
+++ b/tests/segmented-da-config-errors.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Queue DA engine parameters are intentionally limited to FixedArray and
 # LinkedList queues with a filename. The permissive oracle is a successful -N1
 # validation plus the dirty-configuration diagnostic; the strict oracle is a

--- a/tests/segmented-da-engine-transition.sh
+++ b/tests/segmented-da-engine-transition.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Build a real classic disk-assisted action backlog, then restart with the auto
 # selector. The marker, warning, and complete drain prove sticky classic
 # compatibility. A final clean restart with auto-upgrade enabled must replace

--- a/tests/segmented-da-event-properties-fixedarray.sh
+++ b/tests/segmented-da-event-properties-fixedarray.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Run the complete-event persistence oracle through a FixedArray segmented DA
 # child, complementing the LinkedList wrapper with identical typed JSON,
 # message-variable, local-variable, and RFC5424 field comparisons.

--- a/tests/segmented-da-event-properties.sh
+++ b/tests/segmented-da-event-properties.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Run the complete-event persistence oracle through a segmented DA child.
 export SEGDISK_EVENT_DA=1
 . ${srcdir:=.}/segmented-diskqueue-event-properties.sh

--- a/tests/segmented-da-idle-cleanup-failure.sh
+++ b/tests/segmented-da-idle-cleanup-failure.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Force idle cleanup to encounter an unexpected file in the private store
 # directory. The first cleanup must fail visibly while restoring a valid empty
 # materialized store and keeping its worker alive. The restored state must

--- a/tests/segmented-da-idle-crash-directory.sh
+++ b/tests/segmented-da-idle-crash-directory.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Crash after the empty segmented store directory has been removed.
 export SEGDISK_IDLE_FAULT_POINT=idle-directory-removed
 . ${srcdir:=.}/testsuites/segmented-da-idle-crash-driver.sh

--- a/tests/segmented-da-idle-crash-segments.sh
+++ b/tests/segmented-da-idle-crash-segments.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Crash after all segment deletions have been synchronized in two consecutive
 # materialization cycles; final exact drain proves repeated cleanup recovery.
 export SEGDISK_IDLE_FAULT_POINT=idle-segments-unlinked

--- a/tests/segmented-da-idle-crash-state-unlink.sh
+++ b/tests/segmented-da-idle-crash-state-unlink.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Crash after state unlink, when the queue directory is empty.
 export SEGDISK_IDLE_FAULT_POINT=idle-state-unlinked
 . ${srcdir:=.}/testsuites/segmented-da-idle-crash-driver.sh

--- a/tests/segmented-da-idle-crash-state.sh
+++ b/tests/segmented-da-idle-crash-state.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Crash immediately after the durable empty-state publication.
 export SEGDISK_IDLE_FAULT_POINT=idle-empty-published
 . ${srcdir:=.}/testsuites/segmented-da-idle-crash-driver.sh

--- a/tests/segmented-da-idle-dematerialize.sh
+++ b/tests/segmented-da-idle-dematerialize.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Exercise the complete segmented DA idle lifecycle on an action queue. A
 # deliberately slow, tiny memory tier makes each 2000-message burst spill. The
 # filesystem oracle proves lazy creation, grace-period dematerialization, and

--- a/tests/segmented-da-idle-retry.sh
+++ b/tests/segmented-da-idle-retry.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Keep a segmented DA action in retry state for longer than its 100 ms idle
 # timeout. The store must remain materialized while retry-before-commit owns
 # records; after the output directory appears, exact drain plus store removal

--- a/tests/segmented-da-idle-timeout-values.sh
+++ b/tests/segmented-da-idle-timeout-values.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Verify the two boundary values of queue.diskQueueIdleTimeout. Identical slow
 # action queues force a spill; timeout 0 must remove its store immediately,
 # while -1 must retain its drained store and final worker until shutdown. Exact

--- a/tests/segmented-da-maxdiskspace-fixedarray.sh
+++ b/tests/segmented-da-maxdiskspace-fixedarray.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Run the segmented DA disk-space backpressure and reclamation oracle with the
 # FixedArray memory tier; the base test retains LinkedList as its default.
 export DA_QUEUE_TYPE=FixedArray

--- a/tests/segmented-da-maxdiskspace.sh
+++ b/tests/segmented-da-maxdiskspace.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Fill a 64 KiB segmented DA child while a slow consumer keeps the 50-record
 # memory tier above its high watermark, drain it, and repeat. Exact delivery
 # proves producer backpressure without loss and reuse after segment reclamation;

--- a/tests/segmented-da-multiworker-frontier.sh
+++ b/tests/segmented-da-multiworker-frontier.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Seed a pure segmented queue, crash it with twelve uncommitted events, then
 # reopen that store as an automatic segmented DA child with three one-record
 # workers. Workers 1 and 2 hold events 0 and 1 for five and two seconds, so

--- a/tests/segmented-da-persist.sh
+++ b/tests/segmented-da-persist.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Run the shared save-on-shutdown/restart oracle for both DA memory queue types
 # with automatic segmented storage.
 for DA_QUEUE_TYPE in LinkedList FixedArray; do

--- a/tests/segmented-da-recovery-budget.sh
+++ b/tests/segmented-da-recovery-budget.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Run the bounded lazy-recovery oracle through an automatic segmented DA child;
 # the shared driver verifies recovery-pending rescheduling, counters, and later
 # producer delivery while the child owns an undiscovered corrupt range.

--- a/tests/segmented-da-retry-restart.sh
+++ b/tests/segmented-da-retry-restart.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Exercise the shared suspended-action restart oracle for both DA memory queue
 # types with the automatic segmented engine selection.
 for DA_QUEUE_TYPE in LinkedList FixedArray; do

--- a/tests/testsuites/da-engine-behavior-driver.sh
+++ b/tests/testsuites/da-engine-behavior-driver.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Shared pure disk-assisted queue behavior driver. The wrapper selects one
 # engine, memory queue type, and placement (main, ruleset, or action).
 # A tiny queue with single-record, slowed dequeue must spill a 2000-message

--- a/tests/testsuites/da-engine-persist-driver.sh
+++ b/tests/testsuites/da-engine-persist-driver.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Shared DA save-on-shutdown/restart driver. The wrapper selects the memory
 # queue and disk engine. Single-record, deliberately slowed dequeue leaves a
 # durable spill at immediate shutdown; restart must recover every sequence.

--- a/tests/testsuites/da-engine-retry-restart-driver.sh
+++ b/tests/testsuites/da-engine-retry-restart-driver.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Shared DA retry/restart driver. The wrapper selects the memory queue and disk
 # engine. A deliberately suspended omfile action must spill, survive an
 # immediate restart, and preserve retry-before-commit semantics. Exact sequence

--- a/tests/testsuites/segmented-da-idle-crash-driver.sh
+++ b/tests/testsuites/segmented-da-idle-crash-driver.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Shared idle-cleanup crash driver for a segmented disk-assisted main queue.
 # A small, slow memory tier guarantees a spill. The configured imdiag hook must
 # SIGKILL rsyslog during empty-store cleanup; restart must accept the surviving

--- a/tests/unit/queue_da_test.c
+++ b/tests/unit/queue_da_test.c
@@ -1,5 +1,19 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /*
- * Unit coverage for disk-assisted engine selection and its durable marker.
+ * Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * @file queue_da_test.c
+ * @brief Unit coverage for disk-assisted engine selection and its durable marker.
+ *
  * Each case builds an exact temporary spool layout; the oracle is the chosen
  * engine or an explicit rejection, so no daemon timing is involved.
  */

--- a/tests/yaml-segmented-da-config-errors.sh
+++ b/tests/yaml-segmented-da-config-errors.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Verify YAML uses the same DA parameter validation as RainerScript. A
 # segmented-only queue is an invalid context: permissive validation must retain
 # startup compatibility while reporting the dirty configuration, and strict

--- a/tests/yaml-segmented-da-config.sh
+++ b/tests/yaml-segmented-da-config.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Verify YAML reaches the shared DA queue parameter backend. A fresh LinkedList
 # main queue selects the fresh auto default with idle cleanup disabled. The
 # absence of both marker and .segq proves selection remained fully


### PR DESCRIPTION
## What changed

Adds complete Apache-2.0 SPDX and copyright prologues to every file introduced
by the segmented disk-assisted queue work. Expands the Doxygen documentation
for the internal engine resolver, durable engine marker, lazy materialization,
and disk-assisted child lifecycle.

## Why

The original implementation left new files without consistent licensing and
did not fully describe the persistent-engine compatibility and lifecycle
contracts that maintainers and automated tooling need to preserve.

## Impact

Documentation-only change: no queue behavior, configuration, or test oracle
changes.

## Validation

- `devtools/format-code.sh --git-changed`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `shellcheck -S warning` for the newly added DA shell tests
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

