### PR TITLE
tests: support older zlib Python bindings

### DIFF
--- a/tests/imtcp-stream-always-zlib-fragmented-ratio.sh
+++ b/tests/imtcp-stream-always-zlib-fragmented-ratio.sh
@@ -35,7 +35,8 @@ payload = "".join(
     "<129>Mar 10 01:00:00 172.20.245.8 tag: msgnum:%08d AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n" % i
     for i in range(0, 2000)
 ).encode("ascii")
-compressed = zlib.compress(payload, level=1)
+# Solaris' older Python accepts the compression level only positionally.
+compressed = zlib.compress(payload, 1)
 sock = socket.create_connection(("127.0.0.1", port))
 sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 for octet in compressed:


### PR DESCRIPTION
## Summary

- use the positional `zlib.compress()` level argument accepted by Solaris's older Python runtime
- preserve the existing imtcp stream-compression fragmentation scenario and its 2,000-message oracle

## Root cause

Solaris Python rejects `zlib.compress(payload, level=1)`. The client aborts before sending any compressed data, then the test waits for output that cannot arrive.

## Validation

- `bash -n tests/imtcp-stream-always-zlib-fragmented-ratio.sh`
- ShellCheck and `devtools/check-test-antipatterns.sh`
- focused host test
- focused Ubuntu 26.04 CI-container test (`1 pass, 0 fail`)

Closes https://github.com/rsyslog/rsyslog/issues/7300
Closes https://github.com/rsyslog/rsyslog/issues/7317
Closes https://github.com/rsyslog/rsyslog/issues/7327


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

