### PR TITLE
imjournal: stop invalidation reopen busy-loop

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,11 @@
 --------------------------------------------------------------------------------------
 Scheduled Release 8.2608.0 (aka 2026.08) 2026-08-??
 
+- 2026-07-15: imjournal: stop invalidation recovery busy-loop
+  Reopened journal handles now initialize their change notification state
+  before cursor restoration. This prevents journal rotation or invalidation
+  from repeatedly reopening the journal and consuming a full CPU core.
+  Closes https://github.com/rsyslog/rsyslog/issues/7342
 - 2026-07-14: queue: add segmented disk-assisted storage
   FixedArray and LinkedList disk-assisted queues now use the segmented disk
   engine by default for new stores while automatically retaining existing

--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -875,9 +875,23 @@ finalize_it:
 
 static rsRetVal reopenJournal(struct journalContext_s *journalContext) {
     DEFiRet;
+    int waitRet;
 
     closeJournal(journalContext);
     CHKiRet(openJournal(journalContext));
+
+    /* The first sd_journal_wait() on a newly opened handle intentionally
+     * returns immediately after installing its watches. Consume that initial
+     * state here; otherwise an INVALIDATE-triggered reopen causes every fresh
+     * handle to report another INVALIDATE and imjournal busy-loops forever.
+     * Cursor restoration follows this call, so sequential delivery still
+     * resumes from the last processed entry. */
+    waitRet = sd_journal_wait(journalContext->j, 0);
+    if (waitRet < 0) {
+        LogError(-waitRet, RS_RET_ERR, "imjournal: sd_journal_wait() failed while initializing reopened journal");
+        closeJournal(journalContext);
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
 
 finalize_it:
     RETiRet;


### PR DESCRIPTION
## Summary

- initialize each reopened sd-journal handle's change-notification state before restoring the saved cursor
- preserve the journal reopen added to avoid reusing invalidated mappings
- document the operator-visible fix for the scheduled 8.2608 release

## Root cause

The 8.2606.0 invalidation hardening closes and reopens the journal handle after `SD_JOURNAL_INVALIDATE`. libsystemd intentionally makes the first `sd_journal_wait()` on a newly opened handle return immediately after installing its watches.

imjournal restored its cursor and returned to the read loop without consuming that initial state. The next wait therefore reported another invalidation, which reopened another fresh handle and repeated indefinitely. This matches the reported reopen/inotify teardown trace and the repeated `journal files changed, reloading` diagnostics.

The fix performs one zero-timeout wait immediately after reopening. This installs and consumes the fresh handle's initial notification state before cursor restoration, so subsequent idle waits can block normally.

## User impact

On affected systems, an idle imjournal input could pin one CPU core and flood internal diagnostics after journal invalidation or rotation. With this change, imjournal retains its safety reopen and resumes sequential delivery from the saved cursor without entering the reopen loop.

## Validation

- host build: `make -j10 check TESTS=""`
- usable host journal: `./tests/imjournal-basic.sh`
- clang-format-18 check: passed
- local Cubic review: no issues
- Ubuntu 26.04 clang static analyzer: no bugs found
- change-gated Ubuntu 26.04 container validation: 1,350 passed, 15 expected skips, 0 failures
  - an unrelated segmented disk-assisted queue test failed transiently in the first run, passed immediately in isolation, and the complete selected suite then passed on rerun
- validation image: `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`)

Closes https://github.com/rsyslog/rsyslog/issues/7342

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

