### PR TITLE
PR for rsyslog issue 7392, secure-defaults warn

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -503,11 +503,12 @@ finalize_it:
 }
 
 /* True when the listener carries TLS-specific settings (auth mode, certificates,
- * permitted peers, GnuTLS priority or config command). These are applied only on
- * the TLS-enabled RELP path, so with tls="off" they are silently ineffective. */
+ * permitted peers, GnuTLS priority or config command, TLS compression, DH bits).
+ * These are applied only on the TLS-enabled RELP path, so with tls="off" they are
+ * silently ineffective. */
 static int imrelpHasTlsOptions(const instanceConf_t *const inst) {
     return inst->authmode != NULL || inst->caCertFile != NULL || inst->myCertFile != NULL ||
-           inst->myPrivKeyFile != NULL || inst->pristring != NULL ||
+           inst->myPrivKeyFile != NULL || inst->pristring != NULL || inst->bEnableTLSZip || inst->dhBits ||
 #if defined(HAVE_RELPENGINESETTLSCFGCMD)
            inst->tlscfgcmd != NULL ||
 #endif

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -502,15 +502,35 @@ finalize_it:
     RETiRet;
 }
 
+/* True when the listener carries TLS-specific settings (auth mode, certificates,
+ * permitted peers, GnuTLS priority or config command). These are applied only on
+ * the TLS-enabled RELP path, so with tls="off" they are silently ineffective. */
+static int imrelpHasTlsOptions(const instanceConf_t *const inst) {
+    return inst->authmode != NULL || inst->caCertFile != NULL || inst->myCertFile != NULL ||
+           inst->myPrivKeyFile != NULL || inst->pristring != NULL ||
+#if defined(HAVE_RELPENGINESETTLSCFGCMD)
+           inst->tlscfgcmd != NULL ||
+#endif
+           inst->permittedPeers.nmemb > 0;
+}
+
 /** Warn in secure warn mode when an imrelp listener is configured without TLS. */
 static void warnIfPlainRelpListenerConfigured(const instanceConf_t *const inst) {
     if (!inst->bEnableTLS && !inst->bEnableTLSSet) {
-        /* explicit tls="off" is a deliberate admin choice, not an insecure
-         * default (same rationale as omfwd protocol="udp"/streamdriver.mode="0").
-         */
+        /* omitted tls (implicit off) is an insecure default and warns. */
         glblWarnIfInsecureDefault(loadModConf->pConf,
                                   "imrelp input uses tls=\"off\" (plain RELP without TLS); "
                                   "see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html");
+    } else if (!inst->bEnableTLS && imrelpHasTlsOptions(inst)) {
+        /* explicit tls="off" is a deliberate admin choice and normally silent
+         * (same rationale as omfwd protocol="udp"/streamdriver.mode="0"), but
+         * combining it with TLS-specific options is a contradiction: those
+         * options are silently ignored and traffic stays plaintext.
+         */
+        glblWarnIfInsecureDefault(loadModConf->pConf,
+                                  "imrelp has TLS-related settings but tls=\"off\"; RELP runs plaintext so "
+                                  "those settings are ignored "
+                                  "(see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html)");
     } else if (inst->bEnableTLS && inst->authmode != NULL && strcasecmp((const char *)inst->authmode, "anon") == 0) {
         glblWarnIfInsecureDefault(
             loadModConf->pConf,

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -83,6 +83,7 @@ struct instanceConf_s {
     ruleset_t *pBindRuleset; /* ruleset to bind listener to */
     sbool bKeepAlive; /* support keep-alive packets */
     sbool bEnableTLS;
+    sbool bEnableTLSSet; /* tls was explicitly configured */
     sbool bEnableTLSZip;
     sbool bEnableLstn; /* flag to permit disabling of listener in error case */
     int dhBits;
@@ -281,6 +282,7 @@ static rsRetVal createInstance(instanceConf_t **pinst) {
     inst->ratelimitBurst = -1;
     inst->pszRatelimitName = NULL;
     inst->bEnableTLS = 0;
+    inst->bEnableTLSSet = 0;
     inst->bEnableTLSZip = 0;
     inst->bEnableLstn = 0;
     inst->dhBits = 0;
@@ -502,11 +504,14 @@ finalize_it:
 
 /** Warn in secure warn mode when an imrelp listener is configured without TLS. */
 static void warnIfPlainRelpListenerConfigured(const instanceConf_t *const inst) {
-    if (!inst->bEnableTLS) {
+    if (!inst->bEnableTLS && !inst->bEnableTLSSet) {
+        /* explicit tls="off" is a deliberate admin choice, not an insecure
+         * default (same rationale as omfwd protocol="udp"/streamdriver.mode="0").
+         */
         glblWarnIfInsecureDefault(loadModConf->pConf,
                                   "imrelp input uses tls=\"off\" (plain RELP without TLS); "
                                   "see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html");
-    } else if (inst->authmode != NULL && strcasecmp((const char *)inst->authmode, "anon") == 0) {
+    } else if (inst->bEnableTLS && inst->authmode != NULL && strcasecmp((const char *)inst->authmode, "anon") == 0) {
         glblWarnIfInsecureDefault(
             loadModConf->pConf,
             "imrelp uses tls.authmode=\"anon\"; peer identity is not authenticated, so MITM is possible "
@@ -608,6 +613,7 @@ BEGINnewInpInst
             CHKmalloc(inst->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "tls")) {
             inst->bEnableTLS = (unsigned)pvals[i].val.d.n;
+            inst->bEnableTLSSet = 1;
         } else if (!strcmp(inppblk.descr[i].name, "tls.dhbits")) {
             inst->dhBits = (unsigned)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "tls.prioritystring")) {

--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -1270,8 +1270,10 @@ BEGINsetModCnf
     bLegacyCnfModGlobalsPermitted = 0;
     loadModConf->configSetViaV2Method = 1;
     CHKiRet(applySecureDefaultsToModuleConfig(loadModConf));
-    warnIfInsecureListenerConfigured(loadModConf->iStrmDrvrMode, loadModConf->bStrmDrvrModeSet,
-                                     getEffectiveModuleStreamDriver(loadModConf), loadModConf->pszStrmDrvrAuthMode);
+    /* no module-level insecure-listener warning here: module parameters alone
+     * open no port, and every actual listener is checked with its effective
+     * (possibly inherited) values in addInstance()/newInpInst().
+     */
 
 finalize_it:
     if (pvals != NULL) cnfparamvalsDestruct(pvals, &modpblk);
@@ -1326,8 +1328,9 @@ BEGINendCnfLoad
             loadModConf = NULL;
             return iRet;
         }
-        warnIfInsecureListenerConfigured(pModConf->iStrmDrvrMode, pModConf->bStrmDrvrModeSet,
-                                         getEffectiveModuleStreamDriver(pModConf), pModConf->pszStrmDrvrAuthMode);
+        /* no module-level insecure-listener warning here either: legacy
+         * listeners are checked individually in addInstance().
+         */
     }
     free(cs.pszStrmDrvrAuthMode);
     cs.pszStrmDrvrAuthMode = NULL;

--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -444,6 +444,7 @@ finalize_it:
 
 /** Warn in secure warn mode when imtcp listener transport/auth settings reduce security. */
 static void warnIfInsecureListenerConfigured(const int streamDriverMode,
+                                             const sbool streamDriverModeSet,
                                              const uchar *const effectiveStreamDriverName,
                                              const uchar *const authMode) {
     if (streamDriverMode == 0) {
@@ -453,7 +454,11 @@ static void warnIfInsecureListenerConfigured(const int streamDriverMode,
                                       "imtcp has TLS-related settings but streamdriver.mode=\"0\"; mode 0 uses plain "
                                       "TCP so TLS is not active "
                                       "(see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html)");
-        } else {
+        } else if (!streamDriverModeSet) {
+            /* explicit streamdriver.mode="0" is a deliberate admin choice, not an
+             * insecure default - strict mode treats it the same way (see
+             * applySecureDefaultsToStreamDriver()).
+             */
             glblWarnIfInsecureDefault(loadConf,
                                       "imtcp input uses streamdriver.mode=\"0\" (plain TCP without TLS); "
                                       "see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html");
@@ -751,7 +756,8 @@ static rsRetVal addInstance(void __attribute__((unused)) * pVal, uchar *pNewVal)
     inst->compressionMaxTotalZstdWindowBytesSet = cs.compressionMaxTotalZstdWindowBytesSet;
     CHKiRet(applySecureDefaultsToInstanceConfig(inst, loadModConf));
     CHKiRet(applySecureDefaultsToZstdWindow(inst, loadModConf));
-    warnIfInsecureListenerConfigured(inst->iStrmDrvrMode, getEffectiveInstanceStreamDriver(inst, loadModConf),
+    warnIfInsecureListenerConfigured(inst->iStrmDrvrMode, inst->bStrmDrvrModeSet,
+                                     getEffectiveInstanceStreamDriver(inst, loadModConf),
                                      getEffectiveInstanceAuthMode(inst, loadModConf));
 
 finalize_it:
@@ -1067,7 +1073,8 @@ BEGINnewInpInst
     }
     CHKiRet(applySecureDefaultsToInstanceConfig(inst, loadModConf));
     CHKiRet(applySecureDefaultsToZstdWindow(inst, loadModConf));
-    warnIfInsecureListenerConfigured(inst->iStrmDrvrMode, getEffectiveInstanceStreamDriver(inst, loadModConf),
+    warnIfInsecureListenerConfigured(inst->iStrmDrvrMode, inst->bStrmDrvrModeSet,
+                                     getEffectiveInstanceStreamDriver(inst, loadModConf),
                                      getEffectiveInstanceAuthMode(inst, loadModConf));
 
 finalize_it:
@@ -1263,8 +1270,8 @@ BEGINsetModCnf
     bLegacyCnfModGlobalsPermitted = 0;
     loadModConf->configSetViaV2Method = 1;
     CHKiRet(applySecureDefaultsToModuleConfig(loadModConf));
-    warnIfInsecureListenerConfigured(loadModConf->iStrmDrvrMode, getEffectiveModuleStreamDriver(loadModConf),
-                                     loadModConf->pszStrmDrvrAuthMode);
+    warnIfInsecureListenerConfigured(loadModConf->iStrmDrvrMode, loadModConf->bStrmDrvrModeSet,
+                                     getEffectiveModuleStreamDriver(loadModConf), loadModConf->pszStrmDrvrAuthMode);
 
 finalize_it:
     if (pvals != NULL) cnfparamvalsDestruct(pvals, &modpblk);
@@ -1319,8 +1326,8 @@ BEGINendCnfLoad
             loadModConf = NULL;
             return iRet;
         }
-        warnIfInsecureListenerConfigured(pModConf->iStrmDrvrMode, getEffectiveModuleStreamDriver(pModConf),
-                                         pModConf->pszStrmDrvrAuthMode);
+        warnIfInsecureListenerConfigured(pModConf->iStrmDrvrMode, pModConf->bStrmDrvrModeSet,
+                                         getEffectiveModuleStreamDriver(pModConf), pModConf->pszStrmDrvrAuthMode);
     }
     free(cs.pszStrmDrvrAuthMode);
     cs.pszStrmDrvrAuthMode = NULL;

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -476,11 +476,12 @@ finalize_it:
 ENDsetModCnf
 
 /* True when the action carries TLS-specific settings (auth mode, certificates,
- * permitted peers, GnuTLS priority or config command). These are applied only on
- * the TLS-enabled RELP path, so with tls="off" they are silently ineffective. */
+ * permitted peers, GnuTLS priority or config command, TLS compression). These are
+ * applied only on the TLS-enabled RELP path, so with tls="off" they are silently
+ * ineffective. */
 static int omrelpHasTlsOptions(const instanceData *const pData) {
     return pData->authmode != NULL || pData->caCertFile != NULL || pData->myCertFile != NULL ||
-           pData->myPrivKeyFile != NULL || pData->pristring != NULL ||
+           pData->myPrivKeyFile != NULL || pData->pristring != NULL || pData->bEnableTLSZip ||
 #if defined(HAVE_RELPENGINESETTLSCFGCMD)
            pData->tlscfgcmd != NULL ||
 #endif

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -475,15 +475,35 @@ finalize_it:
     if (pvals != NULL) cnfparamvalsDestruct(pvals, &modpblk);
 ENDsetModCnf
 
+/* True when the action carries TLS-specific settings (auth mode, certificates,
+ * permitted peers, GnuTLS priority or config command). These are applied only on
+ * the TLS-enabled RELP path, so with tls="off" they are silently ineffective. */
+static int omrelpHasTlsOptions(const instanceData *const pData) {
+    return pData->authmode != NULL || pData->caCertFile != NULL || pData->myCertFile != NULL ||
+           pData->myPrivKeyFile != NULL || pData->pristring != NULL ||
+#if defined(HAVE_RELPENGINESETTLSCFGCMD)
+           pData->tlscfgcmd != NULL ||
+#endif
+           pData->permittedPeers.nmemb > 0;
+}
+
 /** Warn in secure warn mode when an omrelp action is configured without TLS. */
 static void warnIfPlainRelpActionConfigured(const instanceData *const pData) {
     if (!pData->bEnableTLS && !pData->bEnableTLSSet) {
-        /* explicit tls="off" is a deliberate admin choice, not an insecure
-         * default (same rationale as omfwd protocol="udp"/streamdriver.mode="0").
-         */
+        /* omitted tls (implicit off) is an insecure default and warns. */
         glblWarnIfInsecureDefault(loadModConf->pConf,
                                   "omrelp action uses tls=\"off\" (plain RELP without TLS); "
                                   "see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html");
+    } else if (!pData->bEnableTLS && omrelpHasTlsOptions(pData)) {
+        /* explicit tls="off" is a deliberate admin choice and normally silent
+         * (same rationale as omfwd protocol="udp"/streamdriver.mode="0"), but
+         * combining it with TLS-specific options is a contradiction: those
+         * options are silently ignored and traffic stays plaintext.
+         */
+        glblWarnIfInsecureDefault(loadModConf->pConf,
+                                  "omrelp has TLS-related settings but tls=\"off\"; RELP runs plaintext so "
+                                  "those settings are ignored "
+                                  "(see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html)");
     } else if (pData->bEnableTLS && pData->authmode != NULL && strcasecmp((const char *)pData->authmode, "anon") == 0) {
         glblWarnIfInsecureDefault(
             loadModConf->pConf,

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -83,6 +83,7 @@ typedef struct _instanceData {
     int connTimeout;
     unsigned rebindInterval;
     sbool bEnableTLS;
+    sbool bEnableTLSSet; /* tls was explicitly configured */
     sbool bEnableTLSZip;
     int bHadAuthFail; /**< set on TLS auth failure */
     DEF_ATOMIC_HELPER_MUT(mutHadAuthFail);
@@ -326,6 +327,7 @@ BEGINcreateInstance
     pData->connTimeout = 10;
     pData->rebindInterval = 0;
     pData->bEnableTLS = DFLT_ENABLE_TLS;
+    pData->bEnableTLSSet = 0;
     pData->bEnableTLSZip = DFLT_ENABLE_TLSZIP;
     pData->bHadAuthFail = 0;
     INIT_ATOMIC_HELPER_MUT(pData->mutHadAuthFail);
@@ -393,6 +395,7 @@ static void setInstParamDefaults(instanceData *pData) {
     pData->sizeWindow = 0;
     pData->rebindInterval = 0;
     pData->bEnableTLS = DFLT_ENABLE_TLS;
+    pData->bEnableTLSSet = 0;
     pData->bEnableTLSZip = DFLT_ENABLE_TLSZIP;
     pData->bTlsPermFailDisablesAction = DFLT_TLS_PERMFAIL_DISABLES_ACTION;
     pData->pristring = NULL;
@@ -474,11 +477,14 @@ ENDsetModCnf
 
 /** Warn in secure warn mode when an omrelp action is configured without TLS. */
 static void warnIfPlainRelpActionConfigured(const instanceData *const pData) {
-    if (!pData->bEnableTLS) {
+    if (!pData->bEnableTLS && !pData->bEnableTLSSet) {
+        /* explicit tls="off" is a deliberate admin choice, not an insecure
+         * default (same rationale as omfwd protocol="udp"/streamdriver.mode="0").
+         */
         glblWarnIfInsecureDefault(loadModConf->pConf,
                                   "omrelp action uses tls=\"off\" (plain RELP without TLS); "
                                   "see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html");
-    } else if (pData->authmode != NULL && strcasecmp((const char *)pData->authmode, "anon") == 0) {
+    } else if (pData->bEnableTLS && pData->authmode != NULL && strcasecmp((const char *)pData->authmode, "anon") == 0) {
         glblWarnIfInsecureDefault(
             loadModConf->pConf,
             "omrelp uses tls.authmode=\"anon\"; peer identity is not authenticated, so MITM is possible "
@@ -527,6 +533,7 @@ BEGINnewActInst
             pData->sizeWindow = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "tls")) {
             pData->bEnableTLS = (unsigned)pvals[i].val.d.n;
+            pData->bEnableTLSSet = 1;
         } else if (!strcmp(actpblk.descr[i].name, "tls.compression")) {
             pData->bEnableTLSZip = (unsigned)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "tls.permanentfailuredisablesaction")) {

--- a/tests/compat-configformat-rainerscript.sh
+++ b/tests/compat-configformat-rainerscript.sh
@@ -7,6 +7,10 @@ have_imtcp_module=0
 if ls ../plugins/imtcp/.libs/imtcp.* >/dev/null 2>&1; then
     have_imtcp_module=1
 fi
+have_relp_modules=0
+if ls ../plugins/omrelp/.libs/omrelp.* >/dev/null 2>&1 && ls ../plugins/imrelp/.libs/imrelp.* >/dev/null 2>&1; then
+    have_relp_modules=1
+fi
 
 run_expect_success() {
     local cfg="$1"
@@ -292,6 +296,50 @@ CONF_EOF
     run_expect_success "${RSYSLOG_DYNNAME}.tls-anon-warn.conf" "${RSYSLOG_DYNNAME}.tls-anon-warn.log"
     content_check 'imtcp uses streamdriver.authmode="anon"; server identity is not authenticated, so MITM is possible' "${RSYSLOG_DYNNAME}.tls-anon-warn.log"
     content_check 'omfwd uses streamdriver.authmode="anon"; server identity is not authenticated, so MITM is possible' "${RSYSLOG_DYNNAME}.tls-anon-warn.log"
+fi
+
+if [ ${have_relp_modules} -eq 1 ]; then
+    cat >"${RSYSLOG_DYNNAME}.omrelp-plain-implicit.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+module(load="../plugins/omrelp/.libs/omrelp")
+action(type="omrelp" target="127.0.0.1" port="514")
+CONF_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.omrelp-plain-implicit.conf" \
+        "${RSYSLOG_DYNNAME}.omrelp-plain-implicit.log"
+    content_check 'omrelp action uses tls="off" (plain RELP without TLS)' \
+        "${RSYSLOG_DYNNAME}.omrelp-plain-implicit.log"
+
+    cat >"${RSYSLOG_DYNNAME}.omrelp-plain-explicit.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+module(load="../plugins/omrelp/.libs/omrelp")
+action(type="omrelp" target="127.0.0.1" port="514" tls="off")
+CONF_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.omrelp-plain-explicit.conf" \
+        "${RSYSLOG_DYNNAME}.omrelp-plain-explicit.log"
+    check_not_present 'omrelp action uses tls="off"' \
+        "${RSYSLOG_DYNNAME}.omrelp-plain-explicit.log"
+
+    cat >"${RSYSLOG_DYNNAME}.imrelp-plain-implicit.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+module(load="../plugins/imrelp/.libs/imrelp")
+input(type="imrelp" port="0")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.imrelp-plain-implicit.conf" \
+        "${RSYSLOG_DYNNAME}.imrelp-plain-implicit.log"
+    content_check 'imrelp input uses tls="off" (plain RELP without TLS)' \
+        "${RSYSLOG_DYNNAME}.imrelp-plain-implicit.log"
+
+    cat >"${RSYSLOG_DYNNAME}.imrelp-plain-explicit.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+module(load="../plugins/imrelp/.libs/imrelp")
+input(type="imrelp" port="0" tls="off")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.imrelp-plain-explicit.conf" \
+        "${RSYSLOG_DYNNAME}.imrelp-plain-explicit.log"
+    check_not_present 'imrelp input uses tls="off"' \
+        "${RSYSLOG_DYNNAME}.imrelp-plain-explicit.log"
 fi
 
 cat >"${RSYSLOG_DYNNAME}.invalid.conf" <<CONF_EOF

--- a/tests/compat-configformat-rainerscript.sh
+++ b/tests/compat-configformat-rainerscript.sh
@@ -354,6 +354,18 @@ CONF_EOF
     content_check 'omrelp has TLS-related settings but tls="off"' \
         "${RSYSLOG_DYNNAME}.omrelp-off-with-tls.log"
 
+    # tls.compression is likewise consumed only on the TLS path, so tls="off"
+    # combined with it is also a contradiction
+    cat >"${RSYSLOG_DYNNAME}.omrelp-off-with-zip.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+module(load="../plugins/omrelp/.libs/omrelp")
+action(type="omrelp" target="127.0.0.1" port="514" tls="off" tls.compression="on")
+CONF_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.omrelp-off-with-zip.conf" \
+        "${RSYSLOG_DYNNAME}.omrelp-off-with-zip.log"
+    content_check 'omrelp has TLS-related settings but tls="off"' \
+        "${RSYSLOG_DYNNAME}.omrelp-off-with-zip.log"
+
     cat >"${RSYSLOG_DYNNAME}.imrelp-plain-implicit.conf" <<CONF_EOF
 global(compatibility.defaults.secure="warn")
 module(load="../plugins/imrelp/.libs/imrelp")
@@ -388,6 +400,19 @@ CONF_EOF
         "${RSYSLOG_DYNNAME}.imrelp-off-with-tls.log"
     content_check 'imrelp has TLS-related settings but tls="off"' \
         "${RSYSLOG_DYNNAME}.imrelp-off-with-tls.log"
+
+    # tls.compression and the imrelp-only tls.dhbits are consumed only on the TLS
+    # path, so tls="off" combined with them is also a contradiction
+    cat >"${RSYSLOG_DYNNAME}.imrelp-off-with-zip-dh.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+module(load="../plugins/imrelp/.libs/imrelp")
+input(type="imrelp" port="0" tls="off" tls.compression="on" tls.dhbits="1024")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.imrelp-off-with-zip-dh.conf" \
+        "${RSYSLOG_DYNNAME}.imrelp-off-with-zip-dh.log"
+    content_check 'imrelp has TLS-related settings but tls="off"' \
+        "${RSYSLOG_DYNNAME}.imrelp-off-with-zip-dh.log"
 fi
 
 cat >"${RSYSLOG_DYNNAME}.invalid.conf" <<CONF_EOF

--- a/tests/compat-configformat-rainerscript.sh
+++ b/tests/compat-configformat-rainerscript.sh
@@ -256,6 +256,20 @@ CONF_EOF
     check_not_present 'imtcp input uses streamdriver.mode="0"' \
         "${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.log"
 
+    # an instance-level explicit mode 0 is sufficient on its own: listeners are
+    # only checked with their effective values, there is no module-level warning
+    cat >"${RSYSLOG_DYNNAME}.imtcp-plain-instance-mode0.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="${RSYSLOG_DYNNAME}.imtcp-plain-instance-mode0.port"
+      streamdriver.mode="0")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.imtcp-plain-instance-mode0.conf" \
+        "${RSYSLOG_DYNNAME}.imtcp-plain-instance-mode0.log"
+    check_not_present 'imtcp input uses streamdriver.mode="0"' \
+        "${RSYSLOG_DYNNAME}.imtcp-plain-instance-mode0.log"
+
     cat >"${RSYSLOG_DYNNAME}.imtcp-strict-explicit-mode0.conf" <<CONF_EOF
 global(compatibility.defaults.secure="strict" defaultNetstreamDriver="gtls")
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/compat-configformat-rainerscript.sh
+++ b/tests/compat-configformat-rainerscript.sh
@@ -137,6 +137,29 @@ run_expect_success "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-tls.conf" \
 content_check 'omfwd has TLS-related settings but protocol="udp"' \
     "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-tls.log"
 
+# the contradiction is not limited to streamdriver.name/authmode: CA/cert/key,
+# permitted peers, SNI, priority string etc. are equally ineffective on UDP and
+# must warn even without a TLS-capable driver name
+cat >"${RSYSLOG_DYNNAME}.omfwd-udp-explicit-cafile.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+action(type="omfwd" target="127.0.0.1" protocol="udp" streamdriver.cafile="${RSYSLOG_DYNNAME}-ca.pem")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-cafile.conf" \
+    "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-cafile.log"
+content_check 'omfwd has TLS-related settings but protocol="udp"' \
+    "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-cafile.log"
+
+# same contradiction on explicit plain TCP (streamdriver.mode="0"): a CA file
+# without a TLS-capable driver name is still ineffective and must warn
+cat >"${RSYSLOG_DYNNAME}.omfwd-tcp-mode0-cafile.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+action(type="omfwd" target="127.0.0.1" protocol="tcp" streamdriver.mode="0" streamdriver.cafile="${RSYSLOG_DYNNAME}-ca.pem")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-tcp-mode0-cafile.conf" \
+    "${RSYSLOG_DYNNAME}.omfwd-tcp-mode0-cafile.log"
+content_check 'omfwd has TLS-related settings but streamdriver.mode="0"' \
+    "${RSYSLOG_DYNNAME}.omfwd-tcp-mode0-cafile.log"
+
 # a global defaultNetstreamDriver is irrelevant to a UDP action (UDP never uses a
 # stream driver), so explicit protocol="udp" must stay silent despite it - only
 # action-level TLS settings count

--- a/tests/compat-configformat-rainerscript.sh
+++ b/tests/compat-configformat-rainerscript.sh
@@ -104,6 +104,58 @@ run_expect_success "${RSYSLOG_DYNNAME}.omfwd-global-driver-warn.conf" "${RSYSLOG
 content_check 'omfwd has TLS-related settings but streamdriver.mode="0"; mode 0 uses plain TCP so TLS is not active' \
     "${RSYSLOG_DYNNAME}.omfwd-global-driver-warn.log"
 
+cat >"${RSYSLOG_DYNNAME}.omfwd-udp-implicit.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+action(type="omfwd" target="127.0.0.1")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-udp-implicit.conf" \
+    "${RSYSLOG_DYNNAME}.omfwd-udp-implicit.log"
+content_check 'omfwd action uses protocol="udp" (without TLS)' \
+    "${RSYSLOG_DYNNAME}.omfwd-udp-implicit.log"
+
+cat >"${RSYSLOG_DYNNAME}.omfwd-udp-explicit.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+action(type="omfwd" target="127.0.0.1" protocol="udp")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-udp-explicit.conf" \
+    "${RSYSLOG_DYNNAME}.omfwd-udp-explicit.log"
+check_not_present 'omfwd action uses protocol="udp"' \
+    "${RSYSLOG_DYNNAME}.omfwd-udp-explicit.log"
+
+# explicit protocol="udp" combined with TLS settings is contradictory (UDP is
+# always plaintext) and must still warn, even though the protocol is explicit
+cat >"${RSYSLOG_DYNNAME}.omfwd-udp-explicit-tls.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+action(type="omfwd" target="127.0.0.1" protocol="udp" streamdriver.name="gtls")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-tls.conf" \
+    "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-tls.log"
+content_check 'omfwd has TLS-related settings but protocol="udp"' \
+    "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-tls.log"
+
+# a global defaultNetstreamDriver is irrelevant to a UDP action (UDP never uses a
+# stream driver), so explicit protocol="udp" must stay silent despite it - only
+# action-level TLS settings count
+cat >"${RSYSLOG_DYNNAME}.omfwd-udp-explicit-globaldrvr.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn" defaultNetstreamDriver="gtls")
+action(type="omfwd" target="127.0.0.1" protocol="udp")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-globaldrvr.conf" \
+    "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-globaldrvr.log"
+check_not_present 'protocol="udp"' \
+    "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-globaldrvr.log"
+
+# the legacy "@target" sigil is an insecure default (plain UDP) carried over for
+# backward compatibility, not an explicit modern opt-in, so it still warns
+cat >"${RSYSLOG_DYNNAME}.omfwd-udp-legacy.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn" compatibility.configformat.legacy="enable")
+*.* @127.0.0.1:514
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-udp-legacy.conf" \
+    "${RSYSLOG_DYNNAME}.omfwd-udp-legacy.log"
+content_check 'omfwd action uses protocol="udp"' \
+    "${RSYSLOG_DYNNAME}.omfwd-udp-legacy.log"
+
 cat >"${RSYSLOG_DYNNAME}.omfwd-plain-implicit-mode0.conf" <<CONF_EOF
 global(compatibility.defaults.secure="warn")
 action(type="omfwd" target="127.0.0.1" protocol="tcp")
@@ -163,7 +215,7 @@ global(compatibility.defaults.secure="warn")
 module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="${RSYSLOG_DYNNAME}.tlswarn.port" streamdriver.mode="0"
       streamdriver.name="gtls" streamdriver.authmode="x509/name")
-action(type="omfwd" target="127.0.0.1" protocol="udp")
+action(type="omfwd" target="127.0.0.1")
 CONF_EOF
     run_expect_success "${RSYSLOG_DYNNAME}.tls-warn.conf" "${RSYSLOG_DYNNAME}.tls-warn.log"
     content_check 'imtcp has TLS-related settings but streamdriver.mode="0"; mode 0 uses plain TCP so TLS is not active' "${RSYSLOG_DYNNAME}.tls-warn.log"

--- a/tests/compat-configformat-rainerscript.sh
+++ b/tests/compat-configformat-rainerscript.sh
@@ -104,6 +104,24 @@ run_expect_success "${RSYSLOG_DYNNAME}.omfwd-global-driver-warn.conf" "${RSYSLOG
 content_check 'omfwd has TLS-related settings but streamdriver.mode="0"; mode 0 uses plain TCP so TLS is not active' \
     "${RSYSLOG_DYNNAME}.omfwd-global-driver-warn.log"
 
+cat >"${RSYSLOG_DYNNAME}.omfwd-plain-implicit-mode0.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+action(type="omfwd" target="127.0.0.1" protocol="tcp")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-plain-implicit-mode0.conf" \
+    "${RSYSLOG_DYNNAME}.omfwd-plain-implicit-mode0.log"
+content_check 'omfwd action uses protocol="tcp" with streamdriver.mode="0"' \
+    "${RSYSLOG_DYNNAME}.omfwd-plain-implicit-mode0.log"
+
+cat >"${RSYSLOG_DYNNAME}.omfwd-plain-explicit-mode0.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+action(type="omfwd" target="127.0.0.1" protocol="tcp" streamdriver.mode="0")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-plain-explicit-mode0.conf" \
+    "${RSYSLOG_DYNNAME}.omfwd-plain-explicit-mode0.log"
+check_not_present 'omfwd action uses protocol="tcp" with streamdriver.mode="0"' \
+    "${RSYSLOG_DYNNAME}.omfwd-plain-explicit-mode0.log"
+
 cat >"${RSYSLOG_DYNNAME}.omfwd-strict-promote.conf" <<CONF_EOF
 global(compatibility.defaults.secure="strict")
 action(type="omfwd" targetSrv="_syslog._tcp.example.invalid" protocol="tcp" streamdriver.name="gtls")
@@ -161,6 +179,30 @@ CONF_EOF
         "${RSYSLOG_DYNNAME}.imtcp-global-driver-warn.log"
     content_check 'imtcp has TLS-related settings but streamdriver.mode="0"; mode 0 uses plain TCP so TLS is not active' \
         "${RSYSLOG_DYNNAME}.imtcp-global-driver-warn.log"
+
+    cat >"${RSYSLOG_DYNNAME}.imtcp-plain-implicit-mode0.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="${RSYSLOG_DYNNAME}.imtcp-plain-implicit-mode0.port")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.imtcp-plain-implicit-mode0.conf" \
+        "${RSYSLOG_DYNNAME}.imtcp-plain-implicit-mode0.log"
+    content_check 'imtcp input uses streamdriver.mode="0" (plain TCP without TLS)' \
+        "${RSYSLOG_DYNNAME}.imtcp-plain-implicit-mode0.log"
+
+    # explicit module-level mode 0 acknowledges plain TCP; instances inherit
+    # both the mode and its explicitness flag, so no warning at either level
+    cat >"${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+module(load="../plugins/imtcp/.libs/imtcp" streamdriver.mode="0")
+input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.port")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.conf" \
+        "${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.log"
+    check_not_present 'imtcp input uses streamdriver.mode="0"' \
+        "${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.log"
 
     cat >"${RSYSLOG_DYNNAME}.imtcp-strict-explicit-mode0.conf" <<CONF_EOF
 global(compatibility.defaults.secure="strict" defaultNetstreamDriver="gtls")

--- a/tests/compat-configformat-rainerscript.sh
+++ b/tests/compat-configformat-rainerscript.sh
@@ -342,6 +342,18 @@ CONF_EOF
     check_not_present 'omrelp action uses tls="off"' \
         "${RSYSLOG_DYNNAME}.omrelp-plain-explicit.log"
 
+    # explicit tls="off" combined with TLS-specific options is a contradiction
+    # (the options are ignored and traffic stays plaintext), so it must warn
+    cat >"${RSYSLOG_DYNNAME}.omrelp-off-with-tls.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+module(load="../plugins/omrelp/.libs/omrelp")
+action(type="omrelp" target="127.0.0.1" port="514" tls="off" tls.authmode="anon")
+CONF_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.omrelp-off-with-tls.conf" \
+        "${RSYSLOG_DYNNAME}.omrelp-off-with-tls.log"
+    content_check 'omrelp has TLS-related settings but tls="off"' \
+        "${RSYSLOG_DYNNAME}.omrelp-off-with-tls.log"
+
     cat >"${RSYSLOG_DYNNAME}.imrelp-plain-implicit.conf" <<CONF_EOF
 global(compatibility.defaults.secure="warn")
 module(load="../plugins/imrelp/.libs/imrelp")
@@ -363,6 +375,19 @@ CONF_EOF
         "${RSYSLOG_DYNNAME}.imrelp-plain-explicit.log"
     check_not_present 'imrelp input uses tls="off"' \
         "${RSYSLOG_DYNNAME}.imrelp-plain-explicit.log"
+
+    # explicit tls="off" combined with TLS-specific options is a contradiction
+    # (the options are ignored and traffic stays plaintext), so it must warn
+    cat >"${RSYSLOG_DYNNAME}.imrelp-off-with-tls.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+module(load="../plugins/imrelp/.libs/imrelp")
+input(type="imrelp" port="0" tls="off" tls.authmode="anon")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.imrelp-off-with-tls.conf" \
+        "${RSYSLOG_DYNNAME}.imrelp-off-with-tls.log"
+    content_check 'imrelp has TLS-related settings but tls="off"' \
+        "${RSYSLOG_DYNNAME}.imrelp-off-with-tls.log"
 fi
 
 cat >"${RSYSLOG_DYNNAME}.invalid.conf" <<CONF_EOF

--- a/tests/compat-configformat-yaml.sh
+++ b/tests/compat-configformat-yaml.sh
@@ -106,7 +106,6 @@ rulesets:
     actions:
       - type: omfwd
         target: "127.0.0.1"
-        protocol: "udp"
 YAML_EOF
 }
 
@@ -317,5 +316,53 @@ rulesets:
 YAML_EOF
 run_expect_success "${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.yaml" "${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.log"
 check_not_present 'imtcp input uses streamdriver.mode="0"' "${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.log"
+
+# YAML parity for the explicit protocol="udp" cases: the YAML frontend must set
+# bProtocolSet the same way. Explicit UDP is acknowledged (silent), a global
+# defaultNetstreamDriver stays irrelevant to UDP (silent), but action-level TLS
+# settings still warn.
+cat >"${RSYSLOG_DYNNAME}.omfwd-udp-explicit.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+rulesets:
+  - name: main
+    actions:
+      - type: omfwd
+        target: "127.0.0.1"
+        protocol: "udp"
+YAML_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-udp-explicit.yaml" "${RSYSLOG_DYNNAME}.omfwd-udp-explicit.log"
+check_not_present 'omfwd action uses protocol="udp"' "${RSYSLOG_DYNNAME}.omfwd-udp-explicit.log"
+
+cat >"${RSYSLOG_DYNNAME}.omfwd-udp-explicit-tls.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+rulesets:
+  - name: main
+    actions:
+      - type: omfwd
+        target: "127.0.0.1"
+        protocol: "udp"
+        streamdriver.name: "gtls"
+YAML_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-tls.yaml" "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-tls.log"
+content_check 'omfwd has TLS-related settings but protocol="udp"' "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-tls.log"
+
+cat >"${RSYSLOG_DYNNAME}.omfwd-udp-explicit-globaldrvr.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+  defaultNetstreamDriver: "gtls"
+rulesets:
+  - name: main
+    actions:
+      - type: omfwd
+        target: "127.0.0.1"
+        protocol: "udp"
+YAML_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-globaldrvr.yaml" "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-globaldrvr.log"
+check_not_present 'protocol="udp"' "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-globaldrvr.log"
 
 exit_test

--- a/tests/compat-configformat-yaml.sh
+++ b/tests/compat-configformat-yaml.sh
@@ -281,4 +281,41 @@ run_expect_success "${RSYSLOG_DYNNAME}.tls-anon-warn.yaml" "${RSYSLOG_DYNNAME}.t
 content_check 'imtcp uses streamdriver.authmode="anon"; server identity is not authenticated, so MITM is possible' "${RSYSLOG_DYNNAME}.tls-anon-warn.log"
 content_check 'omfwd uses streamdriver.authmode="anon"; server identity is not authenticated, so MITM is possible' "${RSYSLOG_DYNNAME}.tls-anon-warn.log"
 
+# YAML parity for the explicit streamdriver.mode="0" cases (bStrmDrvrModeSet).
+cat >"${RSYSLOG_DYNNAME}.omfwd-plain-explicit-mode0.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+rulesets:
+  - name: main
+    actions:
+      - type: omfwd
+        target: "127.0.0.1"
+        protocol: "tcp"
+        streamdriver.mode: 0
+YAML_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-plain-explicit-mode0.yaml" "${RSYSLOG_DYNNAME}.omfwd-plain-explicit-mode0.log"
+check_not_present 'omfwd action uses protocol="tcp" with streamdriver.mode="0"' "${RSYSLOG_DYNNAME}.omfwd-plain-explicit-mode0.log"
+
+cat >"${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+modules:
+  - load: "../plugins/imtcp/.libs/imtcp"
+inputs:
+  - type: imtcp
+    address: "127.0.0.1"
+    port: "0"
+    listenPortFileName: "${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.port"
+    streamdriver.mode: 0
+rulesets:
+  - name: main
+    actions:
+      - type: omfile
+        file: "${RSYSLOG_DYNNAME}.out"
+YAML_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.yaml" "${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.log"
+check_not_present 'imtcp input uses streamdriver.mode="0"' "${RSYSLOG_DYNNAME}.imtcp-plain-explicit-mode0.log"
+
 exit_test

--- a/tests/compat-configformat-yaml.sh
+++ b/tests/compat-configformat-yaml.sh
@@ -417,6 +417,24 @@ YAML_EOF
     run_expect_success "${RSYSLOG_DYNNAME}.omrelp-off-with-tls.yaml" "${RSYSLOG_DYNNAME}.omrelp-off-with-tls.log"
     content_check 'omrelp has TLS-related settings but tls="off"' "${RSYSLOG_DYNNAME}.omrelp-off-with-tls.log"
 
+    cat >"${RSYSLOG_DYNNAME}.omrelp-off-with-zip.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+modules:
+  - load: "../plugins/omrelp/.libs/omrelp"
+rulesets:
+  - name: main
+    actions:
+      - type: omrelp
+        target: "127.0.0.1"
+        port: "514"
+        tls: "off"
+        tls.compression: "on"
+YAML_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.omrelp-off-with-zip.yaml" "${RSYSLOG_DYNNAME}.omrelp-off-with-zip.log"
+    content_check 'omrelp has TLS-related settings but tls="off"' "${RSYSLOG_DYNNAME}.omrelp-off-with-zip.log"
+
     cat >"${RSYSLOG_DYNNAME}.imrelp-explicit.yaml" <<YAML_EOF
 version: 2
 global:
@@ -455,6 +473,27 @@ rulesets:
 YAML_EOF
     run_expect_success "${RSYSLOG_DYNNAME}.imrelp-off-with-tls.yaml" "${RSYSLOG_DYNNAME}.imrelp-off-with-tls.log"
     content_check 'imrelp has TLS-related settings but tls="off"' "${RSYSLOG_DYNNAME}.imrelp-off-with-tls.log"
+
+    cat >"${RSYSLOG_DYNNAME}.imrelp-off-with-zip-dh.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+modules:
+  - load: "../plugins/imrelp/.libs/imrelp"
+inputs:
+  - type: imrelp
+    port: "0"
+    tls: "off"
+    tls.compression: "on"
+    tls.dhbits: "1024"
+rulesets:
+  - name: main
+    actions:
+      - type: omfile
+        file: "${RSYSLOG_DYNNAME}.out"
+YAML_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.imrelp-off-with-zip-dh.yaml" "${RSYSLOG_DYNNAME}.imrelp-off-with-zip-dh.log"
+    content_check 'imrelp has TLS-related settings but tls="off"' "${RSYSLOG_DYNNAME}.imrelp-off-with-zip-dh.log"
 fi
 
 exit_test

--- a/tests/compat-configformat-yaml.sh
+++ b/tests/compat-configformat-yaml.sh
@@ -365,4 +365,43 @@ YAML_EOF
 run_expect_success "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-globaldrvr.yaml" "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-globaldrvr.log"
 check_not_present 'protocol="udp"' "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-globaldrvr.log"
 
+# YAML parity for the explicit RELP tls="off" cases (bEnableTLSSet).
+if ls ../plugins/omrelp/.libs/omrelp.* >/dev/null 2>&1 && ls ../plugins/imrelp/.libs/imrelp.* >/dev/null 2>&1; then
+    cat >"${RSYSLOG_DYNNAME}.omrelp-explicit.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+modules:
+  - load: "../plugins/omrelp/.libs/omrelp"
+rulesets:
+  - name: main
+    actions:
+      - type: omrelp
+        target: "127.0.0.1"
+        port: "514"
+        tls: "off"
+YAML_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.omrelp-explicit.yaml" "${RSYSLOG_DYNNAME}.omrelp-explicit.log"
+    check_not_present 'omrelp action uses tls="off"' "${RSYSLOG_DYNNAME}.omrelp-explicit.log"
+
+    cat >"${RSYSLOG_DYNNAME}.imrelp-explicit.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+modules:
+  - load: "../plugins/imrelp/.libs/imrelp"
+inputs:
+  - type: imrelp
+    port: "0"
+    tls: "off"
+rulesets:
+  - name: main
+    actions:
+      - type: omfile
+        file: "${RSYSLOG_DYNNAME}.out"
+YAML_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.imrelp-explicit.yaml" "${RSYSLOG_DYNNAME}.imrelp-explicit.log"
+    check_not_present 'imrelp input uses tls="off"' "${RSYSLOG_DYNNAME}.imrelp-explicit.log"
+fi
+
 exit_test

--- a/tests/compat-configformat-yaml.sh
+++ b/tests/compat-configformat-yaml.sh
@@ -350,6 +350,21 @@ YAML_EOF
 run_expect_success "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-tls.yaml" "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-tls.log"
 content_check 'omfwd has TLS-related settings but protocol="udp"' "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-tls.log"
 
+cat >"${RSYSLOG_DYNNAME}.omfwd-udp-explicit-cafile.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+rulesets:
+  - name: main
+    actions:
+      - type: omfwd
+        target: "127.0.0.1"
+        protocol: "udp"
+        streamdriver.cafile: "${RSYSLOG_DYNNAME}-ca.pem"
+YAML_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-cafile.yaml" "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-cafile.log"
+content_check 'omfwd has TLS-related settings but protocol="udp"' "${RSYSLOG_DYNNAME}.omfwd-udp-explicit-cafile.log"
+
 cat >"${RSYSLOG_DYNNAME}.omfwd-udp-explicit-globaldrvr.yaml" <<YAML_EOF
 version: 2
 global:

--- a/tests/compat-configformat-yaml.sh
+++ b/tests/compat-configformat-yaml.sh
@@ -399,6 +399,24 @@ YAML_EOF
     run_expect_success "${RSYSLOG_DYNNAME}.omrelp-explicit.yaml" "${RSYSLOG_DYNNAME}.omrelp-explicit.log"
     check_not_present 'omrelp action uses tls="off"' "${RSYSLOG_DYNNAME}.omrelp-explicit.log"
 
+    cat >"${RSYSLOG_DYNNAME}.omrelp-off-with-tls.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+modules:
+  - load: "../plugins/omrelp/.libs/omrelp"
+rulesets:
+  - name: main
+    actions:
+      - type: omrelp
+        target: "127.0.0.1"
+        port: "514"
+        tls: "off"
+        tls.authmode: "anon"
+YAML_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.omrelp-off-with-tls.yaml" "${RSYSLOG_DYNNAME}.omrelp-off-with-tls.log"
+    content_check 'omrelp has TLS-related settings but tls="off"' "${RSYSLOG_DYNNAME}.omrelp-off-with-tls.log"
+
     cat >"${RSYSLOG_DYNNAME}.imrelp-explicit.yaml" <<YAML_EOF
 version: 2
 global:
@@ -417,6 +435,26 @@ rulesets:
 YAML_EOF
     run_expect_success "${RSYSLOG_DYNNAME}.imrelp-explicit.yaml" "${RSYSLOG_DYNNAME}.imrelp-explicit.log"
     check_not_present 'imrelp input uses tls="off"' "${RSYSLOG_DYNNAME}.imrelp-explicit.log"
+
+    cat >"${RSYSLOG_DYNNAME}.imrelp-off-with-tls.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+modules:
+  - load: "../plugins/imrelp/.libs/imrelp"
+inputs:
+  - type: imrelp
+    port: "0"
+    tls: "off"
+    tls.authmode: "anon"
+rulesets:
+  - name: main
+    actions:
+      - type: omfile
+        file: "${RSYSLOG_DYNNAME}.out"
+YAML_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.imrelp-off-with-tls.yaml" "${RSYSLOG_DYNNAME}.imrelp-off-with-tls.log"
+    content_check 'imrelp has TLS-related settings but tls="off"' "${RSYSLOG_DYNNAME}.imrelp-off-with-tls.log"
 fi
 
 exit_test

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -2135,7 +2135,11 @@ static void warnIfNonTlsForwardingConfigured(const instanceData *const pData) {
                                       "omfwd has TLS-related settings but streamdriver.mode=\"0\"; mode 0 uses plain "
                                       "TCP so TLS is not active "
                                       "(see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html)");
-        } else {
+        } else if (!pData->bStrmDrvrModeSet) {
+            /* explicit streamdriver.mode="0" is a deliberate admin choice, not an
+             * insecure default - strict mode treats it the same way (see
+             * applySecureDefaultsToForwarding()).
+             */
             glblWarnIfInsecureDefault(
                 loadModConf->pConf,
                 "omfwd action uses protocol=\"tcp\" with streamdriver.mode=\"0\" "

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -126,6 +126,7 @@ typedef struct _instanceData {
 #define COMPRESS_DRIVER_ZSTD 1
     uint8_t compressionDriver;
     int protocol;
+    sbool bProtocolSet; /* protocol was explicitly configured */
     char *networkNamespace;
     int originalNamespace;
     int iRebindInterval; /* rebind interval */
@@ -2024,6 +2025,7 @@ static void setInstParamDefaults(instanceData *pData) {
     pData->pAction = NULL;
     pData->targetSrv = NULL;
     pData->protocol = FORW_UDP;
+    pData->bProtocolSet = 0;
     pData->networkNamespace = NULL;
     pData->originalNamespace = -1;
     pData->tcp_framing = TCP_FRAMING_OCTET_STUFFING;
@@ -2123,9 +2125,34 @@ finalize_it:
 /** Warn in secure warn mode when omfwd is configured without TLS transport protection. */
 static void warnIfNonTlsForwardingConfigured(const instanceData *const pData) {
     if (pData->protocol == FORW_UDP) {
-        glblWarnIfInsecureDefault(loadModConf->pConf,
-                                  "omfwd action uses protocol=\"udp\" (without TLS); "
-                                  "see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html");
+        /* Only action-level TLS settings count here. UDP never uses a stream
+         * driver, so the global defaultNetstreamDriver is irrelevant to a UDP
+         * action and must NOT trigger a warning for an explicit protocol="udp"
+         * (unlike the TCP mode-0 branch below, where the effective driver does
+         * matter). streamdriver.name / streamdriver.authmode set on the action
+         * itself, however, are a real contradiction.
+         */
+        const int tlsHintsConfigured =
+            (pData->pszStrmDrvrAuthMode != NULL) || glblIsTlsCapableNetstrmDrvr(pData->pszStrmDrvr);
+        if (tlsHintsConfigured) {
+            /* TLS-related settings on a UDP action are silently ineffective: UDP
+             * never uses a stream driver, so traffic stays plaintext. Warn about
+             * the contradiction even when protocol="udp" is explicit.
+             */
+            glblWarnIfInsecureDefault(loadModConf->pConf,
+                                      "omfwd has TLS-related settings but protocol=\"udp\"; UDP is always plaintext "
+                                      "so TLS is not active "
+                                      "(see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html)");
+        } else if (!pData->bProtocolSet) {
+            /* An omitted protocol parameter falls back to UDP and deserves the
+             * warning, as does the legacy "@target" selector (which never sets
+             * bProtocolSet). Only an explicit action() protocol="udp" is a
+             * deliberate admin choice and is silenced.
+             */
+            glblWarnIfInsecureDefault(loadModConf->pConf,
+                                      "omfwd action uses protocol=\"udp\" (without TLS); "
+                                      "see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html");
+        }
     } else if (pData->protocol == FORW_TCP && pData->iStrmDrvrMode == 0) {
         const uchar *const effectiveDrvr = glblGetEffectiveNetstrmDrvr(loadModConf->pConf, pData->pszStrmDrvr);
         const int tlsHintsConfigured =
@@ -2274,6 +2301,7 @@ BEGINnewActInst
                 free(str);
                 ABORT_FINALIZE(RS_RET_INVLD_PROTOCOL);
             }
+            pData->bProtocolSet = 1;
         } else if (!strcmp(actpblk.descr[i].name, "networknamespace")) {
             CHKmalloc(pData->networkNamespace = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "tcp_framing")) {
@@ -2610,6 +2638,12 @@ BEGINparseSelectorAct
     } else {
         pData->protocol = FORW_UDP;
     }
+    /* Note: we deliberately do NOT set pData->bProtocolSet here. The legacy
+     * "@"/"@@" selector is an insecure default carried over for backward
+     * compatibility, not an explicit modern opt-in, so it must still trigger the
+     * secure-defaults warning (plain UDP for "@", plain-TCP mode 0 for "@@").
+     * Only the action() "protocol" parameter counts as an explicit choice.
+     */
     /* we are now after the protocol indicator. Now check if we should
      * use compression. We begin to use a new option format for this:
      * @(option,option)host:port

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -2122,6 +2122,18 @@ finalize_it:
     RETiRet;
 }
 
+/* True when the action carries TLS-specific settings other than the stream
+ * driver name and authmode (which the callers check separately): CA/CRL/key/cert
+ * files, permitted peers, remote SNI, expired-cert handling, or a GnuTLS priority
+ * string. These are consumed only when the TCP stream driver runs in TLS mode, so
+ * on a plain transport (UDP, or streamdriver.mode="0") they are silently ignored
+ * and their presence signals a misconfiguration. */
+static int omfwdActionHasTlsOptions(const instanceData *const pData) {
+    return pData->pszStrmDrvrCAFile != NULL || pData->pszStrmDrvrCRLFile != NULL || pData->pszStrmDrvrKeyFile != NULL ||
+           pData->pszStrmDrvrCertFile != NULL || pData->pPermPeers != NULL || pData->pszStrmDrvrRemoteSNI != NULL ||
+           pData->pszStrmDrvrPermitExpiredCerts != NULL || pData->gnutlsPriorityString != NULL;
+}
+
 /** Warn in secure warn mode when omfwd is configured without TLS transport protection. */
 static void warnIfNonTlsForwardingConfigured(const instanceData *const pData) {
     if (pData->protocol == FORW_UDP) {
@@ -2129,11 +2141,13 @@ static void warnIfNonTlsForwardingConfigured(const instanceData *const pData) {
          * driver, so the global defaultNetstreamDriver is irrelevant to a UDP
          * action and must NOT trigger a warning for an explicit protocol="udp"
          * (unlike the TCP mode-0 branch below, where the effective driver does
-         * matter). streamdriver.name / streamdriver.authmode set on the action
-         * itself, however, are a real contradiction.
+         * matter). Any TLS-specific setting placed on the action itself
+         * (streamdriver.name/authmode, certificates, permitted peers, ...) is,
+         * however, a real contradiction.
          */
-        const int tlsHintsConfigured =
-            (pData->pszStrmDrvrAuthMode != NULL) || glblIsTlsCapableNetstrmDrvr(pData->pszStrmDrvr);
+        const int tlsHintsConfigured = (pData->pszStrmDrvrAuthMode != NULL) ||
+                                       glblIsTlsCapableNetstrmDrvr(pData->pszStrmDrvr) ||
+                                       omfwdActionHasTlsOptions(pData);
         if (tlsHintsConfigured) {
             /* TLS-related settings on a UDP action are silently ineffective: UDP
              * never uses a stream driver, so traffic stays plaintext. Warn about
@@ -2155,8 +2169,8 @@ static void warnIfNonTlsForwardingConfigured(const instanceData *const pData) {
         }
     } else if (pData->protocol == FORW_TCP && pData->iStrmDrvrMode == 0) {
         const uchar *const effectiveDrvr = glblGetEffectiveNetstrmDrvr(loadModConf->pConf, pData->pszStrmDrvr);
-        const int tlsHintsConfigured =
-            (pData->pszStrmDrvrAuthMode != NULL) || glblIsTlsCapableNetstrmDrvr(effectiveDrvr);
+        const int tlsHintsConfigured = (pData->pszStrmDrvrAuthMode != NULL) ||
+                                       glblIsTlsCapableNetstrmDrvr(effectiveDrvr) || omfwdActionHasTlsOptions(pData);
         if (tlsHintsConfigured) {
             glblWarnIfInsecureDefault(loadModConf->pConf,
                                       "omfwd has TLS-related settings but streamdriver.mode=\"0\"; mode 0 uses plain "


### PR DESCRIPTION
This is a PR for issue rsyslog#7392
_[General]: secure-defaults warn mode ignores explicit streamdriver.mode="0"_

A fix has been implemented, split into seven focused commits so each concern can
be reviewed (and reverted) independently. The first is exactly the change
proposed in this issue; the next three extend the same principle to related cases
(UDP forwarding, plain RELP) and remove a redundancy found along the way; the last
three tighten the contradiction detection so that any TLS-specific setting left on
a plain transport is flagged.

The guiding rule: an **insecure rsyslog-provided default** (something the admin
never asked for) warns, while an **explicit opt-in to an insecure setting** does
not. A setting that is *silently ineffective* on the chosen transport
(TLS options on a plain link) is a **contradiction** and always warns.

### 1. `omfwd/imtcp: don't warn on explicit streamdriver.mode="0"`

This is the fix described in the issue. Warn mode now honors the
`bStrmDrvrModeSet` explicitness flag that strict mode already uses (via
`applySecureDefaultsToForwarding()` / `applySecureDefaultsToStreamDriver()`):

- omfwd: the plain-TCP branch of `warnIfNonTlsForwardingConfigured()` is gated on
  `!pData->bStrmDrvrModeSet`.
- imtcp: the flag is passed into `warnIfInsecureListenerConfigured()` and gates
  the plain branch. Instances inherit both the mode and its explicitness flag
  from the module, so acknowledging at module level covers inherited listeners.

The "TLS-related settings but mode 0" warning and the `authmode="anon"` warning
are unchanged — those flag genuine contradictions, not defaults.

### 2. `omfwd: don't warn on explicit protocol="udp"`

The issue intentionally left UDP out of scope, but the same reasoning applies:
`protocol="udp"` set explicitly is intent, not a default. A new `bProtocolSet`
flag is set only when the protocol comes from the `action()` `protocol`
parameter. An omitted `protocol` parameter, which silently falls back to UDP,
still warns — and so does the legacy `@`/`@@` selector, which is a
backward-compatibility default rather than a modern explicit opt-in (it
deliberately does not set `bProtocolSet`).

TLS-related settings placed on a UDP action are silently ineffective — UDP never
uses a stream driver — so that contradiction still warns even when
`protocol="udp"` is explicit. Because UDP ignores the stream driver, this check
looks only at action-level settings, not at the global `defaultNetstreamDriver`
(which is meaningful for the TCP branch but irrelevant to a UDP action).

### 3. `imtcp: drop redundant module-level insecure-listener warning`

While implementing (1), it turned out imtcp emits the insecure-listener warning
at module-config time — before any `input()` exists and while no port is open.
That check is redundant with the per-listener check (every listener is validated
with its effective, possibly inherited, values) and it produces false positives:
a loaded module with no listener, or module defaults overridden by every input.
This commit removes the two module-level `warnIfInsecureListenerConfigured()`
calls; `applySecureDefaultsToModuleConfig()` (strict-mode promotion/rejection) is
kept intact.

The one default-behavior change: loading imtcp without any listener no longer
warns. That seems correct, since no port is exposed.

### 4. `omrelp/imrelp: don't warn on explicit tls="off"`

The same false positive exists for RELP: warn mode reports "plain RELP without
TLS" even when `tls="off"` is set explicitly. RELP has no explicitness flag
equivalent to omfwd/imtcp's `bStrmDrvrModeSet`, so this mirrors the fresh
`bProtocolSet` flag from (2): a `bEnableTLSSet` flag is set when the `tls`
parameter is parsed, and the plain-RELP warning branch is gated on it. Applies to
both omrelp (output) and imrelp (input). Omitting `tls` (implicit off) still
warns; the `tls.authmode="anon"` warning is unchanged.

### 5. `omfwd: warn on any TLS setting combined with a plain transport`

Commit (2) only treated `streamdriver.name` / `streamdriver.authmode` as a "TLS
hint". An action such as `protocol="udp" streamdriver.cafile="..."` (or
`crlfile`/`keyfile`/`certfile`, permitted peers, remote SNI, expired-cert
handling, GnuTLS priority) therefore stayed silent, even though those options are
consumed only by the TLS-enabled TCP stream setup and are silently ignored on a
plain transport — so traffic stays plaintext while the config looks TLS-protected.

A new `omfwdActionHasTlsOptions()` helper reports whether the action carries any
such TLS-specific setting, and it is folded into the contradiction check of both
the UDP branch and the plain-TCP (`streamdriver.mode="0"`) branch. Now any TLS
setting on an explicit plain transport warns; a bare explicit plain transport is
unaffected.

### 6. `omrelp/imrelp: warn on tls="off" combined with TLS settings`

The same gap existed for RELP after (4): `tls="off"` combined with `tls.authmode`,
certificates, permitted peers, or a priority string was completely silent, even
though those options apply only on the TLS-enabled path — the endpoint runs
plaintext while looking TLS-configured. `omrelpHasTlsOptions()` /
`imrelpHasTlsOptions()` detect any such setting, and a contradiction branch is
inserted between the implicit-off and `anon` branches. A bare explicit `tls="off"`
stays silent; `tls="off"` combined with any TLS option now warns.

### 7. `omrelp/imrelp: flag tls.compression / tls.dhbits when tls="off"`

Completing (6): the helper initially covered auth mode, certificates, permitted
peers and the priority / config-command settings, but omitted `tls.compression`
(`bEnableTLSZip`) and, for imrelp, `tls.dhbits` (`dhBits`). Both are consumed only
inside the TLS-enabled RELP path, so `tls="off" tls.compression="on"` (or
`tls.dhbits=...`) was still accepted silently. They are added to
`omrelpHasTlsOptions()` / `imrelpHasTlsOptions()`; all default to 0, so they only
trip when explicitly configured.

### Resulting behavior

| Configuration | Warn mode |
|---|---|
| `protocol` omitted (implicit UDP) | warns |
| `protocol="udp"` explicit | silent |
| legacy `@host` / `@@host` | warns (backward-compat default) |
| `protocol="udp"` + any TLS setting on the action | warns (contradiction) |
| TCP, mode omitted (implicit 0), plain driver | warns |
| TCP, `streamdriver.mode="0"` explicit, plain driver | silent |
| TCP, `streamdriver.mode="0"` + any TLS setting (driver/authmode/cert/…) | warns (contradiction) |
| imtcp listener, mode omitted, plain driver | warns |
| imtcp listener, `streamdriver.mode="0"` explicit | silent |
| omrelp/imrelp, `tls` omitted (implicit off) | warns |
| omrelp/imrelp, `tls="off"` explicit (bare) | silent |
| omrelp/imrelp, `tls="off"` + any TLS setting (authmode/cert/peer/priority/compression, imrelp dhbits) | warns (contradiction) |

_With the help of Claude AI_
