### PR TITLE
rainerscript: warn on constant AND/OR operand at parse time

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -1413,6 +1413,26 @@ void cnfobjPrint(struct cnfobj *o) {
 struct cnfexpr *cnfexprNew(unsigned nodetype, struct cnfexpr *l, struct cnfexpr *r) {
     struct cnfexpr *expr;
 
+    /* Warn on bare constant AND/OR operands as written in the config, e.g.
+     * `$msg contains "a" or "b"` (issue #1046). This must happen here, at
+     * construction time, rather than in the optimizer: constFoldCmp() later
+     * reduces legitimate constant comparisons (typically backtick-expanded
+     * environment variables, e.g. `echo $FLAG` == "on") to constant operands,
+     * which must not warn. At this point such an operand is still a comparison
+     * node, and cnfcurrfn/yylineno still point at the offending expression, so
+     * the reported file and line are accurate.
+     */
+    if (nodetype == AND || nodetype == OR) {
+        if (l != NULL && (l->nodetype == 'N' || l->nodetype == 'S')) {
+            parser_warnmsg("boolean operator '%s' has constant left operand; did you mean to repeat the comparison?",
+                           tokenToString(nodetype));
+        }
+        if (r != NULL && (r->nodetype == 'N' || r->nodetype == 'S')) {
+            parser_warnmsg("boolean operator '%s' has constant right operand; did you mean to repeat the comparison?",
+                           tokenToString(nodetype));
+        }
+    }
+
     /* optimize some constructs during parsing */
     if (nodetype == 'M' && r->nodetype == 'N') {
         ((struct cnfnumval *)r)->val *= -1;
@@ -5627,15 +5647,9 @@ static struct cnfexpr *cnfexprOptimize_NOT(struct cnfexpr *expr) {
 static struct cnfexpr *cnfexprOptimize_AND_OR(struct cnfexpr *expr) {
     struct cnffunc *funcl, *funcr;
 
-    if (expr->l->nodetype == 'N' || expr->l->nodetype == 'S') {
-        parser_warnmsg("boolean operator '%s' has constant left operand; did you mean to repeat the comparison?",
-                       tokenToString(expr->nodetype));
-    }
-    if (expr->r->nodetype == 'N' || expr->r->nodetype == 'S') {
-        parser_warnmsg("boolean operator '%s' has constant right operand; did you mean to repeat the comparison?",
-                       tokenToString(expr->nodetype));
-    }
-
+    /* the constant-operand warning is emitted at construction time in
+     * cnfexprNew(); see the comment there for why it cannot live here.
+     */
     if (expr->l->nodetype == 'F') {
         if (expr->r->nodetype == 'F') {
             funcl = (struct cnffunc *)expr->l;

--- a/tests/rscript_bool_constant_warning.sh
+++ b/tests/rscript_bool_constant_warning.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 # Verify that a common RainerScript boolean mistake logs a config warning:
 # `$msg contains "a" or "b"` keeps historical truthiness semantics, but the
-# bare string literal is probably a missing repeated comparison. The oracle is
-# rsyslogd config-check output because the warning is emitted while optimizing
-# the parsed configuration, before normal message routing is relevant.
+# bare string literal is probably a missing repeated comparison. The warning
+# must only fire on constants as written: comparisons that merely constant-fold
+# to a constant (e.g. backtick-expanded environment variables) are legitimate
+# and must stay silent. The oracle is rsyslogd config-check output.
 . ${srcdir:=.}/diag.sh init
 
+export MY_FEATURE="on"
 generate_conf
 add_conf '
 if $msg contains "alpha" or "beta" then {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+}
+if `echo $MY_FEATURE` == "on" and $msg contains "gamma" then {
 	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 }
 '
@@ -18,4 +23,5 @@ rsyslogd_config_check
 unset RS_REDIR
 
 content_check "boolean operator 'OR' has constant right operand" "${RSYSLOG_DYNNAME}.rsyslog.log"
+check_not_present "boolean operator 'AND' has constant" "${RSYSLOG_DYNNAME}.rsyslog.log"
 exit_test


### PR DESCRIPTION
# rainerscript: warn on constant AND/OR operand at parse time

## Summary

Moves the AND/OR constant-operand warning (issue #1046) from the optimizer to
expression construction time, so it no longer fires on legitimate constant
comparisons and reports the correct file/line.

Follows up the discussion with @rgerhards in #7228 (2026-07-17).

## Background

The warning "boolean operator '%s' has constant left/right operand; did you mean
to repeat the comparison?" was added to catch the classic mistake
`$msg contains "a" or "b"` (#1046). It ran in `cnfexprOptimize_AND_OR()`, i.e.
during optimization, which has two consequences:

1. **False positives on folded comparisons.** `constFoldCmp()` reduces a
   constant comparison to a single constant node *before* the check runs. A
   common, legitimate pattern — feature flags driven by backtick-expanded
   environment variables — is flagged even though nothing is wrong:

   ```
   if (`echo $MY_FEATURE` == "on" and $app-name == "myapp") then { ... }
   ```

   expands to `("on" == "on" and ...)`; the left comparison folds to a constant,
   which the optimizer-stage check then reports as a "constant left operand".

2. **Wrong location.** The optimizer runs from `rulesetOptimizeAll()` after
   `yyparse()` has completed, so `cnfcurrfn`/`yylineno` point at the last line of
   the master config file for every occurrence, not at the offending expression.

## Change

The check is moved to `cnfexprNew()`, which is the single construction point for
every expression node and runs only at parse time. There:

- the operand is still the comparison node *as written* (constant folding has not
  happened yet), so a folded comparison is no longer mistaken for a bare literal;
- `cnfcurrfn`/`yylineno` still point at the expression, so the reported file and
  line are accurate.

The warning message text is unchanged, so tooling that matches it keeps working.

## Note on backtick operands

A backtick expansion used *directly* as a bare boolean operand still warns, and
this is intended:

```
if ($msg contains "alpha" or `echo $MY_FLAG`) then { ... }
```

The lexer expands the backtick before the expression tree is built, so this is
identical to a hand-written `... or "value"` — exactly the mistake the warning
targets, and treated the same as `$a contains "b" or "c"`. It is *not* the same
as the fixed case, where the backtick is an operand of a *comparison*
(`` `echo $FLAG` == "on" ``): there the boolean operand is the comparison, which
is legitimate and no longer warns.

## Testing

`tests/rscript_bool_constant_warning.sh` is extended: the positive case
(`$msg contains "a" or "b"` still warns) is unchanged, and a negative case using
a backtick-expanded feature flag verifies the folded comparison stays silent.
Manual `rsyslogd -N1` on a config using backtick-based feature flags confirms the
warnings are gone and that the bare-literal case is still reported, now at the
correct location.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

