### PR TITLE
imtcp: bound aggregate zstd decoder window memory

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -732,6 +732,7 @@ EXTRA_DIST = \
     source/reference/parameters/imtcp-compression-driver.rst \
     source/reference/parameters/imtcp-compression-maxdecompressedbytesperreceive.rst \
     source/reference/parameters/imtcp-compression-maxexpansionratio.rst \
+    source/reference/parameters/imtcp-compression-maxtotalzstdwindowbytes.rst \
     source/reference/parameters/imtcp-compression-mode.rst \
     source/reference/parameters/imtcp-disablelfdelimiter.rst \
     source/reference/parameters/imtcp-discardtruncatedmsg.rst \

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -40,6 +40,17 @@ runtime_ratelimit:
     - perSourceMaxStates is enforced approximately through shard-local caps; values below the shard count keep one active state per shard, and per_source_evicted reports source-state evictions.
     - HUP snapshots named configs under shard read locks, then reloads policy files without holding registry locks.
 
+runtime_tcpsrv:
+  paths:
+    - "runtime/tcpsrv.c"
+    - "runtime/tcpsrv.h"
+    - "runtime/tcps_sess.c"
+    - "runtime/tcps_sess.h"
+  requires_serialization: false
+  notes:
+    - imtcp sessions own independent decompressor state.
+    - A finite zstd aggregate-window limit uses a listener-local 64-bit atomic reservation counter; only platforms without 64-bit atomics use the helper-mutex fallback.
+
 runtime_msg:
   paths: ["runtime/msg.c", "runtime/msg.h"]
   requires_serialization: true

--- a/doc/source/configuration/modules/imtcp.rst
+++ b/doc/source/configuration/modules/imtcp.rst
@@ -120,6 +120,14 @@ receive operation. The defaults allow a 1024:1 stream expansion ratio and
 ``compression.maxDecompressedBytesPerReceive`` to ``0`` only for tightly
 controlled deployments that need to disable the corresponding guard.
 
+For zstd streams, ``compression.maxTotalZstdWindowBytes`` can additionally
+bound aggregate advertised decoder-window memory across concurrent sessions on
+each listener. Its compatibility default is ``0`` (unlimited). The default
+secure-policy mode warns when an active zstd listener omits the setting;
+``compatibility.defaults.secure="strict"`` requires an explicit positive value.
+This aggregate limit is independent of the per-receive decompressed-output
+limit.
+
 ``imtcp`` stream decompression is for ``stream:always`` only. It does not
 receive the sender-side ``single`` compression mode.
 
@@ -196,6 +204,10 @@ Module Parameters
         :end-before: .. summary-end
    * - :ref:`param-imtcp-compression-maxdecompressedbytesperreceive`
      - .. include:: ../../reference/parameters/imtcp-compression-maxdecompressedbytesperreceive.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imtcp-compression-maxtotalzstdwindowbytes`
+     - .. include:: ../../reference/parameters/imtcp-compression-maxtotalzstdwindowbytes.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
    * - :ref:`param-imtcp-notifyonconnectionopen`
@@ -336,6 +348,7 @@ Module Parameters
    ../../reference/parameters/imtcp-compression-driver
    ../../reference/parameters/imtcp-compression-maxexpansionratio
    ../../reference/parameters/imtcp-compression-maxdecompressedbytesperreceive
+   ../../reference/parameters/imtcp-compression-maxtotalzstdwindowbytes
    ../../reference/parameters/imtcp-name
    ../../reference/parameters/imtcp-ruleset
    ../../reference/parameters/imtcp-supportoctetcountedframing
@@ -384,6 +397,10 @@ Input Parameters
         :end-before: .. summary-end
    * - :ref:`param-imtcp-compression-maxdecompressedbytesperreceive`
      - .. include:: ../../reference/parameters/imtcp-compression-maxdecompressedbytesperreceive.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imtcp-compression-maxtotalzstdwindowbytes`
+     - .. include:: ../../reference/parameters/imtcp-compression-maxtotalzstdwindowbytes.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
    * - :ref:`param-imtcp-name`

--- a/doc/source/reference/parameters/imtcp-compression-maxtotalzstdwindowbytes.rst
+++ b/doc/source/reference/parameters/imtcp-compression-maxtotalzstdwindowbytes.rst
@@ -1,0 +1,96 @@
+.. _param-imtcp-compression-maxtotalzstdwindowbytes:
+.. _imtcp.parameter.input.compression-maxtotalzstdwindowbytes:
+
+.. meta::
+   :description: Reference for the imtcp compression.maxTotalZstdWindowBytes parameter.
+   :keywords: rsyslog, imtcp, compression.maxTotalZstdWindowBytes, zstd, decoder window, memory limit
+
+compression.maxTotalZstdWindowBytes
+===================================
+
+.. index::
+   single: imtcp; compression.maxTotalZstdWindowBytes
+   single: compression.maxTotalZstdWindowBytes
+
+.. summary-start
+
+Limits aggregate advertised zstd decoder-window bytes across active sessions
+for one ``imtcp`` listener.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imtcp`.
+
+:Name: compression.maxTotalZstdWindowBytes
+:Scope: input/module
+:Type: integer
+:Default: 0
+:Required?: no
+:Introduced: 8.2608.0
+
+Description
+-----------
+
+``compression.maxTotalZstdWindowBytes`` limits the sum of advertised zstd
+decoder-window sizes retained by active compressed sessions on one ``imtcp``
+listener. It applies only when ``compression.mode="stream:always"`` and
+``compression.driver="zstd"`` are active. A frame whose reservation would
+exceed the limit is rejected and its session is closed without affecting
+already admitted sessions.
+
+The default ``0`` leaves aggregate decoder-window memory unlimited for
+compatibility. This setting is independent of
+:ref:`param-imtcp-compression-maxdecompressedbytesperreceive`, which limits
+decompressed output from one TCP receive operation.
+
+The secure-default policy controls omitted values:
+
+- ``compatibility.defaults.secure="backward-compatible"`` accepts the
+  unlimited default silently.
+- ``compatibility.defaults.secure="warn"`` accepts it and emits a startup
+  warning. Explicitly setting ``0`` acknowledges unlimited operation and
+  suppresses that warning.
+- ``compatibility.defaults.secure="strict"`` requires an explicitly configured
+  positive value and rejects omitted or explicit-zero values.
+
+The accounting uses the window size declared by each zstd frame. It bounds the
+dominant retained decoder-window allocation, but does not attempt to account
+for every byte of decoder bookkeeping or unrelated per-connection memory.
+
+RainerScript usage
+------------------
+
+.. code-block:: rsyslog
+
+   input(
+       type="imtcp"
+       address="127.0.0.1"
+       port="514"
+       compression.mode="stream:always"
+       compression.driver="zstd"
+       compression.maxTotalZstdWindowBytes="536870912"
+   )
+
+YAML usage
+----------
+
+.. code-block:: yaml
+
+   inputs:
+     - type: imtcp
+       address: "127.0.0.1"
+       port: "514"
+       compression.mode: "stream:always"
+       compression.driver: "zstd"
+       compression.maxTotalZstdWindowBytes: "536870912"
+
+The same parameter may be placed on ``module(load="imtcp" ...)`` or its YAML
+module entry to provide an explicitly configured default inherited by inputs.
+
+See also
+--------
+
+See also :ref:`param-imtcp-compression-mode`,
+:ref:`param-imtcp-compression-driver`,
+:ref:`param-imtcp-compression-maxdecompressedbytesperreceive`, and
+:doc:`../../configuration/modules/imtcp`.

--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -128,6 +128,8 @@ static struct configSettings_s {
     int compressionDriver;
     uint64_t compressionMaxExpansionRatio;
     uint64_t compressionMaxDecompressedBytesPerReceive;
+    uint64_t compressionMaxTotalZstdWindowBytes;
+    sbool compressionMaxTotalZstdWindowBytesSet;
 } cs;
 
 struct instanceConf_s {
@@ -179,6 +181,8 @@ struct instanceConf_s {
     int compressionDriver;
     uint64_t compressionMaxExpansionRatio;
     uint64_t compressionMaxDecompressedBytesPerReceive;
+    uint64_t compressionMaxTotalZstdWindowBytes;
+    sbool compressionMaxTotalZstdWindowBytesSet;
     struct instanceConf_s *next;
 };
 
@@ -227,6 +231,8 @@ struct modConfData_s {
     int compressionDriver;
     uint64_t compressionMaxExpansionRatio;
     uint64_t compressionMaxDecompressedBytesPerReceive;
+    uint64_t compressionMaxTotalZstdWindowBytes;
+    sbool compressionMaxTotalZstdWindowBytesSet;
 };
 
 static modConfData_t *loadModConf = NULL; /* modConf ptr to use for the current load process */
@@ -270,6 +276,7 @@ static struct cnfparamdescr modpdescr[] = {{"flowcontrol", eCmdHdlrBinary, 0},
                                            {"compression.driver", eCmdHdlrString, 0},
                                            {"compression.maxexpansionratio", eCmdHdlrNonNegInt, 0},
                                            {"compression.maxdecompressedbytesperreceive", eCmdHdlrNonNegInt, 0},
+                                           {"compression.maxtotalzstdwindowbytes", eCmdHdlrNonNegInt, 0},
                                            {"networknamespace", eCmdHdlrString, 0}};
 static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / sizeof(struct cnfparamdescr), modpdescr};
 
@@ -322,6 +329,7 @@ static struct cnfparamdescr inppdescr[] = {{"port", eCmdHdlrString, CNFPARAM_REQ
                                            {"compression.driver", eCmdHdlrString, 0},
                                            {"compression.maxexpansionratio", eCmdHdlrNonNegInt, 0},
                                            {"compression.maxdecompressedbytesperreceive", eCmdHdlrNonNegInt, 0},
+                                           {"compression.maxtotalzstdwindowbytes", eCmdHdlrNonNegInt, 0},
                                            {"multiline", eCmdHdlrBinary, 0},
                                            {"framing.delimiter.regex", eCmdHdlrString, 0}};
 static struct cnfparamblk inppblk = {CNFPARAMBLK_VERSION, sizeof(inppdescr) / sizeof(struct cnfparamdescr), inppdescr};
@@ -505,6 +513,32 @@ static rsRetVal applySecureDefaultsToInstanceConfig(instanceConf_t *const inst, 
                                              getEffectiveInstanceStreamDriver(inst, modConf), "imtcp input");
 }
 
+static rsRetVal applySecureDefaultsToZstdWindow(instanceConf_t *const inst, const modConfData_t *const modConf) {
+    const int secure_policy = modConf->pConf->globals.compatDefaultsSecure;
+
+    if (inst->compressionMode != TCPSRV_COMPRESS_STREAM_ALWAYS ||
+        inst->compressionDriver != TCPSRV_COMPRESS_DRIVER_ZSTD) {
+        return RS_RET_OK;
+    }
+
+    if (secure_policy == COMPAT_DEFAULTS_SECURE_STRICT &&
+        (!inst->compressionMaxTotalZstdWindowBytesSet || inst->compressionMaxTotalZstdWindowBytes == 0)) {
+        LogError(0, RS_RET_PARAM_ERROR,
+                 "imtcp input: compatibility.defaults.secure=\"strict\" requires an explicit positive "
+                 "compression.maxTotalZstdWindowBytes value for zstd stream decompression");
+        return RS_RET_PARAM_ERROR;
+    }
+
+    if (!inst->compressionMaxTotalZstdWindowBytesSet) {
+        glblWarnIfInsecureDefault(
+            modConf->pConf,
+            "imtcp zstd stream decompression has unlimited aggregate decoder-window memory because "
+            "compression.maxTotalZstdWindowBytes was not explicitly set; configure a positive byte limit, or "
+            "set it to 0 explicitly to acknowledge unlimited operation");
+    }
+    return RS_RET_OK;
+}
+
 static rsRetVal setLegacyStrmDrvrMode(void __attribute__((unused)) * pVal, int mode) {
     cs.iStrmDrvrMode = mode;
     cs.bStrmDrvrModeSet = 1;
@@ -632,6 +666,8 @@ static rsRetVal createInstance(instanceConf_t **pinst) {
     inst->compressionDriver = loadModConf->compressionDriver;
     inst->compressionMaxExpansionRatio = loadModConf->compressionMaxExpansionRatio;
     inst->compressionMaxDecompressedBytesPerReceive = loadModConf->compressionMaxDecompressedBytesPerReceive;
+    inst->compressionMaxTotalZstdWindowBytes = loadModConf->compressionMaxTotalZstdWindowBytes;
+    inst->compressionMaxTotalZstdWindowBytesSet = loadModConf->compressionMaxTotalZstdWindowBytesSet;
     inst->pAllowedSendersRoot = NULL;
     inst->pAllowedSendersLast = NULL;
     inst->bAllowedSendersSet = 0;
@@ -711,7 +747,10 @@ static rsRetVal addInstance(void __attribute__((unused)) * pVal, uchar *pNewVal)
     inst->compressionDriver = cs.compressionDriver;
     inst->compressionMaxExpansionRatio = cs.compressionMaxExpansionRatio;
     inst->compressionMaxDecompressedBytesPerReceive = cs.compressionMaxDecompressedBytesPerReceive;
+    inst->compressionMaxTotalZstdWindowBytes = cs.compressionMaxTotalZstdWindowBytes;
+    inst->compressionMaxTotalZstdWindowBytesSet = cs.compressionMaxTotalZstdWindowBytesSet;
     CHKiRet(applySecureDefaultsToInstanceConfig(inst, loadModConf));
+    CHKiRet(applySecureDefaultsToZstdWindow(inst, loadModConf));
     warnIfInsecureListenerConfigured(inst->iStrmDrvrMode, getEffectiveInstanceStreamDriver(inst, loadModConf),
                                      getEffectiveInstanceAuthMode(inst, loadModConf));
 
@@ -757,6 +796,7 @@ static rsRetVal addListner(modConfData_t *modConf, instanceConf_t *inst) {
     CHKiRet(tcpsrv.SetCompressionMaxExpansionRatio(pOurTcpsrv, inst->compressionMaxExpansionRatio));
     CHKiRet(tcpsrv.SetCompressionMaxDecompressedBytesPerReceive(pOurTcpsrv,
                                                                 inst->compressionMaxDecompressedBytesPerReceive));
+    CHKiRet(tcpsrv.SetCompressionMaxTotalZstdWindowBytes(pOurTcpsrv, inst->compressionMaxTotalZstdWindowBytes));
     CHKiRet(tcpsrv.SetbDisableLFDelim(pOurTcpsrv, inst->bDisableLFDelim));
     CHKiRet(tcpsrv.SetDiscardTruncatedMsg(pOurTcpsrv, inst->discardTruncatedMsg));
     CHKiRet(tcpsrv.SetNotificationOnRemoteClose(pOurTcpsrv, inst->bEmitMsgOnClose));
@@ -995,6 +1035,9 @@ BEGINnewInpInst
             inst->compressionMaxExpansionRatio = (uint64_t)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "compression.maxdecompressedbytesperreceive")) {
             inst->compressionMaxDecompressedBytesPerReceive = (uint64_t)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "compression.maxtotalzstdwindowbytes")) {
+            inst->compressionMaxTotalZstdWindowBytes = (uint64_t)pvals[i].val.d.n;
+            inst->compressionMaxTotalZstdWindowBytesSet = RSTRUE;
         } else if (!strcmp(inppblk.descr[i].name, "multiline")) {
             inst->cnf_params->bMultiLine = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "framing.delimiter.regex")) {
@@ -1023,6 +1066,7 @@ BEGINnewInpInst
         }
     }
     CHKiRet(applySecureDefaultsToInstanceConfig(inst, loadModConf));
+    CHKiRet(applySecureDefaultsToZstdWindow(inst, loadModConf));
     warnIfInsecureListenerConfigured(inst->iStrmDrvrMode, getEffectiveInstanceStreamDriver(inst, loadModConf),
                                      getEffectiveInstanceAuthMode(inst, loadModConf));
 
@@ -1077,6 +1121,8 @@ BEGINbeginCnfLoad
     loadModConf->compressionDriver = TCPSRV_COMPRESS_DRIVER_ZLIB;
     loadModConf->compressionMaxExpansionRatio = TCPSRV_COMPRESS_MAX_EXPANSION_RATIO_DEFAULT;
     loadModConf->compressionMaxDecompressedBytesPerReceive = TCPSRV_COMPRESS_MAX_DECOMPRESSED_BYTES_PER_RECEIVE_DEFAULT;
+    loadModConf->compressionMaxTotalZstdWindowBytes = TCPSRV_COMPRESS_MAX_TOTAL_ZSTD_WINDOW_BYTES_DEFAULT;
+    loadModConf->compressionMaxTotalZstdWindowBytesSet = RSFALSE;
     bLegacyCnfModGlobalsPermitted = 1;
     /* init legacy config variables */
     resetConfigVariables(NULL, NULL); /* dummy parameters just to fulfill interface def */
@@ -1200,6 +1246,9 @@ BEGINsetModCnf
             loadModConf->compressionMaxExpansionRatio = (uint64_t)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "compression.maxdecompressedbytesperreceive")) {
             loadModConf->compressionMaxDecompressedBytesPerReceive = (uint64_t)pvals[i].val.d.n;
+        } else if (!strcmp(modpblk.descr[i].name, "compression.maxtotalzstdwindowbytes")) {
+            loadModConf->compressionMaxTotalZstdWindowBytes = (uint64_t)pvals[i].val.d.n;
+            loadModConf->compressionMaxTotalZstdWindowBytesSet = RSTRUE;
         } else {
             dbgprintf(
                 "imtcp: program error, non-handled "
@@ -1249,6 +1298,8 @@ BEGINendCnfLoad
         pModConf->iKeepAliveTime = cs.iKeepAliveTime;
         pModConf->compressionMode = cs.compressionMode;
         pModConf->compressionDriver = cs.compressionDriver;
+        pModConf->compressionMaxTotalZstdWindowBytes = cs.compressionMaxTotalZstdWindowBytes;
+        pModConf->compressionMaxTotalZstdWindowBytesSet = cs.compressionMaxTotalZstdWindowBytesSet;
         if (pPermPeersRoot != NULL) {
             assert(pModConf->pPermPeersRoot == NULL);
             pModConf->pPermPeersRoot = pPermPeersRoot;
@@ -1520,6 +1571,8 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) * pp, void __
     cs.compressionDriver = TCPSRV_COMPRESS_DRIVER_ZLIB;
     cs.compressionMaxExpansionRatio = TCPSRV_COMPRESS_MAX_EXPANSION_RATIO_DEFAULT;
     cs.compressionMaxDecompressedBytesPerReceive = TCPSRV_COMPRESS_MAX_DECOMPRESSED_BYTES_PER_RECEIVE_DEFAULT;
+    cs.compressionMaxTotalZstdWindowBytes = TCPSRV_COMPRESS_MAX_TOTAL_ZSTD_WINDOW_BYTES_DEFAULT;
+    cs.compressionMaxTotalZstdWindowBytesSet = RSFALSE;
     free(cs.pszStrmDrvrAuthMode);
     cs.pszStrmDrvrAuthMode = NULL;
     free(cs.pszInputName);

--- a/runtime/atomic.h
+++ b/runtime/atomic.h
@@ -334,8 +334,15 @@ static inline int ATOMIC_CAS_PTR(void **data, void *oldVal, void *newVal, pthrea
 #ifdef HAVE_ATOMIC_BUILTINS64
     #define ATOMIC_INC_uint64(data, phlpmut) ((void)__atomic_fetch_add((data), 1, __ATOMIC_SEQ_CST))
     #define ATOMIC_ADD_uint64(data, phlpmut, value) ((void)__atomic_fetch_add((data), (value), __ATOMIC_SEQ_CST))
+    #define ATOMIC_SUB_uint64(data, phlpmut, value) ((void)__atomic_fetch_sub((data), (value), __ATOMIC_SEQ_CST))
     #define ATOMIC_DEC_uint64(data, phlpmut) ((void)__atomic_sub_fetch((data), 1, __ATOMIC_SEQ_CST))
     #define ATOMIC_INC_AND_FETCH_uint64(data, phlpmut) __atomic_add_fetch((data), 1, __ATOMIC_SEQ_CST)
+    #define ATOMIC_LOAD_uint64(data, phlpmut) ((uint64)__atomic_load_n((data), __ATOMIC_ACQUIRE))
+    #define ATOMIC_CAS_uint64(data, oldVal, newVal, phlpmut)                                                           \
+        ({                                                                                                             \
+            __typeof__(*(data)) rs_atomic_expected = (oldVal);                                                         \
+            __atomic_compare_exchange_n((data), &rs_atomic_expected, (newVal), 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); \
+        })
     #define ATOMIC_STORE_uint64(data, phlpmut, value) ((void)__atomic_store_n((data), (value), __ATOMIC_RELEASE))
     #define ATOMIC_INC_uint64_RELAXED(data, phlpmut) ((void)__atomic_fetch_add((data), 1, __ATOMIC_RELAXED))
     #define ATOMIC_ADD_uint64_RELAXED(data, phlpmut, value) \
@@ -364,6 +371,12 @@ static inline int ATOMIC_CAS_PTR(void **data, void *oldVal, void *newVal, pthrea
         {                                           \
             pthread_mutex_lock(phlpmut);            \
             *data += value;                         \
+            pthread_mutex_unlock(phlpmut);          \
+        }
+    #define ATOMIC_SUB_uint64(data, phlpmut, value) \
+        {                                           \
+            pthread_mutex_lock(phlpmut);            \
+            *data -= value;                         \
             pthread_mutex_unlock(phlpmut);          \
         }
     #define ATOMIC_DEC_uint64(data, phlpmut) \
@@ -414,6 +427,27 @@ static inline uint64 ATOMIC_INC_AND_FETCH_uint64(uint64 *data, pthread_mutex_t *
     val = ++(*data);
     pthread_mutex_unlock(phlpmut);
     return (val);
+}
+
+static inline uint64 ATOMIC_LOAD_uint64(uint64 *data, pthread_mutex_t *phlpmut) {
+    uint64 val;
+    pthread_mutex_lock(phlpmut);
+    val = *data;
+    pthread_mutex_unlock(phlpmut);
+    return val;
+}
+
+static inline int ATOMIC_CAS_uint64(uint64 *data, uint64 oldVal, uint64 newVal, pthread_mutex_t *phlpmut) {
+    int bSuccess;
+    pthread_mutex_lock(phlpmut);
+    if (*data == oldVal) {
+        *data = newVal;
+        bSuccess = 1;
+    } else {
+        bSuccess = 0;
+    }
+    pthread_mutex_unlock(phlpmut);
+    return bSuccess;
 }
 
     #define DEF_ATOMIC_HELPER_MUT64(x) pthread_mutex_t x

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -89,6 +89,7 @@ BEGINobjConstruct(tcps_sess) /* be sure to specify the object type also in END m
     pThis->tlsMismatchWarned = 0;
     pThis->compressionMode = TCPSRV_COMPRESS_NEVER;
     pThis->compressionDriver = TCPSRV_COMPRESS_DRIVER_ZLIB;
+    pThis->compressionMaxTotalZstdWindowBytes = TCPSRV_COMPRESS_MAX_TOTAL_ZSTD_WINDOW_BYTES_DEFAULT;
     pThis->compressionTotalBytesIn = 0;
     pThis->compressionTotalBytesOut = 0;
     pThis->zipInitDone = 0;
@@ -140,13 +141,34 @@ finalize_it:
 
 
 #ifdef ENABLE_LIBZSTD
+static sbool reserve_zstd_window(tcps_sess_t *const pThis, const uint64 window_size) {
+    tcpLstnPortList_t *const listener = pThis->pLstnInfo;
+    const uint64 limit = pThis->compressionMaxTotalZstdWindowBytes;
+    uint64 in_use;
+
+    assert(listener != NULL);
+    assert(pThis->zstd_window_reservation == 0);
+    if (window_size > limit) return RSFALSE;
+
+    in_use = ATOMIC_LOAD_uint64(&listener->compressionZstdWindowBytesInUse, &listener->mutCompressionZstdWindow);
+    for (;;) {
+        if (in_use > limit - window_size) return RSFALSE;
+        if (ATOMIC_CAS_uint64(&listener->compressionZstdWindowBytesInUse, in_use, in_use + window_size,
+                              &listener->mutCompressionZstdWindow)) {
+            pThis->zstd_window_reservation = window_size;
+            return RSTRUE;
+        }
+        in_use = ATOMIC_LOAD_uint64(&listener->compressionZstdWindowBytesInUse, &listener->mutCompressionZstdWindow);
+    }
+}
+
 static void release_zstd_window_reservation(tcps_sess_t *const pThis) {
     if (pThis->zstd_window_reservation == 0 || pThis->pLstnInfo == NULL) return;
 
-    pthread_mutex_lock(&pThis->pLstnInfo->mut_compression_zstd_window);
-    assert(pThis->pLstnInfo->compression_zstd_window_bytes_in_use >= pThis->zstd_window_reservation);
-    pThis->pLstnInfo->compression_zstd_window_bytes_in_use -= pThis->zstd_window_reservation;
-    pthread_mutex_unlock(&pThis->pLstnInfo->mut_compression_zstd_window);
+    assert(ATOMIC_LOAD_uint64(&pThis->pLstnInfo->compressionZstdWindowBytesInUse,
+                              &pThis->pLstnInfo->mutCompressionZstdWindow) >= pThis->zstd_window_reservation);
+    ATOMIC_SUB_uint64(&pThis->pLstnInfo->compressionZstdWindowBytesInUse, &pThis->pLstnInfo->mutCompressionZstdWindow,
+                      pThis->zstd_window_reservation);
     pThis->zstd_window_reservation = 0;
 }
 #endif
@@ -319,6 +341,7 @@ static rsRetVal SetLstnInfo(tcps_sess_t *pThis, tcpLstnPortList_t *pLstnInfo) {
     pThis->compressionDriver = pLstnInfo->compressionDriver;
     pThis->compressionMaxExpansionRatio = pLstnInfo->compressionMaxExpansionRatio;
     pThis->compressionMaxDecompressedBytesPerReceive = pLstnInfo->compressionMaxDecompressedBytesPerReceive;
+    pThis->compressionMaxTotalZstdWindowBytes = pLstnInfo->compressionMaxTotalZstdWindowBytes;
     RETiRet;
 }
 
@@ -933,29 +956,6 @@ finalize_it:
     RETiRet;
 }
 
-#if defined(ENABLE_LIBZSTD) && defined(ZSTD_VERSION_NUMBER) && ZSTD_VERSION_NUMBER >= 10308
-    #define ZSTD_RSYSLOG_WINDOWLOG_MIN 10U
-    #define ZSTD_RSYSLOG_WINDOWLOG_MAX 31U
-static unsigned zstd_window_log_max_from_bytes(uint64_t max_bytes) {
-    unsigned window_log_max = 0;
-    uint64_t window_size = 1;
-
-    while (window_size < max_bytes && window_log_max < 63) {
-        window_size <<= 1;
-        ++window_log_max;
-    }
-
-    /* zstd only exposes a power-of-two window-log cap. Round up so frames
-     * within the configured byte limit are not rejected unnecessarily. */
-    if (window_log_max < ZSTD_RSYSLOG_WINDOWLOG_MIN) {
-        window_log_max = ZSTD_RSYSLOG_WINDOWLOG_MIN;
-    } else if (window_log_max > ZSTD_RSYSLOG_WINDOWLOG_MAX) {
-        window_log_max = ZSTD_RSYSLOG_WINDOWLOG_MAX;
-    }
-    return window_log_max;
-}
-#endif
-
 static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
                                        char *const pData,
                                        const size_t iLen,
@@ -970,7 +970,7 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
     }
 
     size_t input_offset = 0;
-    while (!pThis->zstd_frame_header_processed) {
+    while (pThis->compressionMaxTotalZstdWindowBytes != 0 && !pThis->zstd_frame_header_processed) {
         ZSTD_frameHeader frame_header;
         const size_t header_ret =
             ZSTD_getFrameHeader(&frame_header, pThis->zstd_frame_header, pThis->zstd_frame_header_len);
@@ -979,21 +979,12 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
             ABORT_FINALIZE(RS_RET_ZLIB_ERR);
         }
         if (header_ret == 0) {
-            if (frame_header.frameType == ZSTD_frame && pThis->compressionMaxDecompressedBytesPerReceive != 0) {
-                const uint64_t budget = pThis->compressionMaxDecompressedBytesPerReceive;
-                const uint64_t window_size = frame_header.windowSize;
-                tcpLstnPortList_t *const listener = pThis->pLstnInfo;
-
-                pthread_mutex_lock(&listener->mut_compression_zstd_window);
-                if (window_size > budget || listener->compression_zstd_window_bytes_in_use > budget - window_size) {
-                    pthread_mutex_unlock(&listener->mut_compression_zstd_window);
+            if (frame_header.frameType == ZSTD_frame) {
+                if (!reserve_zstd_window(pThis, frame_header.windowSize)) {
                     logCompressedStreamFailure(pThis, "received invalid compressed stream",
                                                "zstd decoder window budget exhausted");
                     ABORT_FINALIZE(RS_RET_ZLIB_ERR);
                 }
-                listener->compression_zstd_window_bytes_in_use += window_size;
-                pThis->zstd_window_reservation = window_size;
-                pthread_mutex_unlock(&listener->mut_compression_zstd_window);
             }
             pThis->zstd_frame_header_processed = RSTRUE;
             break;
@@ -1021,23 +1012,14 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
             logCompressedStreamFailure(pThis, "received invalid compressed stream", "zstd context allocation failed");
             ABORT_FINALIZE(RS_RET_ZLIB_ERR);
         }
-    #if defined(ZSTD_VERSION_NUMBER) && ZSTD_VERSION_NUMBER >= 10308
-        if (pThis->compressionMaxDecompressedBytesPerReceive != 0) {
-            const unsigned window_log_max =
-                zstd_window_log_max_from_bytes(pThis->compressionMaxDecompressedBytesPerReceive);
-            const size_t zret =
-                ZSTD_DCtx_setParameter((ZSTD_DCtx *)pThis->zstdDctx, ZSTD_d_windowLogMax, (int)window_log_max);
-            if (ZSTD_isError(zret)) {
-                logCompressedStreamFailure(pThis, "received invalid compressed stream", ZSTD_getErrorName(zret));
-                ABORT_FINALIZE(RS_RET_ZLIB_ERR);
-            }
-        }
-    #endif
     }
 
-    for (unsigned input_part = 0; input_part < 2; ++input_part) {
+    const unsigned input_parts = pThis->compressionMaxTotalZstdWindowBytes == 0 ? 1 : 2;
+    for (unsigned input_part = 0; input_part < input_parts; ++input_part) {
         ZSTD_inBuffer input;
-        if (input_part == 0) {
+        if (pThis->compressionMaxTotalZstdWindowBytes == 0) {
+            input = (ZSTD_inBuffer){pData, iLen, 0};
+        } else if (input_part == 0) {
             if (pThis->zstd_frame_header_len == 0) {
                 continue;
             }
@@ -1070,7 +1052,8 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
 
             if (remaining == 0) {
                 pThis->compressedStreamEnded = 1;
-                if (input.pos != input.size || (input_part == 0 && iLen != input_offset)) {
+                if (input.pos != input.size ||
+                    (pThis->compressionMaxTotalZstdWindowBytes != 0 && input_part == 0 && iLen != input_offset)) {
                     logCompressedStreamFailure(pThis, "received invalid compressed stream",
                                                "data after end of zstd stream");
                     ABORT_FINALIZE(RS_RET_ZLIB_ERR);
@@ -1090,7 +1073,10 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
             break;
         }
     }
-    pThis->zstd_frame_header_len = 0;
+    if (pThis->compressionMaxTotalZstdWindowBytes != 0 && pThis->zstd_frame_header_processed) {
+        /* Incomplete headers exit through FINALIZE above and remain buffered across receives. */
+        pThis->zstd_frame_header_len = 0;
+    }
 
 finalize_it:
     if (iRet != RS_RET_OK) {

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -95,9 +95,9 @@ BEGINobjConstruct(tcps_sess) /* be sure to specify the object type also in END m
     pThis->compressedStreamEnded = 0;
     pThis->streamDecompressed = 0;
     pThis->zstdDctx = NULL;
-    pThis->zstdFrameHeaderLen = 0;
-    pThis->zstdFrameHeaderProcessed = 0;
-    pThis->zstdWindowReservation = 0;
+    pThis->zstd_frame_header_len = 0;
+    pThis->zstd_frame_header_processed = 0;
+    pThis->zstd_window_reservation = 0;
     memset(&pThis->zstrm, 0, sizeof(pThis->zstrm));
     memset(pThis->tlsProbeBuf, 0, sizeof(pThis->tlsProbeBuf));
     /* now allocate the message reception buffer */
@@ -140,14 +140,14 @@ finalize_it:
 
 
 #ifdef ENABLE_LIBZSTD
-static void releaseZstdWindowReservation(tcps_sess_t *const pThis) {
-    if (pThis->zstdWindowReservation == 0 || pThis->pLstnInfo == NULL) return;
+static void release_zstd_window_reservation(tcps_sess_t *const pThis) {
+    if (pThis->zstd_window_reservation == 0 || pThis->pLstnInfo == NULL) return;
 
-    pthread_mutex_lock(&pThis->pLstnInfo->mutCompressionZstdWindow);
-    assert(pThis->pLstnInfo->compressionZstdWindowBytesInUse >= pThis->zstdWindowReservation);
-    pThis->pLstnInfo->compressionZstdWindowBytesInUse -= pThis->zstdWindowReservation;
-    pthread_mutex_unlock(&pThis->pLstnInfo->mutCompressionZstdWindow);
-    pThis->zstdWindowReservation = 0;
+    pthread_mutex_lock(&pThis->pLstnInfo->mut_compression_zstd_window);
+    assert(pThis->pLstnInfo->compression_zstd_window_bytes_in_use >= pThis->zstd_window_reservation);
+    pThis->pLstnInfo->compression_zstd_window_bytes_in_use -= pThis->zstd_window_reservation;
+    pthread_mutex_unlock(&pThis->pLstnInfo->mut_compression_zstd_window);
+    pThis->zstd_window_reservation = 0;
 }
 #endif
 
@@ -164,7 +164,7 @@ BEGINobjDestruct(tcps_sess) /* be sure to specify the object type also in END an
         ZSTD_freeDCtx((ZSTD_DCtx *)pThis->zstdDctx);
         pThis->zstdDctx = NULL;
     }
-    releaseZstdWindowReservation(pThis);
+    release_zstd_window_reservation(pThis);
 #endif
     if (pThis->pStrm != NULL) netstrm.Destruct(&pThis->pStrm);
 
@@ -936,23 +936,23 @@ finalize_it:
 #if defined(ENABLE_LIBZSTD) && defined(ZSTD_VERSION_NUMBER) && ZSTD_VERSION_NUMBER >= 10308
     #define ZSTD_RSYSLOG_WINDOWLOG_MIN 10U
     #define ZSTD_RSYSLOG_WINDOWLOG_MAX 31U
-static unsigned zstdWindowLogMaxFromBytes(uint64_t maxBytes) {
-    unsigned windowLogMax = 0;
-    uint64_t windowSize = 1;
+static unsigned zstd_window_log_max_from_bytes(uint64_t max_bytes) {
+    unsigned window_log_max = 0;
+    uint64_t window_size = 1;
 
-    while (windowSize < maxBytes && windowLogMax < 63) {
-        windowSize <<= 1;
-        ++windowLogMax;
+    while (window_size < max_bytes && window_log_max < 63) {
+        window_size <<= 1;
+        ++window_log_max;
     }
 
     /* zstd only exposes a power-of-two window-log cap. Round up so frames
      * within the configured byte limit are not rejected unnecessarily. */
-    if (windowLogMax < ZSTD_RSYSLOG_WINDOWLOG_MIN) {
-        windowLogMax = ZSTD_RSYSLOG_WINDOWLOG_MIN;
-    } else if (windowLogMax > ZSTD_RSYSLOG_WINDOWLOG_MAX) {
-        windowLogMax = ZSTD_RSYSLOG_WINDOWLOG_MAX;
+    if (window_log_max < ZSTD_RSYSLOG_WINDOWLOG_MIN) {
+        window_log_max = ZSTD_RSYSLOG_WINDOWLOG_MIN;
+    } else if (window_log_max > ZSTD_RSYSLOG_WINDOWLOG_MAX) {
+        window_log_max = ZSTD_RSYSLOG_WINDOWLOG_MAX;
     }
-    return windowLogMax;
+    return window_log_max;
 }
 #endif
 
@@ -969,46 +969,47 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
         ABORT_FINALIZE(RS_RET_ZLIB_ERR);
     }
 
-    size_t inputOffset = 0;
-    while (!pThis->zstdFrameHeaderProcessed) {
-        ZSTD_frameHeader frameHeader;
-        const size_t headerRet = ZSTD_getFrameHeader(&frameHeader, pThis->zstdFrameHeader, pThis->zstdFrameHeaderLen);
-        if (ZSTD_isError(headerRet)) {
-            logCompressedStreamFailure(pThis, "received invalid compressed stream", ZSTD_getErrorName(headerRet));
+    size_t input_offset = 0;
+    while (!pThis->zstd_frame_header_processed) {
+        ZSTD_frameHeader frame_header;
+        const size_t header_ret =
+            ZSTD_getFrameHeader(&frame_header, pThis->zstd_frame_header, pThis->zstd_frame_header_len);
+        if (ZSTD_isError(header_ret)) {
+            logCompressedStreamFailure(pThis, "received invalid compressed stream", ZSTD_getErrorName(header_ret));
             ABORT_FINALIZE(RS_RET_ZLIB_ERR);
         }
-        if (headerRet == 0) {
-            if (frameHeader.frameType == ZSTD_frame && pThis->compressionMaxDecompressedBytesPerReceive != 0) {
+        if (header_ret == 0) {
+            if (frame_header.frameType == ZSTD_frame && pThis->compressionMaxDecompressedBytesPerReceive != 0) {
                 const uint64_t budget = pThis->compressionMaxDecompressedBytesPerReceive;
-                const uint64_t windowSize = frameHeader.windowSize;
+                const uint64_t window_size = frame_header.windowSize;
                 tcpLstnPortList_t *const listener = pThis->pLstnInfo;
 
-                pthread_mutex_lock(&listener->mutCompressionZstdWindow);
-                if (windowSize > budget || listener->compressionZstdWindowBytesInUse > budget - windowSize) {
-                    pthread_mutex_unlock(&listener->mutCompressionZstdWindow);
+                pthread_mutex_lock(&listener->mut_compression_zstd_window);
+                if (window_size > budget || listener->compression_zstd_window_bytes_in_use > budget - window_size) {
+                    pthread_mutex_unlock(&listener->mut_compression_zstd_window);
                     logCompressedStreamFailure(pThis, "received invalid compressed stream",
                                                "zstd decoder window budget exhausted");
                     ABORT_FINALIZE(RS_RET_ZLIB_ERR);
                 }
-                listener->compressionZstdWindowBytesInUse += windowSize;
-                pThis->zstdWindowReservation = windowSize;
-                pthread_mutex_unlock(&listener->mutCompressionZstdWindow);
+                listener->compression_zstd_window_bytes_in_use += window_size;
+                pThis->zstd_window_reservation = window_size;
+                pthread_mutex_unlock(&listener->mut_compression_zstd_window);
             }
-            pThis->zstdFrameHeaderProcessed = RSTRUE;
+            pThis->zstd_frame_header_processed = RSTRUE;
             break;
         }
 
-        if (headerRet > TCPSRV_ZSTD_FRAME_HEADER_MAX || headerRet <= pThis->zstdFrameHeaderLen) {
+        if (header_ret > TCPSRV_ZSTD_FRAME_HEADER_MAX || header_ret <= pThis->zstd_frame_header_len) {
             logCompressedStreamFailure(pThis, "received invalid compressed stream", "invalid zstd frame header size");
             ABORT_FINALIZE(RS_RET_ZLIB_ERR);
         }
 
-        const size_t need = headerRet - pThis->zstdFrameHeaderLen;
-        const size_t available = iLen - inputOffset;
+        const size_t need = header_ret - pThis->zstd_frame_header_len;
+        const size_t available = iLen - input_offset;
         const size_t take = need < available ? need : available;
-        memcpy(pThis->zstdFrameHeader + pThis->zstdFrameHeaderLen, pData + inputOffset, take);
-        pThis->zstdFrameHeaderLen += take;
-        inputOffset += take;
+        memcpy(pThis->zstd_frame_header + pThis->zstd_frame_header_len, pData + input_offset, take);
+        pThis->zstd_frame_header_len += take;
+        input_offset += take;
         if (take < need) {
             FINALIZE;
         }
@@ -1022,9 +1023,10 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
         }
     #if defined(ZSTD_VERSION_NUMBER) && ZSTD_VERSION_NUMBER >= 10308
         if (pThis->compressionMaxDecompressedBytesPerReceive != 0) {
-            const unsigned windowLogMax = zstdWindowLogMaxFromBytes(pThis->compressionMaxDecompressedBytesPerReceive);
+            const unsigned window_log_max =
+                zstd_window_log_max_from_bytes(pThis->compressionMaxDecompressedBytesPerReceive);
             const size_t zret =
-                ZSTD_DCtx_setParameter((ZSTD_DCtx *)pThis->zstdDctx, ZSTD_d_windowLogMax, (int)windowLogMax);
+                ZSTD_DCtx_setParameter((ZSTD_DCtx *)pThis->zstdDctx, ZSTD_d_windowLogMax, (int)window_log_max);
             if (ZSTD_isError(zret)) {
                 logCompressedStreamFailure(pThis, "received invalid compressed stream", ZSTD_getErrorName(zret));
                 ABORT_FINALIZE(RS_RET_ZLIB_ERR);
@@ -1033,15 +1035,15 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
     #endif
     }
 
-    for (unsigned inputPart = 0; inputPart < 2; ++inputPart) {
+    for (unsigned input_part = 0; input_part < 2; ++input_part) {
         ZSTD_inBuffer input;
-        if (inputPart == 0) {
-            if (pThis->zstdFrameHeaderLen == 0) {
+        if (input_part == 0) {
+            if (pThis->zstd_frame_header_len == 0) {
                 continue;
             }
-            input = (ZSTD_inBuffer){pThis->zstdFrameHeader, pThis->zstdFrameHeaderLen, 0};
+            input = (ZSTD_inBuffer){pThis->zstd_frame_header, pThis->zstd_frame_header_len, 0};
         } else {
-            input = (ZSTD_inBuffer){pData + inputOffset, iLen - inputOffset, 0};
+            input = (ZSTD_inBuffer){pData + input_offset, iLen - input_offset, 0};
         }
         if (input.size == 0) {
             continue;
@@ -1052,7 +1054,7 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
             output.dst = out;
             output.size = sizeof(out);
             output.pos = 0;
-            const size_t oldInputPos = input.pos;
+            const size_t old_input_pos = input.pos;
             const size_t remaining = ZSTD_decompressStream((ZSTD_DCtx *)pThis->zstdDctx, &output, &input);
             if (ZSTD_isError(remaining)) {
                 logCompressedStreamFailure(pThis, "received invalid compressed stream", ZSTD_getErrorName(remaining));
@@ -1068,18 +1070,18 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
 
             if (remaining == 0) {
                 pThis->compressedStreamEnded = 1;
-                if (input.pos != input.size || (inputPart == 0 && iLen != inputOffset)) {
+                if (input.pos != input.size || (input_part == 0 && iLen != input_offset)) {
                     logCompressedStreamFailure(pThis, "received invalid compressed stream",
                                                "data after end of zstd stream");
                     ABORT_FINALIZE(RS_RET_ZLIB_ERR);
                 }
                 ZSTD_freeDCtx((ZSTD_DCtx *)pThis->zstdDctx);
                 pThis->zstdDctx = NULL;
-                releaseZstdWindowReservation(pThis);
+                release_zstd_window_reservation(pThis);
                 break;
             }
 
-            if (input.pos == oldInputPos && output.pos == 0) {
+            if (input.pos == old_input_pos && output.pos == 0) {
                 break;
             }
         } while (input.pos < input.size || output.pos == output.size);
@@ -1088,13 +1090,13 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
             break;
         }
     }
-    pThis->zstdFrameHeaderLen = 0;
+    pThis->zstd_frame_header_len = 0;
 
 finalize_it:
     if (iRet != RS_RET_OK) {
         ZSTD_freeDCtx((ZSTD_DCtx *)pThis->zstdDctx);
         pThis->zstdDctx = NULL;
-        releaseZstdWindowReservation(pThis);
+        release_zstd_window_reservation(pThis);
     }
     RETiRet;
 #else
@@ -1130,7 +1132,7 @@ static rsRetVal finishCompressedStream(tcps_sess_t *pThis) {
     }
 
     if (pThis->compressionDriver == TCPSRV_COMPRESS_DRIVER_ZSTD && !pThis->compressedStreamEnded) {
-        if (pThis->zstdDctx == NULL && pThis->zstdFrameHeaderLen == 0) {
+        if (pThis->zstdDctx == NULL && pThis->zstd_frame_header_len == 0) {
             FINALIZE;
         }
         logCompressedStreamFailure(pThis, "detected truncated compressed stream", "zstd stream ended before trailer");

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -35,6 +35,7 @@
 #include <errno.h>
 #include <ctype.h>
 #ifdef ENABLE_LIBZSTD
+    #define ZSTD_STATIC_LINKING_ONLY
     #include <zstd.h>
 #endif
 
@@ -94,6 +95,9 @@ BEGINobjConstruct(tcps_sess) /* be sure to specify the object type also in END m
     pThis->compressedStreamEnded = 0;
     pThis->streamDecompressed = 0;
     pThis->zstdDctx = NULL;
+    pThis->zstdFrameHeaderLen = 0;
+    pThis->zstdFrameHeaderProcessed = 0;
+    pThis->zstdWindowReservation = 0;
     memset(&pThis->zstrm, 0, sizeof(pThis->zstrm));
     memset(pThis->tlsProbeBuf, 0, sizeof(pThis->tlsProbeBuf));
     /* now allocate the message reception buffer */
@@ -135,6 +139,19 @@ finalize_it:
 }
 
 
+#ifdef ENABLE_LIBZSTD
+static void releaseZstdWindowReservation(tcps_sess_t *const pThis) {
+    if (pThis->zstdWindowReservation == 0 || pThis->pLstnInfo == NULL) return;
+
+    pthread_mutex_lock(&pThis->pLstnInfo->mutCompressionZstdWindow);
+    assert(pThis->pLstnInfo->compressionZstdWindowBytesInUse >= pThis->zstdWindowReservation);
+    pThis->pLstnInfo->compressionZstdWindowBytesInUse -= pThis->zstdWindowReservation;
+    pthread_mutex_unlock(&pThis->pLstnInfo->mutCompressionZstdWindow);
+    pThis->zstdWindowReservation = 0;
+}
+#endif
+
+
 /* destructor for the tcps_sess object */
 BEGINobjDestruct(tcps_sess) /* be sure to specify the object type also in END and CODESTART macros! */
     CODESTARTobjDestruct(tcps_sess);
@@ -147,6 +164,7 @@ BEGINobjDestruct(tcps_sess) /* be sure to specify the object type also in END an
         ZSTD_freeDCtx((ZSTD_DCtx *)pThis->zstdDctx);
         pThis->zstdDctx = NULL;
     }
+    releaseZstdWindowReservation(pThis);
 #endif
     if (pThis->pStrm != NULL) netstrm.Destruct(&pThis->pStrm);
 
@@ -944,12 +962,56 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
                                        decompressReceiveGuard_t *const guard) {
 #ifdef ENABLE_LIBZSTD
     uchar out[64 * 1024];
-    ZSTD_inBuffer input = {pData, iLen, 0};
     DEFiRet;
 
     if (pThis->compressedStreamEnded) {
         logCompressedStreamFailure(pThis, "received invalid compressed stream", "data after end of zstd stream");
         ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+    }
+
+    size_t inputOffset = 0;
+    while (!pThis->zstdFrameHeaderProcessed) {
+        ZSTD_frameHeader frameHeader;
+        const size_t headerRet = ZSTD_getFrameHeader(&frameHeader, pThis->zstdFrameHeader, pThis->zstdFrameHeaderLen);
+        if (ZSTD_isError(headerRet)) {
+            logCompressedStreamFailure(pThis, "received invalid compressed stream", ZSTD_getErrorName(headerRet));
+            ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+        }
+        if (headerRet == 0) {
+            if (frameHeader.frameType == ZSTD_frame && pThis->compressionMaxDecompressedBytesPerReceive != 0) {
+                const uint64_t budget = pThis->compressionMaxDecompressedBytesPerReceive;
+                const uint64_t windowSize = frameHeader.windowSize;
+                tcpLstnPortList_t *const listener = pThis->pLstnInfo;
+
+                pthread_mutex_lock(&listener->mutCompressionZstdWindow);
+                if (windowSize > budget || listener->compressionZstdWindowBytesInUse > budget - windowSize) {
+                    pthread_mutex_unlock(&listener->mutCompressionZstdWindow);
+                    logCompressedStreamFailure(pThis, "received invalid compressed stream",
+                                               "zstd decoder window budget exhausted");
+                    ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+                }
+                listener->compressionZstdWindowBytesInUse += windowSize;
+                pThis->zstdWindowReservation = windowSize;
+                pthread_mutex_unlock(&listener->mutCompressionZstdWindow);
+            }
+            pThis->zstdFrameHeaderProcessed = RSTRUE;
+            break;
+        }
+
+        if (headerRet > TCPSRV_ZSTD_FRAME_HEADER_MAX || headerRet <= pThis->zstdFrameHeaderLen) {
+            logCompressedStreamFailure(pThis, "received invalid compressed stream", "invalid zstd frame header size");
+            ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+        }
+
+        const size_t need = headerRet - pThis->zstdFrameHeaderLen;
+        const size_t available = iLen - inputOffset;
+        const size_t take = need < available ? need : available;
+        memcpy(pThis->zstdFrameHeader + pThis->zstdFrameHeaderLen, pData + inputOffset, take);
+        pThis->zstdFrameHeaderLen += take;
+        inputOffset += take;
+        if (take < need) {
+            FINALIZE;
+        }
     }
 
     if (pThis->zstdDctx == NULL) {
@@ -971,41 +1033,69 @@ static rsRetVal DataRcvdCompressedZstd(tcps_sess_t *const pThis,
     #endif
     }
 
-    ZSTD_outBuffer output;
-    do {
-        output.dst = out;
-        output.size = sizeof(out);
-        output.pos = 0;
-        const size_t oldInputPos = input.pos;
-        const size_t remaining = ZSTD_decompressStream((ZSTD_DCtx *)pThis->zstdDctx, &output, &input);
-        if (ZSTD_isError(remaining)) {
-            logCompressedStreamFailure(pThis, "received invalid compressed stream", ZSTD_getErrorName(remaining));
-            ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+    for (unsigned inputPart = 0; inputPart < 2; ++inputPart) {
+        ZSTD_inBuffer input;
+        if (inputPart == 0) {
+            if (pThis->zstdFrameHeaderLen == 0) {
+                continue;
+            }
+            input = (ZSTD_inBuffer){pThis->zstdFrameHeader, pThis->zstdFrameHeaderLen, 0};
+        } else {
+            input = (ZSTD_inBuffer){pData + inputOffset, iLen - inputOffset, 0};
+        }
+        if (input.size == 0) {
+            continue;
         }
 
-        if (output.pos != 0) {
-            CHKiRet(checkDecompressedBytesLimit(pThis, guard, output.pos));
-            STATSCOUNTER_ADD(pThis->pLstnInfo->ctrBytesDecompressed, pThis->pLstnInfo->mutCtrBytesDecompressed,
-                             output.pos);
-            CHKiRet(DataRcvdUncompressedFromStream(pThis, (char *)out, output.pos, 0));
-        }
-
-        if (remaining == 0) {
-            pThis->compressedStreamEnded = 1;
-            if (input.pos != input.size) {
-                logCompressedStreamFailure(pThis, "received invalid compressed stream",
-                                           "data after end of zstd stream");
+        ZSTD_outBuffer output;
+        do {
+            output.dst = out;
+            output.size = sizeof(out);
+            output.pos = 0;
+            const size_t oldInputPos = input.pos;
+            const size_t remaining = ZSTD_decompressStream((ZSTD_DCtx *)pThis->zstdDctx, &output, &input);
+            if (ZSTD_isError(remaining)) {
+                logCompressedStreamFailure(pThis, "received invalid compressed stream", ZSTD_getErrorName(remaining));
                 ABORT_FINALIZE(RS_RET_ZLIB_ERR);
             }
-            break;
-        }
 
-        if (input.pos == oldInputPos && output.pos == 0) {
+            if (output.pos != 0) {
+                CHKiRet(checkDecompressedBytesLimit(pThis, guard, output.pos));
+                STATSCOUNTER_ADD(pThis->pLstnInfo->ctrBytesDecompressed, pThis->pLstnInfo->mutCtrBytesDecompressed,
+                                 output.pos);
+                CHKiRet(DataRcvdUncompressedFromStream(pThis, (char *)out, output.pos, 0));
+            }
+
+            if (remaining == 0) {
+                pThis->compressedStreamEnded = 1;
+                if (input.pos != input.size || (inputPart == 0 && iLen != inputOffset)) {
+                    logCompressedStreamFailure(pThis, "received invalid compressed stream",
+                                               "data after end of zstd stream");
+                    ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+                }
+                ZSTD_freeDCtx((ZSTD_DCtx *)pThis->zstdDctx);
+                pThis->zstdDctx = NULL;
+                releaseZstdWindowReservation(pThis);
+                break;
+            }
+
+            if (input.pos == oldInputPos && output.pos == 0) {
+                break;
+            }
+        } while (input.pos < input.size || output.pos == output.size);
+
+        if (pThis->compressedStreamEnded) {
             break;
         }
-    } while (input.pos < input.size || output.pos == output.size);
+    }
+    pThis->zstdFrameHeaderLen = 0;
 
 finalize_it:
+    if (iRet != RS_RET_OK) {
+        ZSTD_freeDCtx((ZSTD_DCtx *)pThis->zstdDctx);
+        pThis->zstdDctx = NULL;
+        releaseZstdWindowReservation(pThis);
+    }
     RETiRet;
 #else
     DEFiRet;
@@ -1040,7 +1130,7 @@ static rsRetVal finishCompressedStream(tcps_sess_t *pThis) {
     }
 
     if (pThis->compressionDriver == TCPSRV_COMPRESS_DRIVER_ZSTD && !pThis->compressedStreamEnded) {
-        if (pThis->zstdDctx == NULL) {
+        if (pThis->zstdDctx == NULL && pThis->zstdFrameHeaderLen == 0) {
             FINALIZE;
         }
         logCompressedStreamFailure(pThis, "detected truncated compressed stream", "zstd stream ended before trailer");

--- a/runtime/tcps_sess.h
+++ b/runtime/tcps_sess.h
@@ -86,10 +86,10 @@ struct tcps_sess_s {
         sbool streamDecompressed;
         z_stream zstrm;
         void *zstdDctx;
-        uchar zstdFrameHeader[TCPSRV_ZSTD_FRAME_HEADER_MAX];
-        size_t zstdFrameHeaderLen;
-        sbool zstdFrameHeaderProcessed;
-        uint64_t zstdWindowReservation;
+        uchar zstd_frame_header[TCPSRV_ZSTD_FRAME_HEADER_MAX];
+        size_t zstd_frame_header_len;
+        sbool zstd_frame_header_processed;
+        uint64_t zstd_window_reservation;
 };
 
 

--- a/runtime/tcps_sess.h
+++ b/runtime/tcps_sess.h
@@ -38,6 +38,7 @@ struct tcpsrv_s;
 
 #define TCPSRV_COMPRESS_MAX_EXPANSION_RATIO_DEFAULT 1024
 #define TCPSRV_COMPRESS_MAX_DECOMPRESSED_BYTES_PER_RECEIVE_DEFAULT (64ULL * 1024ULL * 1024ULL)
+#define TCPSRV_COMPRESS_MAX_TOTAL_ZSTD_WINDOW_BYTES_DEFAULT 0
 #define TCPSRV_ZSTD_FRAME_HEADER_MAX 18
 
 /* the tcps_sess object */
@@ -78,6 +79,7 @@ struct tcps_sess_s {
         uint8_t compressionDriver;
         uint64_t compressionMaxExpansionRatio;
         uint64_t compressionMaxDecompressedBytesPerReceive;
+        uint64_t compressionMaxTotalZstdWindowBytes;
         uint64_t compressionTotalBytesIn;
         uint64_t compressionTotalBytesOut;
         sbool zipInitDone;

--- a/runtime/tcps_sess.h
+++ b/runtime/tcps_sess.h
@@ -38,6 +38,7 @@ struct tcpsrv_s;
 
 #define TCPSRV_COMPRESS_MAX_EXPANSION_RATIO_DEFAULT 1024
 #define TCPSRV_COMPRESS_MAX_DECOMPRESSED_BYTES_PER_RECEIVE_DEFAULT (64ULL * 1024ULL * 1024ULL)
+#define TCPSRV_ZSTD_FRAME_HEADER_MAX 18
 
 /* the tcps_sess object */
 struct tcps_sess_s {
@@ -85,6 +86,10 @@ struct tcps_sess_s {
         sbool streamDecompressed;
         z_stream zstrm;
         void *zstdDctx;
+        uchar zstdFrameHeader[TCPSRV_ZSTD_FRAME_HEADER_MAX];
+        size_t zstdFrameHeaderLen;
+        sbool zstdFrameHeaderProcessed;
+        uint64_t zstdWindowReservation;
 };
 
 

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -385,12 +385,7 @@ static rsRetVal ATTR_NONNULL() addNewLstnPort(tcpsrv_t *const pThis, tcpLstnPara
     /* create entry */
     CHKmalloc(pEntry = (tcpLstnPortList_t *)calloc(1, sizeof(tcpLstnPortList_t)));
     pEntry->cnf_params = cnf_params;
-    const int mutex_ret = pthread_mutex_init(&pEntry->mut_compression_zstd_window, NULL);
-    if (mutex_ret != 0) {
-        LogError(mutex_ret, RS_RET_ERR, "imtcp: failed to initialize zstd window budget mutex");
-        ABORT_FINALIZE(RS_RET_ERR);
-    }
-    pEntry->compression_zstd_window_mutex_initialized = RSTRUE;
+    INIT_ATOMIC_HELPER_MUT64(pEntry->mutCompressionZstdWindow);
 
     u_cstr_copy(pEntry->cnf_params->dfltTZ, pThis->dfltTZ, sizeof(pEntry->cnf_params->dfltTZ));
     pEntry->cnf_params->bSPFramingFix = pThis->bSPFramingFix;
@@ -400,6 +395,7 @@ static rsRetVal ATTR_NONNULL() addNewLstnPort(tcpsrv_t *const pThis, tcpLstnPara
     pEntry->compressionDriver = pThis->compressionDriver;
     pEntry->compressionMaxExpansionRatio = pThis->compressionMaxExpansionRatio;
     pEntry->compressionMaxDecompressedBytesPerReceive = pThis->compressionMaxDecompressedBytesPerReceive;
+    pEntry->compressionMaxTotalZstdWindowBytes = pThis->compressionMaxTotalZstdWindowBytes;
 
 #ifdef FEATURE_REGEXP
     if (cnf_params->pszStartRegex != NULL) {
@@ -471,9 +467,7 @@ finalize_it:
                 regexp.regfree(&pEntry->start_preg);
             }
 #endif
-            if (pEntry->compression_zstd_window_mutex_initialized) {
-                pthread_mutex_destroy(&pEntry->mut_compression_zstd_window);
-            }
+            DESTROY_ATOMIC_HELPER_MUT64(pEntry->mutCompressionZstdWindow);
             free(pEntry);
         }
     }
@@ -620,9 +614,7 @@ static void ATTR_NONNULL() deinit_tcp_listener(tcpsrv_t *const pThis) {
         if (pEntry->stats != NULL) {
             statsobj.Destruct(&(pEntry->stats));
         }
-        if (pEntry->compression_zstd_window_mutex_initialized) {
-            pthread_mutex_destroy(&pEntry->mut_compression_zstd_window);
-        }
+        DESTROY_ATOMIC_HELPER_MUT64(pEntry->mutCompressionZstdWindow);
         pDel = pEntry;
         pEntry = pEntry->pNext;
         free(pDel);
@@ -1821,6 +1813,7 @@ BEGINobjConstruct(tcpsrv) /* be sure to specify the object type also in END macr
     pThis->compressionDriver = TCPSRV_COMPRESS_DRIVER_ZLIB;
     pThis->compressionMaxExpansionRatio = TCPSRV_COMPRESS_MAX_EXPANSION_RATIO_DEFAULT;
     pThis->compressionMaxDecompressedBytesPerReceive = TCPSRV_COMPRESS_MAX_DECOMPRESSED_BYTES_PER_RECEIVE_DEFAULT;
+    pThis->compressionMaxTotalZstdWindowBytes = TCPSRV_COMPRESS_MAX_TOTAL_ZSTD_WINDOW_BYTES_DEFAULT;
 ENDobjConstruct(tcpsrv)
 
 
@@ -2095,6 +2088,13 @@ static rsRetVal ATTR_NONNULL(1) SetCompressionMaxDecompressedBytesPerReceive(tcp
     DEFiRet;
     ISOBJ_TYPE_assert(pThis, tcpsrv);
     pThis->compressionMaxDecompressedBytesPerReceive = maxBytes;
+    RETiRet;
+}
+
+static rsRetVal ATTR_NONNULL(1) SetCompressionMaxTotalZstdWindowBytes(tcpsrv_t *pThis, const uint64_t maxBytes) {
+    DEFiRet;
+    ISOBJ_TYPE_assert(pThis, tcpsrv);
+    pThis->compressionMaxTotalZstdWindowBytes = maxBytes;
     RETiRet;
 }
 
@@ -2412,6 +2412,7 @@ BEGINobjQueryInterface(tcpsrv)
     pIf->SetCompressionDriver = SetCompressionDriver;
     pIf->SetCompressionMaxExpansionRatio = SetCompressionMaxExpansionRatio;
     pIf->SetCompressionMaxDecompressedBytesPerReceive = SetCompressionMaxDecompressedBytesPerReceive;
+    pIf->SetCompressionMaxTotalZstdWindowBytes = SetCompressionMaxTotalZstdWindowBytes;
     pIf->SetbDisableLFDelim = SetbDisableLFDelim;
     pIf->SetDiscardTruncatedMsg = SetDiscardTruncatedMsg;
     pIf->SetSessMax = SetSessMax;

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -385,12 +385,12 @@ static rsRetVal ATTR_NONNULL() addNewLstnPort(tcpsrv_t *const pThis, tcpLstnPara
     /* create entry */
     CHKmalloc(pEntry = (tcpLstnPortList_t *)calloc(1, sizeof(tcpLstnPortList_t)));
     pEntry->cnf_params = cnf_params;
-    const int mutexRet = pthread_mutex_init(&pEntry->mutCompressionZstdWindow, NULL);
-    if (mutexRet != 0) {
-        LogError(mutexRet, RS_RET_ERR, "imtcp: failed to initialize zstd window budget mutex");
+    const int mutex_ret = pthread_mutex_init(&pEntry->mut_compression_zstd_window, NULL);
+    if (mutex_ret != 0) {
+        LogError(mutex_ret, RS_RET_ERR, "imtcp: failed to initialize zstd window budget mutex");
         ABORT_FINALIZE(RS_RET_ERR);
     }
-    pEntry->compressionZstdWindowMutexInitialized = RSTRUE;
+    pEntry->compression_zstd_window_mutex_initialized = RSTRUE;
 
     u_cstr_copy(pEntry->cnf_params->dfltTZ, pThis->dfltTZ, sizeof(pEntry->cnf_params->dfltTZ));
     pEntry->cnf_params->bSPFramingFix = pThis->bSPFramingFix;
@@ -471,8 +471,8 @@ finalize_it:
                 regexp.regfree(&pEntry->start_preg);
             }
 #endif
-            if (pEntry->compressionZstdWindowMutexInitialized) {
-                pthread_mutex_destroy(&pEntry->mutCompressionZstdWindow);
+            if (pEntry->compression_zstd_window_mutex_initialized) {
+                pthread_mutex_destroy(&pEntry->mut_compression_zstd_window);
             }
             free(pEntry);
         }
@@ -620,8 +620,8 @@ static void ATTR_NONNULL() deinit_tcp_listener(tcpsrv_t *const pThis) {
         if (pEntry->stats != NULL) {
             statsobj.Destruct(&(pEntry->stats));
         }
-        if (pEntry->compressionZstdWindowMutexInitialized) {
-            pthread_mutex_destroy(&pEntry->mutCompressionZstdWindow);
+        if (pEntry->compression_zstd_window_mutex_initialized) {
+            pthread_mutex_destroy(&pEntry->mut_compression_zstd_window);
         }
         pDel = pEntry;
         pEntry = pEntry->pNext;

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -385,6 +385,12 @@ static rsRetVal ATTR_NONNULL() addNewLstnPort(tcpsrv_t *const pThis, tcpLstnPara
     /* create entry */
     CHKmalloc(pEntry = (tcpLstnPortList_t *)calloc(1, sizeof(tcpLstnPortList_t)));
     pEntry->cnf_params = cnf_params;
+    const int mutexRet = pthread_mutex_init(&pEntry->mutCompressionZstdWindow, NULL);
+    if (mutexRet != 0) {
+        LogError(mutexRet, RS_RET_ERR, "imtcp: failed to initialize zstd window budget mutex");
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    pEntry->compressionZstdWindowMutexInitialized = RSTRUE;
 
     u_cstr_copy(pEntry->cnf_params->dfltTZ, pThis->dfltTZ, sizeof(pEntry->cnf_params->dfltTZ));
     pEntry->cnf_params->bSPFramingFix = pThis->bSPFramingFix;
@@ -465,6 +471,9 @@ finalize_it:
                 regexp.regfree(&pEntry->start_preg);
             }
 #endif
+            if (pEntry->compressionZstdWindowMutexInitialized) {
+                pthread_mutex_destroy(&pEntry->mutCompressionZstdWindow);
+            }
             free(pEntry);
         }
     }
@@ -610,6 +619,9 @@ static void ATTR_NONNULL() deinit_tcp_listener(tcpsrv_t *const pThis) {
         }
         if (pEntry->stats != NULL) {
             statsobj.Destruct(&(pEntry->stats));
+        }
+        if (pEntry->compressionZstdWindowMutexInitialized) {
+            pthread_mutex_destroy(&pEntry->mutCompressionZstdWindow);
         }
         pDel = pEntry;
         pEntry = pEntry->pNext;

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -83,11 +83,11 @@ struct tcpLstnPortList_s {
     uint64_t compressionMaxExpansionRatio;
     uint64_t compressionMaxDecompressedBytesPerReceive;
     /* Concurrency & Locking: all sessions for this listener share the zstd
-     * window budget. Access to compressionZstdWindowBytesInUse is serialized
-     * by mutCompressionZstdWindow. */
-    pthread_mutex_t mutCompressionZstdWindow;
-    sbool compressionZstdWindowMutexInitialized;
-    uint64_t compressionZstdWindowBytesInUse;
+     * window budget. Access to compression_zstd_window_bytes_in_use is
+     * serialized by mut_compression_zstd_window. */
+    pthread_mutex_t mut_compression_zstd_window;
+    sbool compression_zstd_window_mutex_initialized;
+    uint64_t compression_zstd_window_bytes_in_use;
 #ifdef FEATURE_REGEXP
     regex_t start_preg;
     sbool bHasStartRegex;

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -82,12 +82,12 @@ struct tcpLstnPortList_s {
     uint8_t compressionDriver;
     uint64_t compressionMaxExpansionRatio;
     uint64_t compressionMaxDecompressedBytesPerReceive;
-    /* Concurrency & Locking: all sessions for this listener share the zstd
-     * window budget. Access to compression_zstd_window_bytes_in_use is
-     * serialized by mut_compression_zstd_window. */
-    pthread_mutex_t mut_compression_zstd_window;
-    sbool compression_zstd_window_mutex_initialized;
-    uint64_t compression_zstd_window_bytes_in_use;
+    uint64_t compressionMaxTotalZstdWindowBytes;
+    /* Concurrency & Locking: sessions have independent decoder state and share
+     * only this listener-wide zstd window counter. Native 64-bit atomics avoid
+     * serialization; the helper mutex exists only on no-64-bit-atomics builds. */
+    uint64 compressionZstdWindowBytesInUse;
+    DEF_ATOMIC_HELPER_MUT64(mutCompressionZstdWindow);
 #ifdef FEATURE_REGEXP
     regex_t start_preg;
     sbool bHasStartRegex;
@@ -198,6 +198,7 @@ struct tcpsrv_s {
         uint8_t compressionDriver;
         uint64_t compressionMaxExpansionRatio;
         uint64_t compressionMaxDecompressedBytesPerReceive;
+        uint64_t compressionMaxTotalZstdWindowBytes;
         int bDisableLFDelim; /**< if 1, standard LF frame delimiter is disabled (*very dangerous*) */
         int discardTruncatedMsg; /**< discard msg part that has been truncated*/
         sbool bPreserveCase; /**< preserve case in fromhost */
@@ -258,6 +259,8 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
     rsRetVal (*SetCompressionDriver)(tcpsrv_t *, int);
     rsRetVal (*SetCompressionMaxExpansionRatio)(tcpsrv_t *, uint64_t);
     rsRetVal (*SetCompressionMaxDecompressedBytesPerReceive)(tcpsrv_t *, uint64_t);
+    /* added v32 */
+    rsRetVal (*SetCompressionMaxTotalZstdWindowBytes)(tcpsrv_t *, uint64_t);
     /**
      * Set the input name for a listener configuration.
      *
@@ -354,7 +357,7 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
                                     const char *const networkNamespace);
 
 ENDinterface(tcpsrv)
-#define tcpsrvCURR_IF_VERSION 31 /* increment whenever you change the interface structure! */
+#define tcpsrvCURR_IF_VERSION 32 /* increment whenever you change the interface structure! */
 /* change for v4:
  * - SetAddtlFrameDelim() added -- rgerhards, 2008-12-10
  * - SetInputName() added -- rgerhards, 2008-12-10

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -82,6 +82,12 @@ struct tcpLstnPortList_s {
     uint8_t compressionDriver;
     uint64_t compressionMaxExpansionRatio;
     uint64_t compressionMaxDecompressedBytesPerReceive;
+    /* Concurrency & Locking: all sessions for this listener share the zstd
+     * window budget. Access to compressionZstdWindowBytesInUse is serialized
+     * by mutCompressionZstdWindow. */
+    pthread_mutex_t mutCompressionZstdWindow;
+    sbool compressionZstdWindowMutexInitialized;
+    uint64_t compressionZstdWindowBytesInUse;
 #ifdef FEATURE_REGEXP
     regex_t start_preg;
     sbool bHasStartRegex;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -851,6 +851,7 @@ TESTS_IMTCP_STREAM_ALWAYS_ZSTD = \
 	imtcp-stream-always-zstd-truncated.sh \
 	imtcp-stream-always-zstd-empty-close.sh \
 	imtcp-stream-always-zstd-window-guard.sh \
+	imtcp-stream-always-zstd-window-budget.sh \
 	imtcp-stream-always-zstd-expansion-guard.sh \
 	imtcp-stream-always-zstd-to-zlib-mismatch.sh
 
@@ -2170,7 +2171,8 @@ imtcp-stream-always-zstd-corrupt.log: imtcp-stream-always-zstd-flushoff.log
 imtcp-stream-always-zstd-truncated.log: imtcp-stream-always-zstd-corrupt.log
 imtcp-stream-always-zstd-empty-close.log: imtcp-stream-always-zstd-truncated.log
 imtcp-stream-always-zstd-window-guard.log: imtcp-stream-always-zstd-empty-close.log
-imtcp-stream-always-zstd-expansion-guard.log: imtcp-stream-always-zstd-window-guard.log
+imtcp-stream-always-zstd-window-budget.log: imtcp-stream-always-zstd-window-guard.log
+imtcp-stream-always-zstd-expansion-guard.log: imtcp-stream-always-zstd-window-budget.log
 imtcp-stream-always-zstd-to-zlib-mismatch.log: imtcp-stream-always-zstd-expansion-guard.log
 imtcp-impstats.log: imtcp-stream-always-zlib-truncated.log
 imtcp-stream-always-zlib-impstats.log: imtcp-impstats.log

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -852,8 +852,12 @@ TESTS_IMTCP_STREAM_ALWAYS_ZSTD = \
 	imtcp-stream-always-zstd-empty-close.sh \
 	imtcp-stream-always-zstd-window-guard.sh \
 	imtcp-stream-always-zstd-window-budget.sh \
+	imtcp-stream-always-zstd-secure-defaults.sh \
 	imtcp-stream-always-zstd-expansion-guard.sh \
 	imtcp-stream-always-zstd-to-zlib-mismatch.sh
+
+TESTS_IMTCP_STREAM_ALWAYS_ZSTD_YAML = \
+	yaml-imtcp-stream-always-zstd-secure-defaults.sh
 
 TESTS_IMTCP_STREAM_ALWAYS_ZSTD_IMPSTATS = \
 	imtcp-stream-always-zstd-impstats.sh
@@ -2172,7 +2176,9 @@ imtcp-stream-always-zstd-truncated.log: imtcp-stream-always-zstd-corrupt.log
 imtcp-stream-always-zstd-empty-close.log: imtcp-stream-always-zstd-truncated.log
 imtcp-stream-always-zstd-window-guard.log: imtcp-stream-always-zstd-empty-close.log
 imtcp-stream-always-zstd-window-budget.log: imtcp-stream-always-zstd-window-guard.log
-imtcp-stream-always-zstd-expansion-guard.log: imtcp-stream-always-zstd-window-budget.log
+imtcp-stream-always-zstd-secure-defaults.log: imtcp-stream-always-zstd-window-budget.log
+yaml-imtcp-stream-always-zstd-secure-defaults.log: imtcp-stream-always-zstd-secure-defaults.log
+imtcp-stream-always-zstd-expansion-guard.log: imtcp-stream-always-zstd-secure-defaults.log
 imtcp-stream-always-zstd-to-zlib-mismatch.log: imtcp-stream-always-zstd-expansion-guard.log
 imtcp-impstats.log: imtcp-stream-always-zlib-truncated.log
 imtcp-stream-always-zlib-impstats.log: imtcp-impstats.log
@@ -2293,6 +2299,7 @@ EXTRA_DIST += $(TESTS_IMTCP)
 EXTRA_DIST += $(TESTS_IMTCP_STREAM_ALWAYS_ZLIB)
 EXTRA_DIST += $(TESTS_IMTCP_STREAM_ALWAYS_ZLIB_IMPSTATS)
 EXTRA_DIST += $(TESTS_IMTCP_STREAM_ALWAYS_ZSTD)
+EXTRA_DIST += $(TESTS_IMTCP_STREAM_ALWAYS_ZSTD_YAML)
 EXTRA_DIST += $(TESTS_IMTCP_STREAM_ALWAYS_ZSTD_IMPSTATS)
 EXTRA_DIST += $(TESTS_IMTCP_STREAM_ALWAYS_GNUTLS)
 EXTRA_DIST += $(TESTS_IMTCP_STREAM_ALWAYS_MBEDTLS)
@@ -2887,6 +2894,9 @@ TESTS += $(TESTS_IMTCP)
 TESTS += $(TESTS_IMTCP_STREAM_ALWAYS_ZLIB)
 if ENABLE_LIBZSTD
 TESTS += $(TESTS_IMTCP_STREAM_ALWAYS_ZSTD)
+if HAVE_LIBYAML
+TESTS += $(TESTS_IMTCP_STREAM_ALWAYS_ZSTD_YAML)
+endif # HAVE_LIBYAML
 endif # ENABLE_LIBZSTD
 
 if HAVE_LIBYAML

--- a/tests/imtcp-stream-always-zstd-secure-defaults.sh
+++ b/tests/imtcp-stream-always-zstd-secure-defaults.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# added 2026-07-20 by Codex, released under ASL 2.0
+# Validates the RainerScript secure-default policy for the aggregate zstd
+# decoder-window limit. Configuration-validation exit status and startup
+# diagnostics are the oracle; no listener runtime timing is involved.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+require_plugin lmzstdw ../runtime
+
+modpath="${RSYSLOG_MODDIR}"
+
+run_expect_success() {
+    local cfg="$1"
+    local log="$2"
+    ../tools/rsyslogd -C -N1 -M"${modpath}" -f"${cfg}" >"${log}" 2>&1
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "FAIL: expected ${cfg} to validate"
+        cat "${log}"
+        error_exit 1
+    fi
+}
+
+run_expect_failure() {
+    local cfg="$1"
+    local log="$2"
+    ../tools/rsyslogd -C -N1 -M"${modpath}" -f"${cfg}" >"${log}" 2>&1
+    local rc=$?
+    if [ $rc -eq 0 ]; then
+        echo "FAIL: expected ${cfg} to fail validation"
+        cat "${log}"
+        error_exit 1
+    fi
+}
+
+write_input_config() {
+    local cfg="$1"
+    local policy="$2"
+    local mode="$3"
+    local driver="$4"
+    local limit="$5"
+    cat >"${cfg}" <<CONF_EOF
+global(compatibility.defaults.secure="${policy}")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" compression.mode="${mode}" compression.driver="${driver}" ${limit})
+action(type="omfile" file="/dev/null")
+CONF_EOF
+}
+
+warning='compression.maxTotalZstdWindowBytes was not explicitly set'
+strict_error='compatibility.defaults.secure="strict" requires an explicit positive compression.maxTotalZstdWindowBytes'
+
+write_input_config "${RSYSLOG_DYNNAME}.warn-omitted.conf" warn stream:always zstd ""
+run_expect_success "${RSYSLOG_DYNNAME}.warn-omitted.conf" "${RSYSLOG_DYNNAME}.warn-omitted.log"
+content_check "${warning}" "${RSYSLOG_DYNNAME}.warn-omitted.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.backcompat-omitted.conf" backward-compatible stream:always zstd ""
+run_expect_success "${RSYSLOG_DYNNAME}.backcompat-omitted.conf" "${RSYSLOG_DYNNAME}.backcompat-omitted.log"
+check_not_present "${warning}" "${RSYSLOG_DYNNAME}.backcompat-omitted.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.warn-zero.conf" warn stream:always zstd \
+    'compression.maxTotalZstdWindowBytes="0"'
+run_expect_success "${RSYSLOG_DYNNAME}.warn-zero.conf" "${RSYSLOG_DYNNAME}.warn-zero.log"
+check_not_present "${warning}" "${RSYSLOG_DYNNAME}.warn-zero.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.warn-positive.conf" warn stream:always zstd \
+    'compression.maxTotalZstdWindowBytes="2097152"'
+run_expect_success "${RSYSLOG_DYNNAME}.warn-positive.conf" "${RSYSLOG_DYNNAME}.warn-positive.log"
+check_not_present "${warning}" "${RSYSLOG_DYNNAME}.warn-positive.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.strict-omitted.conf" strict stream:always zstd ""
+run_expect_failure "${RSYSLOG_DYNNAME}.strict-omitted.conf" "${RSYSLOG_DYNNAME}.strict-omitted.log"
+content_check "${strict_error}" "${RSYSLOG_DYNNAME}.strict-omitted.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.strict-zero.conf" strict stream:always zstd \
+    'compression.maxTotalZstdWindowBytes="0"'
+run_expect_failure "${RSYSLOG_DYNNAME}.strict-zero.conf" "${RSYSLOG_DYNNAME}.strict-zero.log"
+content_check "${strict_error}" "${RSYSLOG_DYNNAME}.strict-zero.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.strict-positive.conf" strict stream:always zstd \
+    'compression.maxTotalZstdWindowBytes="2097152"'
+run_expect_success "${RSYSLOG_DYNNAME}.strict-positive.conf" "${RSYSLOG_DYNNAME}.strict-positive.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.warn-zlib.conf" warn stream:always zlib ""
+run_expect_success "${RSYSLOG_DYNNAME}.warn-zlib.conf" "${RSYSLOG_DYNNAME}.warn-zlib.log"
+check_not_present "${warning}" "${RSYSLOG_DYNNAME}.warn-zlib.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.warn-inactive.conf" warn none zstd ""
+run_expect_success "${RSYSLOG_DYNNAME}.warn-inactive.conf" "${RSYSLOG_DYNNAME}.warn-inactive.log"
+check_not_present "${warning}" "${RSYSLOG_DYNNAME}.warn-inactive.log"
+
+cat >"${RSYSLOG_DYNNAME}.strict-module-inherit.conf" <<'CONF_EOF'
+global(compatibility.defaults.secure="strict")
+module(load="../plugins/imtcp/.libs/imtcp"
+       compression.mode="stream:always"
+       compression.driver="zstd"
+       compression.maxTotalZstdWindowBytes="2097152")
+input(type="imtcp" port="0")
+action(type="omfile" file="/dev/null")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.strict-module-inherit.conf" \
+    "${RSYSLOG_DYNNAME}.strict-module-inherit.log"
+
+exit_test

--- a/tests/imtcp-stream-always-zstd-window-budget.sh
+++ b/tests/imtcp-stream-always-zstd-window-budget.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# added 2026-07-13 by Codex, released under ASL 2.0
+# Holds an incomplete zstd frame that consumes the listener's configured 1 MiB
+# decoder-window budget, then proves a second session is rejected. It also
+# keeps a completed connection open while proving its reservation is reusable.
+# The first complete frame sends its header in two writes separated by 50 ms so
+# the receive path must retain partial header bytes. Polling has a ten-second CI
+# tolerance; diagnostics and delivered messages, not elapsed time, are the
+# oracle.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+require_plugin lmzstdw ../runtime
+check_command_available python3
+export NUMMESSAGES=1
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+
+generate_conf
+add_conf '
+global(processInternalMessages="on")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	compression.mode="stream:always"
+	compression.driver="zstd"
+	compression.maxDecompressedBytesPerReceive="1048576")
+
+if $syslogtag contains "rsyslogd" then {
+	action(type="omfile" file="'$RSYSLOG2_OUT_LOG'")
+	stop
+}
+template(name="outfmt" type="string" string="%msg%\n")
+if $msg contains "window-budget-control" then
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+assign_tcpflood_port "$RSYSLOG_DYNNAME.tcpflood_port"
+
+printf '<129>Mar 10 01:00:00 127.0.0.1 tag: window-budget-control\n' > "$RSYSLOG_DYNNAME.rawmsg"
+
+python3 - "$TCPFLOOD_PORT" "$RSYSLOG2_OUT_LOG" "$RSYSLOG_OUT_LOG" "$RSYSLOG_DYNNAME.rawmsg" <<'PY'
+import socket
+import sys
+import time
+
+port = int(sys.argv[1])
+diagnostic_path = sys.argv[2]
+output_path = sys.argv[3]
+payload_path = sys.argv[4]
+
+
+def wait_for(path, needle, deadline):
+    while time.monotonic() < deadline:
+        try:
+            with open(path, "rb") as stream:
+                if needle in stream.read():
+                    return True
+        except FileNotFoundError:
+            pass
+        time.sleep(0.05)
+    return False
+
+
+# Standard zstd magic, a frame descriptor without a content size, and a window
+# descriptor for windowLog=20 (1 MiB). The absent block keeps the frame live.
+incomplete_1m_header = bytes.fromhex("28b52ffd0050")
+held = socket.create_connection(("127.0.0.1", port))
+held.sendall(incomplete_1m_header)
+
+denied = socket.create_connection(("127.0.0.1", port))
+denied.sendall(incomplete_1m_header)
+if not wait_for(diagnostic_path, b"zstd decoder window budget exhausted", time.monotonic() + 10):
+    raise SystemExit("listener did not reject a second 1 MiB decoder window")
+denied.close()
+held.close()
+
+with open(payload_path, "rb") as stream:
+    control = stream.read()
+
+
+def raw_1m_frame(payload):
+    # A final raw block keeps the advertised 1 MiB window while producing a
+    # complete, standards-compliant frame without needing a custom compressor.
+    block_header = (1 | (len(payload) << 3)).to_bytes(3, "little")
+    return incomplete_1m_header + block_header + payload
+
+
+first_payload = control.rstrip(b"\n") + b"-first\n"
+first_completed = None
+deadline = time.monotonic() + 10
+while time.monotonic() < deadline:
+    candidate = socket.create_connection(("127.0.0.1", port))
+    candidate.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    first_frame = raw_1m_frame(first_payload)
+    candidate.sendall(first_frame[:2])
+    # Give the server a chance to consume the deliberately incomplete header;
+    # message delivery below remains the pass/fail oracle, not this delay.
+    time.sleep(0.05)
+    candidate.sendall(first_frame[2:])
+    if wait_for(output_path, b"window-budget-control-first", time.monotonic() + 0.2):
+        first_completed = candidate
+        break
+    candidate.close()
+if first_completed is None:
+    raise SystemExit("listener did not accept the first complete 1 MiB-window frame")
+
+# Keep the first TCP connection open. The second full-budget frame can only
+# succeed if completion freed the first decoder context and its reservation.
+second_payload = control.rstrip(b"\n") + b"-second\n"
+with socket.create_connection(("127.0.0.1", port)) as second_completed:
+    second_completed.sendall(raw_1m_frame(second_payload))
+if not wait_for(output_path, b"window-budget-control-second", time.monotonic() + 10):
+    raise SystemExit("completed stream retained its decoder-window reservation")
+first_completed.close()
+PY
+
+wait_file_lines "$RSYSLOG_OUT_LOG" 2
+shutdown_when_empty
+wait_shutdown
+
+content_check "zstd decoder window budget exhausted" "$RSYSLOG2_OUT_LOG"
+content_check "window-budget-control-first" "$RSYSLOG_OUT_LOG"
+content_check "window-budget-control-second" "$RSYSLOG_OUT_LOG"
+
+exit_test

--- a/tests/imtcp-stream-always-zstd-window-budget.sh
+++ b/tests/imtcp-stream-always-zstd-window-budget.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 # added 2026-07-13 by Codex, released under ASL 2.0
-# Holds an incomplete zstd frame that consumes the listener's configured 1 MiB
-# decoder-window budget, then proves a second session is rejected. It also
-# keeps a completed connection open while proving its reservation is reusable.
-# The first complete frame sends its header in two writes separated by 50 ms so
-# the receive path must retain partial header bytes. Polling has a ten-second CI
-# tolerance; diagnostics and delivered messages, not elapsed time, are the
-# oracle.
+# Exercises the listener-wide zstd decoder-window budget with deliberately held
+# frames. Diagnostics prove exact aggregate rejection and oversized-window
+# rejection; delivered messages prove reservations are released after close,
+# completion, and decode failure. A second unlimited listener holds three
+# simultaneous windows and later completes them, proving that explicit zero
+# does not impose a hidden cap. Polling allows ten seconds for loaded CI, while
+# diagnostics and delivered messages—not elapsed time—are the oracle.
 . ${srcdir:=.}/diag.sh init
 require_plugin imtcp
 require_plugin lmzstdw ../runtime
 check_command_available python3
-export NUMMESSAGES=1
+export NUMMESSAGES=6
 export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 
 generate_conf
@@ -19,10 +19,14 @@ add_conf '
 global(processInternalMessages="on")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.limited_port"
 	compression.mode="stream:always"
 	compression.driver="zstd"
-	compression.maxDecompressedBytesPerReceive="1048576")
+	compression.maxTotalZstdWindowBytes="2097152")
+input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.unlimited_port"
+	compression.mode="stream:always"
+	compression.driver="zstd"
+	compression.maxTotalZstdWindowBytes="0")
 
 if $syslogtag contains "rsyslogd" then {
 	action(type="omfile" file="'$RSYSLOG2_OUT_LOG'")
@@ -33,19 +37,32 @@ if $msg contains "window-budget-control" then
 	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
-assign_tcpflood_port "$RSYSLOG_DYNNAME.tcpflood_port"
 
 printf '<129>Mar 10 01:00:00 127.0.0.1 tag: window-budget-control\n' > "$RSYSLOG_DYNNAME.rawmsg"
 
-python3 - "$TCPFLOOD_PORT" "$RSYSLOG2_OUT_LOG" "$RSYSLOG_OUT_LOG" "$RSYSLOG_DYNNAME.rawmsg" <<'PY'
+python3 - "$RSYSLOG_DYNNAME.limited_port" "$RSYSLOG_DYNNAME.unlimited_port" "$RSYSLOG2_OUT_LOG" \
+    "$RSYSLOG_OUT_LOG" "$RSYSLOG_DYNNAME.rawmsg" <<'PY'
 import socket
 import sys
 import time
 
-port = int(sys.argv[1])
-diagnostic_path = sys.argv[2]
-output_path = sys.argv[3]
-payload_path = sys.argv[4]
+
+def read_port(path):
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        try:
+            with open(path, "r", encoding="ascii") as stream:
+                return int(stream.read().strip())
+        except (FileNotFoundError, ValueError):
+            time.sleep(0.05)
+    raise SystemExit(f"listener port was not published: {path}")
+
+
+limited_port = read_port(sys.argv[1])
+unlimited_port = read_port(sys.argv[2])
+diagnostic_path = sys.argv[3]
+output_path = sys.argv[4]
+payload_path = sys.argv[5]
 
 
 def wait_for(path, needle, deadline):
@@ -60,65 +77,132 @@ def wait_for(path, needle, deadline):
     return False
 
 
-# Standard zstd magic, a frame descriptor without a content size, and a window
-# descriptor for windowLog=20 (1 MiB). The absent block keeps the frame live.
-incomplete_1m_header = bytes.fromhex("28b52ffd0050")
-held = socket.create_connection(("127.0.0.1", port))
-held.sendall(incomplete_1m_header)
+def wait_for_count(path, needle, count, deadline):
+    while time.monotonic() < deadline:
+        try:
+            with open(path, "rb") as stream:
+                if stream.read().count(needle) >= count:
+                    return True
+        except FileNotFoundError:
+            pass
+        time.sleep(0.05)
+    return False
 
-denied = socket.create_connection(("127.0.0.1", port))
-denied.sendall(incomplete_1m_header)
-if not wait_for(diagnostic_path, b"zstd decoder window budget exhausted", time.monotonic() + 10):
-    raise SystemExit("listener did not reject a second 1 MiB decoder window")
-denied.close()
-held.close()
+
+def connect(port):
+    return socket.create_connection(("127.0.0.1", port))
+
+
+# Standard zstd magic, a frame descriptor without a content size, and window
+# descriptors for 1 MiB and 4 MiB. Omitting the block keeps the reservation live.
+header_1m = bytes.fromhex("28b52ffd0050")
+header_4m = bytes.fromhex("28b52ffd0060")
 
 with open(payload_path, "rb") as stream:
-    control = stream.read()
+    control = stream.read().rstrip(b"\n")
 
 
-def raw_1m_frame(payload):
-    # A final raw block keeps the advertised 1 MiB window while producing a
-    # complete, standards-compliant frame without needing a custom compressor.
-    block_header = (1 | (len(payload) << 3)).to_bytes(3, "little")
-    return incomplete_1m_header + block_header + payload
+def raw_tail(payload):
+    # A final raw block completes the frame without a custom compressor.
+    body = payload + b"\n"
+    return (1 | (len(body) << 3)).to_bytes(3, "little") + body
 
 
-first_payload = control.rstrip(b"\n") + b"-first\n"
+def complete_frame(payload):
+    return header_1m + raw_tail(payload)
+
+
+held_one = connect(limited_port)
+held_one.sendall(header_1m)
+held_two = connect(limited_port)
+held_two.sendall(header_1m)
+
+denied = connect(limited_port)
+denied.sendall(header_1m)
+if not wait_for(diagnostic_path, b"zstd decoder window budget exhausted", time.monotonic() + 10):
+    raise SystemExit("listener admitted a third window beyond its 2 MiB budget")
+denied.close()
+
+oversized = connect(limited_port)
+oversized.sendall(header_4m)
+if not wait_for_count(
+        diagnostic_path, b"zstd decoder window budget exhausted", 2, time.monotonic() + 10):
+    raise SystemExit("listener did not reject a frame larger than its entire budget")
+oversized.close()
+
+# Closing one held session must make exactly one 1 MiB slot reusable. Split the
+# replacement header across writes to exercise fragmented-header retention.
+# TCP_NODELAY and the short gap let the server observe the incomplete prefix;
+# retries below tolerate scheduler variation while preserving that oracle.
+held_one.close()
 first_completed = None
 deadline = time.monotonic() + 10
 while time.monotonic() < deadline:
-    candidate = socket.create_connection(("127.0.0.1", port))
+    candidate = connect(limited_port)
     candidate.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-    first_frame = raw_1m_frame(first_payload)
-    candidate.sendall(first_frame[:2])
-    # Give the server a chance to consume the deliberately incomplete header;
-    # message delivery below remains the pass/fail oracle, not this delay.
+    frame = complete_frame(control + b"-close-release")
+    candidate.sendall(frame[:2])
     time.sleep(0.05)
-    candidate.sendall(first_frame[2:])
-    if wait_for(output_path, b"window-budget-control-first", time.monotonic() + 0.2):
+    candidate.sendall(frame[2:])
+    if wait_for(output_path, b"window-budget-control-close-release", time.monotonic() + 0.2):
         first_completed = candidate
         break
     candidate.close()
 if first_completed is None:
-    raise SystemExit("listener did not accept the first complete 1 MiB-window frame")
+    raise SystemExit("closing an incomplete frame did not release its reservation")
 
-# Keep the first TCP connection open. The second full-budget frame can only
-# succeed if completion freed the first decoder context and its reservation.
-second_payload = control.rstrip(b"\n") + b"-second\n"
-with socket.create_connection(("127.0.0.1", port)) as second_completed:
-    second_completed.sendall(raw_1m_frame(second_payload))
-if not wait_for(output_path, b"window-budget-control-second", time.monotonic() + 10):
-    raise SystemExit("completed stream retained its decoder-window reservation")
+# Keep the completed TCP connection open. A new full-budget frame succeeds only
+# if frame completion released the decoder context and reservation.
+with connect(limited_port) as completed_again:
+    completed_again.sendall(complete_frame(control + b"-completion-release"))
+if not wait_for(output_path, b"window-budget-control-completion-release", time.monotonic() + 10):
+    raise SystemExit("completed frame retained its decoder-window reservation")
 first_completed.close()
+
+# Release the remaining held slot, then force a decoder error after reservation.
+# A subsequent valid frame proves that the error path returned the slot.
+held_two.close()
+corrupt = connect(limited_port)
+corrupt.sendall(header_1m + bytes.fromhex("060000"))
+corrupt.close()
+error_release = None
+deadline = time.monotonic() + 10
+while time.monotonic() < deadline:
+    candidate = connect(limited_port)
+    candidate.sendall(complete_frame(control + b"-error-release"))
+    if wait_for(output_path, b"window-budget-control-error-release", time.monotonic() + 0.2):
+        error_release = candidate
+        break
+    candidate.close()
+if error_release is None:
+    raise SystemExit("decode failure did not release its decoder-window reservation")
+error_release.close()
+
+# Explicit zero must leave aggregate accounting disabled. Hold three 1 MiB
+# headers simultaneously, then complete all three and require all messages.
+unlimited = [connect(unlimited_port) for _ in range(3)]
+for connection in unlimited:
+    connection.sendall(header_1m)
+for index, connection in enumerate(unlimited, start=1):
+    connection.sendall(raw_tail(control + f"-unlimited-{index}".encode("ascii")))
+for connection in unlimited:
+    connection.close()
+for index in range(1, 4):
+    needle = f"window-budget-control-unlimited-{index}".encode("ascii")
+    if not wait_for(output_path, needle, time.monotonic() + 10):
+        raise SystemExit("explicit zero imposed an aggregate decoder-window cap")
 PY
 
-wait_file_lines "$RSYSLOG_OUT_LOG" 2
+wait_file_lines "$RSYSLOG_OUT_LOG" 6
 shutdown_when_empty
 wait_shutdown
 
 content_check "zstd decoder window budget exhausted" "$RSYSLOG2_OUT_LOG"
-content_check "window-budget-control-first" "$RSYSLOG_OUT_LOG"
-content_check "window-budget-control-second" "$RSYSLOG_OUT_LOG"
+content_check "window-budget-control-close-release" "$RSYSLOG_OUT_LOG"
+content_check "window-budget-control-completion-release" "$RSYSLOG_OUT_LOG"
+content_check "window-budget-control-error-release" "$RSYSLOG_OUT_LOG"
+content_check "window-budget-control-unlimited-1" "$RSYSLOG_OUT_LOG"
+content_check "window-budget-control-unlimited-2" "$RSYSLOG_OUT_LOG"
+content_check "window-budget-control-unlimited-3" "$RSYSLOG_OUT_LOG"
 
 exit_test

--- a/tests/imtcp-stream-always-zstd-window-guard.sh
+++ b/tests/imtcp-stream-always-zstd-window-guard.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 # added 2026-06-23 by Codex, released under ASL 2.0
 # Sends a minimal zstd frame that advertises a 128 MiB window while the imtcp
-# input allows only a 1 MiB decompressed receive burst. The oracle is that zstd
-# rejects the frame as an invalid compressed stream before any message is
-# submitted, proving the configured receive limit also bounds decoder windows.
+# listener allows only 1 MiB of aggregate retained decoder-window memory. The
+# oracle is that imtcp rejects the reservation before decoder allocation and no
+# message is submitted. The decompressed-output guard is deliberately separate.
 . ${srcdir:=.}/diag.sh init
 require_plugin imtcp
 require_plugin lmzstdw ../runtime
 check_command_available python3
 
 wait_invalid_stream_log() {
-	content_check --check-only "received invalid compressed stream" "$RSYSLOG_OUT_LOG"
+	content_check --check-only "zstd decoder window budget exhausted" "$RSYSLOG_OUT_LOG"
 }
 export QUEUE_EMPTY_CHECK_FUNC=wait_invalid_stream_log
 
@@ -23,7 +23,8 @@ module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
 	compression.mode="stream:always"
 	compression.driver="zstd"
-	compression.maxDecompressedBytesPerReceive="1048576")
+	compression.maxDecompressedBytesPerReceive="1048576"
+	compression.maxTotalZstdWindowBytes="1048576")
 
 if $syslogtag contains "rsyslogd" then {
 	action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
@@ -50,7 +51,7 @@ PY
 shutdown_when_empty
 wait_shutdown
 
-content_check "received invalid compressed stream" "$RSYSLOG_OUT_LOG"
+content_check "zstd decoder window budget exhausted" "$RSYSLOG_OUT_LOG"
 if [ -s "$RSYSLOG2_OUT_LOG" ]; then
 	echo "FAIL: window-guarded zstd stream unexpectedly produced messages"
 	cat "$RSYSLOG2_OUT_LOG"

--- a/tests/yaml-imtcp-stream-always-zstd-secure-defaults.sh
+++ b/tests/yaml-imtcp-stream-always-zstd-secure-defaults.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# added 2026-07-20 by Codex, released under ASL 2.0
+# Provides YAML parity for the aggregate zstd window limit and secure-default
+# policy. Configuration-validation status and diagnostics are the oracle.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+require_plugin lmzstdw ../runtime
+
+modpath="${RSYSLOG_MODDIR}"
+
+run_expect_success() {
+    local cfg="$1"
+    local log="$2"
+    ../tools/rsyslogd -C -N1 -M"${modpath}" -f"${cfg}" >"${log}" 2>&1
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "FAIL: expected ${cfg} to validate"
+        cat "${log}"
+        error_exit 1
+    fi
+}
+
+run_expect_failure() {
+    local cfg="$1"
+    local log="$2"
+    ../tools/rsyslogd -C -N1 -M"${modpath}" -f"${cfg}" >"${log}" 2>&1
+    local rc=$?
+    if [ $rc -eq 0 ]; then
+        echo "FAIL: expected ${cfg} to fail validation"
+        cat "${log}"
+        error_exit 1
+    fi
+}
+
+write_input_config() {
+    local cfg="$1"
+    local policy="$2"
+    local mode="$3"
+    local driver="$4"
+    local limit="$5"
+    cat >"${cfg}" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "${policy}"
+modules:
+  - load: "../plugins/imtcp/.libs/imtcp"
+inputs:
+  - type: imtcp
+    port: "0"
+    ruleset: sink
+    compression.mode: "${mode}"
+    compression.driver: "${driver}"
+${limit}
+rulesets:
+  - name: sink
+    statements:
+      - type: omfile
+        file: "/dev/null"
+YAML_EOF
+}
+
+warning='compression.maxTotalZstdWindowBytes was not explicitly set'
+strict_error='compatibility.defaults.secure="strict" requires an explicit positive compression.maxTotalZstdWindowBytes'
+
+write_input_config "${RSYSLOG_DYNNAME}.yaml-warn-omitted.yaml" warn stream:always zstd ""
+run_expect_success "${RSYSLOG_DYNNAME}.yaml-warn-omitted.yaml" "${RSYSLOG_DYNNAME}.yaml-warn-omitted.log"
+content_check "${warning}" "${RSYSLOG_DYNNAME}.yaml-warn-omitted.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.yaml-backcompat-omitted.yaml" backward-compatible stream:always zstd ""
+run_expect_success "${RSYSLOG_DYNNAME}.yaml-backcompat-omitted.yaml" \
+    "${RSYSLOG_DYNNAME}.yaml-backcompat-omitted.log"
+check_not_present "${warning}" "${RSYSLOG_DYNNAME}.yaml-backcompat-omitted.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.yaml-warn-zero.yaml" warn stream:always zstd \
+    '    compression.maxTotalZstdWindowBytes: "0"'
+run_expect_success "${RSYSLOG_DYNNAME}.yaml-warn-zero.yaml" "${RSYSLOG_DYNNAME}.yaml-warn-zero.log"
+check_not_present "${warning}" "${RSYSLOG_DYNNAME}.yaml-warn-zero.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.yaml-warn-positive.yaml" warn stream:always zstd \
+    '    compression.maxTotalZstdWindowBytes: "2097152"'
+run_expect_success "${RSYSLOG_DYNNAME}.yaml-warn-positive.yaml" "${RSYSLOG_DYNNAME}.yaml-warn-positive.log"
+check_not_present "${warning}" "${RSYSLOG_DYNNAME}.yaml-warn-positive.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.yaml-strict-omitted.yaml" strict stream:always zstd ""
+run_expect_failure "${RSYSLOG_DYNNAME}.yaml-strict-omitted.yaml" "${RSYSLOG_DYNNAME}.yaml-strict-omitted.log"
+content_check "${strict_error}" "${RSYSLOG_DYNNAME}.yaml-strict-omitted.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.yaml-strict-zero.yaml" strict stream:always zstd \
+    '    compression.maxTotalZstdWindowBytes: "0"'
+run_expect_failure "${RSYSLOG_DYNNAME}.yaml-strict-zero.yaml" "${RSYSLOG_DYNNAME}.yaml-strict-zero.log"
+content_check "${strict_error}" "${RSYSLOG_DYNNAME}.yaml-strict-zero.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.yaml-strict-positive.yaml" strict stream:always zstd \
+    '    compression.maxTotalZstdWindowBytes: "2097152"'
+run_expect_success "${RSYSLOG_DYNNAME}.yaml-strict-positive.yaml" "${RSYSLOG_DYNNAME}.yaml-strict-positive.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.yaml-warn-zlib.yaml" warn stream:always zlib ""
+run_expect_success "${RSYSLOG_DYNNAME}.yaml-warn-zlib.yaml" "${RSYSLOG_DYNNAME}.yaml-warn-zlib.log"
+check_not_present "${warning}" "${RSYSLOG_DYNNAME}.yaml-warn-zlib.log"
+
+write_input_config "${RSYSLOG_DYNNAME}.yaml-warn-inactive.yaml" warn none zstd ""
+run_expect_success "${RSYSLOG_DYNNAME}.yaml-warn-inactive.yaml" "${RSYSLOG_DYNNAME}.yaml-warn-inactive.log"
+check_not_present "${warning}" "${RSYSLOG_DYNNAME}.yaml-warn-inactive.log"
+
+cat >"${RSYSLOG_DYNNAME}.yaml-strict-module-inherit.yaml" <<'YAML_EOF'
+version: 2
+global:
+  compatibility.defaults.secure: "strict"
+modules:
+  - load: "../plugins/imtcp/.libs/imtcp"
+    compression.mode: "stream:always"
+    compression.driver: "zstd"
+    compression.maxTotalZstdWindowBytes: "2097152"
+inputs:
+  - type: imtcp
+    port: "0"
+    ruleset: sink
+rulesets:
+  - name: sink
+    statements:
+      - type: omfile
+        file: "/dev/null"
+YAML_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.yaml-strict-module-inherit.yaml" \
+    "${RSYSLOG_DYNNAME}.yaml-strict-module-inherit.log"
+
+exit_test


### PR DESCRIPTION
## Summary

- bound aggregate zstd decoder-window memory per imtcp listener
- parse and retain fragmented zstd frame headers before allocating decoder state
- release decoder contexts and reservations on completion, decode errors, and session teardown
- add regression coverage for budget exhaustion, teardown reuse, completed-frame reuse, and split headers

## Root cause

The existing zstd window limit applied independently to each TCP session. A remote client could therefore keep many valid large-window frames incomplete and multiply retained decoder memory across concurrent sessions.

This change treats the existing nonzero `compression.maxDecompressedBytesPerReceive` value as the listener-wide retained-window budget while preserving zero as the explicit opt-out.

## Validation

- `devtools/local-validation-plan.sh --run`: passed on commit `3b213a2cd`
  - Ubuntu 26.04 change-gated suite: 1,385 total, 1,351 passed, 34 skipped, 0 failed/errors
  - mock `make distcheck`: passed
  - Clang static analyzer: passed, no bugs found
  - formatting and test antipattern checks: passed
- Ubuntu 26.04 TSAN: 1,253 total, 1,207 passed, 46 skipped, 0 failed/errors
- Ubuntu 26.04 imtcp no-epoll: 178 total, 170 passed, 8 skipped, 0 failed/errors
- Clang 21 no-debug and GCC 15 GNU23 debug compile lanes: passed
- focused zstd budget, corruption, window, expansion, truncation, and basic tests: passed
- shellcheck, Bash syntax, diff integrity, and test registration checks: passed
- local Cubic review identified completion-lifetime cleanup, which was fixed; follow-up findings prompted fragmented-header coverage and direct decode-error cleanup

Container image: `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

