### PR TITLE
tests: expand template transformation coverage

### DIFF
--- a/tests/template-property-transformations.sh
+++ b/tests/template-property-transformations.sh
@@ -2,10 +2,12 @@
 # This focused template/property test covers deterministic MsgGetProp
 # transformations without network timing: field extraction, substring bounds,
 # regex match/no-match handling, control-character modes, string modifiers,
-# timestamp formatting, secure-path sanitizing, and CSV/JSON formatting. The
-# sorted omfile output is the oracle: imdiag-injected messages may reach the
-# action queue in a different order under parallel CI, but every rendered
-# property line and duplicate count must match exactly.
+# timestamp formatting, secure-path sanitizing, CSV/JSON formatting, and the
+# equivalent legacy string-template parser. One configuration renders all
+# cases from fixed messages. The sorted omfile output is the oracle:
+# imdiag-injected messages may reach the action queue in a different order
+# under parallel CI, but every rendered property line and duplicate count must
+# match exactly.
 # Note that spifno1stsp emits only a conditional separator space, not the
 # original property value, so its expected output is intentionally just markers
 # around an inserted or suppressed space.
@@ -16,22 +18,36 @@ add_conf '
 template(name="outfmt" type="list") {
 	constant(value="field2=")
 	property(name="$!fields" field.number="2" field.delimiter="44")
-	constant(value="\nfield_missing=")
+	constant(value="\nfield_empty=<")
+	property(name="$!fields" field.number="3" field.delimiter="44")
+	constant(value=">\nfield_final=<")
 	property(name="$!fields" field.number="5" field.delimiter="44")
+	constant(value=">")
+	constant(value="\nfield_missing=")
+	property(name="$!fields" field.number="6" field.delimiter="44")
 	constant(value="\nsubstr=")
 	property(name="$!word" position.from="2" position.to="4")
 	constant(value="\nsubstr_neg_to=")
 	property(name="$!word" position.from="2" position.to="-2")
+	constant(value="\nsubstr_neg_underflow=")
+	property(name="$!word" position.from="1" position.to="-99")
 	constant(value="\nsubstr_beyond=")
 	property(name="$!word" position.from="99" position.to="120")
 	constant(value="\nsubstr_superset=")
 	property(name="$!word" position.from="1" position.to="999")
 	constant(value="\nrelend=")
 	property(name="$!word" position.from="3" position.to="1" position.relativetoend="on")
+	constant(value="\nrelend_underflow=")
+	property(name="$!short" position.from="99" position.to="50" position.relativetoend="on")
 	constant(value="\nfixed=")
 	property(name="$!short" position.from="1" position.to="5" fixedwidth="on")
 	constant(value="|\nregex_second=")
 	property(name="$!regexsrc" regex.expression="([a-z]+)-([0-9]+)" regex.type="ERE" regex.match="1" regex.submatch="2")
+	constant(value="\nregex_third=")
+	property(name="$!regexsrc" regex.expression="([a-z]+)-([0-9]+)" regex.type="ERE" regex.match="2" regex.submatch="2")
+	constant(value="\nregex_optional_blank=<")
+	property(name="$!optional" regex.expression="([a-z]+)(-([0-9]+))?" regex.type="ERE" regex.submatch="3" regex.nomatchmode="BLANK")
+	constant(value=">")
 	constant(value="\nregex_default=")
 	property(name="$!word" regex.expression="ZZZ" regex.type="ERE" regex.nomatchmode="DFLT")
 	constant(value="\nregex_blank=<")
@@ -47,6 +63,8 @@ template(name="outfmt" type="list") {
 	property(name="$!mixed" caseconversion="lower")
 	constant(value="\ncompress=")
 	property(name="$!spaces" compressspace="on")
+	constant(value="\ncompress_msg=")
+	property(name="msg" compressspace="on")
 	constant(value="\ndroplastlf=")
 	property(name="$!line" droplastlf="on")
 	constant(value="\nspif_nonspace=<")
@@ -67,6 +85,8 @@ template(name="outfmt" type="list") {
 	property(name="$!path" securepath="drop")
 	constant(value="\nsec_replace=")
 	property(name="$!path" securepath="replace")
+	constant(value="\nsec_replace_msg=")
+	property(name="msg" securepath="replace")
 	constant(value="\nsec_empty=")
 	property(name="$!empty" securepath="drop")
 	constant(value="\nsec_dot=")
@@ -75,6 +95,8 @@ template(name="outfmt" type="list") {
 	property(name="$!dotdot" securepath="drop")
 	constant(value="\ncsv=")
 	property(name="$!csvsrc" format="csv")
+	constant(value="\ncombo_msg=")
+	property(name="msg" securepath="replace" compressspace="on" format="csv")
 	constant(value="\njson=")
 	property(name="$!jsonsrc" format="json")
 	constant(value="\njsonf=")
@@ -83,6 +105,15 @@ template(name="outfmt" type="list") {
 	property(name="$!jsonrsrc" format="jsonr")
 	constant(value="\njsonfr=")
 	property(name="$!jsonrsrc" outname="jsonrsrc" format="jsonfr")
+	constant(value="\njson_zero=<")
+	property(name="$!zero" outname="zero" format="jsonf" datatype="number" omitIfZero="on")
+	constant(value=">\njson_empty=<")
+	property(name="$!empty" outname="empty" format="jsonf" onEmpty="skip")
+	constant(value=">\njson_auto=<")
+	property(name="$!auto" outname="auto" format="jsonf" datatype="auto")
+	constant(value=">\njson_false=<")
+	property(name="$!false" outname="false" format="jsonf" datatype="bool")
+	constant(value=">")
 	constant(value="\nmsg=")
 	property(name="msg")
 	constant(value="\nhostname=")
@@ -172,6 +203,9 @@ template(name="outfmt" type="list") {
 	constant(value="\n")
 }
 
+template(name="legacyfmt" type="string"
+	string="legacy_upper=%$!mixed:::uppercase%\nlegacy_fixed=%$!short:1:5:fixed-width%|\nlegacy_relend=%$!word:3:1:pos-end-relative%\nlegacy_swap=%$!word:4:2%\nlegacy_field=%$!fields:F,44:2%\nlegacy_escape=%$!control:::escape-cc%\nlegacy_sec_replace=%$!path:::secpath-replace%\nlegacy_jsonf=%$!jsonsrc:::jsonf%\nlegacy_jsonr=%$!jsonrsrc:::jsonr%\nlegacy_jsonfr=%$!jsonrsrc:::jsonfr%\nlegacy_date=%timereported:::date-wdayname%/%timereported:::date-week%\n")
+
 template(name="shapefmt" type="list") {
 	constant(value="shape_msg=")
 	property(name="msg")
@@ -200,10 +234,11 @@ local4.* {
 	if ($rawmsg contains "shape") then {
 		action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="shapefmt")
 	} else {
-		set $!fields = "one,two,,four";
+		set $!fields = "one,two,,four,";
 		set $!word = "alphabet";
 		set $!short = "xy";
-		set $!regexsrc = "abc-123 def-456";
+		set $!regexsrc = "abc-123 def-456 ghi-789";
+		set $!optional = "abc";
 		set $!mixed = "MiXeD";
 		set $!spaces = "a   b  c";
 		set $!line = "tail\n";
@@ -216,29 +251,39 @@ local4.* {
 		set $!csvsrc = "a,\"b\"";
 		set $!jsonsrc = "a \\ \"b\"";
 		set $!jsonrsrc = "a \\n b";
+		set $!zero = 0;
+		set $!auto = 42;
+		set $!false = 0;
 		action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+		action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="legacyfmt")
 	}
 }
 '
 
 startup
-injectmsg_literal '<167>1 2003-08-24T05:14:15.000003-07:00 host app proc msgid - trigger'
+injectmsg_literal '<167>1 2003-08-24T05:14:15.000003-07:00 host/name app proc msgid - trigger/path  a  b'
 injectmsg_literal '<167>Aug 24 05:14:15 legacyhost legacyprog[42]: shape3164'
 injectmsg_literal '<167>1 2003-08-24T05:14:15.000003-07:00 nilhost - - - - shape5424nil'
 injectmsg_literal '<167>Aug 24 05:14:15 oddhost shape3164notag'
-wait_file_lines --abort-on-oversize "$RSYSLOG_OUT_LOG" 91
+wait_file_lines --abort-on-oversize "$RSYSLOG_OUT_LOG" 115
 shutdown_when_empty
 wait_shutdown
 
 export EXPECTED='field2=two
+field_empty=<>
+field_final=<>
 field_missing=**FIELD NOT FOUND**
 substr=lph
 substr_neg_to=lphab
+substr_neg_underflow=a
 substr_beyond=
 substr_superset=alphabet
 relend=bet
+relend_underflow=x
 fixed=xy   |
 regex_second=456
+regex_third=789
+regex_optional_blank=<>
 regex_default=**NO MATCH**
 regex_blank=<>
 regex_field=alphabet
@@ -246,6 +291,7 @@ regex_zero=0
 upper=MIXED
 lower=mixed
 compress=a b c
+compress_msg=trigger/path a b
 droplastlf=tail
 spif_nonspace=< >
 spif_space=<>
@@ -255,18 +301,24 @@ cc_escape=a#010b#009c
 cc_escape_octal=a#012b#011c
 sec_drop=abc
 sec_replace=a_b_c
+sec_replace_msg=trigger_path  a  b
 sec_empty=_
 sec_dot=_
 sec_dotdot=_.
 csv="a,""b"""
+combo_msg="trigger_path a b"
 json=a \\ \"b\"
 jsonf="jsonsrc":"a \\ \"b\""
 jsonr=a \n b
 jsonfr="jsonrsrc":"a \n b"
-msg=trigger
-hostname=host
+json_zero=<>
+json_empty=<>
+json_auto=<"auto":42>
+json_false=<"false":false>
+msg=trigger/path  a  b
+hostname=host/name
 syslogtag=app[proc]
-rawmsg_after_pri=1 2003-08-24T05:14:15.000003-07:00 host app proc msgid - trigger
+rawmsg_after_pri=1 2003-08-24T05:14:15.000003-07:00 host/name app proc msgid - trigger/path  a  b
 pri=167
 pri_text=local4.debug
 iut=1
@@ -291,6 +343,17 @@ reported_local_subseconds=000003
 reported_local_misc=Sun/0/07:00/-/236/35
 reported_utc_formats=20030824121415/2003-08-24 12:14:15/Aug 24 12:14:15/1061727255/000003
 reported_parts=2003-08-24T12:14:15
+legacy_upper=MIXED
+legacy_fixed=xy   |
+legacy_relend=bet
+legacy_swap=lph
+legacy_field=two
+legacy_escape=a#010b#009c
+legacy_sec_replace=a_b_c
+legacy_jsonf="jsonsrc":"a \\ \"b\""
+legacy_jsonr=a \n b
+legacy_jsonfr="jsonrsrc":"a \n b"
+legacy_date=Sun/35
 shape_msg= shape3164
 shape_hostname=legacyhost
 shape_syslogtag=legacyprog[42]:


### PR DESCRIPTION
## Summary

- expand the existing deterministic template/property transformation test
- cover empty/final fields, substring clamping, repeated and optional regex submatches
- exercise borrowed values through secure-path replacement, compression, and CSV formatting
- cover JSON datatype/on-empty/omit-zero handling and legacy string-template options
- keep one configuration, fixed messages, and one exact sorted-output oracle

No production code or public API changes are included.

## Matched local coverage

Both traces use refreshed `main` `1c49cf97a`, the regular Ubuntu 26.04 profile plus `--enable-coverage`, forced service-test inclusion for full runs, and `-j60` for build/check.

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Overall lines | 56,978 / 75,938 | 57,045 / 75,938 | +67 |
| `runtime/msg.c` | 2,247 / 2,913 | 2,266 / 2,913 | +19 |
| `MsgGetProp` | 466 / 615 | 485 / 615 | +19 |
| `runtime/template.c` | 1,401 / 1,837 | 1,424 / 1,837 | +23 |
| `doOptions` | 81 / 115 | 100 / 115 | +19 |
| `do_Parameter` | 105 / 180 | 109 / 180 | +4 |

Focused comparison of this single test: `MsgGetProp` 337 -> 365 (+28), `doOptions` 61 -> 80 (+19), and `do_Parameter` 47 -> 65 (+18), with no lost baseline target lines.

The baseline full suite had one unrelated ratelimit allowance-count failure; the after suite completed with 1,491 pass, 29 skip, and 0 fail.

## Validation

- focused Ubuntu 26.04 GCC coverage test: pass
- forced-service complete Ubuntu 26.04 coverage suite: pass after change
- focused clang ASan/UBSan: pass
- repository focused Ubuntu 26.04 container validation, build/check jobs 60/60: pass
- MOCK-OK `make distcheck -j60`: pass
- shell syntax, ShellCheck, and test-antipattern review: pass
- local Cubic: no issues

The test exposed an existing optional-regex-submatch defect, tracked separately in https://github.com/rsyslog/rsyslog/issues/7399.
