### PR TITLE
  omfwd/ossl: support PKCS#11 URIs for TLS objects and fix client-auth loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,8 +102,10 @@ utils/*
 *.sw*
 clang_output_*
 tools/logctl
+tools/msggen
 tools/rscryutil
 tools/rscryutil.1
+tools/rsyslog_diag_hostname
 /bin/
 # RPM CI build output
 /build-result/

--- a/.gitignore
+++ b/.gitignore
@@ -103,8 +103,10 @@ utils/*
 *.sw*
 clang_output_*
 tools/logctl
+tools/msggen
 tools/rscryutil
 tools/rscryutil.1
+tools/rsyslog_diag_hostname
 /bin/
 # RPM CI build output
 /build-result/

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -72,6 +72,21 @@ mmnormalize:
     - Turbo contexts are worker-owned and remain lock-free while normalizing; HUP increments a generation and each worker rebuilds and reclaims its own context between messages.
     - When debugFile is configured, liblognorm callbacks share an instance FILE and use flockfile to serialize writes.
 
+netstream_driver_api:
+  paths:
+    - "runtime/nsd.h"
+    - "runtime/netstrm.h"
+    - "runtime/netstrm.c"
+    - "runtime/nsd_gtls.c"
+    - "runtime/nsd_mbedtls.c"
+    - "runtime/nsd_ossl.c"
+    - "runtime/nsd_ptcp.c"
+  requires_serialization: false
+  notes:
+    - netstrm API v20 delegates SetDrvrTlsCAExtraFiles() to NSD API v21 SetTlsCAExtraFiles().
+    - Every NSD driver implementation must provide SetTlsCAExtraFiles(), returning its normal unsupported-setting result when it cannot load additional CA sources.
+    - The ossl driver accepts comma-separated file lists or strict pkcs11: URI lists; the other current drivers reject non-null extra CA sources as unsupported.
+
 omfile:
   paths: ["plugins/omfile/"]
   requires_serialization: true

--- a/doc/source/configuration/modules/omfwd.rst
+++ b/doc/source/configuration/modules/omfwd.rst
@@ -36,6 +36,20 @@ To configure global defaults, use ``builtin:omfwd``.
    system resolver. Reverse lookup cache settings (:ref:`reverse_dns_cache`)
    do not affect outbound name resolution.
 
+.. note::
+   When ``StreamDriver="ossl"`` is used on supported OpenSSL 3 builds,
+   ``StreamDriver.CAFile``, ``StreamDriver.CAExtraFiles``,
+   ``StreamDriver.CertFile``, and ``StreamDriver.KeyFile`` on either the
+   ``omfwd`` action or the ``builtin:omfwd`` module may be configured either
+   as normal filesystem paths or as strict ``pkcs11:`` URIs. This allows TLS
+   trust anchors, additional intermediate CA certificates, certificates, and
+   private keys to be loaded from provider-backed PKCS#11 objects instead of
+   PEM files on disk. The global default parameters
+   ``DefaultNetstreamDriverCAFile``, ``DefaultNetstreamDriverCertFile``,
+   ``DefaultNetstreamDriverKeyFile``, and ``NetstreamDriverCAExtraFiles``
+   still validate as filesystem paths today and therefore must not be set to
+   ``pkcs11:`` URIs.
+
 Best Practices
 ==============
 
@@ -97,6 +111,55 @@ The most common forwarding examples:
        StreamDriverMode="1"        # TLS-only mode
        StreamDriverAuthMode="x509/name"
        StreamDriverPermittedPeers="logs.example.com"
+   )
+
+**2a. Secure log forwarding with TLS and PKCS#11 URIs**
+
+.. note::
+   The ``pkcs11:`` values shown in the examples are illustrative. Replace
+   ``token=``, ``object=``, and any other URI attributes with values that
+   match the objects provisioned in your own PKCS#11 token or device.
+   rsyslog recognizes only the strict ``pkcs11:`` prefix and otherwise passes
+   the URI through to OpenSSL and the configured PKCS#11 provider. The exact
+   URI attributes and matching behavior therefore depend on that provider and
+   backend implementation.
+
+.. code-block:: rsyslog
+
+   # Set shared PKCS#11-backed TLS defaults for omfwd actions
+   module(
+       load="builtin:omfwd"
+       StreamDriver.CAFile="pkcs11:token=rsyslog;object=ca-cert;type=cert"
+       StreamDriver.CAExtraFiles="pkcs11:token=rsyslog;object=intermediate-ca-cert;type=cert"
+       StreamDriver.CertFile="pkcs11:token=rsyslog;object=client-cert;type=cert"
+       StreamDriver.KeyFile="pkcs11:token=rsyslog;object=client-key;type=private"
+   )
+
+   # Forward logs securely using those defaults, while overriding
+   # the additional CA list and permitted peer name for this action
+   action(
+       type="omfwd"
+       target="logs.example.com"
+       port="6514"
+       protocol="tcp"
+       StreamDriver="ossl"
+       StreamDriverMode="1"
+       StreamDriverAuthMode="x509/name"
+       StreamDriver.CAExtraFiles="pkcs11:token=rsyslog;object=region2-intermediate-ca-cert;type=cert"
+       StreamDriverPermittedPeers="logs.example.com"
+       queue.type="linkedList"
+   )
+
+   # A second action may reuse the module defaults unchanged
+   action(
+       type="omfwd"
+       target="logs-backup.example.com"
+       port="6514"
+       protocol="tcp"
+       StreamDriver="ossl"
+       StreamDriverMode="1"
+       StreamDriverAuthMode="x509/name"
+       StreamDriverPermittedPeers="logs-backup.example.com"
    )
 
 **3. Discover receivers via DNS SRV**
@@ -199,6 +262,145 @@ You only need filters (e.g., `if ... then ...`) when you want to **selectively f
    *.* @@remote.example.com
 
 is fully equivalent to the modern example above, **without needing `*.*`.**
+
+Using PKCS#11 Objects with the ossl Driver
+==========================================
+
+When ``omfwd`` is configured with ``StreamDriver="ossl"``, rsyslog can load
+TLS objects from PKCS#11 URIs instead of from PEM files on the local
+filesystem.
+
+This support is useful when you want one or more of the following:
+
+- keep the private key in a hardware security module (HSM), smartcard,
+  trusted platform module (TPM)-backed token, or software
+  token instead of storing it as a readable PEM file
+- use a non-exportable key that OpenSSL may use for signing, but that
+  operators and filesystem backups cannot copy out
+- centralize certificate and key lifecycle in a device or token manager that
+  already speaks PKCS#11
+- satisfy operational or compliance requirements that prohibit writing long
+  lived private key material to disk
+
+Prerequisites
+-------------
+
+Before using PKCS#11 URIs with ``omfwd``, ensure all of the following are true:
+
+- rsyslog is using the ``ossl`` netstream driver
+- OpenSSL 3.x is installed and the rsyslog build uses OpenSSL with provider
+  support
+- an OpenSSL PKCS#11 provider package is installed and configured
+- a PKCS#11 backend implementation for your device or token is installed
+  (for example, a vendor HSM library or a software token such as SoftHSM)
+- the required certificate and private-key objects already exist in the token
+- any required login or PIN handling is configured through the provider or the
+  runtime environment
+
+rsyslog does not implement PKCS#11 token management itself. It passes the
+configured ``pkcs11:`` URI to OpenSSL, and OpenSSL then resolves that URI
+through the configured provider and backend module.
+
+For ``omfwd``, configure PKCS#11 URIs either on the action parameters
+``StreamDriver.CAFile``, ``StreamDriver.CAExtraFiles``,
+``StreamDriver.CertFile``, and ``StreamDriver.KeyFile`` or on the
+``builtin:omfwd`` module defaults with the same parameter names. Do not
+configure ``pkcs11:`` URIs through ``DefaultNetstreamDriverCAFile``,
+``DefaultNetstreamDriverCertFile``, ``DefaultNetstreamDriverKeyFile``, or
+``NetstreamDriverCAExtraFiles`` until those global validation paths are
+extended to accept non-filesystem objects. ``StreamDriver.CRLFile`` also
+remains a filesystem-path setting today.
+
+Action-level Example
+--------------------
+
+Use action parameters when only one forwarding action should use PKCS#11
+objects:
+
+.. code-block:: rsyslog
+
+   action(
+       type="omfwd"
+       target="logs.example.com"
+       port="6514"
+       protocol="tcp"
+       StreamDriver="ossl"
+       StreamDriverMode="1"
+       StreamDriverAuthMode="x509/name"
+       StreamDriverPermittedPeers="logs.example.com"
+       StreamDriver.CAFile="pkcs11:token=rsyslog;object=ca-cert;type=cert"
+       StreamDriver.CAExtraFiles="pkcs11:token=rsyslog;object=intermediate-ca-cert;type=cert"
+       StreamDriver.CertFile="pkcs11:token=rsyslog;object=client-cert;type=cert"
+       StreamDriver.KeyFile="pkcs11:token=rsyslog;object=client-key;type=private"
+       queue.type="linkedList"
+   )
+
+Module-default Example
+----------------------
+
+Use ``builtin:omfwd`` module defaults when multiple ``omfwd`` actions should
+share the same PKCS#11-backed TLS material:
+
+.. code-block:: rsyslog
+
+   module(
+       load="builtin:omfwd"
+       StreamDriver.CAFile="pkcs11:token=rsyslog;object=ca-cert;type=cert"
+       StreamDriver.CAExtraFiles="pkcs11:token=rsyslog;object=intermediate-ca-cert;type=cert"
+       StreamDriver.CertFile="pkcs11:token=rsyslog;object=client-cert;type=cert"
+       StreamDriver.KeyFile="pkcs11:token=rsyslog;object=client-key;type=private"
+   )
+
+   action(
+       type="omfwd"
+       target="logs.example.com"
+       port="6514"
+       protocol="tcp"
+       StreamDriver="ossl"
+       StreamDriverMode="1"
+       StreamDriverAuthMode="x509/name"
+       StreamDriverPermittedPeers="logs.example.com"
+   )
+
+Action-level values override the ``builtin:omfwd`` module defaults for the same
+parameter. The module defaults, in turn, override the global netstream driver
+defaults. Filesystem-backed module defaults remain available to any TLS-capable
+driver, but module defaults whose values are strict ``pkcs11:`` URIs are
+inherited only by actions whose effective stream driver is ``ossl``.
+
+Global Defaults
+---------------
+
+The global default TLS file parameters remain filesystem-path settings today:
+
+- ``DefaultNetstreamDriverCAFile``
+- ``DefaultNetstreamDriverCertFile``
+- ``DefaultNetstreamDriverKeyFile``
+- ``NetstreamDriverCAExtraFiles``
+
+They are validated during configuration loading with ordinary file access
+checks, so they currently cannot be set to ``pkcs11:`` URIs. If multiple
+``omfwd`` actions need PKCS#11-backed material, set the PKCS#11 URIs on each
+action explicitly or use ``builtin:omfwd`` module defaults.
+
+Operational Tips
+----------------
+
+- Prefer provider-based PIN handling over embedding ``pin-value=...`` inside
+  the URI in the rsyslog configuration. Provider configuration is usually
+  easier to rotate and less likely to be copied into configuration management
+  artifacts.
+- rsyslog does not interpret provider-specific PKCS#11 URI attributes beyond
+  recognizing the strict ``pkcs11:`` prefix. If your environment needs vendor
+  attributes, token selectors, or provider-specific matching rules, validate
+  them with OpenSSL and the provider first.
+- Keep the CA, certificate, and private key aligned. A mismatched certificate
+  and key will fail the TLS handshake just as it would with PEM files.
+- Use ordinary filesystem paths when PKCS#11 is not needed. PKCS#11 is most
+  useful when the private key must remain outside the filesystem or when your
+  environment already standardizes on token-backed key management.
+- If you use intermediate CA chains, verify how those certificates are
+  provisioned in your environment before switching away from PEM bundle files.
 
 Configuration Parameters
 ========================
@@ -818,6 +1020,24 @@ StreamDriver.CAFile
 This permits to override the CA file set via `global()` config object at the
 per-action basis. This parameter is ignored if the netstream driver and/or its
 mode does not need or support certificates.
+
+StreamDriver.CAExtraFiles
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "global() default", "no", "none"
+
+.. versionadded:: 8.2608.0
+
+This permits to override the additional CA certificate list set via the
+`global()` config object at the per-action basis. The value is a comma-separated
+list of filesystem paths or, for the ``ossl`` stream driver on supported
+OpenSSL 3 builds, strict ``pkcs11:`` URIs. This parameter is ignored if the
+netstream driver and/or its mode does not need or support certificates.
 
 StreamDriver.CRLFile
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/configuration/modules/omfwd/parameters/module.rst
+++ b/doc/source/configuration/modules/omfwd/parameters/module.rst
@@ -14,6 +14,81 @@ by action parameters.
 List of Module Parameters
 =========================
 
+StreamDriver.CAFile
+^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "none", "no", "none"
+
+Sets the default TLS CA file for ``omfwd`` actions that do not set
+``StreamDriver.CAFile`` on the action itself. If the value is a strict
+``pkcs11:`` URI, that module default is inherited only by actions whose
+effective stream driver is ``ossl``.
+
+StreamDriver.CRLFile
+^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "none", "no", "none"
+
+Sets the default TLS certificate revocation list file for ``omfwd`` actions
+that do not set ``StreamDriver.CRLFile`` on the action itself.
+
+StreamDriver.CAExtraFiles
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "none", "no", "none"
+
+Sets the default additional CA certificate file list or strict ``pkcs11:``
+URI list for ``omfwd`` actions that use the ``ossl`` stream driver and do not
+set ``StreamDriver.CAExtraFiles`` on the action itself. Multiple entries use
+the same comma-separated format as ``NetstreamDriverCAExtraFiles``. Module
+defaults for this parameter are inherited only by actions whose effective
+stream driver is ``ossl``.
+
+StreamDriver.KeyFile
+^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "none", "no", "none"
+
+Sets the default TLS private-key file for ``omfwd`` actions that do not set
+``StreamDriver.KeyFile`` on the action itself. If the value is a strict
+``pkcs11:`` URI, that module default is inherited only by actions whose
+effective stream driver is ``ossl``.
+
+StreamDriver.CertFile
+^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "none", "no", "none"
+
+Sets the default TLS certificate file for ``omfwd`` actions that do not set
+``StreamDriver.CertFile`` on the action itself. If the value is a strict
+``pkcs11:`` URI, that module default is inherited only by actions whose
+effective stream driver is ``ossl``.
+
 Template
 ^^^^^^^^
 

--- a/packaging/docker/dev_env/centos/base/7/Dockerfile
+++ b/packaging/docker/dev_env/centos/base/7/Dockerfile
@@ -81,7 +81,7 @@ RUN	wget -O /etc/yum.repos.d/network:messaging:zeromq:git-stable.repo https://do
 	yum -y install czmq-devel
 	# end of this RUN
 	#wget -O /etc/yum.repos.de/network:messaging:zeromq:git-stable.repo  https://download.opensuse.org/repositories/network:messaging:zeromq:git-stable/CentOS_6/network:messaging:zeromq:git-stable.repo && \
-RUN 	find / -name "pgm*"
+RUN 	find / -name "pgm*" || true
 RUN	mkdir /usr/lib64/pgm-5.2
 RUN	mkdir /usr/lib64/pgm-5.2/include
 # unfortunately, tcl-devel does not properly setup required bits in the environment

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -228,7 +228,7 @@ endif # if ENABLE_INET
 if ENABLE_OSSL
 # noinst_LTLIBRARIES += lmnsd_ossl.la
 pkglib_LTLIBRARIES += lmnsd_ossl.la
-lmnsd_ossl_la_SOURCES = net_ossl.c net_ossl.h nsd_ossl.c nsd_ossl.h
+lmnsd_ossl_la_SOURCES = net_ossl.c net_ossl.h net_ossl_store.c net_ossl_store.h nsd_ossl.c nsd_ossl.h
 lmnsd_ossl_la_LDFLAGS = -module -avoid-version
 
 if ENABLE_WOLFSSL

--- a/runtime/modules.c
+++ b/runtime/modules.c
@@ -78,6 +78,9 @@ static struct cnfparamblk pblk = {CNFPARAMBLK_VERSION, sizeof(actpdescr) / sizeo
 
 typedef rsRetVal (*pModInit_t)(int, int *, rsRetVal (**)(), rsRetVal (*)(), modInfo_t *);
 
+static const char cfgModRefSrc[] = "cfgmodules";
+static rsRetVal Use(const char *srcFile, modInfo_t *pThis);
+
 /* we provide a set of dummy functions for modules that do not support the
  * some interfaces.
  * On the commit feature: As the modules do not support it, they commit each message they
@@ -401,6 +404,12 @@ rsRetVal ATTR_NONNULL(1) addModToCnfList(cfgmodules_etry_t **const pNew, cfgmodu
         abortCnfUse(pNew);
         FINALIZE; /* we are in an early init state */
     }
+
+    /* The config keeps a raw modInfo_t pointer and later calls module entry
+     * points during rsconf teardown, so hold an explicit module reference for
+     * the lifetime of the cfgmodules entry.
+     */
+    CHKiRet(Use(cfgModRefSrc, (*pNew)->pMod));
 
     if (pLast == NULL) {
         loadConf->modules.root = *pNew;

--- a/runtime/net_ossl.c
+++ b/runtime/net_ossl.c
@@ -50,6 +50,7 @@
 #include "errmsg.h"
 #include "net.h"
 #include "net_ossl.h"
+#include "net_ossl_store.h"
 #include "nsd_ptcp.h"
 #include "rsconf.h"
 
@@ -420,10 +421,18 @@ void osslGlblExit(void) {
 }
 
 
-/* initialize openssl context; called on
- * - listener creation
- * - outbound connection creation
- * Once created, the ctx object is used by-subobjects (accepted inbound connections)
+/**
+ * @brief Create and configure the OpenSSL SSL_CTX for a listener or outbound
+ * connection.
+ *
+ * The context is populated from the effective netstream driver configuration,
+ * including CA certificates, certificate chains, and private keys. Those TLS
+ * objects may come from ordinary PEM files or, on supported OpenSSL 3 builds,
+ * from strict pkcs11: URIs handled through the URI-aware lmnsd_ossl helpers.
+ *
+ * @param pThis OpenSSL netstream instance being initialized.
+ * @param method SSL/TLS method used to create the context.
+ * @return RS_RET_OK on success, or an rsyslog TLS-related error code.
  */
 static rsRetVal net_ossl_osslCtxInit(net_ossl_t *pThis, const SSL_METHOD *method) {
     DEFiRet;
@@ -433,21 +442,25 @@ static rsRetVal net_ossl_osslCtxInit(net_ossl_t *pThis, const SSL_METHOD *method
     int bHaveKey;
     int bHaveExtraCAFiles;
     const char *caFile, *crlFile, *certFile, *keyFile;
-    char *extraCaFiles, *extraCaFile;
+    char *caFileSanitized, *crlFileSanitized, *certFileSanitized, *keyFileSanitized, *extraCaFilesSanitized;
+    char *extraCaFiles, *extraCaFilesCopy, *extraCaFile;
+
+    caFileSanitized = crlFileSanitized = certFileSanitized = keyFileSanitized = extraCaFilesSanitized = NULL;
+    extraCaFilesCopy = NULL;
     /* Setup certificates */
     caFile = (char *)((pThis->pszCAFile == NULL) ? glbl.GetDfltNetstrmDrvrCAF(runConf) : pThis->pszCAFile);
     if (caFile == NULL) {
         LogMsg(0, RS_RET_CA_CERT_MISSING, LOG_WARNING, "Warning: CA certificate is not set");
         bHaveCA = 0;
     } else {
-        dbgprintf("osslCtxInit: OSSL CA file: '%s'\n", caFile);
+        dbgprintf("osslCtxInit: OSSL CA file: '%s'\n", net_ossl_sanitize_log_value(caFile, &caFileSanitized));
         bHaveCA = 1;
     }
     crlFile = (char *)((pThis->pszCRLFile == NULL) ? glbl.GetDfltNetstrmDrvrCRLF(runConf) : pThis->pszCRLFile);
     if (crlFile == NULL) {
         bHaveCRL = 0;
     } else {
-        dbgprintf("osslCtxInit: OSSL CRL file: '%s'\n", crlFile);
+        dbgprintf("osslCtxInit: OSSL CRL file: '%s'\n", net_ossl_sanitize_log_value(crlFile, &crlFileSanitized));
         bHaveCRL = 1;
     }
     certFile = (char *)((pThis->pszCertFile == NULL) ? glbl.GetDfltNetstrmDrvrCertFile(runConf) : pThis->pszCertFile);
@@ -455,7 +468,7 @@ static rsRetVal net_ossl_osslCtxInit(net_ossl_t *pThis, const SSL_METHOD *method
         LogMsg(0, RS_RET_CERT_MISSING, LOG_WARNING, "Warning: Certificate file is not set");
         bHaveCert = 0;
     } else {
-        dbgprintf("osslCtxInit: OSSL CERT file: '%s'\n", certFile);
+        dbgprintf("osslCtxInit: OSSL CERT file: '%s'\n", net_ossl_sanitize_log_value(certFile, &certFileSanitized));
         bHaveCert = 1;
     }
     keyFile = (char *)((pThis->pszKeyFile == NULL) ? glbl.GetDfltNetstrmDrvrKeyFile(runConf) : pThis->pszKeyFile);
@@ -463,7 +476,7 @@ static rsRetVal net_ossl_osslCtxInit(net_ossl_t *pThis, const SSL_METHOD *method
         LogMsg(0, RS_RET_CERTKEY_MISSING, LOG_WARNING, "Warning: Key file is not set");
         bHaveKey = 0;
     } else {
-        dbgprintf("osslCtxInit: OSSL KEY file: '%s'\n", keyFile);
+        dbgprintf("osslCtxInit: OSSL KEY file: '%s'\n", net_ossl_sanitize_log_value(keyFile, &keyFileSanitized));
         bHaveKey = 1;
     }
     extraCaFiles =
@@ -471,7 +484,8 @@ static rsRetVal net_ossl_osslCtxInit(net_ossl_t *pThis, const SSL_METHOD *method
     if (extraCaFiles == NULL) {
         bHaveExtraCAFiles = 0;
     } else {
-        dbgprintf("osslCtxInit: OSSL EXTRA CA files: '%s'\n", extraCaFiles);
+        dbgprintf("osslCtxInit: OSSL EXTRA CA files: '%s'\n",
+                  net_ossl_sanitize_log_value(extraCaFiles, &extraCaFilesSanitized));
         bHaveExtraCAFiles = 1;
     }
 
@@ -483,26 +497,38 @@ static rsRetVal net_ossl_osslCtxInit(net_ossl_t *pThis, const SSL_METHOD *method
     pThis->ctx = SSL_CTX_new(method);
 
     if (bHaveExtraCAFiles == 1) {
+        CHKmalloc(extraCaFilesCopy = strdup(extraCaFiles));
+        extraCaFiles = extraCaFilesCopy;
         while ((extraCaFile = strsep(&extraCaFiles, ","))) {
-            if (SSL_CTX_load_verify_locations(pThis->ctx, extraCaFile, NULL) != 1) {
-                LogError(0, RS_RET_TLS_CERT_ERR,
-                         "Error: Extra Certificate file could not be accessed. "
+            iRet = net_ossl_load_ca_file(pThis->ctx, extraCaFile);
+            if (iRet != RS_RET_OK) {
+                char *extraCaFileSanitized = NULL;
+                const char *logExtraCaFile = net_ossl_sanitize_log_value(extraCaFile, &extraCaFileSanitized);
+                LogError(0, iRet,
+                         "Error: Extra Certificate file '%s' could not be accessed. "
                          "Check at least: 1) file path is correct, 2) file exist, "
                          "3) permissions are correct, 4) file content is correct. "
-                         "OpenSSL error info may follow in next messages");
-                net_ossl_lastOpenSSLErrorMsg(NULL, 0, NULL, LOG_ERR, "osslCtxInit", "SSL_CTX_load_verify_locations");
-                ABORT_FINALIZE(RS_RET_TLS_CERT_ERR);
+                         "OpenSSL error info may follow in next messages",
+                         logExtraCaFile);
+                net_ossl_free_sanitized_log_value(&extraCaFileSanitized);
+                ABORT_FINALIZE(iRet);
             }
         }
     }
-    if (bHaveCA == 1 && SSL_CTX_load_verify_locations(pThis->ctx, caFile, NULL) != 1) {
-        LogError(0, RS_RET_TLS_CERT_ERR,
-                 "Error: CA certificate could not be accessed. "
-                 "Check at least: 1) file path is correct, 2) file exist, "
-                 "3) permissions are correct, 4) file content is correct. "
-                 "OpenSSL error info may follow in next messages");
-        net_ossl_lastOpenSSLErrorMsg(NULL, 0, NULL, LOG_ERR, "osslCtxInit", "SSL_CTX_load_verify_locations");
-        ABORT_FINALIZE(RS_RET_TLS_CERT_ERR);
+    if (bHaveCA == 1) {
+        iRet = net_ossl_load_ca_file(pThis->ctx, caFile);
+        if (iRet != RS_RET_OK) {
+            char *caFileLoadSanitized = NULL;
+            const char *logCaFile = net_ossl_sanitize_log_value(caFile, &caFileLoadSanitized);
+            LogError(0, iRet,
+                     "Error: CA certificate '%s' could not be accessed. "
+                     "Check at least: 1) file path is correct, 2) file exist, "
+                     "3) permissions are correct, 4) file content is correct. "
+                     "OpenSSL error info may follow in next messages",
+                     logCaFile);
+            net_ossl_free_sanitized_log_value(&caFileLoadSanitized);
+            ABORT_FINALIZE(iRet);
+        }
     }
     if (bHaveCRL == 1) {
 #if defined(ENABLE_WOLFSSL)
@@ -626,22 +652,33 @@ static rsRetVal net_ossl_osslCtxInit(net_ossl_t *pThis, const SSL_METHOD *method
         dbgprintf("osslCtxInit: wolfSSL OCSP revocation checking enabled\n");
     }
 #endif
-    if (bHaveCert == 1 && SSL_CTX_use_certificate_chain_file(pThis->ctx, certFile) != 1) {
-        LogError(0, RS_RET_TLS_CERT_ERR,
-                 "Error: Certificate file could not be accessed. "
-                 "Check at least: 1) file path is correct, 2) file exist, "
-                 "3) permissions are correct, 4) file content is correct. "
-                 "OpenSSL error info may follow in next messages");
-        net_ossl_lastOpenSSLErrorMsg(NULL, 0, NULL, LOG_ERR, "osslCtxInit", "SSL_CTX_use_certificate_chain_file");
-        ABORT_FINALIZE(RS_RET_TLS_CERT_ERR);
+    if (bHaveKey == 1) {
+        iRet = net_ossl_load_key_file(pThis->ctx, keyFile);
+        if (iRet != RS_RET_OK) {
+            LogError(0, iRet,
+                     "Error: Key could not be accessed. "
+                     "Check at least: 1) file path is correct, 2) file exist, "
+                     "3) permissions are correct, 4) file content is correct. "
+                     "OpenSSL error info may follow in next messages");
+            ABORT_FINALIZE(iRet);
+        }
     }
-    if (bHaveKey == 1 && SSL_CTX_use_PrivateKey_file(pThis->ctx, keyFile, SSL_FILETYPE_PEM) != 1) {
+    if (bHaveCert == 1) {
+        iRet = net_ossl_load_cert_file(pThis->ctx, certFile);
+        if (iRet != RS_RET_OK) {
+            LogError(0, iRet,
+                     "Error: Certificate file could not be accessed. "
+                     "Check at least: 1) file path is correct, 2) file exist, "
+                     "3) permissions are correct, 4) file content is correct. "
+                     "OpenSSL error info may follow in next messages");
+            ABORT_FINALIZE(iRet);
+        }
+    }
+    if (bHaveCert == 1 && bHaveKey == 1 && SSL_CTX_check_private_key(pThis->ctx) != 1) {
         LogError(0, RS_RET_TLS_KEY_ERR,
-                 "Error: Key could not be accessed. "
-                 "Check at least: 1) file path is correct, 2) file exist, "
-                 "3) permissions are correct, 4) file content is correct. "
+                 "Error: Certificate and key are not usable together. "
                  "OpenSSL error info may follow in next messages");
-        net_ossl_lastOpenSSLErrorMsg(NULL, 0, NULL, LOG_ERR, "osslCtxInit", "SSL_CTX_use_PrivateKey_file");
+        net_ossl_lastOpenSSLErrorMsg(NULL, 0, NULL, LOG_ERR, "osslCtxInit", "SSL_CTX_check_private_key");
         ABORT_FINALIZE(RS_RET_TLS_KEY_ERR);
     }
 
@@ -687,6 +724,12 @@ static rsRetVal net_ossl_osslCtxInit(net_ossl_t *pThis, const SSL_METHOD *method
     #endif
 #endif
 finalize_it:
+    net_ossl_free_sanitized_log_value(&caFileSanitized);
+    net_ossl_free_sanitized_log_value(&crlFileSanitized);
+    net_ossl_free_sanitized_log_value(&certFileSanitized);
+    net_ossl_free_sanitized_log_value(&keyFileSanitized);
+    net_ossl_free_sanitized_log_value(&extraCaFilesSanitized);
+    free(extraCaFilesCopy);
     RETiRet;
 }
 

--- a/runtime/net_ossl_store.c
+++ b/runtime/net_ossl_store.c
@@ -1,0 +1,576 @@
+/**
+ * @file net_ossl_store.c
+ * @brief TLS object loading helpers for the OpenSSL netstream driver.
+ *
+ * This module centralizes loading of CA certificates, certificate chains, and
+ * private keys for lmnsd_ossl. On OpenSSL 3 builds it uses the provider/store
+ * API when a strict pkcs11: URI is supplied, while preserving the traditional
+ * filesystem-backed PEM loading path for ordinary filenames.
+ *
+ * Copyright 2026 Cisco Systems, Inc., and/or its affiliates.
+ * Copyright 2026 Adiscon GmbH.
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "net_ossl_store.h"
+#include "debug.h"
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(ENABLE_WOLFSSL) && !defined(LIBRESSL_VERSION_NUMBER)
+    #include <openssl/store.h>
+#endif
+
+/**
+ * @brief Return the delimiter that terminates a sensitive URI attribute.
+ * @param c Character under inspection.
+ * @return Non-zero when @p c ends the current attribute value.
+ */
+static int net_ossl_is_uri_value_delim(int c) {
+    return c == '\0' || c == ';' || c == ',';
+}
+
+/**
+ * @brief Redact a sensitive URI attribute in a caller-supplied buffer.
+ * @param buf Mutable string to update in place.
+ * @param key Attribute key to locate.
+ */
+static void ATTR_NONNULL() net_ossl_redact_uri_value(char *buf, const char *key) {
+    char *pos;
+    char *value;
+    char *end;
+
+    pos = buf;
+    while ((pos = strstr(pos, key)) != NULL) {
+        value = pos + strlen(key);
+        end = value;
+        while (!net_ossl_is_uri_value_delim((unsigned char)*end)) {
+            ++end;
+        }
+
+        memset(value, '*', (size_t)(end - value));
+        pos = end;
+    }
+}
+
+/**
+ * @brief Redact sensitive URI or provider configuration values before they are
+ * emitted to logs.
+ * @param input Original path or URI to sanitize.
+ * @param buf Caller-supplied scratch buffer used when redaction is required.
+ * @param bufSize Size of @p buf in bytes.
+ * @return Either @p input when no redaction was required, or @p buf containing
+ * a redacted copy.
+ */
+const char *ATTR_NONNULL() net_ossl_sanitize_log_value(const char *input, char **sanitized) {
+    static const char redactedFallback[] = "[redacted]";
+
+    *sanitized = NULL;
+
+    if (strstr(input, "pin-value=") == NULL && strstr(input, "pkcs11-module-token-pin=") == NULL) {
+        return input;
+    }
+
+    *sanitized = strdup(input);
+    if (*sanitized == NULL) {
+        return redactedFallback;
+    }
+
+    net_ossl_redact_uri_value(*sanitized, "pin-value=");
+    net_ossl_redact_uri_value(*sanitized, "pkcs11-module-token-pin=");
+    return *sanitized;
+}
+
+void net_ossl_free_sanitized_log_value(char **sanitized) {
+    if (sanitized != NULL) {
+        free(*sanitized);
+        *sanitized = NULL;
+    }
+}
+
+/**
+ * @brief Log the most recent OpenSSL error stack entry for a failed load
+ * operation.
+ * @param errCode rsyslog error code associated with the failure.
+ * @param call OpenSSL API name that failed.
+ * @param objType Human-readable object type being loaded.
+ * @param input Original path or URI that triggered the failure.
+ */
+static void ATTR_NONNULL()
+    net_ossl_store_log_error_impl(rsRetVal errCode, const char *call, const char *objType, const char *input) {
+    unsigned long err;
+    char errbuf[256];
+    char *sanitized = NULL;
+    const char *logInput;
+
+    logInput = net_ossl_sanitize_log_value(input, &sanitized);
+
+    err = ERR_get_error();
+    if (err == 0) {
+        LogError(0, errCode, "%s: %s load failed for '%s'. OpenSSL Error Stack: no OpenSSL error on stack", call,
+                 objType, logInput);
+        dbgprintf("%s: %s load failed for '%s'. OpenSSL Error Stack: no OpenSSL error on stack\n", call, objType,
+                  logInput);
+        net_ossl_free_sanitized_log_value(&sanitized);
+        return;
+    }
+
+    while (err != 0) {
+        ERR_error_string_n(err, errbuf, sizeof(errbuf));
+        LogError(0, errCode, "%s: %s load failed for '%s'. OpenSSL Error Stack: err=0x%lx lib=%d reason=%d msg='%s'",
+                 call, objType, logInput, err, ERR_GET_LIB(err), ERR_GET_REASON(err), errbuf);
+        dbgprintf("%s: %s load failed for '%s'. OpenSSL Error Stack: err=0x%lx lib=%d reason=%d msg='%s'\n", call,
+                  objType, logInput, err, ERR_GET_LIB(err), ERR_GET_REASON(err), errbuf);
+        err = ERR_get_error();
+    }
+    net_ossl_free_sanitized_log_value(&sanitized);
+}
+
+/**
+ * @brief Log the current OpenSSL error stack and return the supplied rsyslog
+ * error code.
+ * @param errCode rsyslog error code to return to the caller.
+ * @param call OpenSSL API name that failed.
+ * @param objType Human-readable object type being loaded.
+ * @param input Original path or URI that triggered the failure.
+ * @return The @p errCode argument.
+ */
+static rsRetVal ATTR_NONNULL()
+    net_ossl_store_log_error(rsRetVal errCode, const char *call, const char *objType, const char *input) {
+    net_ossl_store_log_error_impl(errCode, call, objType, input);
+    return errCode;
+}
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(ENABLE_WOLFSSL) && !defined(LIBRESSL_VERSION_NUMBER)
+/**
+ * @brief Determine whether a configuration value should be treated as a PKCS#11
+ * URI.
+ * @param value Configuration value to inspect.
+ * @return Non-zero when @p value begins with the strict @c pkcs11: prefix.
+ */
+static int net_ossl_is_uri(const char *value) {
+    return value != NULL && strncmp(value, "pkcs11:", sizeof("pkcs11:") - 1) == 0;
+}
+
+/**
+ * @brief Open an OpenSSL store loader for a URI-backed object source.
+ * @param errCode rsyslog error code to report if opening the store fails.
+ * @param uri Object locator passed to OSSL_STORE.
+ * @param expect Expected OSSL_STORE object type.
+ * @param store Receives the opened store context on success.
+ * @return RS_RET_OK on success, or the caller-supplied rsyslog error code.
+ */
+static rsRetVal ATTR_NONNULL(2, 4)
+    net_ossl_store_open(rsRetVal errCode, const char *uri, int expect, OSSL_STORE_CTX **store) {
+    DEFiRet;
+
+    assert(store != NULL);
+    *store = OSSL_STORE_open_ex(uri, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    if (*store == NULL) {
+        ABORT_FINALIZE(net_ossl_store_log_error(errCode, "OSSL_STORE_open_ex", "store", uri));
+    }
+    if (OSSL_STORE_expect(*store, expect) != 1) {
+        /* Preference only; keep going if the loader ignores it. */
+        net_ossl_store_log_error_impl(RS_RET_OK, "OSSL_STORE_expect", "store", uri);
+        ERR_clear_error();
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+/**
+ * @brief Load CA certificates from an OpenSSL store source into an SSL
+ * context.
+ * @param ctx SSL context that receives the trust anchors.
+ * @param caFile PKCS#11 URI to open through OSSL_STORE.
+ * @return RS_RET_OK on success, or an rsyslog TLS certificate error code.
+ */
+static rsRetVal ATTR_NONNULL() net_ossl_store_load_ca_file(SSL_CTX *ctx, const char *caFile) {
+    DEFiRet;
+    OSSL_STORE_CTX *store = NULL;
+    OSSL_STORE_INFO *info = NULL;
+    X509_STORE *x509_store;
+    int loaded = 0;
+
+    assert(ctx != NULL);
+    assert(caFile != NULL);
+
+    x509_store = SSL_CTX_get_cert_store(ctx);
+    if (x509_store == NULL) {
+        char *sanitized = NULL;
+        const char *logCaFile = net_ossl_sanitize_log_value(caFile, &sanitized);
+        LogError(0, RS_RET_TLS_CERT_ERR, "SSL_CTX_get_cert_store: CA load failed for '%s': no X509 store on SSL_CTX",
+                 logCaFile);
+        dbgprintf("SSL_CTX_get_cert_store: CA load failed for '%s': no X509 store on SSL_CTX\n", logCaFile);
+        net_ossl_free_sanitized_log_value(&sanitized);
+        ABORT_FINALIZE(RS_RET_TLS_CERT_ERR);
+    }
+
+    CHKiRet(net_ossl_store_open(RS_RET_TLS_CERT_ERR, caFile, OSSL_STORE_INFO_CERT, &store));
+
+    while ((info = OSSL_STORE_load(store)) != NULL) {
+        if (OSSL_STORE_INFO_get_type(info) == OSSL_STORE_INFO_CERT) {
+            X509 *cert = OSSL_STORE_INFO_get1_CERT(info);
+            if (cert != NULL) {
+                if (X509_STORE_add_cert(x509_store, cert) == 1) {
+                    loaded++;
+                } else {
+                    unsigned long err = ERR_peek_last_error();
+                    if (ERR_GET_LIB(err) == ERR_LIB_X509 && ERR_GET_REASON(err) == X509_R_CERT_ALREADY_IN_HASH_TABLE) {
+                        ERR_clear_error();
+                        loaded++;
+                    } else {
+                        ABORT_FINALIZE(
+                            net_ossl_store_log_error(RS_RET_TLS_CERT_ERR, "X509_STORE_add_cert", "CA", caFile));
+                    }
+                }
+                X509_free(cert);
+            }
+        }
+        OSSL_STORE_INFO_free(info);
+        info = NULL;
+    }
+
+    if (OSSL_STORE_error(store)) {
+        ABORT_FINALIZE(net_ossl_store_log_error(RS_RET_TLS_CERT_ERR, "OSSL_STORE_load", "CA", caFile));
+    }
+    if (loaded == 0) {
+        char *sanitized = NULL;
+        const char *logCaFile = net_ossl_sanitize_log_value(caFile, &sanitized);
+        LogError(0, RS_RET_TLS_CERT_ERR, "OSSL store CA load failed for '%s': no certificate objects were loaded",
+                 logCaFile);
+        dbgprintf("OSSL store CA load failed for '%s': no certificate objects were loaded\n", logCaFile);
+        net_ossl_free_sanitized_log_value(&sanitized);
+        ABORT_FINALIZE(RS_RET_TLS_CERT_ERR);
+    }
+
+finalize_it:
+    if (info != NULL) {
+        OSSL_STORE_INFO_free(info);
+    }
+    if (store != NULL) {
+        OSSL_STORE_close(store);
+    }
+    RETiRet;
+}
+
+/**
+ * @brief Load a certificate chain from an OpenSSL store source into an SSL
+ * context.
+ * @param ctx SSL context that receives the certificate chain.
+ * @param certFile PKCS#11 URI to open through OSSL_STORE.
+ * @return RS_RET_OK on success, or an rsyslog TLS certificate error code.
+ */
+static int ATTR_NONNULL() net_ossl_store_cert_issues_other(X509 *candidate, const STACK_OF(X509) * certs) {
+    int i;
+
+    assert(candidate != NULL);
+    assert(certs != NULL);
+
+    for (i = 0; i < sk_X509_num(certs); ++i) {
+        X509 *other = sk_X509_value(certs, i);
+        if (other != NULL && other != candidate && X509_check_issued(candidate, other) == X509_V_OK) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static rsRetVal ATTR_NONNULL(1, 2, 3)
+    net_ossl_store_select_leaf_cert(STACK_OF(X509) * certs, const char *certFile, X509 **leaf) {
+    DEFiRet;
+    int i;
+    X509 *fallback = NULL;
+    int fallbackCount = 0;
+    X509 *preferred = NULL;
+    int preferredCount = 0;
+
+    assert(certs != NULL);
+    assert(certFile != NULL);
+    assert(leaf != NULL);
+
+    *leaf = NULL;
+
+    for (i = 0; i < sk_X509_num(certs); ++i) {
+        X509 *cert = sk_X509_value(certs, i);
+        if (cert == NULL || net_ossl_store_cert_issues_other(cert, certs)) {
+            continue;
+        }
+
+        fallback = cert;
+        ++fallbackCount;
+        if (X509_check_ca(cert) == 0) {
+            preferred = cert;
+            ++preferredCount;
+        }
+    }
+
+    if (preferredCount == 1) {
+        *leaf = preferred;
+    } else if (preferredCount > 1) {
+        char *sanitized = NULL;
+        const char *logCertFile = net_ossl_sanitize_log_value(certFile, &sanitized);
+        LogError(0, RS_RET_TLS_CERT_ERR,
+                 "OSSL store certificate load failed for '%s': multiple end-entity certificates were loaded",
+                 logCertFile);
+        dbgprintf("OSSL store certificate load failed for '%s': multiple end-entity certificates were loaded\n",
+                  logCertFile);
+        net_ossl_free_sanitized_log_value(&sanitized);
+        ABORT_FINALIZE(RS_RET_TLS_CERT_ERR);
+    } else if (fallbackCount == 1) {
+        *leaf = fallback;
+    } else if (fallbackCount > 1) {
+        char *sanitized = NULL;
+        const char *logCertFile = net_ossl_sanitize_log_value(certFile, &sanitized);
+        LogError(0, RS_RET_TLS_CERT_ERR,
+                 "OSSL store certificate load failed for '%s': unable to identify a unique leaf certificate",
+                 logCertFile);
+        dbgprintf("OSSL store certificate load failed for '%s': unable to identify a unique leaf certificate\n",
+                  logCertFile);
+        net_ossl_free_sanitized_log_value(&sanitized);
+        ABORT_FINALIZE(RS_RET_TLS_CERT_ERR);
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal ATTR_NONNULL() net_ossl_store_load_cert_file(SSL_CTX *ctx, const char *certFile) {
+    DEFiRet;
+    OSSL_STORE_CTX *store = NULL;
+    OSSL_STORE_INFO *info = NULL;
+    STACK_OF(X509) *certs = NULL;
+    X509 *leaf = NULL;
+    int i;
+
+    assert(ctx != NULL);
+    assert(certFile != NULL);
+
+    CHKiRet(net_ossl_store_open(RS_RET_TLS_CERT_ERR, certFile, OSSL_STORE_INFO_CERT, &store));
+    certs = sk_X509_new_null();
+    if (certs == NULL) {
+        ABORT_FINALIZE(net_ossl_store_log_error(RS_RET_TLS_CERT_ERR, "sk_X509_new_null", "certificate", certFile));
+    }
+
+    while ((info = OSSL_STORE_load(store)) != NULL) {
+        if (OSSL_STORE_INFO_get_type(info) == OSSL_STORE_INFO_CERT) {
+            X509 *cert = OSSL_STORE_INFO_get1_CERT(info);
+            if (cert != NULL && !sk_X509_push(certs, cert)) {
+                X509_free(cert);
+                ABORT_FINALIZE(net_ossl_store_log_error(RS_RET_TLS_CERT_ERR, "sk_X509_push", "certificate", certFile));
+            }
+        }
+        OSSL_STORE_INFO_free(info);
+        info = NULL;
+    }
+
+    if (OSSL_STORE_error(store)) {
+        ABORT_FINALIZE(net_ossl_store_log_error(RS_RET_TLS_CERT_ERR, "OSSL_STORE_load", "certificate", certFile));
+    }
+
+    CHKiRet(net_ossl_store_select_leaf_cert(certs, certFile, &leaf));
+    if (leaf == NULL) {
+        char *sanitized = NULL;
+        const char *logCertFile = net_ossl_sanitize_log_value(certFile, &sanitized);
+        LogError(0, RS_RET_TLS_CERT_ERR,
+                 "OSSL store certificate load failed for '%s': no leaf certificate object was loaded", logCertFile);
+        dbgprintf("OSSL store certificate load failed for '%s': no leaf certificate object was loaded\n", logCertFile);
+        net_ossl_free_sanitized_log_value(&sanitized);
+        ABORT_FINALIZE(RS_RET_TLS_CERT_ERR);
+    }
+
+    for (i = 0; i < sk_X509_num(certs); ++i) {
+        X509 *cert = sk_X509_value(certs, i);
+        if (cert != NULL && cert != leaf) {
+            if (SSL_CTX_add_extra_chain_cert(ctx, cert) != 1) {
+                X509_free(cert);
+                sk_X509_set(certs, i, NULL);
+                ABORT_FINALIZE(net_ossl_store_log_error(RS_RET_TLS_CERT_ERR, "SSL_CTX_add_extra_chain_cert",
+                                                        "certificate", certFile));
+            }
+            sk_X509_set(certs, i, NULL);
+        }
+    }
+
+    if (SSL_CTX_use_certificate(ctx, leaf) != 1) {
+        net_ossl_store_log_error_impl(RS_RET_TLS_CERT_ERR, "SSL_CTX_use_certificate", "certificate", certFile);
+        ABORT_FINALIZE(RS_RET_TLS_CERT_ERR);
+    }
+
+finalize_it:
+    if (certs != NULL) {
+        sk_X509_pop_free(certs, X509_free);
+    }
+    if (info != NULL) {
+        OSSL_STORE_INFO_free(info);
+    }
+    if (store != NULL) {
+        OSSL_STORE_close(store);
+    }
+    RETiRet;
+}
+
+/**
+ * @brief Load a private key from an OpenSSL store source into an SSL context.
+ * @param ctx SSL context that receives the private key.
+ * @param keyFile PKCS#11 URI to open through OSSL_STORE.
+ * @return RS_RET_OK on success, or an rsyslog TLS key error code.
+ */
+static rsRetVal ATTR_NONNULL() net_ossl_store_load_key_file(SSL_CTX *ctx, const char *keyFile) {
+    DEFiRet;
+    OSSL_STORE_CTX *store = NULL;
+    OSSL_STORE_INFO *info = NULL;
+    EVP_PKEY *pkey = NULL;
+
+    assert(ctx != NULL);
+    assert(keyFile != NULL);
+
+    CHKiRet(net_ossl_store_open(RS_RET_TLS_KEY_ERR, keyFile, OSSL_STORE_INFO_PKEY, &store));
+
+    while ((info = OSSL_STORE_load(store)) != NULL) {
+        if (OSSL_STORE_INFO_get_type(info) == OSSL_STORE_INFO_PKEY) {
+            pkey = OSSL_STORE_INFO_get1_PKEY(info);
+            OSSL_STORE_INFO_free(info);
+            info = NULL;
+            break;
+        }
+        OSSL_STORE_INFO_free(info);
+        info = NULL;
+    }
+
+    if (OSSL_STORE_error(store)) {
+        ABORT_FINALIZE(net_ossl_store_log_error(RS_RET_TLS_KEY_ERR, "OSSL_STORE_load", "private key", keyFile));
+    }
+    if (pkey == NULL || SSL_CTX_use_PrivateKey(ctx, pkey) != 1) {
+        if (pkey == NULL) {
+            char *sanitized = NULL;
+            const char *logKeyFile = net_ossl_sanitize_log_value(keyFile, &sanitized);
+            LogError(0, RS_RET_TLS_KEY_ERR, "OSSL store key load failed for '%s': no private key object was loaded",
+                     logKeyFile);
+            dbgprintf("OSSL store key load failed for '%s': no private key object was loaded\n", logKeyFile);
+            net_ossl_free_sanitized_log_value(&sanitized);
+        } else {
+            net_ossl_store_log_error_impl(RS_RET_TLS_KEY_ERR, "SSL_CTX_use_PrivateKey", "private key", keyFile);
+        }
+        ABORT_FINALIZE(RS_RET_TLS_KEY_ERR);
+    }
+
+finalize_it:
+    if (pkey != NULL) {
+        EVP_PKEY_free(pkey);
+    }
+    if (info != NULL) {
+        OSSL_STORE_INFO_free(info);
+    }
+    if (store != NULL) {
+        OSSL_STORE_close(store);
+    }
+    RETiRet;
+}
+#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(ENABLE_WOLFSSL) && !defined(LIBRESSL_VERSION_NUMBER) */
+
+/**
+ * @brief Load CA certificates into an SSL context from a file path or PKCS#11
+ * URI.
+ * @param ctx SSL context that receives the trust anchors.
+ * @param caFile Path or pkcs11: URI describing the CA certificate source.
+ * @return RS_RET_OK on success, or an rsyslog TLS certificate error code.
+ */
+rsRetVal net_ossl_load_ca_file(SSL_CTX *ctx, const char *caFile) {
+    DEFiRet;
+
+    assert(ctx != NULL);
+    assert(caFile != NULL);
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(ENABLE_WOLFSSL) && !defined(LIBRESSL_VERSION_NUMBER)
+    if (net_ossl_is_uri(caFile)) {
+        CHKiRet(net_ossl_store_load_ca_file(ctx, caFile));
+        FINALIZE;
+    }
+#endif
+
+    if (SSL_CTX_load_verify_locations(ctx, caFile, NULL) != 1) {
+        ABORT_FINALIZE(net_ossl_store_log_error(RS_RET_TLS_CERT_ERR, "SSL_CTX_load_verify_locations", "CA", caFile));
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+/**
+ * @brief Load a certificate chain into an SSL context from a file path or
+ * PKCS#11 URI.
+ * @param ctx SSL context that receives the certificate chain.
+ * @param certFile Path or pkcs11: URI describing the certificate source.
+ * @return RS_RET_OK on success, or an rsyslog TLS certificate error code.
+ */
+rsRetVal net_ossl_load_cert_file(SSL_CTX *ctx, const char *certFile) {
+    DEFiRet;
+
+    assert(ctx != NULL);
+    assert(certFile != NULL);
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(ENABLE_WOLFSSL) && !defined(LIBRESSL_VERSION_NUMBER)
+    if (net_ossl_is_uri(certFile)) {
+        CHKiRet(net_ossl_store_load_cert_file(ctx, certFile));
+        FINALIZE;
+    }
+#endif
+
+    if (SSL_CTX_use_certificate_chain_file(ctx, certFile) != 1) {
+        ABORT_FINALIZE(net_ossl_store_log_error(RS_RET_TLS_CERT_ERR, "SSL_CTX_use_certificate_chain_file",
+                                                "certificate", certFile));
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+/**
+ * @brief Load a private key into an SSL context from a file path or PKCS#11
+ * URI.
+ * @param ctx SSL context that receives the private key.
+ * @param keyFile Path or pkcs11: URI describing the private key source.
+ * @return RS_RET_OK on success, or an rsyslog TLS key error code.
+ */
+rsRetVal net_ossl_load_key_file(SSL_CTX *ctx, const char *keyFile) {
+    DEFiRet;
+
+    assert(ctx != NULL);
+    assert(keyFile != NULL);
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(ENABLE_WOLFSSL) && !defined(LIBRESSL_VERSION_NUMBER)
+    if (net_ossl_is_uri(keyFile)) {
+        CHKiRet(net_ossl_store_load_key_file(ctx, keyFile));
+        FINALIZE;
+    }
+#endif
+
+    if (SSL_CTX_use_PrivateKey_file(ctx, keyFile, SSL_FILETYPE_PEM) != 1) {
+        ABORT_FINALIZE(
+            net_ossl_store_log_error(RS_RET_TLS_KEY_ERR, "SSL_CTX_use_PrivateKey_file", "private key", keyFile));
+    }
+
+finalize_it:
+    RETiRet;
+}

--- a/runtime/net_ossl_store.h
+++ b/runtime/net_ossl_store.h
@@ -1,0 +1,79 @@
+/**
+ * @file net_ossl_store.h
+ * @brief Helper interfaces for loading TLS objects into the OpenSSL
+ * netstream driver.
+ *
+ * The declarations in this header are private to the lmnsd_ossl runtime
+ * module. They provide a single entry point for loading trust anchors,
+ * certificates, and private keys from either traditional filesystem-backed
+ * PEM files or provider-backed pkcs11: URIs.
+ *
+ * Copyright 2026 Cisco Systems, Inc., and/or its affiliates.
+ * Copyright 2026 Adiscon GmbH.
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef INCLUDED_NET_OSSL_STORE_H
+#define INCLUDED_NET_OSSL_STORE_H
+
+#include "rsyslog.h"
+#include "net_ossl.h"
+
+/**
+ * @brief Load CA certificates into an SSL context.
+ * @param ctx SSL context that receives the trust anchors.
+ * @param caFile Path or pkcs11: URI describing the CA certificate source.
+ * @return RS_RET_OK on success, or an rsyslog TLS certificate error code.
+ */
+rsRetVal net_ossl_load_ca_file(SSL_CTX *ctx, const char *caFile);
+
+/**
+ * @brief Load an end-entity certificate chain into an SSL context.
+ * @param ctx SSL context that receives the certificate chain.
+ * @param certFile Path or pkcs11: URI describing the certificate source.
+ * @return RS_RET_OK on success, or an rsyslog TLS certificate error code.
+ */
+rsRetVal net_ossl_load_cert_file(SSL_CTX *ctx, const char *certFile);
+
+/**
+ * @brief Load a private key into an SSL context.
+ * @param ctx SSL context that receives the private key.
+ * @param keyFile Path or pkcs11: URI describing the private key source.
+ * @return RS_RET_OK on success, or an rsyslog TLS key error code.
+ */
+rsRetVal net_ossl_load_key_file(SSL_CTX *ctx, const char *keyFile);
+
+/**
+ * @brief Redact sensitive fields from a TLS object locator before logging it.
+ * @param input Original path or URI to sanitize.
+ * @param sanitized Allocated sanitized copy when redaction is required, or
+ * NULL when the original input is safe to log as-is.
+ * @return Either @p input when no redaction was needed, an allocated sanitized
+ * copy stored in @p sanitized, or a constant fallback redaction string when
+ * memory allocation fails.
+ */
+const char *ATTR_NONNULL() net_ossl_sanitize_log_value(const char *input, char **sanitized);
+
+/**
+ * @brief Release a sanitized log value allocated by
+ * net_ossl_sanitize_log_value().
+ * @param sanitized Pointer to the allocated sanitized string, or NULL when no
+ * allocation was needed.
+ */
+void net_ossl_free_sanitized_log_value(char **sanitized);
+
+#endif /* INCLUDED_NET_OSSL_STORE_H */

--- a/runtime/netstrm.c
+++ b/runtime/netstrm.c
@@ -298,6 +298,23 @@ finalize_it:
     RETiRet;
 }
 
+/**
+ * @brief Set additional CA certificate sources on the active netstream
+ * driver.
+ * @param pThis Netstream instance whose driver should receive the setting.
+ * @param file Comma-separated file list or strict ``pkcs11:`` URI list to
+ * forward to the driver.
+ * @return RS_RET_OK on success or a driver-specific error code.
+ */
+static rsRetVal SetDrvrTlsCAExtraFiles(netstrm_t *const pThis, const uchar *const file) {
+    DEFiRet;
+    NULL_CHECK(pThis);
+    iRet = pThis->Drvr.SetTlsCAExtraFiles(pThis->pDrvrData, file);
+
+finalize_it:
+    RETiRet;
+}
+
 static rsRetVal SetDrvrTlsKeyFile(netstrm_t *const pThis, const uchar *const file) {
     DEFiRet;
     NULL_CHECK(pThis);
@@ -528,6 +545,7 @@ BEGINobjQueryInterface(netstrm)
     pIf->SetDrvrTlsRevocationCheck = SetDrvrTlsRevocationCheck;
     pIf->SetDrvrTlsCAFile = SetDrvrTlsCAFile;
     pIf->SetDrvrTlsCRLFile = SetDrvrTlsCRLFile;
+    pIf->SetDrvrTlsCAExtraFiles = SetDrvrTlsCAExtraFiles;
     pIf->SetDrvrTlsKeyFile = SetDrvrTlsKeyFile;
     pIf->SetDrvrTlsCertFile = SetDrvrTlsCertFile;
     pIf->SetDrvrRemoteSNI = SetDrvrRemoteSNI;

--- a/runtime/netstrm.h
+++ b/runtime/netstrm.h
@@ -92,12 +92,13 @@ BEGINinterface(netstrm) /* name must also be changed in ENDinterface macro! */
     /* v15 -- Tls cert functions */
     rsRetVal (*SetDrvrTlsCAFile)(netstrm_t *pThis, const uchar *file);
     rsRetVal (*SetDrvrTlsCRLFile)(netstrm_t *pThis, const uchar *file);
+    rsRetVal (*SetDrvrTlsCAExtraFiles)(netstrm_t *pThis, const uchar *file);
     rsRetVal (*SetDrvrTlsKeyFile)(netstrm_t *pThis, const uchar *file);
     rsRetVal (*SetDrvrTlsCertFile)(netstrm_t *pThis, const uchar *file);
     /* v18 -- allow remote server's TLS SNI to be set manually */
     rsRetVal (*SetDrvrRemoteSNI)(netstrm_t *pThis, uchar *pszRemoteSNI);
 ENDinterface(netstrm)
-#define netstrmCURR_IF_VERSION 19 /* increment whenever you change the interface structure! */
+#define netstrmCURR_IF_VERSION 20 /* increment whenever you change the interface structure! */
 /* interface version 3 added GetRemAddr()
  * interface version 4 added EnableKeepAlive() -- rgerhards, 2009-06-02
  * interface version 5 changed return of CheckConnection from void to rsRetVal -- alorbach, 2012-09-06
@@ -110,6 +111,7 @@ ENDinterface(netstrm)
  * interface version 17 added nextIODirection parameter to Rcv() -- rgehards, 2025-04-17
  * interface version 18 added SetDrvrRemoteSNI -- jfcantu, 2020-01-15
  * interface version 19 added SetTcpUserTimeout
+ * interface version 20 added SetDrvrTlsCAExtraFiles
  * */
 
 /* prototypes */

--- a/runtime/nsd.h
+++ b/runtime/nsd.h
@@ -86,6 +86,7 @@ BEGINinterface(nsd) /* name must also be changed in ENDinterface macro! */
 
     /* v16 - Tls CRL */
     rsRetVal (*SetTlsCRLFile)(nsd_t *pThis, const uchar *);
+    rsRetVal (*SetTlsCAExtraFiles)(nsd_t *pThis, const uchar *);
 
     /* v17 - Remote Port */
     rsRetVal (*GetRemotePort)(nsd_t *pThis, int *);
@@ -98,7 +99,7 @@ BEGINinterface(nsd) /* name must also be changed in ENDinterface macro! */
     rsRetVal (*SetTlsRevocationCheck)(nsd_t *pThis, int enabled);
 
 ENDinterface(nsd)
-#define nsdCURR_IF_VERSION 20 /* increment whenever you change the interface structure! */
+#define nsdCURR_IF_VERSION 21 /* increment whenever you change the interface structure! */
     /* interface version 4 added GetRemAddr()
      * interface version 5 added EnableKeepAlive() -- rgerhards, 2009-06-02
      * interface version 6 changed return of CheckConnection from void to rsRetVal -- alorbach, 2012-09-06
@@ -109,6 +110,7 @@ ENDinterface(nsd)
      * interface version 11 added oserr to Rcv() signature -- rgerhards, 2017-09-04
      * interface version 18 added SetRemoteSNI -- jfcantu, 2020-01-15
      * interface version 20 added SetTcpUserTimeout
+     * interface version 21 added SetTlsCAExtraFiles
      */
 
 #endif /* #ifndef INCLUDED_NSD_H */

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1844,6 +1844,19 @@ finalize_it:
     RETiRet;
 }
 
+static rsRetVal SetTlsCAExtraFiles(nsd_t __attribute__((unused)) * pNsd, const uchar *const pszFile) {
+    DEFiRet;
+    if (pszFile != NULL) {
+        LogError(0, RS_RET_VALUE_NOT_SUPPORTED,
+                 "error: extra CA Files setting not supported by "
+                 "gtls netstream driver");
+        ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+    }
+
+finalize_it:
+    RETiRet;
+}
+
 static rsRetVal SetTlsKeyFile(nsd_t *pNsd, const uchar *const pszFile) {
     DEFiRet;
     nsd_gtls_t *const pThis = nsd_gtls_from_nsd(pNsd);
@@ -2617,6 +2630,7 @@ BEGINobjQueryInterface(nsd_gtls)
     pIf->SetTlsVerifyDepth = SetTlsVerifyDepth;
     pIf->SetTlsCAFile = SetTlsCAFile;
     pIf->SetTlsCRLFile = SetTlsCRLFile;
+    pIf->SetTlsCAExtraFiles = SetTlsCAExtraFiles;
     pIf->SetTlsKeyFile = SetTlsKeyFile;
     pIf->SetTlsCertFile = SetTlsCertFile;
     pIf->GetRemotePort = GetRemotePort;

--- a/runtime/nsd_mbedtls.c
+++ b/runtime/nsd_mbedtls.c
@@ -540,6 +540,19 @@ finalize_it:
     RETiRet;
 }
 
+static rsRetVal SetTlsCAExtraFiles(nsd_t __attribute__((unused)) * pNsd, const uchar *const pszFile) {
+    DEFiRet;
+    if (pszFile != NULL) {
+        LogError(0, RS_RET_VALUE_NOT_SUPPORTED,
+                 "error: extra CA Files setting not supported by "
+                 "mbedtls netstream driver");
+        ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+    }
+
+finalize_it:
+    RETiRet;
+}
+
 static rsRetVal SetTlsKeyFile(nsd_t *pNsd, const uchar *const pszFile) {
     DEFiRet;
     nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
@@ -1497,6 +1510,7 @@ BEGINobjQueryInterface(nsd_mbedtls)
     pIf->SetPrioritizeSAN = SetPrioritizeSAN;
     pIf->SetTlsVerifyDepth = SetTlsVerifyDepth;
     pIf->SetTlsCAFile = SetTlsCAFile;
+    pIf->SetTlsCAExtraFiles = SetTlsCAExtraFiles;
     pIf->SetTlsKeyFile = SetTlsKeyFile;
     pIf->SetTlsCertFile = SetTlsCertFile;
     pIf->SetTlsCRLFile = SetTlsCRLFile;

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -1616,6 +1616,22 @@ finalize_it:
     RETiRet;
 }
 
+static rsRetVal SetTlsCAExtraFiles(nsd_t *pNsd, const uchar *const extraCaFiles) {
+    DEFiRet;
+    nsd_ossl_t *const pThis = (nsd_ossl_t *)pNsd;
+
+    ISOBJ_TYPE_assert((pThis), nsd_ossl);
+    free((void *)pThis->pNetOssl->pszExtraCAFiles);
+    pThis->pNetOssl->pszExtraCAFiles = NULL;
+
+    if (extraCaFiles != NULL) {
+        CHKmalloc(pThis->pNetOssl->pszExtraCAFiles = (const uchar *)strdup((const char *)extraCaFiles));
+    }
+
+finalize_it:
+    RETiRet;
+}
+
 
 static rsRetVal SetTlsKeyFile(nsd_t *pNsd, const uchar *const pszFile) {
     DEFiRet;
@@ -1720,6 +1736,7 @@ BEGINobjQueryInterface(nsd_ossl)
     pIf->SetTlsRevocationCheck = SetTlsRevocationCheck;
     pIf->SetTlsCAFile = SetTlsCAFile;
     pIf->SetTlsCRLFile = SetTlsCRLFile;
+    pIf->SetTlsCAExtraFiles = SetTlsCAExtraFiles;
     pIf->SetTlsKeyFile = SetTlsKeyFile;
     pIf->SetTlsCertFile = SetTlsCertFile;
     pIf->GetRemotePort = GetRemotePort;

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -251,6 +251,18 @@ finalize_it:
     RETiRet;
 }
 
+static rsRetVal SetTlsCAExtraFiles(nsd_t __attribute__((unused)) * pNsd, const uchar *const pszFile) {
+    DEFiRet;
+    if (pszFile != NULL) {
+        LogError(0, RS_RET_VALUE_NOT_SUPPORTED,
+                 "error: extra CA Files setting not supported by "
+                 "ptcp netstream driver");
+        ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+    }
+finalize_it:
+    RETiRet;
+}
+
 static rsRetVal SetTlsKeyFile(nsd_t __attribute__((unused)) * pNsd, const uchar *const pszFile) {
     DEFiRet;
     if (pszFile != NULL) {
@@ -774,6 +786,7 @@ static rsRetVal ATTR_NONNULL(1, 3, 5) LstnInit(netstrms_t *const pNS,
         CHKiRet(pNS->Drvr.SetPrioritizeSAN(pNewNsd, netstrms.GetDrvrPrioritizeSAN(pNS)));
         CHKiRet(pNS->Drvr.SetTlsCAFile(pNewNsd, netstrms.GetDrvrTlsCAFile(pNS)));
         CHKiRet(pNS->Drvr.SetTlsCRLFile(pNewNsd, netstrms.GetDrvrTlsCRLFile(pNS)));
+        CHKiRet(pNS->Drvr.SetTlsCAExtraFiles(pNewNsd, NULL));
         CHKiRet(pNS->Drvr.SetTlsKeyFile(pNewNsd, netstrms.GetDrvrTlsKeyFile(pNS)));
         CHKiRet(pNS->Drvr.SetTlsCertFile(pNewNsd, netstrms.GetDrvrTlsCertFile(pNS)));
         CHKiRet(pNS->Drvr.SetTlsVerifyDepth(pNewNsd, netstrms.GetDrvrTlsVerifyDepth(pNS)));
@@ -1272,6 +1285,7 @@ BEGINobjQueryInterface(nsd_ptcp)
     pIf->SetTlsVerifyDepth = SetTlsVerifyDepth;
     pIf->SetTlsCAFile = SetTlsCAFile;
     pIf->SetTlsCRLFile = SetTlsCRLFile;
+    pIf->SetTlsCAExtraFiles = SetTlsCAExtraFiles;
     pIf->SetTlsKeyFile = SetTlsKeyFile;
     pIf->SetTlsCertFile = SetTlsCertFile;
     pIf->SetRemoteSNI = SetRemoteSNI;

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -87,6 +87,7 @@ DEFobjCurrIf(ruleset) DEFobjCurrIf(module) DEFobjCurrIf(conf) DEFobjCurrIf(glbl)
     /* exported static data */
     rsconf_t *runConf = NULL; /* the currently running config */
 rsconf_t *loadConf = NULL; /* the config currently being loaded (no concurrent config load supported!) */
+static const char cfgModRefSrc[] = "cfgmodules";
 
 #ifdef HAVE_LIBSYSTEMD
 /* module readiness barrier: modules that need startup time call rsconfRegisterReadiness(),
@@ -440,20 +441,32 @@ static rsRetVal rsconfConstructFinalize(rsconf_t __attribute__((unused)) * pThis
 }
 
 
-/* call freeCnf() module entry points AND free the module entries themselfes.
+/* call freeCnf() module entry points.
+ * Module references are released later, after all other config-owned objects
+ * that may still call back into those modules have been destroyed.
  */
 static void freeCnf(rsconf_t *pThis) {
-    cfgmodules_etry_t *etry, *del;
+    cfgmodules_etry_t *etry;
     etry = pThis->modules.root;
     while (etry != NULL) {
         if (etry->pMod->beginCnfLoad != NULL) {
             dbgprintf("calling freeCnf(%p) for module '%s'\n", etry->modCnf, (char *)module.GetName(etry->pMod));
             etry->pMod->freeCnf(etry->modCnf);
         }
+        etry = etry->next;
+    }
+}
+
+static void releaseCnfModRefs(rsconf_t *pThis) {
+    cfgmodules_etry_t *etry, *del;
+    etry = pThis->modules.root;
+    while (etry != NULL) {
         del = etry;
         etry = etry->next;
+        module.Release(cfgModRefSrc, &del->pMod);
         free(del);
     }
+    pThis->modules.root = NULL;
 }
 
 
@@ -498,6 +511,7 @@ BEGINobjDestruct(rsconf) /* be sure to specify the object type also in END and C
     freeActionNames(pThis);
     llDestroy(&(pThis->rulesets.llRulesets));
     ratelimit_cfgsDestruct(&pThis->ratelimit_cfgs);
+    releaseCnfModRefs(pThis);
 ENDobjDestruct(rsconf)
 
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -14,3 +14,6 @@ check_relpEngineVersion
 testbench_test_failed_rsyslog
 gnutls_sni_server
 openssl_sni_server
+openssl_mtls_server
+runtime_unit_msg_replace
+runtime_unit_ommongodb_date

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -44,7 +44,6 @@ TESTS_SEGMENTED_DISK_QUEUE = \
 	segmented-diskqueue-multiworker-frontier.sh \
 	segmented-diskqueue-fsync.sh \
 	segmented-diskqueue-maxdiskspace.sh \
-	segmented-diskqueue-omprog-restart-save.sh \
 	segmented-diskqueue-rfc5424.sh \
 	segmented-diskqueue-cee.sh \
 	segmented-diskqueue-fromhost-port.sh \
@@ -1130,6 +1129,7 @@ TESTS_OMPROG = \
 	omprog-restart-terminated.sh \
 	omprog-restart-terminated-outfile.sh \
 	omprog-diskq-restart-save.sh \
+	segmented-diskqueue-omprog-restart-save.sh \
 	omprog-single-instance.sh \
 	omprog-single-instance-outfile.sh \
 	omprog-invalid-args.sh \
@@ -1613,6 +1613,9 @@ TESTS_LIBYAML_IMTCP = \
 TESTS_LIBYAML_IMTCP_OSSL = \
 	yaml-imtcp-tls-ossl-prioritize-san-reject-cn.sh
 
+TESTS_LIBYAML_OSSL = \
+	yaml-omfwd-tls-ossl-pkcs11-module-defaults.sh
+
 TESTS_LIBYAML_IMHTTP = \
 	yaml-imhttp-apikeyfile.sh \
 	yaml-imhttp-metrics-apikeyfile.sh
@@ -1787,6 +1790,8 @@ TESTS_GNUTLS_VALGRIND = \
 	manytcp-too-few-tls-vg.sh
 
 TESTS_GNUTLS_OPENSSL = \
+	omfwd-tls-gtls-module-files-mtls.sh \
+	omfwd-tls-gtls-module-pkcs11-defaults-isolation.sh \
 	imtcp-multi-drvr-basic-ptcp_gtls_ossl.sh
 
 TESTS_MBEDTLS = \
@@ -1854,6 +1859,9 @@ TESTS_OSSL_OPENSSL = \
 	imtcp-tls-ossl-input-basic.sh \
 	imtcp-tls-ossl-basic-tlscommands.sh \
 	imtcp-tls-ossl-error-key2.sh \
+	omfwd-tls-ossl-pkcs11-error-ca.sh \
+	omfwd-tls-ossl-pkcs11-error-cert.sh \
+	omfwd-tls-ossl-pkcs11-error-key.sh \
 	sndrcv_tls_ossl_native_pq_group.sh \
 	sndrcv_tls_ossl_anon_ipv4.sh \
 	sndrcv_tls_ossl_anon_ipv6.sh \
@@ -1865,10 +1873,49 @@ TESTS_OSSL_OPENSSL = \
 	sndrcv_tls_ossl_certvalid_revoked.sh
 
 TESTS_OSSL_OPENSSL_VALGRIND = \
+	omfwd-tls-ossl-files-mtls-vg.sh \
+	omfwd-tls-ossl-pkcs11-ca-mtls-ecdsa-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs-negative-vg.sh \
+	omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-cert-mtls-ecdsa-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs-negative-vg.sh \
+	omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-error-ca-vg.sh \
+	omfwd-tls-ossl-pkcs11-error-cert-vg.sh \
+	omfwd-tls-ossl-pkcs11-error-key-vg.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-ecdsa-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-vg.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-sigalgs-negative-vg.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-mtls-ecdsa-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-mtls-sigalgs-negative-vg.sh \
+	omfwd-tls-ossl-pkcs11-mtls-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-module-mtls-vg.sh \
+	omfwd-tls-ossl-pkcs11-module-precedence-vg.sh \
+	omfwd-tls-ossl-pkcs11-mtls-vg.sh \
+	omfwd-tls-ossl-pkcs11-recover-mtls-vg.sh \
 	imtcp-tls-ossl-basic-vg.sh \
 	imtcp-tls-ossl-basic-brokenhandshake-vg.sh
 
 TESTS_OSSL_OPENSSL_SNI = \
+	omfwd-tls-ossl-files-mtls.sh \
+	omfwd-tls-ossl-pkcs11-ca-mtls-ecdsa-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs-negative.sh \
+	omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-cert-mtls-ecdsa-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs-negative.sh \
+	omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-ecdsa-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-sigalgs-negative.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-module-mtls.sh \
+	omfwd-tls-ossl-pkcs11-module-precedence.sh \
+	omfwd-tls-ossl-pkcs11-mtls-ecdsa-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-mtls.sh \
+	omfwd-tls-ossl-pkcs11-mtls-sigalgs-negative.sh \
+	omfwd-tls-ossl-pkcs11-mtls-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-recover-mtls.sh \
 	omfwd-tls-ossl-no-sni.sh \
 	omfwd-tls-ossl-auto-sni.sh \
 	omfwd-tls-ossl-configured-sni.sh
@@ -2284,6 +2331,7 @@ EXTRA_DIST += $(TESTS_RATELIMIT_WATCH)
 EXTRA_DIST += $(TESTS_LIBYAML_IMPTCP_MMJSONPARSE)
 EXTRA_DIST += $(TESTS_LIBYAML_IMTCP)
 EXTRA_DIST += $(TESTS_LIBYAML_IMTCP_OSSL)
+EXTRA_DIST += $(TESTS_LIBYAML_OSSL)
 EXTRA_DIST += $(TESTS_LIBYAML_IMHTTP)
 EXTRA_DIST += $(TESTS_LIBYAML_OMSTDOUT)
 EXTRA_DIST += $(TESTS_IMTCP)
@@ -2808,6 +2856,9 @@ if ENABLE_OSSL
 TESTS += $(TESTS_LIBYAML_IMTCP_OSSL)
 endif # ENABLE_OSSL
 endif # ENABLE_IMTCP_TESTS
+if ENABLE_OSSL
+TESTS += $(TESTS_LIBYAML_OSSL)
+endif # ENABLE_OSSL
 if ENABLE_IMHTTP
 TESTS += $(TESTS_LIBYAML_IMHTTP)
 endif # ENABLE_IMHTTP
@@ -3677,11 +3728,15 @@ gnutls_sni_server_CPPFLAGS = $(GNUTLS_CFLAGS)
 gnutls_sni_server_LDADD = $(GNUTLS_LIBS) $(SOL_LIBS)
 endif
 if ENABLE_OPENSSL
-check_PROGRAMS += openssl_sni_server
+check_PROGRAMS += openssl_sni_server openssl_mtls_server
 openssl_sni_server_SOURCES = openssl_sni_server.c
 openssl_sni_server_CFLAGS = $(OPENSSL_CFLAGS)
 openssl_sni_server_CPPFLAGS = $(OPENSSL_CFLAGS)
 openssl_sni_server_LDADD = $(OPENSSL_LIBS) $(SOL_LIBS)
+openssl_mtls_server_SOURCES = openssl_mtls_server.c
+openssl_mtls_server_CFLAGS = $(OPENSSL_CFLAGS)
+openssl_mtls_server_CPPFLAGS = $(OPENSSL_CFLAGS)
+openssl_mtls_server_LDADD = $(OPENSSL_LIBS) $(SOL_LIBS)
 endif
 
 endif # if ENABLE_TESTBENCH
@@ -3699,6 +3754,10 @@ EXTRA_DIST += \
 	faketime_common.sh \
 	privdrop_common.sh \
 	rscript_compare-common.sh \
+	omfwd-tls-ossl-pkcs11-error.sh \
+	omfwd-tls-ossl-pkcs11-ecdsa-sigalgs-common.sh \
+	omfwd-tls-ossl-pkcs11-sigalgs-negative-common.sh \
+	omfwd-tls-ossl-pkcs11-sigalgs-common.sh \
 	rscript_parse_time_get-ts.py \
 	queue-persist-drvr.sh \
 	daqueue-persist-drvr.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -63,7 +63,6 @@ TESTS_SEGMENTED_DISK_QUEUE = \
 	segmented-diskqueue-multiworker-frontier.sh \
 	segmented-diskqueue-fsync.sh \
 	segmented-diskqueue-maxdiskspace.sh \
-	segmented-diskqueue-omprog-restart-save.sh \
 	segmented-diskqueue-rfc5424.sh \
 	segmented-diskqueue-cee.sh \
 	segmented-diskqueue-fromhost-port.sh \
@@ -1168,6 +1167,7 @@ TESTS_OMPROG = \
 	omprog-restart-terminated.sh \
 	omprog-restart-terminated-outfile.sh \
 	omprog-diskq-restart-save.sh \
+	segmented-diskqueue-omprog-restart-save.sh \
 	omprog-single-instance.sh \
 	omprog-single-instance-outfile.sh \
 	omprog-invalid-args.sh \
@@ -1658,6 +1658,9 @@ TESTS_LIBYAML_IMTCP = \
 TESTS_LIBYAML_IMTCP_OSSL = \
 	yaml-imtcp-tls-ossl-prioritize-san-reject-cn.sh
 
+TESTS_LIBYAML_OSSL = \
+	yaml-omfwd-tls-ossl-pkcs11-module-defaults.sh
+
 TESTS_LIBYAML_IMHTTP = \
 	yaml-imhttp-apikeyfile.sh \
 	yaml-imhttp-metrics-apikeyfile.sh
@@ -1846,6 +1849,8 @@ TESTS_GNUTLS_VALGRIND = \
 	manytcp-too-few-tls-vg.sh
 
 TESTS_GNUTLS_OPENSSL = \
+	omfwd-tls-gtls-module-files-mtls.sh \
+	omfwd-tls-gtls-module-pkcs11-defaults-isolation.sh \
 	imtcp-multi-drvr-basic-ptcp_gtls_ossl.sh
 
 TESTS_MBEDTLS = \
@@ -1913,6 +1918,9 @@ TESTS_OSSL_OPENSSL = \
 	imtcp-tls-ossl-input-basic.sh \
 	imtcp-tls-ossl-basic-tlscommands.sh \
 	imtcp-tls-ossl-error-key2.sh \
+	omfwd-tls-ossl-pkcs11-error-ca.sh \
+	omfwd-tls-ossl-pkcs11-error-cert.sh \
+	omfwd-tls-ossl-pkcs11-error-key.sh \
 	sndrcv_tls_ossl_native_pq_group.sh \
 	sndrcv_tls_ossl_anon_ipv4.sh \
 	sndrcv_tls_ossl_anon_ipv6.sh \
@@ -1924,10 +1932,49 @@ TESTS_OSSL_OPENSSL = \
 	sndrcv_tls_ossl_certvalid_revoked.sh
 
 TESTS_OSSL_OPENSSL_VALGRIND = \
+	omfwd-tls-ossl-files-mtls-vg.sh \
+	omfwd-tls-ossl-pkcs11-ca-mtls-ecdsa-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs-negative-vg.sh \
+	omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-cert-mtls-ecdsa-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs-negative-vg.sh \
+	omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-error-ca-vg.sh \
+	omfwd-tls-ossl-pkcs11-error-cert-vg.sh \
+	omfwd-tls-ossl-pkcs11-error-key-vg.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-ecdsa-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-vg.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-sigalgs-negative-vg.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-mtls-ecdsa-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-mtls-sigalgs-negative-vg.sh \
+	omfwd-tls-ossl-pkcs11-mtls-sigalgs-vg.sh \
+	omfwd-tls-ossl-pkcs11-module-mtls-vg.sh \
+	omfwd-tls-ossl-pkcs11-module-precedence-vg.sh \
+	omfwd-tls-ossl-pkcs11-mtls-vg.sh \
+	omfwd-tls-ossl-pkcs11-recover-mtls-vg.sh \
 	imtcp-tls-ossl-basic-vg.sh \
 	imtcp-tls-ossl-basic-brokenhandshake-vg.sh
 
 TESTS_OSSL_OPENSSL_SNI = \
+	omfwd-tls-ossl-files-mtls.sh \
+	omfwd-tls-ossl-pkcs11-ca-mtls-ecdsa-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs-negative.sh \
+	omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-cert-mtls-ecdsa-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs-negative.sh \
+	omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-ecdsa-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-sigalgs-negative.sh \
+	omfwd-tls-ossl-pkcs11-key-mtls-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-module-mtls.sh \
+	omfwd-tls-ossl-pkcs11-module-precedence.sh \
+	omfwd-tls-ossl-pkcs11-mtls-ecdsa-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-mtls.sh \
+	omfwd-tls-ossl-pkcs11-mtls-sigalgs-negative.sh \
+	omfwd-tls-ossl-pkcs11-mtls-sigalgs.sh \
+	omfwd-tls-ossl-pkcs11-recover-mtls.sh \
 	omfwd-tls-ossl-no-sni.sh \
 	omfwd-tls-ossl-auto-sni.sh \
 	omfwd-tls-ossl-configured-sni.sh
@@ -2356,6 +2403,7 @@ EXTRA_DIST += $(TESTS_RATELIMIT_WATCH)
 EXTRA_DIST += $(TESTS_LIBYAML_IMPTCP_MMJSONPARSE)
 EXTRA_DIST += $(TESTS_LIBYAML_IMTCP)
 EXTRA_DIST += $(TESTS_LIBYAML_IMTCP_OSSL)
+EXTRA_DIST += $(TESTS_LIBYAML_OSSL)
 EXTRA_DIST += $(TESTS_LIBYAML_IMHTTP)
 EXTRA_DIST += $(TESTS_LIBYAML_OMSTDOUT)
 EXTRA_DIST += $(TESTS_IMTCP)
@@ -2910,6 +2958,9 @@ if ENABLE_OSSL
 TESTS += $(TESTS_LIBYAML_IMTCP_OSSL)
 endif # ENABLE_OSSL
 endif # ENABLE_IMTCP_TESTS
+if ENABLE_OSSL
+TESTS += $(TESTS_LIBYAML_OSSL)
+endif # ENABLE_OSSL
 if ENABLE_IMHTTP
 TESTS += $(TESTS_LIBYAML_IMHTTP)
 endif # ENABLE_IMHTTP
@@ -3800,11 +3851,15 @@ gnutls_sni_server_CPPFLAGS = $(GNUTLS_CFLAGS)
 gnutls_sni_server_LDADD = $(GNUTLS_LIBS) $(SOL_LIBS)
 endif
 if ENABLE_OPENSSL
-check_PROGRAMS += openssl_sni_server
+check_PROGRAMS += openssl_sni_server openssl_mtls_server
 openssl_sni_server_SOURCES = openssl_sni_server.c
 openssl_sni_server_CFLAGS = $(OPENSSL_CFLAGS)
 openssl_sni_server_CPPFLAGS = $(OPENSSL_CFLAGS)
 openssl_sni_server_LDADD = $(OPENSSL_LIBS) $(SOL_LIBS)
+openssl_mtls_server_SOURCES = openssl_mtls_server.c
+openssl_mtls_server_CFLAGS = $(OPENSSL_CFLAGS)
+openssl_mtls_server_CPPFLAGS = $(OPENSSL_CFLAGS)
+openssl_mtls_server_LDADD = $(OPENSSL_LIBS) $(SOL_LIBS)
 endif
 
 endif # if ENABLE_TESTBENCH
@@ -3822,6 +3877,10 @@ EXTRA_DIST += \
 	faketime_common.sh \
 	privdrop_common.sh \
 	rscript_compare-common.sh \
+	omfwd-tls-ossl-pkcs11-error.sh \
+	omfwd-tls-ossl-pkcs11-ecdsa-sigalgs-common.sh \
+	omfwd-tls-ossl-pkcs11-sigalgs-negative-common.sh \
+	omfwd-tls-ossl-pkcs11-sigalgs-common.sh \
 	rscript_parse_time_get-ts.py \
 	queue-persist-drvr.sh \
 	daqueue-persist-drvr.sh \

--- a/tests/imdtls-error-cert.sh
+++ b/tests/imdtls-error-cert.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 # added 2018-11-07 by Rainer Gerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-# Verify that imdtls reports certificate load errors during startup. No traffic
-# is sent; the configured rsyslog diagnostics are the pass/fail oracle.
+# Verify that imdtls reports TLS object load errors during startup. This
+# fixture intentionally pairs an invalid private key file with a certificate
+# path so startup fails before any listener becomes functional. No traffic is
+# sent; the configured rsyslog diagnostics are the pass/fail oracle.
 . ${srcdir:=.}/diag.sh init
 generate_conf
 
@@ -24,6 +26,6 @@ startup
 sleep 5 # TODO: FIXME - just checking if we terminate too early
 shutdown_when_empty
 wait_shutdown
-content_check "Error: Certificate file could not be accessed"
+content_check "Error: Key could not be accessed"
 content_check "OpenSSL Error Stack:"
 exit_test

--- a/tests/imtcp-tls-mbedtls-error-cert.sh
+++ b/tests/imtcp-tls-mbedtls-error-cert.sh
@@ -8,7 +8,7 @@ generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert-fail.pem'"
-	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
 )
 
 module(load="../plugins/imtcp/.libs/imtcp"

--- a/tests/imtcp-tls-ossl-error-ca.sh
+++ b/tests/imtcp-tls-ossl-error-ca.sh
@@ -18,6 +18,7 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 startup
 shutdown_when_empty
 wait_shutdown
-content_check "Error: CA certificate could not be accessed"
+content_check "Error: CA certificate '"
+content_check "could not be accessed"
 content_check "OpenSSL Error Stack:"
 exit_test

--- a/tests/imtcp-tls-ossl-error-cert.sh
+++ b/tests/imtcp-tls-ossl-error-cert.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert-fail.pem'"
-	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
 )
 
 module(load="../plugins/imtcp/.libs/imtcp" StreamDriver.Name="ossl" StreamDriver.Mode="1")

--- a/tests/omfwd-tls-gtls-module-files-mtls.sh
+++ b/tests/omfwd-tls-gtls-module-files-mtls.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Verify that builtin:omfwd module defaults for ordinary file-backed TLS
+# objects are inherited by an omfwd action that uses the gtls stream driver and
+# omits action-level StreamDriver.CAFile, StreamDriver.CertFile, and
+# StreamDriver.KeyFile. The oracle is that an OpenSSL helper requiring mutual
+# TLS captures exactly one forwarded payload line.
+. ${srcdir:=.}/diag.sh init
+
+check_command_available openssl
+
+if [ ! -x ./openssl_mtls_server ]; then
+	echo "openssl_mtls_server helper not built - skipping test"
+	exit 77
+fi
+
+gtls_module="$(cd .. && pwd)/runtime/.libs/lmnsd_gtls.so"
+if [ ! -f "$gtls_module" ]; then
+	echo "lmnsd_gtls module not built - skipping test"
+	exit 77
+fi
+
+workdir="$RSYSLOG_DYNNAME.omfwd-tls-gtls-module-files-mtls"
+port_file="$workdir/server.port"
+server_capture="$workdir/server.capture"
+server_stderr="$workdir/server.stderr"
+mkdir -p "$workdir"
+
+cat >"$workdir/server.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+
+cat >"$workdir/client.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EOF
+
+cat >"$workdir/ca.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints = critical,CA:TRUE,pathlen:0
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+EOF
+
+openssl genrsa -out "$workdir/ca.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/ca.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Test-CA" \
+	-out "$workdir/ca.csr" || error_exit 1
+openssl x509 -req -in "$workdir/ca.csr" -signkey "$workdir/ca.key" -sha256 -days 365 \
+	-extfile "$workdir/ca.cnf" -extensions v3_ca \
+	-out "$workdir/ca.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/server.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/server.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=localhost" \
+	-out "$workdir/server.csr" || error_exit 1
+openssl x509 -req -in "$workdir/server.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/server.ext" \
+	-out "$workdir/server.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/client.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/client.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=rsyslog-client" \
+	-out "$workdir/client.csr" || error_exit 1
+openssl x509 -req -in "$workdir/client.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/client.ext" \
+	-out "$workdir/client.pem" || error_exit 1
+
+./openssl_mtls_server 0 "$workdir/server.pem" "$workdir/server.key" "$workdir/ca.pem" \
+	"$port_file" "$server_capture" 2>"$server_stderr" &
+server_pid=$!
+wait_file_exists_for_process "$port_file" "$server_pid" 10 "OpenSSL MTLS helper" "$server_stderr"
+server_port=$(cat "$port_file")
+
+generate_conf
+add_conf '
+global(
+	compatibility.defaults.secure="strict"
+	net.ipprotocol="ipv4-only"
+)
+
+module(load="'$gtls_module'")
+module(
+	load="builtin:omfwd"
+	StreamDriver.CAFile="'$workdir/ca.pem'"
+	StreamDriver.CertFile="'$workdir/client.pem'"
+	StreamDriver.KeyFile="'$workdir/client.key'"
+)
+template(name="outfmt" type="string" string="%msg%\n")
+
+if $msg contains "omfwd-gtls-module-files-mtls" then {
+	action(
+		type="omfwd"
+		target="127.0.0.1"
+		protocol="tcp"
+		port="'$server_port'"
+		template="outfmt"
+		StreamDriver="gtls"
+		StreamDriverMode="1"
+		StreamDriverAuthMode="x509/certvalid"
+	)
+}
+'
+
+startup
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host app - - - omfwd-gtls-module-files-mtls'
+wait_file_lines "$server_capture" 1
+shutdown_when_empty
+wait_shutdown
+
+wait $server_pid || {
+	cat "$server_stderr"
+	error_exit 1
+}
+
+content_count_check --regex '^omfwd-gtls-module-files-mtls$' 1 "$server_capture"
+
+exit_test

--- a/tests/omfwd-tls-gtls-module-pkcs11-defaults-isolation.sh
+++ b/tests/omfwd-tls-gtls-module-pkcs11-defaults-isolation.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Verify that strict pkcs11: builtin:omfwd module defaults are not inherited by
+# a gtls omfwd action. The action relies on valid global file-backed TLS
+# defaults, while the module deliberately supplies incompatible pkcs11: URIs.
+# The oracle is that mutual TLS still succeeds and the OpenSSL helper captures
+# exactly one forwarded payload line.
+. ${srcdir:=.}/diag.sh init
+
+check_command_available openssl
+
+if [ ! -x ./openssl_mtls_server ]; then
+	echo "openssl_mtls_server helper not built - skipping test"
+	exit 77
+fi
+
+gtls_module="$(cd .. && pwd)/runtime/.libs/lmnsd_gtls.so"
+if [ ! -f "$gtls_module" ]; then
+	echo "lmnsd_gtls module not built - skipping test"
+	exit 77
+fi
+
+workdir="$RSYSLOG_DYNNAME.omfwd-tls-gtls-module-pkcs11-defaults-isolation"
+port_file="$workdir/server.port"
+server_capture="$workdir/server.capture"
+server_stderr="$workdir/server.stderr"
+mkdir -p "$workdir"
+
+cat >"$workdir/server.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+
+cat >"$workdir/client.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EOF
+
+cat >"$workdir/ca.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints = critical,CA:TRUE,pathlen:0
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+EOF
+
+openssl genrsa -out "$workdir/ca.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/ca.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Test-CA" \
+	-out "$workdir/ca.csr" || error_exit 1
+openssl x509 -req -in "$workdir/ca.csr" -signkey "$workdir/ca.key" -sha256 -days 365 \
+	-extfile "$workdir/ca.cnf" -extensions v3_ca \
+	-out "$workdir/ca.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/server.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/server.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=localhost" \
+	-out "$workdir/server.csr" || error_exit 1
+openssl x509 -req -in "$workdir/server.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/server.ext" \
+	-out "$workdir/server.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/client.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/client.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=rsyslog-client" \
+	-out "$workdir/client.csr" || error_exit 1
+openssl x509 -req -in "$workdir/client.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/client.ext" \
+	-out "$workdir/client.pem" || error_exit 1
+
+./openssl_mtls_server 0 "$workdir/server.pem" "$workdir/server.key" "$workdir/ca.pem" \
+	"$port_file" "$server_capture" 2>"$server_stderr" &
+server_pid=$!
+wait_file_exists_for_process "$port_file" "$server_pid" 10 "OpenSSL MTLS helper" "$server_stderr"
+server_port=$(cat "$port_file")
+
+generate_conf
+add_conf '
+global(
+	defaultNetstreamDriverCAFile="'$workdir/ca.pem'"
+	defaultNetstreamDriverCertFile="'$workdir/client.pem'"
+	defaultNetstreamDriverKeyFile="'$workdir/client.key'"
+	compatibility.defaults.secure="strict"
+	net.ipprotocol="ipv4-only"
+)
+
+module(load="'$gtls_module'")
+module(
+	load="builtin:omfwd"
+	StreamDriver.CAFile="pkcs11:token=rsyslog-test-token;object=ca-cert;type=cert"
+	StreamDriver.CertFile="pkcs11:token=rsyslog-test-token;object=client-cert;type=cert"
+	StreamDriver.KeyFile="pkcs11:token=rsyslog-test-token;object=client-key;type=private"
+)
+template(name="outfmt" type="string" string="%msg%\n")
+
+if $msg contains "omfwd-gtls-module-pkcs11-defaults-isolation" then {
+	action(
+		type="omfwd"
+		target="127.0.0.1"
+		protocol="tcp"
+		port="'$server_port'"
+		template="outfmt"
+		StreamDriver="gtls"
+		StreamDriverMode="1"
+		StreamDriverAuthMode="x509/certvalid"
+	)
+}
+'
+
+startup
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host app - - - omfwd-gtls-module-pkcs11-defaults-isolation'
+wait_file_lines "$server_capture" 1
+shutdown_when_empty
+wait_shutdown
+
+wait $server_pid || {
+	cat "$server_stderr"
+	error_exit 1
+}
+
+content_count_check --regex '^omfwd-gtls-module-pkcs11-defaults-isolation$' 1 "$server_capture"
+
+exit_test

--- a/tests/omfwd-tls-ossl-files-mtls-vg.sh
+++ b/tests/omfwd-tls-ossl-files-mtls-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-files-mtls.sh

--- a/tests/omfwd-tls-ossl-files-mtls.sh
+++ b/tests/omfwd-tls-ossl-files-mtls.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Verify that omfwd with the ossl driver can establish a mutual-TLS session to
+# an OpenSSL-based remote peer when CA, certificate, and key are all loaded
+# from regular files. The oracle is that the remote helper, which requires a
+# valid client certificate, captures exactly one forwarded payload line for the
+# test message. The helper output may also contain rsyslog's own startup or
+# transport diagnostics, so the test matches the payload line rather than using
+# whole-file equality. All key material is created inside a per-test directory
+# to avoid collisions under parallel execution.
+. ${srcdir:=.}/diag.sh init
+
+check_command_available openssl
+
+if [ ! -x ./openssl_mtls_server ]; then
+	echo "openssl_mtls_server helper not built - skipping test"
+	exit 77
+fi
+
+workdir="$RSYSLOG_DYNNAME.omfwd-tls-ossl-files-mtls"
+port_file="$workdir/server.port"
+server_capture="$workdir/server.capture"
+server_stderr="$workdir/server.stderr"
+mkdir -p "$workdir"
+
+cat >"$workdir/server.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+
+cat >"$workdir/client.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EOF
+
+cat >"$workdir/ca.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints = critical,CA:TRUE,pathlen:0
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+EOF
+
+openssl genrsa -out "$workdir/ca.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/ca.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Test-CA" \
+	-out "$workdir/ca.csr" || error_exit 1
+openssl x509 -req -in "$workdir/ca.csr" -signkey "$workdir/ca.key" -sha256 -days 365 \
+	-extfile "$workdir/ca.cnf" -extensions v3_ca \
+	-out "$workdir/ca.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/server.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/server.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=localhost" \
+	-out "$workdir/server.csr" || error_exit 1
+openssl x509 -req -in "$workdir/server.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/server.ext" \
+	-out "$workdir/server.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/client.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/client.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=rsyslog-client" \
+	-out "$workdir/client.csr" || error_exit 1
+openssl x509 -req -in "$workdir/client.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/client.ext" \
+	-out "$workdir/client.pem" || error_exit 1
+
+./openssl_mtls_server 0 "$workdir/server.pem" "$workdir/server.key" "$workdir/ca.pem" \
+	"$port_file" "$server_capture" 2>"$server_stderr" &
+server_pid=$!
+wait_file_exists_for_process "$port_file" "$server_pid" 10 "OpenSSL MTLS helper" "$server_stderr"
+server_port=$(cat "$port_file")
+
+generate_conf
+add_conf '
+global(
+	defaultNetstreamDriverCAFile="'$workdir/ca.pem'"
+	defaultNetstreamDriverCertFile="'$workdir/client.pem'"
+	defaultNetstreamDriverKeyFile="'$workdir/client.key'"
+	defaultNetstreamDriver="ossl"
+	compatibility.defaults.secure="strict"
+	net.ipprotocol="ipv4-only"
+)
+
+module(load="builtin:omfwd")
+template(name="outfmt" type="string" string="%msg%\n")
+
+if $msg contains "omfwd-ossl-files-mtls" then {
+	action(
+		type="omfwd"
+		target="127.0.0.1"
+		protocol="tcp"
+		port="'$server_port'"
+		template="outfmt"
+		StreamDriver="ossl"
+		StreamDriverMode="1"
+		StreamDriverAuthMode="x509/certvalid"
+	)
+}
+'
+
+startup
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host app - - - omfwd-ossl-files-mtls'
+wait_file_lines "$server_capture" 1
+shutdown_when_empty
+wait_shutdown
+
+wait $server_pid || {
+	cat "$server_stderr"
+	error_exit 1
+}
+
+content_count_check --regex '^omfwd-ossl-files-mtls$' 1 "$server_capture"
+
+exit_test

--- a/tests/omfwd-tls-ossl-pkcs11-ca-mtls-ecdsa-sigalgs-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-ca-mtls-ecdsa-sigalgs-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-ca-mtls-ecdsa-sigalgs.sh

--- a/tests/omfwd-tls-ossl-pkcs11-ca-mtls-ecdsa-sigalgs.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-ca-mtls-ecdsa-sigalgs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_SIGALG_VARIANT=ca_key
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-ecdsa-sigalgs-common.sh

--- a/tests/omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs-negative-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs-negative-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs-negative.sh

--- a/tests/omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs-negative.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs-negative.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_SIGALG_VARIANT=ca_key
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-sigalgs-negative-common.sh

--- a/tests/omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs.sh

--- a/tests/omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-ca-mtls-sigalgs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_SIGALG_VARIANT=ca_key
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-sigalgs-common.sh

--- a/tests/omfwd-tls-ossl-pkcs11-cert-mtls-ecdsa-sigalgs-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-cert-mtls-ecdsa-sigalgs-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-cert-mtls-ecdsa-sigalgs.sh

--- a/tests/omfwd-tls-ossl-pkcs11-cert-mtls-ecdsa-sigalgs.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-cert-mtls-ecdsa-sigalgs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_SIGALG_VARIANT=cert_key
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-ecdsa-sigalgs-common.sh

--- a/tests/omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs-negative-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs-negative-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs-negative.sh

--- a/tests/omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs-negative.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs-negative.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_SIGALG_VARIANT=cert_key
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-sigalgs-negative-common.sh

--- a/tests/omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs.sh

--- a/tests/omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-cert-mtls-sigalgs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_SIGALG_VARIANT=cert_key
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-sigalgs-common.sh

--- a/tests/omfwd-tls-ossl-pkcs11-ecdsa-sigalgs-common.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-ecdsa-sigalgs-common.sh
@@ -1,0 +1,306 @@
+#!/bin/bash
+# Common positive ECDSA matrix for PKCS#11-backed omfwd mTLS signing tests.
+. ${srcdir:=.}/diag.sh init
+
+case "$(basename "$0")" in
+omfwd-tls-ossl-pkcs11-ecdsa-sigalgs-common.sh)
+	printf 'info: shared helper script; skipping direct execution\n'
+	skip_test
+	;;
+esac
+
+check_command_available openssl
+check_command_available softhsm2-util
+check_command_available pkcs11-tool
+
+if [ ! -x ./openssl_mtls_server ]; then
+	echo "openssl_mtls_server helper not built - skipping test"
+	exit 77
+fi
+
+find_first_existing() {
+	for candidate in "$@"; do
+		if [ -f "$candidate" ]; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
+setup_variant() {
+	case "${PKCS11_SIGALG_VARIANT}" in
+	key_only)
+		TEST_MSG_PREFIX="omfwd-ossl-pkcs11-key-mtls-ecdsa-sigalgs"
+		TEST_CA_REF="$workdir/ca.pem"
+		TEST_CERT_REF="$workdir/client.pem"
+		TEST_KEY_REF="$key_uri"
+		;;
+	cert_key)
+		TEST_MSG_PREFIX="omfwd-ossl-pkcs11-cert-mtls-ecdsa-sigalgs"
+		TEST_CA_REF="$workdir/ca.pem"
+		TEST_CERT_REF="$cert_uri"
+		TEST_KEY_REF="$key_uri"
+		;;
+	ca_key)
+		TEST_MSG_PREFIX="omfwd-ossl-pkcs11-ca-mtls-ecdsa-sigalgs"
+		TEST_CA_REF="$ca_uri"
+		TEST_CERT_REF="$workdir/client.pem"
+		TEST_KEY_REF="$key_uri"
+		;;
+	full)
+		TEST_MSG_PREFIX="omfwd-ossl-pkcs11-mtls-ecdsa-sigalgs"
+		TEST_CA_REF="$ca_uri"
+		TEST_CERT_REF="$cert_uri"
+		TEST_KEY_REF="$key_uri"
+		;;
+	*)
+		printf 'unknown PKCS11_SIGALG_VARIANT=%s\n' "${PKCS11_SIGALG_VARIANT}" >&2
+		error_exit 1
+		;;
+	esac
+}
+
+provider_module=$(find_first_existing \
+	/usr/lib64/ossl-modules/pkcs11.so \
+	/usr/lib/ossl-modules/pkcs11.so \
+	/usr/lib/x86_64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/lib/aarch64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/local/lib64/ossl-modules/pkcs11.so \
+	/usr/local/lib/ossl-modules/pkcs11.so) || {
+	printf 'info: skipping test - pkcs11 OpenSSL provider module not found\n'
+	skip_test
+}
+
+softhsm_module=$(find_first_existing \
+	/usr/lib64/pkcs11/libsofthsm2.so \
+	/usr/lib/pkcs11/libsofthsm2.so \
+	/usr/lib64/softhsm/libsofthsm2.so \
+	/usr/lib/softhsm/libsofthsm2.so \
+	/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib64/libsofthsm2.so \
+	/usr/lib/libsofthsm2.so) || {
+	printf 'info: skipping test - SoftHSM PKCS#11 module not found\n'
+	skip_test
+}
+
+token_label="rsyslog-test-token"
+token_pin="123456"
+token_so_pin="12345678"
+workdir="$RSYSLOG_DYNNAME.${PKCS11_SIGALG_VARIANT}.ecdsa"
+softhsm_conf="$workdir/softhsm2.conf"
+openssl_conf="$workdir/openssl-pkcs11.cnf"
+token_dir="$workdir/tokens"
+setup_log="$workdir/setup.log"
+mkdir -p "$workdir" "$token_dir"
+rm -f "$setup_log"
+
+run_setup_cmd() {
+	"$@" >>"$setup_log" 2>&1 || {
+		printf 'setup command failed:'
+		printf ' %s' "$@" >&2
+		printf '\n' >&2
+		cat "$setup_log" >&2
+		error_exit 1
+	}
+}
+
+skip_with_setup_log() {
+	printf '%s\n' "$1"
+	if [ -f "$setup_log" ]; then
+		cat "$setup_log"
+	fi
+	skip_test
+}
+
+cat >"$workdir/server.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+
+cat >"$workdir/client.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature
+extendedKeyUsage=clientAuth
+EOF
+
+cat >"$workdir/ca.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints = critical,CA:TRUE,pathlen:0
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+EOF
+
+run_setup_cmd openssl genrsa -out "$workdir/ca.key" 3072
+run_setup_cmd openssl req -new -key "$workdir/ca.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Test-CA" \
+	-out "$workdir/ca.csr"
+run_setup_cmd openssl x509 -req -in "$workdir/ca.csr" -signkey "$workdir/ca.key" -sha256 -days 365 \
+	-extfile "$workdir/ca.cnf" -extensions v3_ca \
+	-out "$workdir/ca.pem"
+
+run_setup_cmd openssl genrsa -out "$workdir/server.key" 3072
+run_setup_cmd openssl req -new -key "$workdir/server.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=localhost" \
+	-out "$workdir/server.csr"
+run_setup_cmd openssl x509 -req -in "$workdir/server.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/server.ext" \
+	-out "$workdir/server.pem"
+
+run_setup_cmd openssl x509 -in "$workdir/ca.pem" -outform DER -out "$workdir/ca.der"
+
+cat >"$softhsm_conf" <<EOF
+directories.tokendir = $token_dir
+objectstore.backend = file
+slots.removable = false
+EOF
+export SOFTHSM2_CONF="$softhsm_conf"
+
+run_setup_cmd softhsm2-util --init-token --free --label "$token_label" --so-pin "$token_so_pin" --pin "$token_pin"
+
+cat >"$openssl_conf" <<EOF
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+pkcs11 = pkcs11_sect
+
+[default_sect]
+activate = 1
+
+[pkcs11_sect]
+identity = pkcs11
+module = $provider_module
+pkcs11-module-path = $softhsm_module
+pkcs11-module-token-pin = $token_pin
+activate = 1
+EOF
+export OPENSSL_CONF="$openssl_conf"
+
+ca_uri="pkcs11:token=$token_label;object=ca-cert;type=cert"
+cert_uri="pkcs11:token=$token_label;object=client-cert;type=cert"
+key_uri="pkcs11:token=$token_label;object=client-key;type=private"
+
+run_setup_cmd pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--keypairgen --key-type EC:prime256v1 --id 01 --label client-key --usage-sign
+
+run_setup_cmd pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--read-object --type pubkey --id 01 --output-file "$workdir/client.pub.der"
+run_setup_cmd openssl pkey -pubin -inform DER -in "$workdir/client.pub.der" -out "$workdir/client.pub.pem"
+run_setup_cmd openssl x509 -new \
+	-force_pubkey "$workdir/client.pub.pem" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=rsyslog-client-ecdsa" \
+	-CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/client.ext" \
+	-out "$workdir/client.pem"
+run_setup_cmd openssl x509 -in "$workdir/client.pem" -outform DER -out "$workdir/client.der"
+
+run_setup_cmd pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.der" --type cert --id 01 --label client-cert
+run_setup_cmd pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/ca.der" --type cert --id 02 --label ca-cert
+
+printf 'rsyslog pkcs11 ecdsa sign probe\n' >"$workdir/ecdsa-probe.txt"
+if ! openssl dgst -sha256 -sign "$key_uri" -out "$workdir/ecdsa-probe.sig" \
+	"$workdir/ecdsa-probe.txt" >>"$setup_log" 2>&1; then
+	skip_with_setup_log "info: skipping test - OpenSSL pkcs11 provider EVP ECDSA signing failed, though token setup succeeded"
+fi
+
+setup_variant
+
+run_case() {
+	local case_name="$1"
+	local client_cfg="$2"
+	local server_cfg="$3"
+	local msg="${TEST_MSG_PREFIX} ${case_name}"
+	local port_file="$workdir/${case_name}.server.port"
+	local server_capture="$workdir/${case_name}.server.capture"
+	local server_stderr="$workdir/${case_name}.server.stderr"
+	local server_pid=
+	local server_port=
+
+	rm -f "$port_file" "$server_capture" "$server_stderr"
+	printf 'running %s case: %s\n' "$TEST_MSG_PREFIX" "$case_name"
+
+	OPENSSL_MTLS_CFG="$server_cfg" \
+	./openssl_mtls_server 0 "$workdir/server.pem" "$workdir/server.key" "$workdir/ca.pem" \
+		"$port_file" "$server_capture" 2>"$server_stderr" &
+	server_pid=$!
+	wait_file_exists_for_process "$port_file" "$server_pid" 10 "OpenSSL MTLS helper" "$server_stderr"
+	server_port=$(cat "$port_file")
+
+	generate_conf
+	add_conf "$(cat <<EOF
+global(
+	compatibility.defaults.secure="strict"
+	net.ipprotocol="ipv4-only"
+)
+
+module(load="builtin:omfwd")
+template(name="outfmt" type="string" string="%msg%\n")
+
+if \$msg contains "$TEST_MSG_PREFIX" then {
+	action(
+		type="omfwd"
+		target="127.0.0.1"
+		protocol="tcp"
+		port="$server_port"
+		template="outfmt"
+		StreamDriver="ossl"
+		StreamDriverMode="1"
+		StreamDriverAuthMode="x509/certvalid"
+		streamdriver.cafile="$TEST_CA_REF"
+		streamdriver.certfile="$TEST_CERT_REF"
+		streamdriver.keyfile="$TEST_KEY_REF"
+		gnutlsPriorityString="$client_cfg"
+	)
+}
+EOF
+)"
+
+	startup
+	injectmsg_literal "<165>1 2003-03-01T01:00:00.000Z host app - - - ${msg}"
+	wait_file_lines "$server_capture" 1
+	shutdown_when_empty
+	wait_shutdown
+
+	wait $server_pid || {
+		cat "$server_stderr"
+		error_exit 1
+	}
+
+	content_count_check --regex "^${msg}\$" 1 "$server_capture"
+}
+
+run_case \
+	"tls12-ecdsa-sha256" \
+	"MinProtocol=TLSv1.2
+MaxProtocol=TLSv1.2
+ClientSignatureAlgorithms=ECDSA+SHA256" \
+	"MinProtocol=TLSv1.2
+MaxProtocol=TLSv1.2
+ClientSignatureAlgorithms=ECDSA+SHA256"
+
+run_case \
+	"tls13-ecdsa-secp256r1-sha256" \
+	"MinProtocol=TLSv1.3
+MaxProtocol=TLSv1.3
+ClientSignatureAlgorithms=ecdsa_secp256r1_sha256" \
+	"MinProtocol=TLSv1.3
+MaxProtocol=TLSv1.3
+ClientSignatureAlgorithms=ecdsa_secp256r1_sha256"
+
+exit_test

--- a/tests/omfwd-tls-ossl-pkcs11-error-ca-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-error-ca-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-error-ca.sh

--- a/tests/omfwd-tls-ossl-pkcs11-error-ca.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-error-ca.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_FAIL_KIND="ca"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-error.sh

--- a/tests/omfwd-tls-ossl-pkcs11-error-cert-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-error-cert-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-error-cert.sh

--- a/tests/omfwd-tls-ossl-pkcs11-error-cert.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-error-cert.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_FAIL_KIND="cert"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-error.sh

--- a/tests/omfwd-tls-ossl-pkcs11-error-key-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-error-key-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-error-key.sh

--- a/tests/omfwd-tls-ossl-pkcs11-error-key.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-error-key.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_FAIL_KIND="key"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-error.sh

--- a/tests/omfwd-tls-ossl-pkcs11-error.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-error.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+# Verify that omfwd with the ossl driver reports a deterministic error when an
+# action-level TLS object is configured via a pkcs11: URI but the referenced
+# PKCS#11 object does not exist. The test is parameterized by
+# PKCS11_FAIL_KIND=ca|cert|key, provisions a temporary SoftHSM token with the
+# other required TLS objects, injects one message to force the outbound connect
+# path, and then waits for the expected rsyslog-internal startup/error log
+# message in the testbench .started file.
+. ${srcdir:=.}/diag.sh init
+
+check_command_available openssl
+check_command_available softhsm2-util
+check_command_available pkcs11-tool
+
+case "${PKCS11_FAIL_KIND:-}" in
+ca)
+	bad_uri_label="missing-ca"
+	# The CA error now includes the failing pkcs11: URI, so match the stable
+	# prefix here and assert the generic access-failure wording separately.
+	expected_error="Error: CA certificate '"
+	;;
+cert)
+	bad_uri_label="missing-cert"
+	expected_error="Error: Certificate file could not be accessed"
+	;;
+key)
+	bad_uri_label="missing-key"
+	expected_error="Error: Key could not be accessed"
+	;;
+*)
+	printf 'info: skipping helper test %s - PKCS11_FAIL_KIND not set (use ca, cert, or key)\n' "$0"
+	skip_test
+	;;
+esac
+
+find_first_existing() {
+	for candidate in "$@"; do
+		if [ -f "$candidate" ]; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
+workdir="$RSYSLOG_DYNNAME.omfwd-tls-ossl-pkcs11-error"
+softhsm_conf="$workdir/softhsm2.conf"
+openssl_conf="$workdir/openssl-pkcs11.cnf"
+token_dir="$workdir/tokens"
+token_label="rsyslog-test-token"
+token_pin="123456"
+token_so_pin="12345678"
+started_log="$RSYSLOG_DYNNAME.started"
+mkdir -p "$workdir" "$token_dir"
+
+provider_module=$(find_first_existing \
+	/usr/lib64/ossl-modules/pkcs11.so \
+	/usr/lib/ossl-modules/pkcs11.so \
+	/usr/lib/x86_64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/lib/aarch64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/local/lib64/ossl-modules/pkcs11.so \
+	/usr/local/lib/ossl-modules/pkcs11.so) || {
+	printf 'info: skipping test - pkcs11 OpenSSL provider module not found\n'
+	skip_test
+}
+
+softhsm_module=$(find_first_existing \
+	/usr/lib64/pkcs11/libsofthsm2.so \
+	/usr/lib/pkcs11/libsofthsm2.so \
+	/usr/lib64/softhsm/libsofthsm2.so \
+	/usr/lib/softhsm/libsofthsm2.so \
+	/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib64/libsofthsm2.so \
+	/usr/lib/libsofthsm2.so) || {
+	printf 'info: skipping test - SoftHSM PKCS#11 module not found\n'
+	skip_test
+}
+
+cat >"$workdir/client.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EOF
+
+cat >"$workdir/ca.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints = critical,CA:TRUE,pathlen:0
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+EOF
+
+openssl genrsa -out "$workdir/ca.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/ca.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Test-CA" \
+	-out "$workdir/ca.csr" || error_exit 1
+openssl x509 -req -in "$workdir/ca.csr" -signkey "$workdir/ca.key" -sha256 -days 365 \
+	-extfile "$workdir/ca.cnf" -extensions v3_ca \
+	-out "$workdir/ca.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/client.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/client.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=rsyslog-client" \
+	-out "$workdir/client.csr" || error_exit 1
+openssl x509 -req -in "$workdir/client.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/client.ext" \
+	-out "$workdir/client.pem" || error_exit 1
+
+openssl x509 -in "$workdir/ca.pem" -outform DER -out "$workdir/ca.der" || error_exit 1
+openssl x509 -in "$workdir/client.pem" -outform DER -out "$workdir/client.der" || error_exit 1
+openssl pkey -in "$workdir/client.key" -pubout -outform DER -out "$workdir/client.pub.der" || \
+	error_exit 1
+
+cat >"$softhsm_conf" <<EOF
+directories.tokendir = $token_dir
+objectstore.backend = file
+slots.removable = false
+EOF
+export SOFTHSM2_CONF="$softhsm_conf"
+
+softhsm2-util --init-token --free --label "$token_label" --so-pin "$token_so_pin" --pin "$token_pin" || error_exit 1
+softhsm2-util --import "$workdir/client.key" --token "$token_label" --label client-key --id 01 --pin "$token_pin" || error_exit 1
+
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.pub.der" --type pubkey --id 01 --label client-pub || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.der" --type cert --id 01 --label client-cert || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/ca.der" --type cert --id 02 --label ca-cert || error_exit 1
+
+cat >"$openssl_conf" <<EOF
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+pkcs11 = pkcs11_sect
+
+[default_sect]
+activate = 1
+
+[pkcs11_sect]
+identity = pkcs11
+module = $provider_module
+pkcs11-module-path = $softhsm_module
+pkcs11-module-token-pin = $token_pin
+activate = 1
+EOF
+export OPENSSL_CONF="$openssl_conf"
+
+ca_uri="pkcs11:token=$token_label;object=ca-cert;type=cert"
+cert_uri="pkcs11:token=$token_label;object=client-cert;type=cert"
+key_uri="pkcs11:token=$token_label;object=client-key;type=private"
+
+case "$PKCS11_FAIL_KIND" in
+ca)
+	# Force CA loading to fail before any TCP connect is attempted.
+	ca_uri="pkcs11:token=$token_label;object=$bad_uri_label;type=cert"
+	;;
+cert)
+	# Force certificate-chain loading to fail while CA and key remain valid.
+	cert_uri="pkcs11:token=$token_label;object=$bad_uri_label;type=cert"
+	;;
+key)
+	# Force private-key loading to fail while CA and certificate remain valid.
+	key_uri="pkcs11:token=$token_label;object=$bad_uri_label;type=private"
+	;;
+esac
+
+generate_conf
+add_conf '
+global(
+	compatibility.defaults.secure="strict"
+	net.ipprotocol="ipv4-only"
+)
+
+module(load="builtin:omfwd")
+template(name="outfmt" type="string" string="%msg%\n")
+
+if $msg contains "omfwd-ossl-pkcs11-error" then {
+	action(
+		type="omfwd"
+		target="127.0.0.1"
+		protocol="tcp"
+		port="1"
+		template="outfmt"
+		StreamDriver="ossl"
+		StreamDriverMode="1"
+		StreamDriverAuthMode="x509/certvalid"
+		streamdriver.cafile="'$ca_uri'"
+		streamdriver.certfile="'$cert_uri'"
+		streamdriver.keyfile="'$key_uri'"
+	)
+}
+'
+
+startup
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host app - - - omfwd-ossl-pkcs11-error'
+wait_content "$expected_error" "$started_log"
+shutdown_immediate
+wait_shutdown
+content_check "$expected_error" "$started_log"
+if [ "$PKCS11_FAIL_KIND" = "ca" ]; then
+	content_check "could not be accessed" "$started_log"
+fi
+content_check "OpenSSL Error Stack:" "$started_log"
+
+exit_test

--- a/tests/omfwd-tls-ossl-pkcs11-key-mtls-ecdsa-sigalgs-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-key-mtls-ecdsa-sigalgs-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-key-mtls-ecdsa-sigalgs.sh

--- a/tests/omfwd-tls-ossl-pkcs11-key-mtls-ecdsa-sigalgs.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-key-mtls-ecdsa-sigalgs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_SIGALG_VARIANT=key_only
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-ecdsa-sigalgs-common.sh

--- a/tests/omfwd-tls-ossl-pkcs11-key-mtls-sigalgs-negative-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-key-mtls-sigalgs-negative-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-key-mtls-sigalgs-negative.sh

--- a/tests/omfwd-tls-ossl-pkcs11-key-mtls-sigalgs-negative.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-key-mtls-sigalgs-negative.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_SIGALG_VARIANT=key_only
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-sigalgs-negative-common.sh

--- a/tests/omfwd-tls-ossl-pkcs11-key-mtls-sigalgs-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-key-mtls-sigalgs-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-key-mtls-sigalgs.sh

--- a/tests/omfwd-tls-ossl-pkcs11-key-mtls-sigalgs.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-key-mtls-sigalgs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_SIGALG_VARIANT=key_only
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-sigalgs-common.sh

--- a/tests/omfwd-tls-ossl-pkcs11-key-mtls-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-key-mtls-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-key-mtls.sh

--- a/tests/omfwd-tls-ossl-pkcs11-key-mtls.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-key-mtls.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+# Verify that omfwd with the ossl driver can establish a mutual-TLS session to
+# an OpenSSL-based remote peer when the CA certificate and client certificate
+# are loaded from PEM files but the client private key is loaded via a strict
+# pkcs11: URI. This matches the mixed deployment mode used in IOS XR. The
+# oracle is that the remote helper, which requires a valid client certificate,
+# captures exactly one forwarded payload line for the test message. If rsyslog
+# fails to bind the PEM certificate to the PKCS#11-backed key, the helper
+# aborts the handshake with "peer did not return a certificate" and this test
+# fails without matching the payload line.
+. ${srcdir:=.}/diag.sh init
+
+check_command_available openssl
+check_command_available softhsm2-util
+check_command_available pkcs11-tool
+
+if [ ! -x ./openssl_mtls_server ]; then
+	echo "openssl_mtls_server helper not built - skipping test"
+	exit 77
+fi
+
+find_first_existing() {
+	for candidate in "$@"; do
+		if [ -f "$candidate" ]; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
+workdir="$RSYSLOG_DYNNAME.omfwd-tls-ossl-pkcs11-key-mtls"
+port_file="$workdir/server.port"
+server_capture="$workdir/server.capture"
+server_stderr="$workdir/server.stderr"
+softhsm_conf="$workdir/softhsm2.conf"
+openssl_conf="$workdir/openssl-pkcs11.cnf"
+token_dir="$workdir/tokens"
+token_label="rsyslog-test-token"
+token_pin="123456"
+token_so_pin="12345678"
+mkdir -p "$workdir" "$token_dir"
+
+provider_module=$(find_first_existing \
+	/usr/lib64/ossl-modules/pkcs11.so \
+	/usr/lib/ossl-modules/pkcs11.so \
+	/usr/lib/x86_64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/lib/aarch64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/local/lib64/ossl-modules/pkcs11.so \
+	/usr/local/lib/ossl-modules/pkcs11.so) || {
+	printf 'info: skipping test - pkcs11 OpenSSL provider module not found\n'
+	skip_test
+}
+
+softhsm_module=$(find_first_existing \
+	/usr/lib64/pkcs11/libsofthsm2.so \
+	/usr/lib/pkcs11/libsofthsm2.so \
+	/usr/lib64/softhsm/libsofthsm2.so \
+	/usr/lib/softhsm/libsofthsm2.so \
+	/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib64/libsofthsm2.so \
+	/usr/lib/libsofthsm2.so) || {
+	printf 'info: skipping test - SoftHSM PKCS#11 module not found\n'
+	skip_test
+}
+
+cat >"$workdir/server.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+
+cat >"$workdir/client.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EOF
+
+cat >"$workdir/ca.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints = critical,CA:TRUE,pathlen:0
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+EOF
+
+openssl genrsa -out "$workdir/ca.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/ca.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Test-CA" \
+	-out "$workdir/ca.csr" || error_exit 1
+openssl x509 -req -in "$workdir/ca.csr" -signkey "$workdir/ca.key" -sha256 -days 365 \
+	-extfile "$workdir/ca.cnf" -extensions v3_ca \
+	-out "$workdir/ca.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/server.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/server.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=localhost" \
+	-out "$workdir/server.csr" || error_exit 1
+openssl x509 -req -in "$workdir/server.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/server.ext" \
+	-out "$workdir/server.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/client.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/client.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=rsyslog-client" \
+	-out "$workdir/client.csr" || error_exit 1
+openssl x509 -req -in "$workdir/client.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/client.ext" \
+	-out "$workdir/client.pem" || error_exit 1
+
+openssl x509 -in "$workdir/client.pem" -outform DER -out "$workdir/client.der" || error_exit 1
+openssl pkey -in "$workdir/client.key" -pubout -outform DER -out "$workdir/client.pub.der" || \
+	error_exit 1
+
+cat >"$softhsm_conf" <<EOF
+directories.tokendir = $token_dir
+objectstore.backend = file
+slots.removable = false
+EOF
+export SOFTHSM2_CONF="$softhsm_conf"
+
+softhsm2-util --init-token --free --label "$token_label" --so-pin "$token_so_pin" --pin "$token_pin" || error_exit 1
+softhsm2-util --import "$workdir/client.key" --token "$token_label" --label client-key --id 01 --pin "$token_pin" || error_exit 1
+
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.pub.der" --type pubkey --id 01 --label client-pub || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.der" --type cert --id 01 --label client-cert || error_exit 1
+
+cat >"$openssl_conf" <<EOF
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+pkcs11 = pkcs11_sect
+
+[default_sect]
+activate = 1
+
+[pkcs11_sect]
+identity = pkcs11
+module = $provider_module
+pkcs11-module-path = $softhsm_module
+pkcs11-module-token-pin = $token_pin
+activate = 1
+EOF
+export OPENSSL_CONF="$openssl_conf"
+
+key_uri="pkcs11:token=$token_label;object=client-key;type=private"
+
+./openssl_mtls_server 0 "$workdir/server.pem" "$workdir/server.key" "$workdir/ca.pem" \
+	"$port_file" "$server_capture" 2>"$server_stderr" &
+server_pid=$!
+wait_file_exists_for_process "$port_file" "$server_pid" 10 "OpenSSL MTLS helper" "$server_stderr"
+server_port=$(cat "$port_file")
+
+generate_conf
+add_conf '
+global(
+	compatibility.defaults.secure="strict"
+	net.ipprotocol="ipv4-only"
+)
+
+module(load="builtin:omfwd")
+template(name="outfmt" type="string" string="%msg%\n")
+
+if $msg contains "omfwd-ossl-pkcs11-key-mtls" then {
+	action(
+		type="omfwd"
+		target="127.0.0.1"
+		protocol="tcp"
+		port="'$server_port'"
+		template="outfmt"
+		StreamDriver="ossl"
+		StreamDriverMode="1"
+		StreamDriverAuthMode="x509/certvalid"
+		streamdriver.cafile="'$workdir/ca.pem'"
+		streamdriver.certfile="'$workdir/client.pem'"
+		streamdriver.keyfile="'$key_uri'"
+	)
+}
+'
+
+startup
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host app - - - omfwd-ossl-pkcs11-key-mtls'
+wait_file_lines "$server_capture" 1
+shutdown_when_empty
+wait_shutdown
+
+wait $server_pid || {
+	cat "$server_stderr"
+	error_exit 1
+}
+
+content_count_check --regex '^omfwd-ossl-pkcs11-key-mtls$' 1 "$server_capture"
+
+exit_test

--- a/tests/omfwd-tls-ossl-pkcs11-module-mtls-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-module-mtls-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-module-mtls.sh

--- a/tests/omfwd-tls-ossl-pkcs11-module-mtls.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-module-mtls.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+# Verify that builtin:omfwd module defaults can supply PKCS#11-backed TLS
+# objects for an omfwd action that omits action-level StreamDriver.CAFile,
+# StreamDriver.CAExtraFiles, StreamDriver.CertFile, and StreamDriver.KeyFile.
+# The server certificate is signed by an intermediate CA that is intentionally
+# not sent by the helper server, so the client handshake succeeds only if
+# omfwd loads the root CA via StreamDriver.CAFile and the missing intermediate
+# via StreamDriver.CAExtraFiles. The oracle is that the OpenSSL helper, which
+# also requires a valid client certificate, captures exactly one forwarded
+# payload line. All PKCS#11 state is created inside a per-test directory so
+# parallel runs do not collide.
+. ${srcdir:=.}/diag.sh init
+
+check_command_available openssl
+check_command_available softhsm2-util
+check_command_available pkcs11-tool
+
+if [ ! -x ./openssl_mtls_server ]; then
+	echo "openssl_mtls_server helper not built - skipping test"
+	exit 77
+fi
+
+find_first_existing() {
+	for candidate in "$@"; do
+		if [ -f "$candidate" ]; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
+workdir="$RSYSLOG_DYNNAME.omfwd-tls-ossl-pkcs11-module-mtls"
+port_file="$workdir/server.port"
+server_capture="$workdir/server.capture"
+server_stderr="$workdir/server.stderr"
+softhsm_conf="$workdir/softhsm2.conf"
+openssl_conf="$workdir/openssl-pkcs11.cnf"
+token_dir="$workdir/tokens"
+token_label="rsyslog-test-token"
+token_pin="123456"
+token_so_pin="12345678"
+mkdir -p "$workdir" "$token_dir"
+
+provider_module=$(find_first_existing \
+	/usr/lib64/ossl-modules/pkcs11.so \
+	/usr/lib/ossl-modules/pkcs11.so \
+	/usr/lib/x86_64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/lib/aarch64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/local/lib64/ossl-modules/pkcs11.so \
+	/usr/local/lib/ossl-modules/pkcs11.so) || {
+	printf 'info: skipping test - pkcs11 OpenSSL provider module not found\n'
+	skip_test
+}
+
+softhsm_module=$(find_first_existing \
+	/usr/lib64/pkcs11/libsofthsm2.so \
+	/usr/lib/pkcs11/libsofthsm2.so \
+	/usr/lib64/softhsm/libsofthsm2.so \
+	/usr/lib/softhsm/libsofthsm2.so \
+	/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib64/libsofthsm2.so \
+	/usr/lib/libsofthsm2.so) || {
+	printf 'info: skipping test - SoftHSM PKCS#11 module not found\n'
+	skip_test
+}
+
+cat >"$workdir/server.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+
+cat >"$workdir/client.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EOF
+
+cat >"$workdir/ca.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints=critical,CA:TRUE,pathlen:1
+keyUsage=critical,keyCertSign,cRLSign
+subjectKeyIdentifier=hash
+EOF
+
+cat >"$workdir/intermediate.ext" <<'EOF'
+basicConstraints=critical,CA:TRUE,pathlen:0
+keyUsage=critical,keyCertSign,cRLSign
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+EOF
+
+openssl genrsa -out "$workdir/ca.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/ca.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Test-CA" \
+	-out "$workdir/ca.csr" || error_exit 1
+openssl x509 -req -in "$workdir/ca.csr" -signkey "$workdir/ca.key" -sha256 -days 365 \
+	-extfile "$workdir/ca.cnf" -extensions v3_ca \
+	-out "$workdir/ca.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/intermediate.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/intermediate.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Intermediate-CA" \
+	-out "$workdir/intermediate.csr" || error_exit 1
+openssl x509 -req -in "$workdir/intermediate.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/intermediate.ext" \
+	-out "$workdir/intermediate.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/server.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/server.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=localhost" \
+	-out "$workdir/server.csr" || error_exit 1
+openssl x509 -req -in "$workdir/server.csr" -CA "$workdir/intermediate.pem" -CAkey "$workdir/intermediate.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/server.ext" \
+	-out "$workdir/server.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/client.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/client.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=rsyslog-client" \
+	-out "$workdir/client.csr" || error_exit 1
+openssl x509 -req -in "$workdir/client.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/client.ext" \
+	-out "$workdir/client.pem" || error_exit 1
+
+openssl x509 -in "$workdir/ca.pem" -outform DER -out "$workdir/ca.der" || error_exit 1
+openssl x509 -in "$workdir/intermediate.pem" -outform DER -out "$workdir/intermediate.der" || error_exit 1
+openssl x509 -in "$workdir/client.pem" -outform DER -out "$workdir/client.der" || error_exit 1
+openssl pkey -in "$workdir/client.key" -pubout -outform DER -out "$workdir/client.pub.der" || \
+	error_exit 1
+
+cat >"$softhsm_conf" <<EOF
+directories.tokendir = $token_dir
+objectstore.backend = file
+slots.removable = false
+EOF
+export SOFTHSM2_CONF="$softhsm_conf"
+
+softhsm2-util --init-token --free --label "$token_label" --so-pin "$token_so_pin" --pin "$token_pin" || error_exit 1
+softhsm2-util --import "$workdir/client.key" --token "$token_label" --label client-key --id 01 --pin "$token_pin" || error_exit 1
+
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.pub.der" --type pubkey --id 01 --label client-pub || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.der" --type cert --id 01 --label client-cert || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/ca.der" --type cert --id 02 --label ca-cert || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/intermediate.der" --type cert --id 03 --label intermediate-ca-cert || error_exit 1
+
+cat >"$openssl_conf" <<EOF
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+pkcs11 = pkcs11_sect
+
+[default_sect]
+activate = 1
+
+[pkcs11_sect]
+identity = pkcs11
+module = $provider_module
+pkcs11-module-path = $softhsm_module
+pkcs11-module-token-pin = $token_pin
+activate = 1
+EOF
+export OPENSSL_CONF="$openssl_conf"
+
+ca_uri="pkcs11:token=$token_label;object=ca-cert;type=cert"
+extra_ca_uri="pkcs11:token=$token_label;object=intermediate-ca-cert;type=cert"
+cert_uri="pkcs11:token=$token_label;object=client-cert;type=cert"
+key_uri="pkcs11:token=$token_label;object=client-key;type=private"
+
+./openssl_mtls_server 0 "$workdir/server.pem" "$workdir/server.key" "$workdir/ca.pem" \
+	"$port_file" "$server_capture" 2>"$server_stderr" &
+server_pid=$!
+wait_file_exists_for_process "$port_file" "$server_pid" 10 "OpenSSL MTLS helper" "$server_stderr"
+server_port=$(cat "$port_file")
+
+generate_conf
+add_conf '
+global(
+	compatibility.defaults.secure="strict"
+	net.ipprotocol="ipv4-only"
+)
+
+module(
+	load="builtin:omfwd"
+	StreamDriver.CAFile="'$ca_uri'"
+	StreamDriver.CAExtraFiles="'$extra_ca_uri'"
+	StreamDriver.CertFile="'$cert_uri'"
+	StreamDriver.KeyFile="'$key_uri'"
+)
+template(name="outfmt" type="string" string="%msg%\n")
+
+if $msg contains "omfwd-ossl-pkcs11-module-mtls" then {
+	action(
+		type="omfwd"
+		target="127.0.0.1"
+		protocol="tcp"
+		port="'$server_port'"
+		template="outfmt"
+		StreamDriver="ossl"
+		StreamDriverMode="1"
+		StreamDriverAuthMode="x509/certvalid"
+	)
+}
+'
+
+startup
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host app - - - omfwd-ossl-pkcs11-module-mtls'
+wait_file_lines "$server_capture" 1
+shutdown_when_empty
+wait_shutdown
+
+wait $server_pid || {
+	cat "$server_stderr"
+	error_exit 1
+}
+
+content_count_check --regex '^omfwd-ossl-pkcs11-module-mtls$' 1 "$server_capture"
+
+exit_test

--- a/tests/omfwd-tls-ossl-pkcs11-module-precedence-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-module-precedence-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-module-precedence.sh

--- a/tests/omfwd-tls-ossl-pkcs11-module-precedence.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-module-precedence.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+# Verify that action-level StreamDriver.CAExtraFiles overrides the
+# builtin:omfwd module default. The server certificate is signed by an
+# intermediate CA that the helper server does not send. The module provides a
+# valid root CA plus an intentionally invalid extra-CA URI, while the action
+# overrides only StreamDriver.CAExtraFiles with the correct PKCS#11 URI for the
+# missing intermediate. The oracle is that the helper server still receives
+# exactly one forwarded payload line, proving that the action-level
+# StreamDriver.CAExtraFiles took precedence over the broken module default.
+. ${srcdir:=.}/diag.sh init
+
+check_command_available openssl
+check_command_available softhsm2-util
+check_command_available pkcs11-tool
+
+if [ ! -x ./openssl_mtls_server ]; then
+	echo "openssl_mtls_server helper not built - skipping test"
+	exit 77
+fi
+
+find_first_existing() {
+	for candidate in "$@"; do
+		if [ -f "$candidate" ]; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
+workdir="$RSYSLOG_DYNNAME.omfwd-tls-ossl-pkcs11-module-precedence"
+port_file="$workdir/server.port"
+server_capture="$workdir/server.capture"
+server_stderr="$workdir/server.stderr"
+softhsm_conf="$workdir/softhsm2.conf"
+openssl_conf="$workdir/openssl-pkcs11.cnf"
+token_dir="$workdir/tokens"
+token_label="rsyslog-test-token"
+token_pin="123456"
+token_so_pin="12345678"
+mkdir -p "$workdir" "$token_dir"
+
+provider_module=$(find_first_existing \
+	/usr/lib64/ossl-modules/pkcs11.so \
+	/usr/lib/ossl-modules/pkcs11.so \
+	/usr/lib/x86_64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/lib/aarch64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/local/lib64/ossl-modules/pkcs11.so \
+	/usr/local/lib/ossl-modules/pkcs11.so) || {
+	printf 'info: skipping test - pkcs11 OpenSSL provider module not found\n'
+	skip_test
+}
+
+softhsm_module=$(find_first_existing \
+	/usr/lib64/pkcs11/libsofthsm2.so \
+	/usr/lib/pkcs11/libsofthsm2.so \
+	/usr/lib64/softhsm/libsofthsm2.so \
+	/usr/lib/softhsm/libsofthsm2.so \
+	/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib64/libsofthsm2.so \
+	/usr/lib/libsofthsm2.so) || {
+	printf 'info: skipping test - SoftHSM PKCS#11 module not found\n'
+	skip_test
+}
+
+cat >"$workdir/server.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+
+cat >"$workdir/client.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EOF
+
+cat >"$workdir/ca.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints=critical,CA:TRUE,pathlen:1
+keyUsage=critical,keyCertSign,cRLSign
+subjectKeyIdentifier=hash
+EOF
+
+cat >"$workdir/intermediate.ext" <<'EOF'
+basicConstraints=critical,CA:TRUE,pathlen:0
+keyUsage=critical,keyCertSign,cRLSign
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+EOF
+
+openssl genrsa -out "$workdir/ca.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/ca.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Test-CA" \
+	-out "$workdir/ca.csr" || error_exit 1
+openssl x509 -req -in "$workdir/ca.csr" -signkey "$workdir/ca.key" -sha256 -days 365 \
+	-extfile "$workdir/ca.cnf" -extensions v3_ca \
+	-out "$workdir/ca.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/intermediate.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/intermediate.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Intermediate-CA" \
+	-out "$workdir/intermediate.csr" || error_exit 1
+openssl x509 -req -in "$workdir/intermediate.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/intermediate.ext" \
+	-out "$workdir/intermediate.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/server.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/server.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=localhost" \
+	-out "$workdir/server.csr" || error_exit 1
+openssl x509 -req -in "$workdir/server.csr" -CA "$workdir/intermediate.pem" -CAkey "$workdir/intermediate.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/server.ext" \
+	-out "$workdir/server.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/client.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/client.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=rsyslog-client" \
+	-out "$workdir/client.csr" || error_exit 1
+openssl x509 -req -in "$workdir/client.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/client.ext" \
+	-out "$workdir/client.pem" || error_exit 1
+
+openssl x509 -in "$workdir/ca.pem" -outform DER -out "$workdir/ca.der" || error_exit 1
+openssl x509 -in "$workdir/intermediate.pem" -outform DER -out "$workdir/intermediate.der" || error_exit 1
+openssl x509 -in "$workdir/client.pem" -outform DER -out "$workdir/client.der" || error_exit 1
+openssl pkey -in "$workdir/client.key" -pubout -outform DER -out "$workdir/client.pub.der" || \
+	error_exit 1
+
+cat >"$softhsm_conf" <<EOF
+directories.tokendir = $token_dir
+objectstore.backend = file
+slots.removable = false
+EOF
+export SOFTHSM2_CONF="$softhsm_conf"
+
+softhsm2-util --init-token --free --label "$token_label" --so-pin "$token_so_pin" --pin "$token_pin" || error_exit 1
+softhsm2-util --import "$workdir/client.key" --token "$token_label" --label client-key --id 01 --pin "$token_pin" || error_exit 1
+
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.pub.der" --type pubkey --id 01 --label client-pub || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.der" --type cert --id 01 --label client-cert || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/ca.der" --type cert --id 02 --label ca-cert || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/intermediate.der" --type cert --id 03 --label intermediate-ca-cert || error_exit 1
+
+cat >"$openssl_conf" <<EOF
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+pkcs11 = pkcs11_sect
+
+[default_sect]
+activate = 1
+
+[pkcs11_sect]
+identity = pkcs11
+module = $provider_module
+pkcs11-module-path = $softhsm_module
+pkcs11-module-token-pin = $token_pin
+activate = 1
+EOF
+export OPENSSL_CONF="$openssl_conf"
+
+good_ca_uri="pkcs11:token=$token_label;object=ca-cert;type=cert"
+good_extra_ca_uri="pkcs11:token=$token_label;object=intermediate-ca-cert;type=cert"
+good_cert_uri="pkcs11:token=$token_label;object=client-cert;type=cert"
+good_key_uri="pkcs11:token=$token_label;object=client-key;type=private"
+bad_extra_ca_uri="pkcs11:token=$token_label;object=missing-intermediate-ca-cert;type=cert"
+
+./openssl_mtls_server 0 "$workdir/server.pem" "$workdir/server.key" "$workdir/ca.pem" \
+	"$port_file" "$server_capture" 2>"$server_stderr" &
+server_pid=$!
+wait_file_exists_for_process "$port_file" "$server_pid" 10 "OpenSSL MTLS helper" "$server_stderr"
+server_port=$(cat "$port_file")
+
+generate_conf
+add_conf '
+global(
+	compatibility.defaults.secure="strict"
+	net.ipprotocol="ipv4-only"
+)
+
+module(
+	load="builtin:omfwd"
+	StreamDriver.CAFile="'$good_ca_uri'"
+	StreamDriver.CAExtraFiles="'$bad_extra_ca_uri'"
+	StreamDriver.CertFile="'$good_cert_uri'"
+	StreamDriver.KeyFile="'$good_key_uri'"
+)
+template(name="outfmt" type="string" string="%msg%\n")
+
+if $msg contains "omfwd-ossl-pkcs11-module-precedence" then {
+	action(
+		type="omfwd"
+		target="127.0.0.1"
+		protocol="tcp"
+		port="'$server_port'"
+		template="outfmt"
+		StreamDriver="ossl"
+		StreamDriverMode="1"
+		StreamDriverAuthMode="x509/certvalid"
+		StreamDriver.CAExtraFiles="'$good_extra_ca_uri'"
+	)
+}
+'
+
+startup
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host app - - - omfwd-ossl-pkcs11-module-precedence'
+wait_file_lines "$server_capture" 1
+shutdown_when_empty
+wait_shutdown
+
+wait $server_pid || {
+	cat "$server_stderr"
+	error_exit 1
+}
+
+content_count_check --regex '^omfwd-ossl-pkcs11-module-precedence$' 1 "$server_capture"
+
+exit_test

--- a/tests/omfwd-tls-ossl-pkcs11-mtls-ecdsa-sigalgs-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-mtls-ecdsa-sigalgs-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-mtls-ecdsa-sigalgs.sh

--- a/tests/omfwd-tls-ossl-pkcs11-mtls-ecdsa-sigalgs.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-mtls-ecdsa-sigalgs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_SIGALG_VARIANT=full
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-ecdsa-sigalgs-common.sh

--- a/tests/omfwd-tls-ossl-pkcs11-mtls-sigalgs-negative-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-mtls-sigalgs-negative-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-mtls-sigalgs-negative.sh

--- a/tests/omfwd-tls-ossl-pkcs11-mtls-sigalgs-negative.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-mtls-sigalgs-negative.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_SIGALG_VARIANT=full
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-sigalgs-negative-common.sh

--- a/tests/omfwd-tls-ossl-pkcs11-mtls-sigalgs-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-mtls-sigalgs-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-mtls-sigalgs.sh

--- a/tests/omfwd-tls-ossl-pkcs11-mtls-sigalgs.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-mtls-sigalgs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export PKCS11_SIGALG_VARIANT=full
+. ${srcdir:=.}/omfwd-tls-ossl-pkcs11-sigalgs-common.sh

--- a/tests/omfwd-tls-ossl-pkcs11-mtls-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-mtls-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-mtls.sh

--- a/tests/omfwd-tls-ossl-pkcs11-mtls.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-mtls.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# Verify that omfwd with the ossl driver can establish a mutual-TLS session to
+# an OpenSSL-based remote peer when the client CA certificate, client
+# certificate, and client private key are all loaded via strict pkcs11: URIs.
+# The oracle is that the remote helper, which requires a valid client
+# certificate, captures exactly one forwarded payload line for the test
+# message. The helper output may also contain rsyslog's own startup or
+# transport diagnostics, so the test matches the payload line rather than using
+# whole-file equality. The test provisions a temporary SoftHSM token inside a
+# per-test directory and skips cleanly if the required PKCS#11 tooling or
+# provider modules are unavailable.
+. ${srcdir:=.}/diag.sh init
+
+check_command_available openssl
+check_command_available softhsm2-util
+check_command_available pkcs11-tool
+
+if [ ! -x ./openssl_mtls_server ]; then
+	echo "openssl_mtls_server helper not built - skipping test"
+	exit 77
+fi
+
+find_first_existing() {
+	for candidate in "$@"; do
+		if [ -f "$candidate" ]; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
+workdir="$RSYSLOG_DYNNAME.omfwd-tls-ossl-pkcs11-mtls"
+port_file="$workdir/server.port"
+server_capture="$workdir/server.capture"
+server_stderr="$workdir/server.stderr"
+softhsm_conf="$workdir/softhsm2.conf"
+openssl_conf="$workdir/openssl-pkcs11.cnf"
+token_dir="$workdir/tokens"
+token_label="rsyslog-test-token"
+token_pin="123456"
+token_so_pin="12345678"
+mkdir -p "$workdir" "$token_dir"
+
+provider_module=$(find_first_existing \
+	/usr/lib64/ossl-modules/pkcs11.so \
+	/usr/lib/ossl-modules/pkcs11.so \
+	/usr/lib/x86_64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/lib/aarch64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/local/lib64/ossl-modules/pkcs11.so \
+	/usr/local/lib/ossl-modules/pkcs11.so) || {
+	printf 'info: skipping test - pkcs11 OpenSSL provider module not found\n'
+	skip_test
+}
+
+softhsm_module=$(find_first_existing \
+	/usr/lib64/pkcs11/libsofthsm2.so \
+	/usr/lib/pkcs11/libsofthsm2.so \
+	/usr/lib64/softhsm/libsofthsm2.so \
+	/usr/lib/softhsm/libsofthsm2.so \
+	/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib64/libsofthsm2.so \
+	/usr/lib/libsofthsm2.so) || {
+	printf 'info: skipping test - SoftHSM PKCS#11 module not found\n'
+	skip_test
+}
+
+cat >"$workdir/server.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+
+cat >"$workdir/client.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EOF
+
+cat >"$workdir/ca.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints = critical,CA:TRUE,pathlen:0
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+EOF
+
+openssl genrsa -out "$workdir/ca.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/ca.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Test-CA" \
+	-out "$workdir/ca.csr" || error_exit 1
+openssl x509 -req -in "$workdir/ca.csr" -signkey "$workdir/ca.key" -sha256 -days 365 \
+	-extfile "$workdir/ca.cnf" -extensions v3_ca \
+	-out "$workdir/ca.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/server.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/server.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=localhost" \
+	-out "$workdir/server.csr" || error_exit 1
+openssl x509 -req -in "$workdir/server.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/server.ext" \
+	-out "$workdir/server.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/client.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/client.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=rsyslog-client" \
+	-out "$workdir/client.csr" || error_exit 1
+openssl x509 -req -in "$workdir/client.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/client.ext" \
+	-out "$workdir/client.pem" || error_exit 1
+
+openssl x509 -in "$workdir/ca.pem" -outform DER -out "$workdir/ca.der" || error_exit 1
+openssl x509 -in "$workdir/client.pem" -outform DER -out "$workdir/client.der" || error_exit 1
+openssl pkey -in "$workdir/client.key" -pubout -outform DER -out "$workdir/client.pub.der" || \
+	error_exit 1
+
+cat >"$softhsm_conf" <<EOF
+directories.tokendir = $token_dir
+objectstore.backend = file
+slots.removable = false
+EOF
+export SOFTHSM2_CONF="$softhsm_conf"
+
+softhsm2-util --init-token --free --label "$token_label" --so-pin "$token_so_pin" --pin "$token_pin" || error_exit 1
+softhsm2-util --import "$workdir/client.key" --token "$token_label" --label client-key --id 01 --pin "$token_pin" || error_exit 1
+
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.pub.der" --type pubkey --id 01 --label client-pub || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.der" --type cert --id 01 --label client-cert || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/ca.der" --type cert --id 02 --label ca-cert || error_exit 1
+
+cat >"$openssl_conf" <<EOF
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+pkcs11 = pkcs11_sect
+
+[default_sect]
+activate = 1
+
+[pkcs11_sect]
+identity = pkcs11
+module = $provider_module
+pkcs11-module-path = $softhsm_module
+pkcs11-module-token-pin = $token_pin
+activate = 1
+EOF
+export OPENSSL_CONF="$openssl_conf"
+
+ca_uri="pkcs11:token=$token_label;object=ca-cert;type=cert"
+cert_uri="pkcs11:token=$token_label;object=client-cert;type=cert"
+key_uri="pkcs11:token=$token_label;object=client-key;type=private"
+
+./openssl_mtls_server 0 "$workdir/server.pem" "$workdir/server.key" "$workdir/ca.pem" \
+	"$port_file" "$server_capture" 2>"$server_stderr" &
+server_pid=$!
+wait_file_exists_for_process "$port_file" "$server_pid" 10 "OpenSSL MTLS helper" "$server_stderr"
+server_port=$(cat "$port_file")
+
+generate_conf
+add_conf '
+global(
+	compatibility.defaults.secure="strict"
+	net.ipprotocol="ipv4-only"
+)
+
+module(load="builtin:omfwd")
+template(name="outfmt" type="string" string="%msg%\n")
+
+if $msg contains "omfwd-ossl-pkcs11-mtls" then {
+	action(
+		type="omfwd"
+		target="127.0.0.1"
+		protocol="tcp"
+		port="'$server_port'"
+		template="outfmt"
+		StreamDriver="ossl"
+		StreamDriverMode="1"
+		StreamDriverAuthMode="x509/certvalid"
+		streamdriver.cafile="'$ca_uri'"
+		streamdriver.certfile="'$cert_uri'"
+		streamdriver.keyfile="'$key_uri'"
+	)
+}
+'
+
+startup
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host app - - - omfwd-ossl-pkcs11-mtls'
+wait_file_lines "$server_capture" 1
+shutdown_when_empty
+wait_shutdown
+
+wait $server_pid || {
+	cat "$server_stderr"
+	error_exit 1
+}
+
+content_count_check --regex '^omfwd-ossl-pkcs11-mtls$' 1 "$server_capture"
+
+exit_test

--- a/tests/omfwd-tls-ossl-pkcs11-recover-mtls-vg.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-recover-mtls-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omfwd-tls-ossl-pkcs11-recover-mtls.sh

--- a/tests/omfwd-tls-ossl-pkcs11-recover-mtls.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-recover-mtls.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+# Verify that omfwd with the ossl driver recovers from a TLS handshake failure
+# when the client-side CA certificate, client certificate, and client private
+# key are all loaded from valid pkcs11: URIs. The test first presents a server
+# certificate signed by an untrusted CA so the initial handshake fails even
+# though all client-side PKCS#11 objects resolve successfully. It then restarts
+# a server on the same port with a certificate signed by the trusted CA and
+# verifies that omfwd retries automatically and eventually delivers the queued
+# message.
+. ${srcdir:=.}/diag.sh init
+
+check_command_available openssl
+check_command_available softhsm2-util
+check_command_available pkcs11-tool
+
+if [ ! -x ./openssl_mtls_server ]; then
+	echo "openssl_mtls_server helper not built - skipping test"
+	exit 77
+fi
+
+find_first_existing() {
+	for candidate in "$@"; do
+		if [ -f "$candidate" ]; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
+wait_pid_exit_with_timeout() {
+	pid="$1"
+	while kill -0 "$pid" 2>/dev/null; do
+		$TESTTOOL_DIR/msleep 100
+		if [ "$(date +%s)" -gt $(( TB_STARTTEST + TB_TEST_MAX_RUNTIME )) ]; then
+			printf 'TESTBENCH error: timeout waiting for helper pid %s to exit\n' "$pid"
+			ps -fp "$pid"
+			error_exit 1
+		fi
+	done
+	wait "$pid"
+}
+
+workdir="$RSYSLOG_DYNNAME.omfwd-tls-ossl-pkcs11-recover-mtls"
+port_file="$workdir/server.port"
+bad_capture="$workdir/server-bad.capture"
+bad_stderr="$workdir/server-bad.stderr"
+good_capture="$workdir/server-good.capture"
+good_stderr="$workdir/server-good.stderr"
+softhsm_conf="$workdir/softhsm2.conf"
+openssl_conf="$workdir/openssl-pkcs11.cnf"
+token_dir="$workdir/tokens"
+token_label="rsyslog-test-token"
+token_pin="123456"
+token_so_pin="12345678"
+mkdir -p "$workdir" "$token_dir"
+
+provider_module=$(find_first_existing \
+	/usr/lib64/ossl-modules/pkcs11.so \
+	/usr/lib/ossl-modules/pkcs11.so \
+	/usr/lib/x86_64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/lib/aarch64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/local/lib64/ossl-modules/pkcs11.so \
+	/usr/local/lib/ossl-modules/pkcs11.so) || {
+	printf 'info: skipping test - pkcs11 OpenSSL provider module not found\n'
+	skip_test
+}
+
+softhsm_module=$(find_first_existing \
+	/usr/lib64/pkcs11/libsofthsm2.so \
+	/usr/lib/pkcs11/libsofthsm2.so \
+	/usr/lib64/softhsm/libsofthsm2.so \
+	/usr/lib/softhsm/libsofthsm2.so \
+	/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib64/libsofthsm2.so \
+	/usr/lib/libsofthsm2.so) || {
+	printf 'info: skipping test - SoftHSM PKCS#11 module not found\n'
+	skip_test
+}
+
+cat >"$workdir/server.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+
+cat >"$workdir/client.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EOF
+
+cat >"$workdir/ca.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints = critical,CA:TRUE,pathlen:0
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+EOF
+
+openssl genrsa -out "$workdir/trusted-ca.key" 2048 || error_exit 1
+openssl req -x509 -new -key "$workdir/trusted-ca.key" -sha256 -days 365 \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Trusted-CA" \
+	-config "$workdir/ca.cnf" -extensions v3_ca \
+	-out "$workdir/trusted-ca.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/untrusted-ca.key" 2048 || error_exit 1
+openssl req -x509 -new -key "$workdir/untrusted-ca.key" -sha256 -days 365 \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Untrusted-CA" \
+	-config "$workdir/ca.cnf" -extensions v3_ca \
+	-out "$workdir/untrusted-ca.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/client.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/client.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=rsyslog-client" \
+	-out "$workdir/client.csr" || error_exit 1
+openssl x509 -req -in "$workdir/client.csr" -CA "$workdir/trusted-ca.pem" -CAkey "$workdir/trusted-ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/client.ext" \
+	-out "$workdir/client.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/server-bad.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/server-bad.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=localhost" \
+	-out "$workdir/server-bad.csr" || error_exit 1
+openssl x509 -req -in "$workdir/server-bad.csr" -CA "$workdir/untrusted-ca.pem" -CAkey "$workdir/untrusted-ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/server.ext" \
+	-out "$workdir/server-bad.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/server-good.key" 2048 || error_exit 1
+openssl req -new -key "$workdir/server-good.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=localhost" \
+	-out "$workdir/server-good.csr" || error_exit 1
+openssl x509 -req -in "$workdir/server-good.csr" -CA "$workdir/trusted-ca.pem" -CAkey "$workdir/trusted-ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/server.ext" \
+	-out "$workdir/server-good.pem" || error_exit 1
+
+openssl x509 -in "$workdir/trusted-ca.pem" -outform DER -out "$workdir/trusted-ca.der" || \
+	error_exit 1
+openssl x509 -in "$workdir/client.pem" -outform DER -out "$workdir/client.der" || error_exit 1
+openssl pkey -in "$workdir/client.key" -pubout -outform DER -out "$workdir/client.pub.der" || \
+	error_exit 1
+
+cat >"$softhsm_conf" <<EOF
+directories.tokendir = $token_dir
+objectstore.backend = file
+slots.removable = false
+EOF
+export SOFTHSM2_CONF="$softhsm_conf"
+
+softhsm2-util --init-token --free --label "$token_label" --so-pin "$token_so_pin" --pin "$token_pin" || error_exit 1
+softhsm2-util --import "$workdir/client.key" --token "$token_label" --label client-key --id 01 --pin "$token_pin" || error_exit 1
+
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.pub.der" --type pubkey --id 01 --label client-pub || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.der" --type cert --id 01 --label client-cert || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/trusted-ca.der" --type cert --id 02 --label ca-cert || error_exit 1
+
+cat >"$openssl_conf" <<EOF
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+pkcs11 = pkcs11_sect
+
+[default_sect]
+activate = 1
+
+[pkcs11_sect]
+identity = pkcs11
+module = $provider_module
+pkcs11-module-path = $softhsm_module
+pkcs11-module-token-pin = $token_pin
+activate = 1
+EOF
+export OPENSSL_CONF="$openssl_conf"
+
+ca_uri="pkcs11:token=$token_label;object=ca-cert;type=cert"
+cert_uri="pkcs11:token=$token_label;object=client-cert;type=cert"
+key_uri="pkcs11:token=$token_label;object=client-key;type=private"
+
+./openssl_mtls_server 0 "$workdir/server-bad.pem" "$workdir/server-bad.key" "$workdir/trusted-ca.pem" \
+	"$port_file" "$bad_capture" 2>"$bad_stderr" &
+bad_server_pid=$!
+wait_file_exists_for_process "$port_file" "$bad_server_pid" 10 "OpenSSL MTLS helper" "$bad_stderr"
+server_port=$(cat "$port_file")
+
+generate_conf
+add_conf '
+global(
+	compatibility.defaults.secure="strict"
+	net.ipprotocol="ipv4-only"
+)
+
+module(load="builtin:omfwd")
+template(name="outfmt" type="string" string="%msg%\n")
+
+if $msg contains "omfwd-ossl-pkcs11-recover-mtls" then {
+	action(
+		type="omfwd"
+		target="127.0.0.1"
+		protocol="tcp"
+		port="'$server_port'"
+		template="outfmt"
+		StreamDriver="ossl"
+		StreamDriverMode="1"
+		StreamDriverAuthMode="x509/certvalid"
+		streamdriver.cafile="'$ca_uri'"
+		streamdriver.certfile="'$cert_uri'"
+		streamdriver.keyfile="'$key_uri'"
+		pool.resumeInterval="1"
+		action.resumeRetryCount="-1"
+		action.resumeInterval="1"
+	)
+}
+'
+
+startup
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host app - - - omfwd-ossl-pkcs11-recover-mtls'
+
+wait_content "SSL_accept failed" "$bad_stderr"
+if wait_pid_exit_with_timeout $bad_server_pid; then
+	printf 'Testbench ERROR: expected the first helper server to fail the TLS handshake\n'
+	error_exit 1
+fi
+
+./openssl_mtls_server "$server_port" "$workdir/server-good.pem" "$workdir/server-good.key" "$workdir/trusted-ca.pem" \
+	"$workdir/server-good.port" "$good_capture" 2>"$good_stderr" &
+good_server_pid=$!
+wait_file_exists_for_process "$workdir/server-good.port" "$good_server_pid" 10 "OpenSSL MTLS helper" "$good_stderr"
+
+wait_file_lines "$good_capture" 1
+shutdown_when_empty
+wait_shutdown
+
+wait_pid_exit_with_timeout $good_server_pid || {
+	cat "$good_stderr"
+	error_exit 1
+}
+
+content_count_check --regex '^omfwd-ossl-pkcs11-recover-mtls$' 1 "$good_capture"
+
+exit_test

--- a/tests/omfwd-tls-ossl-pkcs11-sigalgs-common.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-sigalgs-common.sh
@@ -1,0 +1,320 @@
+#!/bin/bash
+# Common matrix for PKCS#11-backed omfwd mTLS signing algorithm tests.
+. ${srcdir:=.}/diag.sh init
+
+case "$(basename "$0")" in
+omfwd-tls-ossl-pkcs11-sigalgs-common.sh)
+	printf 'info: shared helper script; skipping direct execution\n'
+	skip_test
+	;;
+esac
+
+check_command_available openssl
+check_command_available softhsm2-util
+check_command_available pkcs11-tool
+
+if [ ! -x ./openssl_mtls_server ]; then
+	echo "openssl_mtls_server helper not built - skipping test"
+	exit 77
+fi
+
+find_first_existing() {
+	for candidate in "$@"; do
+		if [ -f "$candidate" ]; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
+setup_variant() {
+	case "${PKCS11_SIGALG_VARIANT}" in
+	key_only)
+		TEST_SUFFIX="key-mtls-sigalgs"
+		TEST_MSG_PREFIX="omfwd-ossl-pkcs11-key-mtls-sigalgs"
+		TEST_CA_REF="$workdir/ca.pem"
+		TEST_CERT_REF="$workdir/client.pem"
+		TEST_KEY_REF="$key_uri"
+		;;
+	cert_key)
+		TEST_SUFFIX="cert-mtls-sigalgs"
+		TEST_MSG_PREFIX="omfwd-ossl-pkcs11-cert-mtls-sigalgs"
+		TEST_CA_REF="$workdir/ca.pem"
+		TEST_CERT_REF="$cert_uri"
+		TEST_KEY_REF="$key_uri"
+		;;
+	ca_key)
+		TEST_SUFFIX="ca-mtls-sigalgs"
+		TEST_MSG_PREFIX="omfwd-ossl-pkcs11-ca-mtls-sigalgs"
+		TEST_CA_REF="$ca_uri"
+		TEST_CERT_REF="$workdir/client.pem"
+		TEST_KEY_REF="$key_uri"
+		;;
+	full)
+		TEST_SUFFIX="mtls-sigalgs"
+		TEST_MSG_PREFIX="omfwd-ossl-pkcs11-mtls-sigalgs"
+		TEST_CA_REF="$ca_uri"
+		TEST_CERT_REF="$cert_uri"
+		TEST_KEY_REF="$key_uri"
+		;;
+	*)
+		printf 'unknown PKCS11_SIGALG_VARIANT=%s\n' "${PKCS11_SIGALG_VARIANT}" >&2
+		error_exit 1
+		;;
+	esac
+}
+
+provider_module=$(find_first_existing \
+	/usr/lib64/ossl-modules/pkcs11.so \
+	/usr/lib/ossl-modules/pkcs11.so \
+	/usr/lib/x86_64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/lib/aarch64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/local/lib64/ossl-modules/pkcs11.so \
+	/usr/local/lib/ossl-modules/pkcs11.so) || {
+	printf 'info: skipping test - pkcs11 OpenSSL provider module not found\n'
+	skip_test
+}
+
+softhsm_module=$(find_first_existing \
+	/usr/lib64/pkcs11/libsofthsm2.so \
+	/usr/lib/pkcs11/libsofthsm2.so \
+	/usr/lib64/softhsm/libsofthsm2.so \
+	/usr/lib/softhsm/libsofthsm2.so \
+	/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib64/libsofthsm2.so \
+	/usr/lib/libsofthsm2.so) || {
+	printf 'info: skipping test - SoftHSM PKCS#11 module not found\n'
+	skip_test
+}
+
+token_label="rsyslog-test-token"
+token_pin="123456"
+token_so_pin="12345678"
+workdir="$RSYSLOG_DYNNAME.${PKCS11_SIGALG_VARIANT}"
+softhsm_conf="$workdir/softhsm2.conf"
+openssl_conf="$workdir/openssl-pkcs11.cnf"
+token_dir="$workdir/tokens"
+mkdir -p "$workdir" "$token_dir"
+
+cat >"$workdir/server.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+
+cat >"$workdir/client.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EOF
+
+cat >"$workdir/ca.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints = critical,CA:TRUE,pathlen:0
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+EOF
+
+openssl genrsa -out "$workdir/ca.key" 3072 || error_exit 1
+openssl req -new -key "$workdir/ca.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Test-CA" \
+	-out "$workdir/ca.csr" || error_exit 1
+openssl x509 -req -in "$workdir/ca.csr" -signkey "$workdir/ca.key" -sha256 -days 365 \
+	-extfile "$workdir/ca.cnf" -extensions v3_ca \
+	-out "$workdir/ca.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/server.key" 3072 || error_exit 1
+openssl req -new -key "$workdir/server.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=localhost" \
+	-out "$workdir/server.csr" || error_exit 1
+openssl x509 -req -in "$workdir/server.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/server.ext" \
+	-out "$workdir/server.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/client.key" 3072 || error_exit 1
+openssl req -new -key "$workdir/client.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=rsyslog-client" \
+	-out "$workdir/client.csr" || error_exit 1
+openssl x509 -req -in "$workdir/client.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/client.ext" \
+	-out "$workdir/client.pem" || error_exit 1
+
+openssl x509 -in "$workdir/ca.pem" -outform DER -out "$workdir/ca.der" || error_exit 1
+openssl x509 -in "$workdir/client.pem" -outform DER -out "$workdir/client.der" || error_exit 1
+openssl pkey -in "$workdir/client.key" -pubout -outform DER -out "$workdir/client.pub.der" || \
+	error_exit 1
+
+cat >"$softhsm_conf" <<EOF
+directories.tokendir = $token_dir
+objectstore.backend = file
+slots.removable = false
+EOF
+export SOFTHSM2_CONF="$softhsm_conf"
+
+softhsm2-util --init-token --free --label "$token_label" --so-pin "$token_so_pin" --pin "$token_pin" || error_exit 1
+softhsm2-util --import "$workdir/client.key" --token "$token_label" --label client-key --id 01 --pin "$token_pin" || error_exit 1
+
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.pub.der" --type pubkey --id 01 --label client-pub || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.der" --type cert --id 01 --label client-cert || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/ca.der" --type cert --id 02 --label ca-cert || error_exit 1
+
+cat >"$openssl_conf" <<EOF
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+pkcs11 = pkcs11_sect
+
+[default_sect]
+activate = 1
+
+[pkcs11_sect]
+identity = pkcs11
+module = $provider_module
+pkcs11-module-path = $softhsm_module
+pkcs11-module-token-pin = $token_pin
+activate = 1
+EOF
+export OPENSSL_CONF="$openssl_conf"
+
+ca_uri="pkcs11:token=$token_label;object=ca-cert;type=cert"
+cert_uri="pkcs11:token=$token_label;object=client-cert;type=cert"
+key_uri="pkcs11:token=$token_label;object=client-key;type=private"
+
+setup_variant
+
+run_case() {
+	local case_name="$1"
+	local client_cfg="$2"
+	local server_cfg="$3"
+	local msg="${TEST_MSG_PREFIX} ${case_name}"
+	local port_file="$workdir/${case_name}.server.port"
+	local server_capture="$workdir/${case_name}.server.capture"
+	local server_stderr="$workdir/${case_name}.server.stderr"
+	local server_pid=
+	local server_port=
+
+	rm -f "$port_file" "$server_capture" "$server_stderr"
+	printf 'running %s case: %s\n' "$TEST_MSG_PREFIX" "$case_name"
+
+	OPENSSL_MTLS_CFG="$server_cfg" \
+	./openssl_mtls_server 0 "$workdir/server.pem" "$workdir/server.key" "$workdir/ca.pem" \
+		"$port_file" "$server_capture" 2>"$server_stderr" &
+	server_pid=$!
+	wait_file_exists_for_process "$port_file" "$server_pid" 10 "OpenSSL MTLS helper" "$server_stderr"
+	server_port=$(cat "$port_file")
+
+	generate_conf
+	add_conf "$(cat <<EOF
+global(
+	compatibility.defaults.secure="strict"
+	net.ipprotocol="ipv4-only"
+)
+
+module(load="builtin:omfwd")
+template(name="outfmt" type="string" string="%msg%\n")
+
+if \$msg contains "$TEST_MSG_PREFIX" then {
+	action(
+		type="omfwd"
+		target="127.0.0.1"
+		protocol="tcp"
+		port="$server_port"
+		template="outfmt"
+		StreamDriver="ossl"
+		StreamDriverMode="1"
+		StreamDriverAuthMode="x509/certvalid"
+		streamdriver.cafile="$TEST_CA_REF"
+		streamdriver.certfile="$TEST_CERT_REF"
+		streamdriver.keyfile="$TEST_KEY_REF"
+		gnutlsPriorityString="$client_cfg"
+	)
+}
+EOF
+)"
+
+	startup
+	injectmsg_literal "<165>1 2003-03-01T01:00:00.000Z host app - - - ${msg}"
+	wait_file_lines "$server_capture" 1
+	shutdown_when_empty
+	wait_shutdown
+
+	wait $server_pid || {
+		cat "$server_stderr"
+		error_exit 1
+	}
+
+	content_count_check --regex "^${msg}\$" 1 "$server_capture"
+}
+
+run_case \
+	"tls12-rsa-sha256" \
+	"MinProtocol=TLSv1.2
+MaxProtocol=TLSv1.2
+ClientSignatureAlgorithms=RSA+SHA256" \
+	"MinProtocol=TLSv1.2
+MaxProtocol=TLSv1.2
+ClientSignatureAlgorithms=RSA+SHA256"
+
+run_case \
+	"tls12-rsa-sha384" \
+	"MinProtocol=TLSv1.2
+MaxProtocol=TLSv1.2
+ClientSignatureAlgorithms=RSA+SHA384" \
+	"MinProtocol=TLSv1.2
+MaxProtocol=TLSv1.2
+ClientSignatureAlgorithms=RSA+SHA384"
+
+run_case \
+	"tls12-rsa-sha512" \
+	"MinProtocol=TLSv1.2
+MaxProtocol=TLSv1.2
+ClientSignatureAlgorithms=RSA+SHA512" \
+	"MinProtocol=TLSv1.2
+MaxProtocol=TLSv1.2
+ClientSignatureAlgorithms=RSA+SHA512"
+
+run_case \
+	"tls13-rsa-pss-sha256" \
+	"MinProtocol=TLSv1.3
+MaxProtocol=TLSv1.3
+ClientSignatureAlgorithms=rsa_pss_rsae_sha256" \
+	"MinProtocol=TLSv1.3
+MaxProtocol=TLSv1.3
+ClientSignatureAlgorithms=rsa_pss_rsae_sha256"
+
+run_case \
+	"tls13-rsa-pss-sha384" \
+	"MinProtocol=TLSv1.3
+MaxProtocol=TLSv1.3
+ClientSignatureAlgorithms=rsa_pss_rsae_sha384" \
+	"MinProtocol=TLSv1.3
+MaxProtocol=TLSv1.3
+ClientSignatureAlgorithms=rsa_pss_rsae_sha384"
+
+run_case \
+	"tls13-rsa-pss-sha512" \
+	"MinProtocol=TLSv1.3
+MaxProtocol=TLSv1.3
+ClientSignatureAlgorithms=rsa_pss_rsae_sha512" \
+	"MinProtocol=TLSv1.3
+MaxProtocol=TLSv1.3
+ClientSignatureAlgorithms=rsa_pss_rsae_sha512"
+
+exit_test

--- a/tests/omfwd-tls-ossl-pkcs11-sigalgs-negative-common.sh
+++ b/tests/omfwd-tls-ossl-pkcs11-sigalgs-negative-common.sh
@@ -1,0 +1,289 @@
+#!/bin/bash
+# Common negative matrix for PKCS#11-backed omfwd mTLS signing algorithm tests.
+. ${srcdir:=.}/diag.sh init
+
+case "$(basename "$0")" in
+omfwd-tls-ossl-pkcs11-sigalgs-negative-common.sh)
+	printf 'info: shared helper script; skipping direct execution\n'
+	skip_test
+	;;
+esac
+
+check_command_available openssl
+check_command_available softhsm2-util
+check_command_available pkcs11-tool
+
+if [ ! -x ./openssl_mtls_server ]; then
+	echo "openssl_mtls_server helper not built - skipping test"
+	exit 77
+fi
+
+find_first_existing() {
+	for candidate in "$@"; do
+		if [ -f "$candidate" ]; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
+setup_variant() {
+	case "${PKCS11_SIGALG_VARIANT}" in
+	key_only)
+		TEST_SUFFIX="key-mtls-sigalgs-negative"
+		TEST_MSG_PREFIX="omfwd-ossl-pkcs11-key-mtls-sigalgs-negative"
+		TEST_CA_REF="$workdir/ca.pem"
+		TEST_CERT_REF="$workdir/client.pem"
+		TEST_KEY_REF="$key_uri"
+		;;
+	cert_key)
+		TEST_SUFFIX="cert-mtls-sigalgs-negative"
+		TEST_MSG_PREFIX="omfwd-ossl-pkcs11-cert-mtls-sigalgs-negative"
+		TEST_CA_REF="$workdir/ca.pem"
+		TEST_CERT_REF="$cert_uri"
+		TEST_KEY_REF="$key_uri"
+		;;
+	ca_key)
+		TEST_SUFFIX="ca-mtls-sigalgs-negative"
+		TEST_MSG_PREFIX="omfwd-ossl-pkcs11-ca-mtls-sigalgs-negative"
+		TEST_CA_REF="$ca_uri"
+		TEST_CERT_REF="$workdir/client.pem"
+		TEST_KEY_REF="$key_uri"
+		;;
+	full)
+		TEST_SUFFIX="mtls-sigalgs-negative"
+		TEST_MSG_PREFIX="omfwd-ossl-pkcs11-mtls-sigalgs-negative"
+		TEST_CA_REF="$ca_uri"
+		TEST_CERT_REF="$cert_uri"
+		TEST_KEY_REF="$key_uri"
+		;;
+	*)
+		printf 'unknown PKCS11_SIGALG_VARIANT=%s\n' "${PKCS11_SIGALG_VARIANT}" >&2
+		error_exit 1
+		;;
+	esac
+}
+
+provider_module=$(find_first_existing \
+	/usr/lib64/ossl-modules/pkcs11.so \
+	/usr/lib/ossl-modules/pkcs11.so \
+	/usr/lib/x86_64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/lib/aarch64-linux-gnu/ossl-modules/pkcs11.so \
+	/usr/local/lib64/ossl-modules/pkcs11.so \
+	/usr/local/lib/ossl-modules/pkcs11.so) || {
+	printf 'info: skipping test - pkcs11 OpenSSL provider module not found\n'
+	skip_test
+}
+
+softhsm_module=$(find_first_existing \
+	/usr/lib64/pkcs11/libsofthsm2.so \
+	/usr/lib/pkcs11/libsofthsm2.so \
+	/usr/lib64/softhsm/libsofthsm2.so \
+	/usr/lib/softhsm/libsofthsm2.so \
+	/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so \
+	/usr/lib64/libsofthsm2.so \
+	/usr/lib/libsofthsm2.so) || {
+	printf 'info: skipping test - SoftHSM PKCS#11 module not found\n'
+	skip_test
+}
+
+token_label="rsyslog-test-token"
+token_pin="123456"
+token_so_pin="12345678"
+workdir="$RSYSLOG_DYNNAME.${PKCS11_SIGALG_VARIANT}.negative"
+softhsm_conf="$workdir/softhsm2.conf"
+openssl_conf="$workdir/openssl-pkcs11.cnf"
+token_dir="$workdir/tokens"
+started_log="$RSYSLOG_DYNNAME.started"
+mkdir -p "$workdir" "$token_dir"
+
+cat >"$workdir/server.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+
+cat >"$workdir/client.ext" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EOF
+
+cat >"$workdir/ca.cnf" <<'EOF'
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints = critical,CA:TRUE,pathlen:0
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+EOF
+
+openssl genrsa -out "$workdir/ca.key" 3072 || error_exit 1
+openssl req -new -key "$workdir/ca.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=Test-CA" \
+	-out "$workdir/ca.csr" || error_exit 1
+openssl x509 -req -in "$workdir/ca.csr" -signkey "$workdir/ca.key" -sha256 -days 365 \
+	-extfile "$workdir/ca.cnf" -extensions v3_ca \
+	-out "$workdir/ca.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/server.key" 3072 || error_exit 1
+openssl req -new -key "$workdir/server.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=localhost" \
+	-out "$workdir/server.csr" || error_exit 1
+openssl x509 -req -in "$workdir/server.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/server.ext" \
+	-out "$workdir/server.pem" || error_exit 1
+
+openssl genrsa -out "$workdir/client.key" 3072 || error_exit 1
+openssl req -new -key "$workdir/client.key" \
+	-subj "/C=US/ST=CA/L=Test/O=rsyslog/OU=test/CN=rsyslog-client" \
+	-out "$workdir/client.csr" || error_exit 1
+openssl x509 -req -in "$workdir/client.csr" -CA "$workdir/ca.pem" -CAkey "$workdir/ca.key" \
+	-CAcreateserial -sha256 -days 365 -extfile "$workdir/client.ext" \
+	-out "$workdir/client.pem" || error_exit 1
+
+openssl x509 -in "$workdir/ca.pem" -outform DER -out "$workdir/ca.der" || error_exit 1
+openssl x509 -in "$workdir/client.pem" -outform DER -out "$workdir/client.der" || error_exit 1
+openssl pkey -in "$workdir/client.key" -pubout -outform DER -out "$workdir/client.pub.der" || \
+	error_exit 1
+
+cat >"$softhsm_conf" <<EOF
+directories.tokendir = $token_dir
+objectstore.backend = file
+slots.removable = false
+EOF
+export SOFTHSM2_CONF="$softhsm_conf"
+
+softhsm2-util --init-token --free --label "$token_label" --so-pin "$token_so_pin" --pin "$token_pin" || error_exit 1
+softhsm2-util --import "$workdir/client.key" --token "$token_label" --label client-key --id 01 --pin "$token_pin" || error_exit 1
+
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.pub.der" --type pubkey --id 01 --label client-pub || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/client.der" --type cert --id 01 --label client-cert || error_exit 1
+pkcs11-tool --module "$softhsm_module" --login --pin "$token_pin" --token-label "$token_label" \
+	--write-object "$workdir/ca.der" --type cert --id 02 --label ca-cert || error_exit 1
+
+cat >"$openssl_conf" <<EOF
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+pkcs11 = pkcs11_sect
+
+[default_sect]
+activate = 1
+
+[pkcs11_sect]
+identity = pkcs11
+module = $provider_module
+pkcs11-module-path = $softhsm_module
+pkcs11-module-token-pin = $token_pin
+activate = 1
+EOF
+export OPENSSL_CONF="$openssl_conf"
+
+ca_uri="pkcs11:token=$token_label;object=ca-cert;type=cert"
+cert_uri="pkcs11:token=$token_label;object=client-cert;type=cert"
+key_uri="pkcs11:token=$token_label;object=client-key;type=private"
+
+setup_variant
+
+run_negative_case() {
+	local case_name="$1"
+	local client_cfg="$2"
+	local server_cfg="$3"
+	local msg="${TEST_MSG_PREFIX} ${case_name}"
+	local port_file="$workdir/${case_name}.server.port"
+	local server_capture="$workdir/${case_name}.server.capture"
+	local server_stderr="$workdir/${case_name}.server.stderr"
+	local server_pid=
+	local server_port=
+
+	rm -f "$port_file" "$server_capture" "$server_stderr"
+	printf 'running negative %s case: %s\n' "$TEST_MSG_PREFIX" "$case_name"
+
+	OPENSSL_MTLS_CFG="$server_cfg" \
+	./openssl_mtls_server 0 "$workdir/server.pem" "$workdir/server.key" "$workdir/ca.pem" \
+		"$port_file" "$server_capture" 2>"$server_stderr" &
+	server_pid=$!
+	wait_file_exists_for_process "$port_file" "$server_pid" 10 "OpenSSL MTLS helper" "$server_stderr"
+	server_port=$(cat "$port_file")
+
+	generate_conf
+	add_conf "$(cat <<EOF
+global(
+	compatibility.defaults.secure="strict"
+	net.ipprotocol="ipv4-only"
+)
+
+module(load="builtin:omfwd")
+template(name="outfmt" type="string" string="%msg%\n")
+
+if \$msg contains "$TEST_MSG_PREFIX" then {
+	action(
+		type="omfwd"
+		target="127.0.0.1"
+		protocol="tcp"
+		port="$server_port"
+		template="outfmt"
+		StreamDriver="ossl"
+		StreamDriverMode="1"
+		StreamDriverAuthMode="x509/certvalid"
+		streamdriver.cafile="$TEST_CA_REF"
+		streamdriver.certfile="$TEST_CERT_REF"
+		streamdriver.keyfile="$TEST_KEY_REF"
+		gnutlsPriorityString="$client_cfg"
+	)
+}
+EOF
+)"
+
+	startup
+	injectmsg_literal "<165>1 2003-03-01T01:00:00.000Z host app - - - ${msg}"
+
+	if content_check --check-only "SSL_ERROR_SYSCALL" "$started_log"; then
+		:
+	else
+		wait_content "SSL_ERROR_SSL" "$started_log"
+		content_check "SSL_ERROR_SSL" "$started_log"
+		content_check "OpenSSL Error Stack:" "$started_log"
+	fi
+
+	shutdown_immediate
+	wait_shutdown
+
+	wait $server_pid || true
+	content_check "OPENSSL-MTLS: SSL_accept failed" "$server_stderr"
+	content_check "peer did not return a certificate" "$server_stderr"
+	content_count_check --regex "^${msg}\$" 0 "$server_capture"
+}
+
+run_negative_case \
+	"tls12-clientsig-ecdsa-only" \
+	"MinProtocol=TLSv1.2
+MaxProtocol=TLSv1.2" \
+	"MinProtocol=TLSv1.2
+MaxProtocol=TLSv1.2
+ClientSignatureAlgorithms=ECDSA+SHA256"
+
+run_negative_case \
+	"tls13-clientsig-ecdsa-only" \
+	"MinProtocol=TLSv1.3
+MaxProtocol=TLSv1.3" \
+	"MinProtocol=TLSv1.3
+MaxProtocol=TLSv1.3
+ClientSignatureAlgorithms=ecdsa_secp256r1_sha256"
+
+exit_test

--- a/tests/omprog-diskq-restart-save.sh
+++ b/tests/omprog-diskq-restart-save.sh
@@ -12,6 +12,11 @@ QUEUE_TYPE=${QUEUE_TYPE:-Disk}
 export RSYSLOG_OMPROG_RESTART_OK="$PWD/$RSYSLOG_DYNNAME.allow-ok"
 export RSYSLOG_OMPROG_RESTART_OUT="$PWD/$RSYSLOG_OUT_LOG"
 
+if [ ! -f ../plugins/omprog/.libs/omprog.so ]; then
+	echo "omprog module not built - skipping test"
+	exit 77
+fi
+
 cp -f "$srcdir/testsuites/omprog-diskq-restart-save-bin.sh" \
 	"$RSYSLOG_DYNNAME.omprog-diskq-restart-save-bin.sh"
 chmod +x "$RSYSLOG_DYNNAME.omprog-diskq-restart-save-bin.sh"

--- a/tests/openssl_mtls_server.c
+++ b/tests/openssl_mtls_server.c
@@ -1,0 +1,354 @@
+/* Very simple program to listen for a mutual-TLS connection, require a valid
+ * client certificate, and capture application data to a file.
+ * Used for the rsyslog testbench.
+ *
+ * Copyright 2026 Cisco Systems, Inc., and/or its affiliates.
+ * Copyright 2026 Adiscon GmbH.
+ *
+ * This file is part of rsyslog.
+ *
+ * Rsyslog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Rsyslog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rsyslog.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * A copy of the GPL can be found in the file "COPYING" in this distribution.
+ */
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <openssl/conf.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static void write_listen_port_file(const int sock, const char *const port_file) {
+    if (port_file == NULL) {
+        return;
+    }
+
+    struct sockaddr_storage addr;
+    socklen_t addrlen = sizeof(addr);
+    char port[NI_MAXSERV];
+    FILE *fp;
+
+    if (getsockname(sock, (struct sockaddr *)&addr, &addrlen) != 0) {
+        perror("OPENSSL-MTLS: getsockname failed");
+        exit(EXIT_FAILURE);
+    }
+    if (getnameinfo((struct sockaddr *)&addr, addrlen, NULL, 0, port, sizeof(port), NI_NUMERICSERV) != 0) {
+        perror("OPENSSL-MTLS: getnameinfo failed");
+        exit(EXIT_FAILURE);
+    }
+
+    fp = fopen(port_file, "w");
+    if (fp == NULL) {
+        perror("OPENSSL-MTLS: unable to open port file");
+        exit(EXIT_FAILURE);
+    }
+    fprintf(fp, "%s\n", port);
+    fclose(fp);
+}
+
+static int create_socket(const char *const port, const char *const port_file) {
+    struct addrinfo hints;
+    struct addrinfo *res = NULL;
+    struct addrinfo *rp;
+    int s = -1;
+    int optval = 1;
+    int v6only = 0;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+
+    if (getaddrinfo(NULL, port, &hints, &res) != 0) {
+        perror("OPENSSL-MTLS: getaddrinfo failed");
+        exit(EXIT_FAILURE);
+    }
+
+    for (rp = res; rp != NULL; rp = rp->ai_next) {
+        s = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (s < 0) {
+            continue;
+        }
+
+        setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+        if (rp->ai_family == AF_INET6) {
+            setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only));
+        }
+
+        if (bind(s, rp->ai_addr, rp->ai_addrlen) == 0) {
+            if (listen(s, 1) == 0) {
+                write_listen_port_file(s, port_file);
+                break;
+            }
+        }
+        close(s);
+        s = -1;
+    }
+
+    freeaddrinfo(res);
+
+    if (s < 0) {
+        perror("OPENSSL-MTLS: unable to bind or listen");
+        exit(EXIT_FAILURE);
+    }
+
+    return s;
+}
+
+static SSL_CTX *create_context(void) {
+    const SSL_METHOD *method;
+    SSL_CTX *ctx;
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    method = SSLv23_server_method();
+#else
+    method = TLS_server_method();
+#endif
+
+    ctx = SSL_CTX_new(method);
+    if (ctx == NULL) {
+        fprintf(stderr, "OPENSSL-MTLS: unable to create SSL context\n");
+        ERR_print_errors_fp(stderr);
+        exit(EXIT_FAILURE);
+    }
+
+    return ctx;
+}
+
+static void apply_ssl_cfg(SSL_CTX *const ctx, const char *const cfg) {
+    SSL_CONF_CTX *cctx = NULL;
+    char *cfg_copy = NULL;
+    char *cursor;
+
+    if (cfg == NULL || *cfg == '\0') {
+        return;
+    }
+
+    cctx = SSL_CONF_CTX_new();
+    if (cctx == NULL) {
+        fprintf(stderr, "OPENSSL-MTLS: unable to allocate SSL_CONF_CTX\n");
+        ERR_print_errors_fp(stderr);
+        exit(EXIT_FAILURE);
+    }
+
+    SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_FILE | SSL_CONF_FLAG_SERVER | SSL_CONF_FLAG_CERTIFICATE);
+    SSL_CONF_CTX_set_ssl_ctx(cctx, ctx);
+
+    cfg_copy = strdup(cfg);
+    if (cfg_copy == NULL) {
+        perror("OPENSSL-MTLS: strdup failed");
+        SSL_CONF_CTX_free(cctx);
+        exit(EXIT_FAILURE);
+    }
+
+    cursor = cfg_copy;
+    while (cursor != NULL && *cursor != '\0') {
+        char *line = cursor;
+        char *sep;
+        char *eq;
+        int conf_ret;
+
+        sep = strpbrk(cursor, "\n;");
+        if (sep != NULL) {
+            *sep = '\0';
+            cursor = sep + 1;
+        } else {
+            cursor = NULL;
+        }
+
+        while (*line == ' ' || *line == '\t' || *line == '\r') {
+            ++line;
+        }
+        if (*line == '\0') {
+            continue;
+        }
+
+        eq = strchr(line, '=');
+        if (eq == NULL) {
+            fprintf(stderr, "OPENSSL-MTLS: invalid SSL config command '%s'\n", line);
+            free(cfg_copy);
+            SSL_CONF_CTX_free(cctx);
+            exit(EXIT_FAILURE);
+        }
+        *eq = '\0';
+        ++eq;
+
+        conf_ret = SSL_CONF_cmd(cctx, line, eq);
+        if (conf_ret <= 0) {
+            fprintf(stderr, "OPENSSL-MTLS: SSL_CONF_cmd failed for '%s=%s'\n", line, eq);
+            ERR_print_errors_fp(stderr);
+            free(cfg_copy);
+            SSL_CONF_CTX_free(cctx);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    if (SSL_CONF_CTX_finish(cctx) != 1) {
+        fprintf(stderr, "OPENSSL-MTLS: SSL_CONF_CTX_finish failed\n");
+        ERR_print_errors_fp(stderr);
+        free(cfg_copy);
+        SSL_CONF_CTX_free(cctx);
+        exit(EXIT_FAILURE);
+    }
+
+    free(cfg_copy);
+    SSL_CONF_CTX_free(cctx);
+}
+
+static void configure_context(SSL_CTX *const ctx,
+                              const char *const cert_file_path,
+                              const char *const key_file_path,
+                              const char *const ca_file_path) {
+    if (SSL_CTX_use_certificate_file(ctx, cert_file_path, SSL_FILETYPE_PEM) <= 0) {
+        fprintf(stderr, "OPENSSL-MTLS: unable to load server certificate\n");
+        ERR_print_errors_fp(stderr);
+        exit(EXIT_FAILURE);
+    }
+
+    if (SSL_CTX_use_PrivateKey_file(ctx, key_file_path, SSL_FILETYPE_PEM) <= 0) {
+        fprintf(stderr, "OPENSSL-MTLS: unable to load server private key\n");
+        ERR_print_errors_fp(stderr);
+        exit(EXIT_FAILURE);
+    }
+
+    if (SSL_CTX_check_private_key(ctx) != 1) {
+        fprintf(stderr, "OPENSSL-MTLS: server certificate/key mismatch\n");
+        ERR_print_errors_fp(stderr);
+        exit(EXIT_FAILURE);
+    }
+
+    if (SSL_CTX_load_verify_locations(ctx, ca_file_path, NULL) != 1) {
+        fprintf(stderr, "OPENSSL-MTLS: unable to load CA certificate\n");
+        ERR_print_errors_fp(stderr);
+        exit(EXIT_FAILURE);
+    }
+
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+    SSL_CTX_set_mode(ctx, SSL_MODE_AUTO_RETRY);
+    apply_ssl_cfg(ctx, getenv("OPENSSL_MTLS_CFG"));
+}
+
+static FILE *open_output_file(const char *const output_file) {
+    FILE *fp = fopen(output_file, "wb");
+    if (fp == NULL) {
+        perror("OPENSSL-MTLS: unable to open output file");
+        exit(EXIT_FAILURE);
+    }
+    return fp;
+}
+
+int main(int argc, char **argv) {
+    int sock = -1;
+    int client = -1;
+    int exit_status = EXIT_FAILURE;
+    struct sockaddr_storage addr;
+    socklen_t addrlen = sizeof(addr);
+    SSL_CTX *ctx = NULL;
+    SSL *ssl = NULL;
+    FILE *output = NULL;
+    X509 *peer_cert = NULL;
+    unsigned char buf[4096];
+
+    if (argc < 7) {
+        fprintf(stderr, "Usage: %s PORT CERT_FILE KEY_FILE CA_FILE PORT_FILE OUTPUT_FILE\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    SSL_load_error_strings();
+    OpenSSL_add_ssl_algorithms();
+
+    ctx = create_context();
+    configure_context(ctx, argv[2], argv[3], argv[4]);
+    sock = create_socket(argv[1], argv[5]);
+    output = open_output_file(argv[6]);
+
+    client = accept(sock, (struct sockaddr *)&addr, &addrlen);
+    if (client < 0) {
+        perror("OPENSSL-MTLS: accept failed");
+        goto done;
+    }
+
+    ssl = SSL_new(ctx);
+    if (ssl == NULL) {
+        fprintf(stderr, "OPENSSL-MTLS: SSL_new failed\n");
+        ERR_print_errors_fp(stderr);
+        goto done;
+    }
+
+    SSL_set_fd(ssl, client);
+    if (SSL_accept(ssl) <= 0) {
+        fprintf(stderr, "OPENSSL-MTLS: SSL_accept failed\n");
+        ERR_print_errors_fp(stderr);
+        goto done;
+    }
+
+    if (SSL_get_verify_result(ssl) != X509_V_OK) {
+        fprintf(stderr, "OPENSSL-MTLS: client certificate verification failed: %ld\n", SSL_get_verify_result(ssl));
+        goto done;
+    }
+
+    peer_cert = SSL_get_peer_certificate(ssl);
+    if (peer_cert == NULL) {
+        fprintf(stderr, "OPENSSL-MTLS: no client certificate presented\n");
+        goto done;
+    }
+
+    for (;;) {
+        const int nread = SSL_read(ssl, buf, sizeof(buf));
+        if (nread > 0) {
+            if (fwrite(buf, 1, (size_t)nread, output) != (size_t)nread) {
+                perror("OPENSSL-MTLS: fwrite failed");
+                goto done;
+            }
+            fflush(output);
+            continue;
+        }
+        if (nread == 0) {
+            exit_status = EXIT_SUCCESS;
+            break;
+        }
+
+        fprintf(stderr, "OPENSSL-MTLS: SSL_read failed\n");
+        ERR_print_errors_fp(stderr);
+        goto done;
+    }
+
+done:
+    if (ssl != NULL) {
+        SSL_shutdown(ssl);
+        SSL_free(ssl);
+    }
+    if (peer_cert != NULL) {
+        X509_free(peer_cert);
+    }
+    if (client >= 0) {
+        close(client);
+    }
+    if (sock >= 0) {
+        close(sock);
+    }
+    if (output != NULL) {
+        fclose(output);
+    }
+    if (ctx != NULL) {
+        SSL_CTX_free(ctx);
+    }
+    EVP_cleanup();
+    return exit_status;
+}

--- a/tests/yaml-omfwd-tls-ossl-pkcs11-module-defaults.sh
+++ b/tests/yaml-omfwd-tls-ossl-pkcs11-module-defaults.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Verify that the YAML frontend accepts omfwd PKCS#11 TLS module defaults plus
+# an action-level StreamDriver.CAExtraFiles override for the ossl driver. The
+# oracle is successful -N1 config validation, which proves the YAML parser and
+# shared omfwd config backend accept the new module/action parameter family
+# without requiring PKCS#11 runtime setup during the test.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" << 'YAMLEOF'
+modules:
+  - load: "builtin:omfwd"
+    streamdriver.cafile: "pkcs11:token=rsyslog;object=ca-cert;type=cert"
+    streamdriver.caextrafiles: "pkcs11:token=rsyslog;object=intermediate-ca-cert;type=cert"
+    streamdriver.certfile: "pkcs11:token=rsyslog;object=client-cert;type=cert"
+    streamdriver.keyfile: "pkcs11:token=rsyslog;object=client-key;type=private"
+
+rulesets:
+  - name: main
+    actions:
+      - type: omfwd
+        target: "127.0.0.1"
+        port: "6514"
+        protocol: "tcp"
+        streamdriver.name: "ossl"
+        streamdriver.mode: 1
+        streamdriver.authmode: "x509/certvalid"
+        streamdriver.caextrafiles: "pkcs11:token=rsyslog;object=override-intermediate-ca-cert;type=cert"
+YAMLEOF
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -ne 0 ]; then
+    echo "FAIL: expected YAML config validation to accept omfwd PKCS#11 module defaults"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+fi
+
+exit_test

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -110,6 +110,7 @@ typedef struct _instanceData {
     int iStrmTlsVerifyDepth; /**< Verify Depth for certificate chains */
     const uchar *pszStrmDrvrCAFile;
     const uchar *pszStrmDrvrCRLFile;
+    const uchar *pszStrmDrvrCAExtraFiles;
     const uchar *pszStrmDrvrKeyFile;
     const uchar *pszStrmDrvrCertFile;
     int nTargets;
@@ -224,8 +225,11 @@ static configSettings_t cs;
 
 /* tables for interfacing with the v6 config system */
 /* module-global parameters */
-static struct cnfparamdescr modpdescr[] = {{"iobuffer.maxsize", eCmdHdlrNonNegInt, 0},
-                                           {"template", eCmdHdlrGetWord, 0}};
+static struct cnfparamdescr modpdescr[] = {
+    {"iobuffer.maxsize", eCmdHdlrNonNegInt, 0},       {"template", eCmdHdlrGetWord, 0},
+    {"streamdriver.cafile", eCmdHdlrString, 0},       {"streamdriver.crlfile", eCmdHdlrString, 0},
+    {"streamdriver.caextrafiles", eCmdHdlrString, 0}, {"streamdriver.keyfile", eCmdHdlrString, 0},
+    {"streamdriver.certfile", eCmdHdlrString, 0}};
 static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / sizeof(struct cnfparamdescr), modpdescr};
 
 /* action (instance) parameters */
@@ -268,6 +272,7 @@ static struct cnfparamdescr actpdescr[] = {
     {"streamdriver.TlsVerifyDepth", eCmdHdlrPositiveInt, 0},
     {"streamdriver.cafile", eCmdHdlrString, 0},
     {"streamdriver.crlfile", eCmdHdlrString, 0},
+    {"streamdriver.caextrafiles", eCmdHdlrString, 0},
     {"streamdriver.keyfile", eCmdHdlrString, 0},
     {"streamdriver.certfile", eCmdHdlrString, 0},
     {"resendlastmsgonreconnect", eCmdHdlrBinary, 0},
@@ -285,6 +290,11 @@ static struct cnfparamblk actpblk = {CNFPARAMBLK_VERSION, sizeof(actpdescr) / si
 struct modConfData_s {
     rsconf_t *pConf; /* our overall config object */
     uchar *tplName; /* default template */
+    uchar *pszStrmDrvrCAFile; /* module default CA file or URI */
+    uchar *pszStrmDrvrCRLFile; /* module default CRL file or URI */
+    uchar *pszStrmDrvrCAExtraFiles; /* module default extra CA files or URIs */
+    uchar *pszStrmDrvrKeyFile; /* module default private key file or URI */
+    uchar *pszStrmDrvrCertFile; /* module default certificate file or URI */
     int maxLenSndBuf; /* default max usable length of sendbuf - primarily for testing */
 };
 
@@ -324,6 +334,91 @@ static uchar *getDfltTpl(void) {
         return (uchar *)"RSYSLOG_TraditionalForwardFormat";
     else
         return cs.pszTplName;
+}
+
+/**
+ * @brief Check whether the effective netstream driver selects the OpenSSL
+ * driver.
+ * @param drvr Effective netstream driver name, or NULL.
+ * @return Non-zero when the effective driver is ``ossl``.
+ */
+static int isOsslNetstrmDrvr(const uchar *const drvr) {
+    return drvr != NULL && !strcasecmp((const char *)drvr, "ossl");
+}
+
+/**
+ * @brief Check whether a TLS object reference uses a strict PKCS#11 URI.
+ * @param ref TLS object reference string, or NULL.
+ * @return Non-zero when the reference begins with ``pkcs11:``.
+ */
+static int isPkcs11UriRef(const uchar *const ref) {
+    return ref != NULL && !strncasecmp((const char *)ref, "pkcs11:", sizeof("pkcs11:") - 1);
+}
+
+/**
+ * @brief Copy a module-scope TLS object default into an action instance.
+ *
+ * The destination is updated only when the action instance did not already set
+ * the corresponding parameter. This preserves the precedence order of action
+ * setting over module default over global netstream default.
+ */
+static rsRetVal ATTR_NONNULL(1) copyModuleTlsDefaultIfUnset(uchar **const ppDst, const uchar *const pSrc) {
+    DEFiRet;
+
+    if (*ppDst == NULL && pSrc != NULL) {
+        CHKmalloc(*ppDst = ustrdup(pSrc));
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+/**
+ * @brief Apply builtin:omfwd module TLS defaults to an action instance.
+ *
+ * This fills in any unset CA, CRL, key, and certificate references from the
+ * current omfwd module configuration, leaving explicitly configured action
+ * values untouched. Global netstream defaults remain the final fallback in the
+ * driver when both action and module settings are absent.
+ *
+ * Module defaults are applied only when the effective stream driver supports
+ * the corresponding setting. Ordinary filesystem-backed TLS defaults remain
+ * available to every TLS-capable driver, but strict ``pkcs11:`` URI defaults
+ * are inherited only by ``ossl`` actions. This preserves mixed deployments
+ * where ``builtin:omfwd`` provides shared TLS defaults for encrypted
+ * forwarding actions, while other omfwd actions in the same configuration
+ * still use plain TCP or another TLS driver that cannot resolve PKCS#11
+ * objects. Explicit action parameters remain untouched so unsupported
+ * action-level settings still fail in the selected driver instead of being
+ * silently ignored.
+ */
+static rsRetVal ATTR_NONNULL() applyModuleTlsDefaults(instanceData *const pData, const modConfData_t *const pModConf) {
+    DEFiRet;
+    const uchar *const effectiveDrvr = glblGetEffectiveNetstrmDrvr(pModConf->pConf, pData->pszStrmDrvr);
+    const int tlsCapable = glblIsTlsCapableNetstrmDrvr(effectiveDrvr);
+    const int osslDriver = isOsslNetstrmDrvr(effectiveDrvr);
+
+    if (tlsCapable) {
+        if (!isPkcs11UriRef(pModConf->pszStrmDrvrCAFile) || osslDriver) {
+            CHKiRet(copyModuleTlsDefaultIfUnset((uchar **)&pData->pszStrmDrvrCAFile, pModConf->pszStrmDrvrCAFile));
+        }
+        if (!isPkcs11UriRef(pModConf->pszStrmDrvrCRLFile)) {
+            CHKiRet(copyModuleTlsDefaultIfUnset((uchar **)&pData->pszStrmDrvrCRLFile, pModConf->pszStrmDrvrCRLFile));
+        }
+        if (!isPkcs11UriRef(pModConf->pszStrmDrvrKeyFile) || osslDriver) {
+            CHKiRet(copyModuleTlsDefaultIfUnset((uchar **)&pData->pszStrmDrvrKeyFile, pModConf->pszStrmDrvrKeyFile));
+        }
+        if (!isPkcs11UriRef(pModConf->pszStrmDrvrCertFile) || osslDriver) {
+            CHKiRet(copyModuleTlsDefaultIfUnset((uchar **)&pData->pszStrmDrvrCertFile, pModConf->pszStrmDrvrCertFile));
+        }
+    }
+    if (osslDriver) {
+        CHKiRet(
+            copyModuleTlsDefaultIfUnset((uchar **)&pData->pszStrmDrvrCAExtraFiles, pModConf->pszStrmDrvrCAExtraFiles));
+    }
+
+finalize_it:
+    RETiRet;
 }
 
 
@@ -777,6 +872,11 @@ BEGINbeginCnfLoad
     loadModConf = pModConf;
     pModConf->pConf = pConf;
     pModConf->tplName = NULL;
+    pModConf->pszStrmDrvrCAFile = NULL;
+    pModConf->pszStrmDrvrCRLFile = NULL;
+    pModConf->pszStrmDrvrCAExtraFiles = NULL;
+    pModConf->pszStrmDrvrKeyFile = NULL;
+    pModConf->pszStrmDrvrCertFile = NULL;
     pModConf->maxLenSndBuf = -1;
 ENDbeginCnfLoad
 
@@ -815,6 +915,21 @@ BEGINsetModCnf
                     loadModConf->maxLenSndBuf = newLen;
                 }
             }
+        } else if (!strcmp(modpblk.descr[i].name, "streamdriver.cafile")) {
+            free(loadModConf->pszStrmDrvrCAFile);
+            CHKmalloc(loadModConf->pszStrmDrvrCAFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(modpblk.descr[i].name, "streamdriver.crlfile")) {
+            free(loadModConf->pszStrmDrvrCRLFile);
+            CHKmalloc(loadModConf->pszStrmDrvrCRLFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(modpblk.descr[i].name, "streamdriver.caextrafiles")) {
+            free(loadModConf->pszStrmDrvrCAExtraFiles);
+            CHKmalloc(loadModConf->pszStrmDrvrCAExtraFiles = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(modpblk.descr[i].name, "streamdriver.keyfile")) {
+            free(loadModConf->pszStrmDrvrKeyFile);
+            CHKmalloc(loadModConf->pszStrmDrvrKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(modpblk.descr[i].name, "streamdriver.certfile")) {
+            free(loadModConf->pszStrmDrvrCertFile);
+            CHKmalloc(loadModConf->pszStrmDrvrCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             LogMsg(0, RS_RET_INTERNAL_ERROR, LOG_ERR, "omfwd: internal error, non-handled param '%s' in beginCnfLoad",
                    modpblk.descr[i].name);
@@ -844,6 +959,11 @@ ENDactivateCnf
 BEGINfreeCnf
     CODESTARTfreeCnf;
     free(pModConf->tplName);
+    free(pModConf->pszStrmDrvrCAFile);
+    free(pModConf->pszStrmDrvrCRLFile);
+    free(pModConf->pszStrmDrvrCAExtraFiles);
+    free(pModConf->pszStrmDrvrKeyFile);
+    free(pModConf->pszStrmDrvrCertFile);
 ENDfreeCnf
 
 BEGINcreateInstance
@@ -909,9 +1029,16 @@ BEGINsetActionInfo
     pData->pAction = pAction;
 ENDsetActionInfo
 
-
+/**
+ * @brief Release all action-instance resources owned by an omfwd action.
+ *
+ * This includes transport-related configuration strings, dynamically
+ * allocated target metadata, TLS object paths or URIs, and the optional
+ * action-level template name used when building the output message stream.
+ */
 BEGINfreeInstance
     CODESTARTfreeInstance;
+    free(pData->tplName);
     free(pData->pszStrmDrvr);
     free(pData->pszStrmDrvrAuthMode);
     free(pData->pszStrmDrvrPermitExpiredCerts);
@@ -937,6 +1064,7 @@ BEGINfreeInstance
     free(pData->device);
     free((void *)pData->pszStrmDrvrCAFile);
     free((void *)pData->pszStrmDrvrCRLFile);
+    free((void *)pData->pszStrmDrvrCAExtraFiles);
     free((void *)pData->pszStrmDrvrKeyFile);
     free((void *)pData->pszStrmDrvrCertFile);
     free(pData->pszRatelimitName);
@@ -1460,6 +1588,7 @@ static rsRetVal TCPSendInitTarget(targetData_t *const pTarget) {
         CHKiRet(netstrm.SetDrvrPermitExpiredCerts(pTarget->pNetstrm, pData->pszStrmDrvrPermitExpiredCerts));
         CHKiRet(netstrm.SetDrvrTlsCAFile(pTarget->pNetstrm, pData->pszStrmDrvrCAFile));
         CHKiRet(netstrm.SetDrvrTlsCRLFile(pTarget->pNetstrm, pData->pszStrmDrvrCRLFile));
+        CHKiRet(netstrm.SetDrvrTlsCAExtraFiles(pTarget->pNetstrm, pData->pszStrmDrvrCAExtraFiles));
         CHKiRet(netstrm.SetDrvrTlsKeyFile(pTarget->pNetstrm, pData->pszStrmDrvrKeyFile));
         CHKiRet(netstrm.SetDrvrTlsCertFile(pTarget->pNetstrm, pData->pszStrmDrvrCertFile));
 
@@ -2039,6 +2168,7 @@ static void setInstParamDefaults(instanceData *pData) {
     pData->iStrmTlsVerifyDepth = 0;
     pData->pszStrmDrvrCAFile = NULL;
     pData->pszStrmDrvrCRLFile = NULL;
+    pData->pszStrmDrvrCAExtraFiles = NULL;
     pData->pszStrmDrvrKeyFile = NULL;
     pData->pszStrmDrvrCertFile = NULL;
     pData->iRebindInterval = 0;
@@ -2341,6 +2471,8 @@ BEGINnewActInst
             CHKmalloc(pData->pszStrmDrvrCAFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "streamdriver.crlfile")) {
             CHKmalloc(pData->pszStrmDrvrCRLFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(actpblk.descr[i].name, "streamdriver.caextrafiles")) {
+            CHKmalloc(pData->pszStrmDrvrCAExtraFiles = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "streamdriver.keyfile")) {
             CHKmalloc(pData->pszStrmDrvrKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "streamdriver.certfile")) {
@@ -2477,6 +2609,7 @@ BEGINnewActInst
         ABORT_FINALIZE(RS_RET_PARAM_ERROR);
     }
 
+    CHKiRet(applyModuleTlsDefaults(pData, loadModConf));
     CHKiRet(applySecureDefaultsToForwarding(pData));
 
     if (pData->targetSrv != NULL) {
@@ -2751,6 +2884,7 @@ BEGINparseSelectorAct
             cs.pPermPeers = NULL;
         }
     }
+    CHKiRet(applyModuleTlsDefaults(pData, loadModConf));
     CHKiRet(applySecureDefaultsToForwarding(pData));
     warnIfNonTlsForwardingConfigured(pData);
     CODE_STD_FINALIZERparseSelectorAct if (iRet == RS_RET_OK) {


### PR DESCRIPTION

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

This change adds PKCS#11 URI support to the OpenSSL netstream driver used by omfwd, so TLS objects no longer need to be limited to  filesystem PEM files.

A new net_ossl_store helper centralizes TLS object loading for lmnsd_ossl. On supported OpenSSL 3 builds, CA certificates, extra CA certificates, end-entity certificates, and private keys can now be loaded from strict pkcs11: URIs through OSSL_STORE, while preserving the existing file-backed path.

For omfwd with the ossl driver, strict pkcs11: URIs are now supported for:

  - StreamDriver.CAFile
  - StreamDriver.CAExtraFiles
  - StreamDriver.CertFile
  - StreamDriver.KeyFile

These are supported both as action parameters and as builtin:omfwd module defaults. Module defaults are only inherited by drivers that support the corresponding setting, so mixed plain-TCP and TLS forwarding configurations do not break. Explicit unsupported action-level settings still fail in the selected driver.

This also fixes OpenSSL client-auth setup for PKCS#11-backed keys by loading the private key before the certificate and validating the pair with SSL_CTX_check_private_key(). That is required for reliable PKCS#11-backed client authentication, including TLS 1.3 flows.

Logging was tightened so PKCS#11 values are sanitized before being emitted, including outer error paths, to avoid leaking PIN-bearing attributes.

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

https://github.com/rsyslog/rsyslog/issues/7370

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

Tests added or extended in this change cover:

  - file-backed omfwd mutual TLS
  - PKCS#11-backed omfwd mutual TLS
  - module-default precedence and action/default interactions
  - negative PKCS#11 object lookup paths
  - recovery after an initial TLS handshake failure
  - RSA client signature algorithm selection
  - negative signature algorithm mismatch coverage
  - YAML frontend validation for the new omfwd PKCS#11 module defaults

The OpenSSL-based tests were also updated to match the revised key-loading behavior, and generated test CA certificates were tightened so current OpenSSL verification accepts the test trust chains.

ECDSA PKCS#11 signature-algorithm coverage is included, but positive ECDSA cases are skipped when the OpenSSL PKCS#11 provider in the test environment cannot perform EVP ECDSA signing even though the token itself supports ECDSA signing.

Documentation was updated to describe prerequisites, action/module scope, precedence, mixed-driver behavior, and the current filesystem-only limitation of the global TLS defaults.

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

