### PR TITLE
queue: clarify DA transfer worker role

### DIFF
--- a/doc/source/development/dev_queue.rst
+++ b/doc/source/development/dev_queue.rst
@@ -77,6 +77,12 @@ patient if the information is a bit too in-depth ;)
 DA Run Mode Initialization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+A disk-assisted setup has three separate worker roles: regular workers process
+the in-memory parent queue, one DA transfer worker moves messages to the disk
+child, and the disk child has its own regular consumer pool. The child pool is
+sized by ``queue.workerThreads`` and executes the configured action; the DA
+transfer worker does not execute that action.
+
 Three cases:
 
 #. any time during queueEnqObj() when the high water mark is hit

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -685,7 +685,7 @@ static rsRetVal qqueueAdviseMaxWorkers(qqueue_t *pThis) {
         if (pThis->bIsDA && getLogicalQueueSize(pThis) >= pThis->iHighWtrMrk) {
             DBGOPRINT((obj_t *)pThis, "(re)activating DA worker\n");
             wtpAdviseMaxWorkers(pThis->pWtpDA, 1, DENY_WORKER_START_DURING_SHUTDOWN);
-            /* disk queues have always one worker */
+            /* The DA transfer pool intentionally has one worker. */
         }
         if (getLogicalQueueSize(pThis) == 0) {
             iMaxWorkers = 0;

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -108,7 +108,7 @@ struct queue_s {
         int iCurNumWrkThrd; /* current number of active worker threads */
         int iMinMsgsPerWrkr;
         /* minimum nbr of msgs per worker thread, if more, a new worker is started until max wrkrs */
-        wtp_t *pWtpDA;
+        wtp_t *pWtpDA; /* single-worker DA transfer pool, not the DA disk queue child consumer pool */
         wtp_t *pWtpReg;
         action_t *pAction; /* for action queues, ptr to action object; for main queues unused */
         int iUpdsSincePersist; /* nbr of queue updates since the last persist call */


### PR DESCRIPTION
## Summary

Clarify the disk-assisted queue worker topology.

The DA transfer pool has one worker by design, but it only transfers messages
from the memory parent to the disk child. It is not the child queue's consumer
pool. The child continues to use its regular pool sized by
`queue.workerThreads` to run actions.

## Why

An old source comment said disk queues always had one worker, which obscured
the distinction and was incorrect for the regular disk child consumers.

## Validation

- `git diff --check`
- `devtools/format-code.sh --git-changed --check --check-if-available`
- `RSYSLOG_LOCAL_DOC_JOBS=60 ./doc/tools/build-doc-linux.sh --clean --format html --jobs 60`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

