### PR TITLE
tests: add segmented DA TCP spill regression

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -576,6 +576,15 @@ static rsRetVal qqueueSegDiskIdleTimeout(qqueue_t *pThis) {
     if (getLogicalQueueSize(pThis) != 0 || getPhysicalQueueSize(pThis) != 0 ||
         !segdiskStoreCanDematerialize(pThis->tVars.segdisk))
         return RS_RET_RETRY;
+    /* A DA child shares its parent queue mutex.  The child can become empty
+     * while ConsumerDA still owns a parent batch that has not reached the
+     * child store.  The parent physical count includes those logically
+     * dequeued batches until ConsumerDA commits them, so it is the required
+     * transfer-in-flight barrier.  Without it, an immediate idle timeout can
+     * remove the child store and a crash can lose the parent-only batch. */
+    if (pThis->pqParent == NULL || getPhysicalQueueSize(pThis->pqParent) != 0) {
+        return RS_RET_RETRY;
+    }
     if (pThis->segdiskIdleObservedActivity != pThis->pqParent->daActivityGeneration) {
         pThis->segdiskIdleObservedActivity = pThis->pqParent->daActivityGeneration;
         return RS_RET_RETRY;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -74,6 +74,7 @@ TESTS_SEGMENTED_DISK_QUEUE = \
 	segmented-da-event-properties.sh \
 	segmented-da-event-properties-fixedarray.sh \
 	segmented-da-behavior.sh \
+	segmented-da-tcp-spill-exact.sh \
 	classic-da-behavior.sh \
 	segmented-da-persist.sh \
 	classic-da-persist.sh \

--- a/tests/minitcpsrvr.c
+++ b/tests/minitcpsrvr.c
@@ -36,7 +36,11 @@
 #endif
 
 #define MAX_CONNECTIONS 10
-#define BUFFER_SIZE 1024
+/* Keep complete testbench records buffered per connection. The segmented DA
+ * TCP spill regression deliberately uses multi-kilobyte messages so TCP
+ * backpressure cannot be hidden by buffers. The historic 1 KiB buffer treated
+ * a fragmented larger record as a closed connection. */
+#define BUFFER_SIZE (64 * 1024)
 
 /* OK, we use a lot of global. But after all, this is "just" a small
  * testing ... that has evolved a bit ;-)
@@ -56,6 +60,8 @@ char *targetIP = NULL;
 int targetPort = -1;
 char *portFileName = NULL;
 char *waitListenFileName = NULL;
+char *waitReadFileName = NULL;
+char *keepRunningFileName = NULL;
 char *listenReadyFileName = NULL;
 char *acceptReadyFileName = NULL;
 char *fixedResponse = NULL;
@@ -63,8 +69,8 @@ size_t totalWritten = 0;
 int listen_fd, conn_fd, fd, file_fd, nfds, port = 8080;
 struct sockaddr_in server_addr;
 struct pollfd fds[MAX_CONNECTIONS + 1];  // +1 for the listen socket
-char buffer[MAX_CONNECTIONS][BUFFER_SIZE];
-int buffer_offs[MAX_CONNECTIONS];
+char buffer[MAX_CONNECTIONS + 1][BUFFER_SIZE];
+int buffer_offs[MAX_CONNECTIONS + 1];
 
 static void errout(char *reason) {
     perror(reason);
@@ -75,7 +81,7 @@ static void errout(char *reason) {
 static void usage(void) {
     fprintf(stderr,
             "usage: minitcpsrv [-R] [-r response] [-w listenFile] [-L listenReadyFile] [-A acceptReadyFile] "
-            "-t ip-addr -p port -P portFile -f outfile\n");
+            "[-Q readReleaseFile] [-K keepRunningFile] -t ip-addr -p port -P portFile -f outfile\n");
     exit(1);
 }
 
@@ -148,6 +154,20 @@ static void waitForListenRelease(void) {
         sleep(1);
     }
     fprintf(stderr, "minitcpsrv listen release file %s found\n", waitListenFileName);
+}
+
+/* Keep the TCP listener available while deliberately withholding reads. This
+ * lets testbench clients establish connections and eventually apply normal TCP
+ * backpressure without provoking connection failures or retry duplicates.
+ */
+static void waitForReadRelease(void) {
+    if (waitReadFileName == NULL) return;
+
+    fprintf(stderr, "minitcpsrv waits for read release file %s\n", waitReadFileName);
+    while (access(waitReadFileName, F_OK) != 0) {
+        usleep(10000);
+    }
+    fprintf(stderr, "minitcpsrv read release file %s found\n", waitReadFileName);
 }
 
 static void createListenSocket(void) {
@@ -239,7 +259,7 @@ int main(int argc, char *argv[]) {
     memset(fds, 0, sizeof(fds));
     memset(buffer_offs, 0, sizeof(buffer_offs));
 
-    while ((opt = getopt(argc, argv, "aA:B:D:L:Rr:t:p:P:f:s:S:w:")) != -1) {
+    while ((opt = getopt(argc, argv, "aA:B:D:K:L:Q:Rr:t:p:P:f:s:S:w:")) != -1) {
         switch (opt) {
             case 'a':  // abort listener: act like the server has died (shutdown and re-open listen socket)
                 abortListener = 1;
@@ -267,6 +287,12 @@ int main(int argc, char *argv[]) {
                 break;
             case 'L':
                 listenReadyFileName = optarg;
+                break;
+            case 'K':
+                keepRunningFileName = optarg;
+                break;
+            case 'Q':
+                waitReadFileName = optarg;
                 break;
             case 't':
                 targetIP = optarg;
@@ -320,23 +346,37 @@ int main(int argc, char *argv[]) {
 
 
     createListenSocket();
+    waitForReadRelease();
     nfds = 1;
 
     int bKeepRunning;
     while (1) {
-        int poll_count = poll(fds, nfds, -1);  // -1 means no timeout
+        /* A keep-running file turns the receiver into a durable listener for
+         * tests whose clients may briefly disconnect between action batches.
+         * Poll with a short timeout only in that opt-in mode so removal of the
+         * file is noticed even when no sockets are active. */
+        int poll_count = poll(fds, nfds, keepRunningFileName == NULL ? -1 : 100);
         if (poll_count < 0) {
             errout("poll");
         }
 
-        bKeepRunning = 0; /* terminate on last connection close */
+        bKeepRunning = keepRunningFileName != NULL && access(keepRunningFileName, F_OK) == 0;
+        /* Without -K, terminate on the last connection close as before. */
 
         for (int i = 0; i < nfds; i++) {
             if (fds[i].revents == 0) continue;
 
-            if (fds[i].revents != POLLIN) {
-                fprintf(stderr, "Error! revents = %d\n", fds[i].revents);
-                exit(EXIT_FAILURE);
+            if (!(fds[i].revents & POLLIN)) {
+                if (fds[i].fd == listen_fd) {
+                    fprintf(stderr, "Error! listener revents = %d\n", fds[i].revents);
+                    exit(EXIT_FAILURE);
+                }
+                /* POLLHUP/POLLERR is a normal end-of-stream indication for
+                 * an omfwd action connection. It may accompany POLLIN, in
+                 * which case the readable data below is still consumed. */
+                close(fds[i].fd);
+                fds[i].fd = -1;
+                continue;
             }
 
             if (fds[i].fd == listen_fd) {
@@ -347,10 +387,16 @@ int main(int argc, char *argv[]) {
                     perror("Accept failed");
                     continue;
                 }
+                if (nfds >= MAX_CONNECTIONS + 1) {
+                    fprintf(stderr, "minitcpsrv connection limit reached\n");
+                    close(conn_fd);
+                    continue;
+                }
                 writeAcceptReadyMarker();
 
                 fds[nfds].fd = conn_fd;
                 fds[nfds].events = POLLIN;
+                buffer_offs[nfds] = 0;
                 nfds++;
             } else {
                 // Handle data from a client
@@ -374,7 +420,7 @@ int main(int argc, char *argv[]) {
                         --last_lf;
                     }
                     if (last_lf == -1) { /* no LF found at all */
-                        buffer_offs[i] = last_byte;
+                        buffer_offs[i] = last_byte + 1;
                     } else {
                         const int bytes_to_write = last_lf + 1;
 
@@ -428,6 +474,8 @@ int main(int argc, char *argv[]) {
             if (fds[i].fd == -1) {
                 for (int j = i; j < nfds - 1; j++) {
                     fds[j] = fds[j + 1];
+                    memcpy(buffer[j], buffer[j + 1], buffer_offs[j + 1]);
+                    buffer_offs[j] = buffer_offs[j + 1];
                 }
                 i--;
                 nfds--;

--- a/tests/segmented-da-tcp-spill-exact.sh
+++ b/tests/segmented-da-tcp-spill-exact.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
+# Verify a segmented disk-assisted LinkedList main queue under TCP
+# backpressure. Four tcpflood generators send 10,000 independently numbered
+# records through imtcp. minitcpsrv opens the omfwd listener but delays reads
+# until the segmented DA child state file exists. That state file is the spill
+# oracle: it proves the child materialized before output is allowed to drain.
+# The standard sequence checker rejects loss, duplicates, and malformed
+# framing. This is a functionality regression test; it has no throughput or
+# elapsed-time oracle.
+
+. ${srcdir:=.}/diag.sh init
+
+NUMMESSAGES=10000
+TCP_CONNECTIONS=4
+PAYLOAD_BYTES=4096
+SPOOL_DIR="$PWD/${RSYSLOG_DYNNAME}.spool"
+RECEIVER_FILE="$PWD/${RSYSLOG_DYNNAME}.receiver"
+RECEIVER_PORT_FILE="$PWD/${RSYSLOG_DYNNAME}.receiver.port"
+RECEIVER_READY_FILE="$PWD/${RSYSLOG_DYNNAME}.receiver.ready"
+RECEIVER_RELEASE_FILE="$PWD/${RSYSLOG_DYNNAME}.receiver.release"
+RECEIVER_KEEP_FILE="$PWD/${RSYSLOG_DYNNAME}.receiver.keep"
+INPUT_PORT_FILE="$PWD/${RSYSLOG_DYNNAME}.input.port"
+SENDER_MARKER="$PWD/${RSYSLOG_DYNNAME}.sender.marker"
+
+rm -rf "$SPOOL_DIR"
+rm -f "$INPUT_PORT_FILE" "$SENDER_MARKER" "$RECEIVER_FILE" "$RECEIVER_PORT_FILE" "$RECEIVER_READY_FILE" "$RECEIVER_RELEASE_FILE" "$RECEIVER_KEEP_FILE"
+mkdir -p "$SPOOL_DIR" || error_exit 1 "cannot create spool directory"
+: >"$RECEIVER_KEEP_FILE"
+./minitcpsrv -t127.0.0.1 -p0 -P "$RECEIVER_PORT_FILE" -L "$RECEIVER_READY_FILE" \
+	-Q "$RECEIVER_RELEASE_FILE" -K "$RECEIVER_KEEP_FILE" -f "$RECEIVER_FILE" &
+RECEIVER_PID=$!
+wait_file_exists "$RECEIVER_READY_FILE"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+global(workDirectory="'"$SPOOL_DIR"'")
+input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="'"$INPUT_PORT_FILE"'" workerthreads="4")
+main_queue(queue.type="LinkedList" queue.filename="mainq"
+	queue.size="400" queue.highWatermark="320" queue.lowWatermark="80" queue.fullDelayMark="400"
+	queue.maxFileSize="64m" queue.maxDiskSpace="2g" queue.workerThreads="4"
+	queue.workerThreadMinimumMessages="1" queue.dequeueBatchSize="1"
+	queue.diskQueueType="segmentedDisk" queue.diskQueueIdleTimeout="-1"
+	queue.checkpointInterval="0" queue.syncQueueFiles="off")
+template(name="tcpSpillFormat" type="string" string="%msg%\n")
+if ($msg contains "msgnum:") then
+	action(type="omfwd" target="127.0.0.1" port="'"$(cat "$RECEIVER_PORT_FILE")"'" protocol="tcp" template="tcpSpillFormat")
+'
+startup
+wait_file_exists "$INPUT_PORT_FILE"
+
+./tcpflood -p"$(cat "$INPUT_PORT_FILE")" -c"$TCP_CONNECTIONS" -Y -m"$NUMMESSAGES" -d"$PAYLOAD_BYTES" -q "$SENDER_MARKER" &
+SENDER_PID=$!
+deadline=$((SECONDS + 60))
+while [ ! -e "$SPOOL_DIR/mainq.segq/state" ]; do
+	# This bounded wait is a liveness ceiling, not a performance assertion.
+	# Output remains blocked until state proves the DA child was used.
+	[ "$SECONDS" -lt "$deadline" ] || error_exit 1 "segmented DA child did not materialize"
+	./msleep 25
+done
+touch "$RECEIVER_RELEASE_FILE"
+wait "$SENDER_PID"
+if [ $? -ne 0 ] || ! tcpflood_marker_is_valid "$SENDER_MARKER"; then
+	print_tcpflood_marker_file "$SENDER_MARKER"
+	error_exit 1 "tcpflood did not complete cleanly"
+fi
+wait_queueempty
+# A full line count followed by sequence validation proves every delayed TCP
+# record was framed, persisted, forwarded, and drained exactly once.
+wait_file_lines --abort-on-oversize "$RECEIVER_FILE" "$NUMMESSAGES" 120
+shutdown_when_empty
+wait_shutdown
+rm -f "$RECEIVER_KEEP_FILE"
+wait "$RECEIVER_PID" || error_exit 1 "minitcpsrv did not exit cleanly"
+cut -d: -f2 "$RECEIVER_FILE" >"$RSYSLOG_OUT_LOG"
+seq_check 0 $((NUMMESSAGES - 1))
+rm -rf "$SPOOL_DIR"
+exit_test

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -788,6 +788,7 @@ static void holdOpenConnections(void) {
  */
 static void genMsg(char *buf, size_t maxBuf, size_t *pLenBuf, struct instdata *inst) {
     int edLen; /* actual extra data length to use */
+    const unsigned long long messageNumber = inst->lower + inst->numSent;
     char extraData[MAX_EXTRADATA_LEN + 1];
     char dynFileIDBuf[128] = "";
     int done;
@@ -814,11 +815,11 @@ static void genMsg(char *buf, size_t maxBuf, size_t *pLenBuf, struct instdata *i
             *pLenBuf = snprintf(buf, maxBuf,
                                 "<%s>1 2003-03-01T01:00:00.000Z mymachine.example.com "
                                 "tcpflood - tag [tcpflood@32473 MSGNUM"
-                                "=\"%8.8d\"] %s{\"msgnum\":%d}%c",
-                                msgPRI, msgNum, jsonCookie, msgNum, frameDelim);
+                                "=\"%8.8llu\"] %s{\"msgnum\":%llu}%c",
+                                msgPRI, messageNumber, jsonCookie, messageNumber, frameDelim);
         } else {
-            *pLenBuf = snprintf(buf, maxBuf, "<%s>Mar  1 01:00:00 %s tag %s{\"msgnum\":%d}%c", msgPRI, hostname,
-                                jsonCookie, msgNum, frameDelim);
+            *pLenBuf = snprintf(buf, maxBuf, "<%s>Mar  1 01:00:00 %s tag %s{\"msgnum\":%llu}%c", msgPRI, hostname,
+                                jsonCookie, messageNumber, frameDelim);
         }
     } else if (MsgToSend == NULL) {
         if (dynFileIDs > 0) {
@@ -829,13 +830,13 @@ static void genMsg(char *buf, size_t maxBuf, size_t *pLenBuf, struct instdata *i
                 *pLenBuf = snprintf(buf, maxBuf,
                                     "<%s>1 2003-03-01T01:00:00.000Z "
                                     "mymachine.example.com tcpflood - tag [tcpflood@32473 "
-                                    "MSGNUM=\"%8.8d\"] msgnum:%s%8.8d:%c",
-                                    msgPRI, msgNum, dynFileIDBuf, msgNum, frameDelim);
+                                    "MSGNUM=\"%8.8llu\"] msgnum:%s%8.8llu:%c",
+                                    msgPRI, messageNumber, dynFileIDBuf, messageNumber, frameDelim);
             } else {
                 *pLenBuf = snprintf(buf, maxBuf,
                                     "<%s>Mar  1 01:00:00 %s tag "
-                                    "msgnum:%s%8.8d:%c",
-                                    msgPRI, hostname, dynFileIDBuf, msgNum, frameDelim);
+                                    "msgnum:%s%8.8llu:%c",
+                                    msgPRI, hostname, dynFileIDBuf, messageNumber, frameDelim);
             }
         } else {
             if (bRandomizeExtraData)
@@ -848,13 +849,13 @@ static void genMsg(char *buf, size_t maxBuf, size_t *pLenBuf, struct instdata *i
                 *pLenBuf = snprintf(buf, maxBuf,
                                     "<%s>1 2003-03-01T01:00:00.000Z "
                                     "mymachine.example.com tcpflood - tag [tcpflood@32473 "
-                                    "MSGNUM=\"%8.8d\"] msgnum:%s%8.8d:%c",
-                                    msgPRI, msgNum, dynFileIDBuf, msgNum, frameDelim);
+                                    "MSGNUM=\"%8.8llu\"] msgnum:%s%8.8llu:%c",
+                                    msgPRI, messageNumber, dynFileIDBuf, messageNumber, frameDelim);
             } else {
                 *pLenBuf = snprintf(buf, maxBuf,
                                     "<%s>Mar  1 01:00:00 %s tag msgnum"
-                                    ":%s%8.8d:%d:%s%c",
-                                    msgPRI, hostname, dynFileIDBuf, msgNum, edLen, extraData, frameDelim);
+                                    ":%s%8.8llu:%d:%s%c",
+                                    msgPRI, hostname, dynFileIDBuf, messageNumber, edLen, extraData, frameDelim);
             }
         }
     } else {
@@ -1065,7 +1066,6 @@ int sendMessages(struct instdata *inst) {
         if (inst->numSent % batchsize == 0) {
             usleep(waittime);
         }
-        ++msgNum;
         ++i;
     }
     if (transport == TP_TLS && offsSendBuf != 0) {
@@ -1104,7 +1104,7 @@ static void *thrdStarter(void *arg) {
 static void prepareGenerators(void) {
     int i;
     long long msgsThrd;
-    long long starting = 0;
+    unsigned long long starting = (unsigned long long)msgNum;
     pthread_attr_t thrd_attr;
 
     if (runMultithreaded) {
@@ -1251,6 +1251,10 @@ static int runTests(void) {
             endTiming(&tvStart, &stats);
             return 1;
         }
+        /* Generators use disjoint, immutable ranges so -Y has no shared
+         * counter race. Advance the base once, after all threads complete,
+         * to preserve the existing consecutive numbering across -R runs. */
+        msgNum += numMsgsToSend;
         endTiming(&tvStart, &stats);
         if (run == numRuns) break;
         if (!bSilent) printf("sleeping %d seconds before next run\n", sleepBetweenRuns);


### PR DESCRIPTION
## Summary

Adds a normal `make check` regression for a segmented disk-assisted LinkedList main queue under real TCP backpressure.

The test sends 10,000 4 KiB messages through four tcpflood/imtcp connections, withholds receiver reads until the segmented child state exists, then drains and verifies the complete sequence exactly once. There is no elapsed-time or throughput pass/fail threshold.

## Required test-helper changes

- `tcpflood -Y` now assigns immutable, disjoint message ranges to generator threads instead of racing on the global counter. The base advances once after each completed `-R` run, preserving consecutive multi-run numbering.
- `minitcpsrv -Q` opens the listener while deferring reads, which creates deterministic TCP backpressure without connection-refused retries.
- `minitcpsrv -K` keeps the receiver alive across normal action-worker connection churn until the test releases it.
- The receiver buffer now accommodates the 4 KiB records, preserves per-connection partial buffers while compacting poll slots, handles normal hangups, and retains every byte across fragmented reads.

No custom sequence-verifier helper is retained; the test extracts tcpflood numbers and uses the existing `seq_check` oracle. The earlier connection-limit expansion was also removed because four primary plus four DA child workers fit the existing receiver capacity.

## Validation

- `RSYSLOG_LOCAL_BUILD_JOBS=60 RSYSLOG_LOCAL_CHECK_JOBS=60 make -j60 check TESTS="segmented-da-tcp-spill-exact.sh"` — PASS (1/1)
- Focused `tcpflood -c2 -Y -m8 -R2 -S0` smoke check — emitted 0 through 15 exactly once
- C format dry-run, `git diff --check`, Bash syntax, and ShellCheck — PASS
- Test-antipattern scan — no port, fixed-sleep, timing-threshold, or ad-hoc-content findings; the two background helpers have explicit readiness and lifecycle ownership

With the help of AI-Agents: Codex