### PR TITLE
configure/compat_queue: fix STAILQ detection and complete the AIX fallback

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -225,6 +225,7 @@ AC_MSG_CHECKING([for STAILQ macros in sys/queue.h])
 AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM(
         [[
+#include <stddef.h> /* for NULL, used by STAILQ_INIT */
 #include <sys/queue.h>
 struct stailq_test_entry {
     STAILQ_ENTRY(stailq_test_entry) link;

--- a/runtime/compat_queue.h
+++ b/runtime/compat_queue.h
@@ -62,6 +62,15 @@
                 }                                                                         \
             } while (0)
     #endif
+
+    #ifndef STAILQ_NEXT
+        #define STAILQ_NEXT(elm, field) ((elm)->field.stqe_next)
+    #endif
+
+    #ifndef STAILQ_FOREACH
+        #define STAILQ_FOREACH(var, head, field) \
+            for ((var) = STAILQ_FIRST(head); (var); (var) = STAILQ_NEXT((var), field))
+    #endif
 #endif
 
 #endif /* #ifndef INCLUDED_COMPAT_QUEUE_H */


### PR DESCRIPTION
## Summary

Two related, independent bugs around the `sys/queue.h` STAILQ support added in
`5f97985c3` ("runtime: add STAILQ fallback for AIX"):

1. **Broken configure probe** — the detection test references `NULL` without
   `<stddef.h>`, so it fails to compile on platforms whose `sys/queue.h` does not
   pull in `NULL` (e.g. current glibc / Fedora 43). `HAVE_SYS_QUEUE_STAILQ` is
   then left undefined *even though the native macros are present*, and the AIX
   fallback is wrongly activated.
2. **Incomplete AIX fallback** — the fallback never defined `STAILQ_FOREACH`
   (nor `STAILQ_NEXT`). Since `bf1420ba6` ("dynstats: coalesce pending
   persistence writes per bucket") added a `STAILQ_FOREACH` loop to
   `runtime/dynstats.c`, the fallback is missing a macro the code now uses.

## How it manifests

On glibc (Fedora 43, gcc 15) a clean build of `runtime/dynstats.c` fails:

```
runtime/dynstats.c:1376:5: error: implicit declaration of function 'STAILQ_FOREACH' [-Werror=implicit-function-declaration]
```

`config.h` shows `HAVE_SYS_QUEUE_H 1` but `HAVE_SYS_QUEUE_STAILQ` undefined.
`config.log` shows why the probe failed:

```
checking for STAILQ macros in sys/queue.h
conftest.c: error: 'NULL' undeclared (first use in this function)
   STAILQ_INIT(&head);
```

`<sys/queue.h>` is BSD-derived and does not include `<stddef.h>`; the probe uses
`STAILQ_INIT` (which expands to `... = NULL`) with only `<sys/queue.h>`, so `NULL`
is undeclared and the test fails — a false negative. The AIX fallback then takes
over on glibc, and because it lacks `STAILQ_FOREACH`, `dynstats.c` fails. (It only
surfaces on a clean rebuild of `dynstats.c`; a cached object hides it.)

## Why CI did not catch it

- Bug 1 depends on whether the platform's `sys/queue.h` happens to provide `NULL`.
  CI distros where it does keep passing the probe and using native macros, so the
  fallback path is never taken. A glibc where it does not (Fedora 43) exposes it.
- Bug 2 only bites where the fallback is actually used — i.e. AIX, which is not in
  CI. The fallback was added "for AIX" but has not been rebuilt there since
  `bf1420ba6` introduced the `STAILQ_FOREACH` usage, so `dynstats.c` would fail to
  build on AIX today.

## Fixes

1. **configure.ac**: add `#include <stddef.h>` before `<sys/queue.h>` in the
   STAILQ detection test. The probe now compiles, `HAVE_SYS_QUEUE_STAILQ` is
   correctly detected on glibc, and the native macros are used.
2. **compat_queue.h**: add `#ifndef`-guarded `STAILQ_NEXT` and `STAILQ_FOREACH`
   to the fallback, so it provides the full subset `dynstats.c` uses — restoring
   the AIX build the fallback exists to support.

## Verification

After fix 1, `configure` reports *"checking for STAILQ macros in sys/queue.h...
yes"*, `config.h` defines `HAVE_SYS_QUEUE_STAILQ`, and `dynstats.c` compiles
against the system header (fallback bypassed). Fix 2 makes the fallback itself
complete for platforms that rely on it.

_With the help of Claude AI_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

