### PR TITLE
config: do not instantiate actions disabled via config.enabled="off"

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -5317,8 +5317,16 @@ struct cnfstmt *cnfstmtNewAct(struct nvlst *lst) {
         goto done;
     }
     if (nvlstChkDisabled(lst)) {
+        /* Do not instantiate a disabled action: skip actionNewInst() entirely so
+         * the module's instance is never created and its checkCnf/newActInst side
+         * effects (e.g. omelasticsearch probing the server) never run - matching
+         * how disabled includes and input objects are skipped. The statement is
+         * turned into a NOP the optimizer later removes.
+         */
         dbgprintf("action disabled by configuration\n");
-        cnfstmt->nodetype = S_NOP;
+        cnfstmtDisable(cnfstmt);
+        nvlstDestruct(lst);
+        goto done;
     }
     localRet = actionNewInst(lst, &cnfstmt->d.act);
     if (localRet == RS_RET_OK_WARN) {

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -5325,7 +5325,6 @@ struct cnfstmt *cnfstmtNewAct(struct nvlst *lst) {
          */
         dbgprintf("action disabled by configuration\n");
         cnfstmtDisable(cnfstmt);
-        nvlstDestruct(lst);
         goto done;
     }
     localRet = actionNewInst(lst, &cnfstmt->d.act);
@@ -5340,8 +5339,13 @@ struct cnfstmt *cnfstmtNewAct(struct nvlst *lst) {
     namebuf[255] = '\0'; /* be on safe side */
     cnfstmt->printable = (uchar *)strdup(namebuf);
     nvlstChkUnused(lst);
-    nvlstDestruct(lst);
 done:
+    /* Single cleanup point: cnfstmtNewAct owns lst on every path (the module only
+     * reads it, and addAction keeps an independent clone as pSyntaxLst), so one
+     * nvlstDestruct() frees it exactly once. This also covers the early
+     * error / cnfstmtNew()-failure returns that previously leaked lst.
+     */
+    nvlstDestruct(lst);
     return cnfstmt;
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -586,6 +586,7 @@ TESTS_DEFAULT = \
 	lookup_table_rscript_reload_without_stub.sh \
 	config_multiple_include.sh \
 	rscript_bool_constant_warning.sh \
+	config_enabled-off-action.sh \
 	include-obj-text-from-file.sh \
 	include-obj-text-from-file-noexist.sh \
 	multiple_lookup_tables.sh \

--- a/tests/config_enabled-off-action.sh
+++ b/tests/config_enabled-off-action.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# check that an action disabled via config.enabled="off" is not instantiated at
+# all - in both the RainerScript and YAML frontends (YAML parsing produces the
+# same nvlst and calls the same cnfstmtNewAct() path). Its parameters must not be
+# processed, so no "parameter not known" message is emitted for them (an enabled
+# action would report it - see config_enabled-on.sh). This also guarantees module
+# side effects such as omelasticsearch probing its server in checkCnf never run
+# for a disabled action. The oracle is rsyslogd config-check output.
+# added 2026-07-18, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+
+# --- RainerScript frontend ---
+generate_conf
+add_conf '
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" invalid.param="error" config.enabled="off")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
+rsyslogd_config_check
+unset RS_REDIR
+check_not_present 'parameter.*invalid.param.*not known' "${RSYSLOG_DYNNAME}.rsyslog.log"
+
+# --- YAML frontend (same cnfstmtNewAct() path) ---
+cat >"${RSYSLOG_DYNNAME}.disabled.yaml" <<YAML_EOF
+version: 2
+rulesets:
+  - name: main
+    actions:
+      - type: omfile
+        file: "${RSYSLOG_OUT_LOG}"
+        invalid.param: "error"
+        config.enabled: "off"
+      - type: omfile
+        file: "${RSYSLOG_OUT_LOG}"
+YAML_EOF
+../tools/rsyslogd -C -N1 -M"${RSYSLOG_MODDIR}" -f"${RSYSLOG_DYNNAME}.disabled.yaml" \
+    >"${RSYSLOG_DYNNAME}.yaml.log" 2>&1
+check_not_present 'parameter.*invalid.param.*not known' "${RSYSLOG_DYNNAME}.yaml.log"
+exit_test


### PR DESCRIPTION
# config: do not instantiate actions disabled via config.enabled="off"

## Summary

An `action(...)` block with `config.enabled="off"` is still fully instantiated
today: the module's instance is created and its `newActInst`/`checkCnf` side
effects run, even though the action is explicitly disabled. This PR makes a
disabled action be skipped at construction time, like disabled `include()` and
`input` objects already are.

## What triggered this

With a modular, env-driven config, <code>config.enabled=\`echo $FEATURE\`</code>, an
`omelasticsearch` action gated to `off` still emits a config warning **and opens
a TCP connection to the configured server during `rsyslogd -N`** (config
validation):

```
rsyslogd: omelasticsearch: platform detection request to https://127.0.0.1:9200/ failed: ...
rsyslogd: omelasticsearch: unable to detect target platform and version from configured servers
```

`omelasticsearch` probes the server for its version in its `checkCnf` callback
(`detectTargetPlatformAndVersion()`), which runs during `-N`. But the deeper
issue is that the disabled action is instantiated at all — a disabled action
should have no effect whatsoever.

## Root cause (and a bit of history)

`config.enabled` handling was introduced in commit `ba5b68be8` (2020). It made
disabled `include()` statements return early, but for actions it only marked the
statement as a NOP **and still called `actionNewInst()`**:

```c
if (nvlstChkDisabled(lst)) {
    dbgprintf("action disabled by configuration\n");
    cnfstmt->nodetype = S_NOP;          /* runtime no-op ... */
}
localRet = actionNewInst(lst, &cnfstmt->d.act);   /* ... but still instantiated */
```

So the statement never executes at runtime, yet the module instance is created
at load time and its `checkCnf`/`newActInst` side effects (here, a live network
probe) run regardless. This also contradicts the documented `config.enabled="off"`
contract — `tests/config_enabled-off.sh` states it must *"not emit any error
messages"* — which the omelasticsearch warning violates.

Note this predates the `cnfstmtDisable()` helper being used at the other
late-disable sites; the action path kept the inline `S_NOP` assignment.

## Change

In `cnfstmtNewAct()`, when `nvlstChkDisabled()` reports the block disabled, turn
the statement into a NOP via `cnfstmtDisable()` (the optimizer removes NOPs),
free the `nvlst`, and return **before** `actionNewInst()`:

```c
if (nvlstChkDisabled(lst)) {
    dbgprintf("action disabled by configuration\n");
    cnfstmtDisable(cnfstmt);
    nvlstDestruct(lst);
    goto done;
}
localRet = actionNewInst(lst, &cnfstmt->d.act);
```

This mirrors the existing early return for disabled `include()` statements.

## Impact / trade-off

A disabled action is no longer instantiated at all — no module side effects, and
its parameters are not processed. The one behavior change is that a disabled
action's parameters are no longer syntax-checked during `-N` (no "parameter not
known"). This is consistent with how disabled `include`/`input` objects already
behave and with the "off = emits no messages" contract.

## Testing

`tests/config_enabled-off-action.sh` (new): a disabled action carrying a bogus
parameter must not produce a "parameter not known" message (an enabled action
still does — see `config_enabled-on.sh`).

## Out of scope

Independently, one could argue a config-validation run (`-N`) should never open
network connections even for an *enabled* action. That would be a separate
hardening in `omelasticsearch`'s `checkCnf` (e.g. gating the probe on
`iConfigVerify`); this PR does not address it.

_With the help of Claude AI_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

