### PR TITLE
ratelimit: optimize port-based per-source keys

### DIFF
--- a/benchmarks/ratelimit-port-keys/.gitignore
+++ b/benchmarks/ratelimit-port-keys/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/benchmarks/ratelimit-port-keys/README.md
+++ b/benchmarks/ratelimit-port-keys/README.md
@@ -1,0 +1,31 @@
+# Port-key ratelimit benchmark
+
+This benchmark measures input per-source ratelimiting with `%fromhost-port%`,
+`%fromhost-ip%:%fromhost-port%`, and `%fromhost%:%fromhost-port%`. Every trial
+starts and stops rsyslog, uses deterministic per-connection tcpflood workers,
+pins the downstream main queue to one worker, and validates exact delivery
+after recording sender completion. Pinning avoids downstream bimodality when
+the default queue heuristic starts an additional output worker during only
+some trials. The timed interval ends when tcpflood has sent every message;
+file polling and validation remain outside it so their 200 ms sampling period
+cannot quantize the throughput result.
+
+Build both revisions, then run an alternating paired session:
+
+```sh
+benchmarks/ratelimit-port-keys/run.sh \
+  --build-dir /path/to/baseline --label baseline \
+  --output benchmarks/ratelimit-port-keys/artifacts/baseline.json \
+  --pair-build-dir /path/to/candidate --pair-label candidate \
+  --pair-output benchmarks/ratelimit-port-keys/artifacts/candidate.json \
+  --comparison-output benchmarks/ratelimit-port-keys/artifacts/comparison.json
+```
+
+Defaults cover both TCP inputs, all three keys, and 1, 32, and 128
+connections. Use `--churn-rounds` to split the message load across repeated
+connection lifecycles. Run one calibration plus eleven measured pairs and
+repeat the complete session independently before accepting a candidate. The
+comparison report records candidate/baseline paired throughput ratios, their
+median, and median absolute deviation for every workload. The per-revision
+reports include the exact revision, compiler, configure arguments, workload,
+and host metadata.

--- a/benchmarks/ratelimit-port-keys/RESULTS.md
+++ b/benchmarks/ratelimit-port-keys/RESULTS.md
@@ -1,0 +1,52 @@
+# Port-key optimization results
+
+Measurements were recorded on 2026-07-20 on x86_64 WSL2 with GCC 13.3.0.
+Both worktrees used `--enable-debug --enable-testbench --enable-imptcp
+--enable-impstats --enable-imdiag`. The host was kept otherwise idle but was
+not exclusively reserved, and filesystem/cache state was uncontrolled.
+
+Every session used one unrecorded calibration pair followed by eleven
+alternating measured pairs. Ratios are candidate messages/second divided by
+baseline messages/second; MAD is the median absolute deviation of those paired
+ratios. Each trial validated complete, ordered delivery after its timed sender
+interval.
+
+## `%fromhost-port%` shortcut: retained
+
+Baseline `15b12e821c8fb88ca0d7e13d0f35ef8a21e7ba28`, candidate
+`91ec8e9e3964b5c422a8bac40444917beae75df0`, 524,288 messages per trial:
+
+| Input | Connections | Session 1 median / MAD | Session 2 median / MAD |
+| --- | ---: | ---: | ---: |
+| imtcp | 1 | +31.40% / 4.10% | +29.50% / 4.79% |
+| imtcp | 32 | +25.80% / 4.34% | +22.47% / 1.41% |
+| imtcp | 128 | +41.83% / 30.91% | +3.25% / 30.63% |
+| imptcp | 1 | +57.88% / 3.81% | +51.47% / 4.76% |
+| imptcp | 32 | +10.44% / 7.38% | +7.99% / 8.33% |
+| imptcp | 128 | -1.22% / 0.75% | -2.34% / 1.22% |
+
+The shortcut exceeds its 5% improvement gate in both independent sessions,
+and no workload crosses the -3% regression guardrail.
+
+Churn used 32 connections per round, 32 rounds, 131,072 total messages, and
+`maxStates=64`:
+
+| Input | Session 1 median / MAD | Session 2 median / MAD |
+| --- | ---: | ---: |
+| imtcp | +20.31% / 1.96% | +17.61% / 1.33% |
+| imptcp | +10.24% / 2.52% | +6.92% / 3.77% |
+
+## Inline tuple buffer: rejected
+
+The candidate removed the common tuple allocation, but two full independent
+sessions found no repeatable qualifying gain and several regressions beyond
+the -3% guardrail. Examples from session 2 were imptcp IP/port at 32
+connections (-6.68%), imtcp IP/port at one connection (-6.72%), and imtcp
+IP/port at 32 connections (-16.58%). The inline-buffer commit was therefore
+removed from the branch.
+
+Early end-to-end samples are intentionally excluded: their timer included the
+testbench's 200 ms file-line polling interval and produced quantized, bimodal
+results. The committed harness ends timing at tcpflood sender completion,
+keeps polling outside the interval, pins the downstream main queue to one
+worker, and still requires exact post-run delivery.

--- a/benchmarks/ratelimit-port-keys/run.sh
+++ b/benchmarks/ratelimit-port-keys/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Run reproducible port-key ratelimit benchmarks.
+exec "$(dirname "$0")/runner.py" "$@"

--- a/benchmarks/ratelimit-port-keys/runner.py
+++ b/benchmarks/ratelimit-port-keys/runner.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Run paired, alternating port-key ratelimit benchmark trials."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import platform
+import shlex
+import statistics
+import subprocess
+import tempfile
+
+
+def arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-dir", required=True)
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--pair-build-dir")
+    parser.add_argument("--pair-label")
+    parser.add_argument("--pair-output")
+    parser.add_argument("--comparison-output")
+    parser.add_argument("--module", choices=("imtcp", "imptcp"), action="append")
+    parser.add_argument("--key-mode", choices=("port", "ip-port", "host-port"), action="append")
+    parser.add_argument("--connections", type=int, action="append")
+    parser.add_argument("--messages", type=int, default=131072)
+    parser.add_argument("--payload", type=int, default=128)
+    parser.add_argument("--max-states", type=int, default=10000)
+    parser.add_argument("--churn-rounds", type=int, default=1)
+    parser.add_argument("--trials", type=int, default=11)
+    parser.add_argument("--calibration", type=int, default=1)
+    args = parser.parse_args()
+    paired = (args.pair_build_dir, args.pair_label, args.pair_output)
+    if any(paired) and not all(paired):
+        parser.error("pair mode requires all pair arguments")
+    if bool(args.comparison_output) != bool(args.pair_build_dir):
+        parser.error("comparison output is required in pair mode and invalid otherwise")
+    if args.pair_label == args.label:
+        parser.error("pair labels must be distinct")
+    if min(args.messages, args.payload, args.max_states, args.churn_rounds, args.trials) < 1:
+        parser.error("numeric arguments must be positive")
+    if args.calibration < 0:
+        parser.error("calibration must not be negative")
+    connections = args.connections or [1, 32, 128]
+    if any(count < 1 for count in connections):
+        parser.error("connection counts must be positive")
+    if args.messages % args.churn_rounds:
+        parser.error("messages must be divisible by churn rounds")
+    if any((args.messages // args.churn_rounds) % count for count in connections):
+        parser.error("messages per churn round must be divisible by every connection count")
+    return args
+
+
+def revision(build):
+    return subprocess.check_output(["git", "-C", str(build), "rev-parse", "HEAD"], text=True).strip()
+
+
+def build_metadata(build):
+    makefile = build / "Makefile"
+    compiler = "unknown"
+    if makefile.exists():
+        for line in makefile.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.startswith("CC = "):
+                compiler = line[5:].strip()
+                break
+    try:
+        compiler_version = subprocess.check_output(
+            shlex.split(compiler) + ["--version"], text=True, stderr=subprocess.STDOUT).splitlines()[0]
+    except (OSError, subprocess.CalledProcessError):
+        compiler_version = "unavailable"
+    try:
+        configure = subprocess.check_output(
+            [str(build / "config.status"), "--config"], text=True).strip()
+    except (OSError, subprocess.CalledProcessError):
+        configure = "unavailable"
+    return {"revision": revision(build), "compiler": compiler,
+            "compiler_version": compiler_version, "configure": configure}
+
+
+def workload_key(item):
+    return tuple(item[name] for name in
+                 ("module", "key_mode", "connections", "messages", "payload",
+                  "max_states", "churn_rounds", "index"))
+
+
+def median_absolute_deviation(values):
+    center = statistics.median(values)
+    return statistics.median(abs(value - center) for value in values)
+
+
+def comparison_document(baseline_label, candidate_label, results):
+    baseline = {workload_key(item): item for item in results[baseline_label] if item["measured"]}
+    candidate = {workload_key(item): item for item in results[candidate_label] if item["measured"]}
+    if baseline.keys() != candidate.keys():
+        raise RuntimeError("paired results do not contain identical workloads")
+    grouped = {}
+    for key, base in baseline.items():
+        item = candidate[key]
+        group = key[:7]
+        ratio = item["messages_per_second"] / base["messages_per_second"]
+        grouped.setdefault(group, []).append(ratio)
+    workloads = []
+    for group, ratios in sorted(grouped.items()):
+        workloads.append({**dict(zip(("module", "key_mode", "connections", "messages",
+                                     "payload", "max_states", "churn_rounds"), group)),
+                          "paired_ratios": ratios,
+                          "median_ratio": statistics.median(ratios),
+                          "median_absolute_deviation": median_absolute_deviation(ratios)})
+    return {"schema": 1, "baseline": baseline_label, "candidate": candidate_label,
+            "ratio_definition": "candidate_messages_per_second / baseline_messages_per_second",
+            "workloads": workloads}
+
+
+def run_trial(script, build, workload, index, measured, artifacts):
+    metric = artifacts / ("metric-%s-%s-%s-%d.json" %
+                          (workload["module"], workload["key_mode"], workload["connections"], index))
+    env = os.environ.copy()
+    env.update({"BENCH_BUILD_DIR": str(build), "BENCH_METRIC_FILE": str(metric),
+                **{"BENCH_" + key.upper(): str(value) for key, value in workload.items()}})
+    subprocess.run([str(script)], env=env, check=True)
+    value = json.loads(metric.read_text(encoding="utf-8"))
+    value.update({"index": index, "measured": measured})
+    return value
+
+
+def main():
+    args = arguments()
+    script = Path(__file__).with_name("trial.sh").resolve()
+    builds = [(Path(args.build_dir).resolve(), args.label, Path(args.output).resolve())]
+    if args.pair_build_dir:
+        builds.append((Path(args.pair_build_dir).resolve(), args.pair_label, Path(args.pair_output).resolve()))
+    workloads = [{"module": module, "key_mode": mode, "connections": connections,
+                  "messages": args.messages, "payload": args.payload, "max_states": args.max_states,
+                  "churn_rounds": args.churn_rounds}
+                 for module in (args.module or ["imtcp", "imptcp"])
+                 for mode in (args.key_mode or ["port", "ip-port", "host-port"])
+                 for connections in (args.connections or [1, 32, 128])]
+    results = {label: [] for _, label, _ in builds}
+    with tempfile.TemporaryDirectory(prefix="rsyslog-port-key-bench-") as directory:
+        artifacts = Path(directory)
+        total = args.calibration + args.trials
+        for workload in workloads:
+            for index in range(total):
+                order = builds if index % 2 == 0 else list(reversed(builds))
+                for build, label, _ in order:
+                    results[label].append(run_trial(script, build, workload, index,
+                                                    index >= args.calibration, artifacts))
+    for build, label, output in builds:
+        measured = [item for item in results[label] if item["measured"]]
+        document = {"schema": 2, "label": label, **build_metadata(build),
+                    "system": {"platform": platform.platform(), "machine": platform.machine(),
+                               "processor": platform.processor(),
+                               "python": platform.python_version()},
+                    "host_exclusive": False, "cache_state": "uncontrolled",
+                    "trials": results[label],
+                    "median_messages_per_second": statistics.median(
+                        item["messages_per_second"] for item in measured)}
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    if args.comparison_output:
+        output = Path(args.comparison_output).resolve()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(comparison_document(builds[0][1], builds[1][1], results),
+                                     indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/ratelimit-port-keys/trial.sh
+++ b/benchmarks/ratelimit-port-keys/trial.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Run one full rsyslog lifecycle and validate exact delivery.
+: "${BENCH_BUILD_DIR:?}" "${BENCH_MODULE:?}" "${BENCH_KEY_MODE:?}"
+: "${BENCH_CONNECTIONS:?}" "${BENCH_MESSAGES:?}" "${BENCH_PAYLOAD:?}"
+: "${BENCH_MAX_STATES:?}" "${BENCH_CHURN_ROUNDS:?}" "${BENCH_METRIC_FILE:?}"
+
+cd "$BENCH_BUILD_DIR/tests" || exit 1
+export srcdir="$BENCH_BUILD_DIR/tests"
+. "$srcdir/diag.sh" init
+
+PORT_FILE="$PWD/${RSYSLOG_DYNNAME}.input.port"
+POLICY_FILE="$PWD/${RSYSLOG_DYNNAME}.policy.yaml"
+case "$BENCH_KEY_MODE" in
+	port) key_template=BenchPort ;;
+	ip-port) key_template=BenchIpPort ;;
+	host-port) key_template=BenchHostPort ;;
+	*) error_exit 1 "unknown key mode $BENCH_KEY_MODE" ;;
+esac
+cat >"$POLICY_FILE" <<EOF
+perSource:
+  enabled: true
+  keyTemplate: "$key_template"
+  maxStates: $BENCH_MAX_STATES
+  default:
+    max: $BENCH_MESSAGES
+    window: 1h
+EOF
+
+generate_conf
+add_conf '
+main_queue(queue.workerThreads="1")
+template(name="BenchPort" type="string" string="%fromhost-port%")
+template(name="BenchIpPort" type="string" string="%fromhost-ip%:%fromhost-port%")
+template(name="BenchHostPort" type="string" string="%fromhost%:%fromhost-port%")
+ratelimit(name="bench" policy="'"$POLICY_FILE"'")
+module(load="../plugins/'"$BENCH_MODULE"'/.libs/'"$BENCH_MODULE"'")
+input(type="'"$BENCH_MODULE"'" address="127.0.0.1" port="0"
+      listenPortFileName="'"$PORT_FILE"'" ratelimit.name="bench")
+template(name="benchOut" type="string" string="%msg%\n")
+if $msg contains "msgnum:" then
+  action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="benchOut")
+'
+
+startup
+assign_file_content INPUT_PORT "$PORT_FILE"
+start_ns=$(date +%s%N)
+per_round=$((BENCH_MESSAGES / BENCH_CHURN_ROUNDS))
+offset=0
+round=0
+while [ "$round" -lt "$BENCH_CHURN_ROUNDS" ]; do
+	tcpflood -p"$INPUT_PORT" -c"$BENCH_CONNECTIONS" -Y -m"$per_round" \
+		-i"$offset" -d"$BENCH_PAYLOAD" >/dev/null
+	offset=$((offset + per_round))
+	round=$((round + 1))
+done
+end_ns=$(date +%s%N)
+wait_file_lines "$RSYSLOG_OUT_LOG" "$BENCH_MESSAGES" 300
+shutdown_when_empty
+wait_shutdown
+export NUMMESSAGES="$BENCH_MESSAGES"
+cut -d: -f2 "$RSYSLOG_OUT_LOG" >"${RSYSLOG_OUT_LOG}.seq"
+mv "${RSYSLOG_OUT_LOG}.seq" "$RSYSLOG_OUT_LOG"
+seq_check 0 $((BENCH_MESSAGES - 1))
+mkdir -p "$(dirname "$BENCH_METRIC_FILE")"
+printf '{"module":"%s","key_mode":"%s","connections":%d,"messages":%d,"payload":%d,"max_states":%d,"churn_rounds":%d,"elapsed_ns":%d,"messages_per_second":%.3f}\n' \
+	"$BENCH_MODULE" "$BENCH_KEY_MODE" "$BENCH_CONNECTIONS" "$BENCH_MESSAGES" \
+	"$BENCH_PAYLOAD" "$BENCH_MAX_STATES" "$BENCH_CHURN_ROUNDS" "$((end_ns-start_ns))" \
+	"$(awk -v n="$BENCH_MESSAGES" -v t="$((end_ns-start_ns))" 'BEGIN { print n * 1000000000 / t }')" \
+	>"$BENCH_METRIC_FILE"
+exit_test

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -318,6 +318,7 @@ struct ptcpsess_s {
     uchar *pMsg_save; /* message (fragment) save area in regex framing mode */
     prop_t *peerName; /* host name we received messages from */
     prop_t *peerIP;
+    prop_t *peerPort;
     const uchar *startRegex; /* cache for performance reasons */
     int iAddtlFrameDelim; /* cache for performance reasons */
 };
@@ -411,6 +412,7 @@ static void ATTR_NONNULL() destructSess(ptcpsess_t *const pSess) {
     free(pSess->pMsg);
     prop.Destruct(&pSess->peerName);
     prop.Destruct(&pSess->peerIP);
+    prop.Destruct(&pSess->peerPort);
     DESTROY_ATOMIC_HELPER_MUT(pSess->mutWorkQueued);
     /* TODO: make these inits compile-time switch depending: */
     pSess->pMsg = NULL;
@@ -738,10 +740,12 @@ PRAGMA_DIAGNOSTIC_POP
  * on how to deal with that.
  * rgerhards, 2008-03-31
  */
-static rsRetVal getPeerNames(prop_t **peerName, prop_t **peerIP, struct sockaddr *pAddr, sbool bUXServer) {
+static rsRetVal getPeerNames(
+    prop_t **peerName, prop_t **peerIP, prop_t **peerPort, struct sockaddr *pAddr, sbool bUXServer) {
     int error;
     uchar szIP[NI_MAXHOST + 1] = "";
     uchar szHname[NI_MAXHOST + 1] = "";
+    uchar szPort[NI_MAXSERV + 1] = "";
     struct addrinfo hints, *res;
     sbool bMaliciousHName = 0;
 
@@ -749,6 +753,7 @@ static rsRetVal getPeerNames(prop_t **peerName, prop_t **peerIP, struct sockaddr
 
     *peerName = NULL;
     *peerIP = NULL;
+    *peerPort = NULL;
 
     if (bUXServer) {
         const uchar *lhName = glbl.GetLocalHostName();
@@ -763,7 +768,8 @@ static rsRetVal getPeerNames(prop_t **peerName, prop_t **peerIP, struct sockaddr
         szHname[hname_len] = '\0';
         szIP[ip_len] = '\0';
     } else {
-        error = getnameinfo(pAddr, SALEN(pAddr), (char *)szIP, sizeof(szIP), NULL, 0, NI_NUMERICHOST);
+        error = getnameinfo(pAddr, SALEN(pAddr), (char *)szIP, sizeof(szIP), (char *)szPort, sizeof(szPort),
+                            NI_NUMERICHOST | NI_NUMERICSERV);
         if (error) {
             DBGPRINTF("Malformed from address %s\n", gai_strerror(error));
             RS_COPY_LITERAL(szHname, "???");
@@ -803,11 +809,15 @@ static rsRetVal getPeerNames(prop_t **peerName, prop_t **peerIP, struct sockaddr
     CHKiRet(prop.Construct(peerIP));
     CHKiRet(prop.SetString(*peerIP, szIP, ustrlen(szIP)));
     CHKiRet(prop.ConstructFinalize(*peerIP));
+    CHKiRet(prop.Construct(peerPort));
+    CHKiRet(prop.SetString(*peerPort, szPort, ustrlen(szPort)));
+    CHKiRet(prop.ConstructFinalize(*peerPort));
 
 finalize_it:
     if (iRet != RS_RET_OK) {
         if (*peerName != NULL) prop.Destruct(peerName);
         if (*peerIP != NULL) prop.Destruct(peerIP);
+        if (*peerPort != NULL) prop.Destruct(peerPort);
     }
     if (bMaliciousHName) iRet = RS_RET_MALICIOUS_HNAME;
     RETiRet;
@@ -885,7 +895,7 @@ finalize_it:
  * rgerhards, 2008-04-22
  */
 static rsRetVal ATTR_NONNULL()
-    AcceptConnReq(ptcplstn_t *const pLstn, int *const newSock, prop_t **peerName, prop_t **peerIP) {
+    AcceptConnReq(ptcplstn_t *const pLstn, int *const newSock, prop_t **peerName, prop_t **peerIP, prop_t **peerPort) {
     int sockflags;
     struct sockaddr_storage addr;
     socklen_t addrlen = sizeof(addr);
@@ -894,6 +904,8 @@ static rsRetVal ATTR_NONNULL()
     DEFiRet;
 
     *peerName = NULL; /* ensure we know if we don't have one! */
+    *peerIP = NULL;
+    *peerPort = NULL;
     iNewSock = accept(pLstn->sock, (struct sockaddr *)&addr, &addrlen);
     if (iNewSock < 0) {
         if (CHK_EAGAIN_EWOULDBLOCK || errno == EMFILE) ABORT_FINALIZE(RS_RET_NO_MORE_DATA);
@@ -912,7 +924,7 @@ static rsRetVal ATTR_NONNULL()
 
     if (pLstn->pSrv->bKeepAlive) EnableKeepAlive(pLstn, iNewSock); /* we ignore errors, best to do! */
 
-    CHKiRet(getPeerNames(peerName, peerIP, (struct sockaddr *)&addr, pLstn->pSrv->bUnixSocket));
+    CHKiRet(getPeerNames(peerName, peerIP, peerPort, (struct sockaddr *)&addr, pLstn->pSrv->bUnixSocket));
 
     /* set the new socket to non-blocking IO */
     const char *fcntl_operation = "F_GETFL";
@@ -932,6 +944,7 @@ static rsRetVal ATTR_NONNULL()
                  fcntl_operation, iNewSock);
         prop.Destruct(peerName);
         prop.Destruct(peerIP);
+        prop.Destruct(peerPort);
         ABORT_FINALIZE(RS_RET_IO_ERROR);
     }
     if (pLstn->pSrv->bEmitMsgOnOpen) {
@@ -994,6 +1007,7 @@ static rsRetVal doSubmitMsg(ptcpsess_t *pThis, struct syslogTime *stTime, time_t
     }
     MsgSetRcvFrom(pMsg, pThis->peerName);
     CHKiRet(MsgSetRcvFromIP(pMsg, pThis->peerIP));
+    CHKiRet(MsgSetRcvFromPort(pMsg, pThis->peerPort));
     MsgSetRuleset(pMsg, pSrv->pRuleset);
     if (pThis->bFrameOversize) {
         writeOversizeMessageLog(pMsg);
@@ -1654,7 +1668,8 @@ finalize_it:
 
 /* add a session to the server
  */
-static rsRetVal addSess(ptcplstn_t *const pLstn, const int sock, prop_t *const peerName, prop_t *const peerIP) {
+static rsRetVal addSess(
+    ptcplstn_t *const pLstn, const int sock, prop_t *const peerName, prop_t *const peerIP, prop_t *const peerPort) {
     DEFiRet;
     ptcpsess_t *pSess = NULL;
     ptcpsrv_t *pSrv = pLstn->pSrv;
@@ -1664,6 +1679,7 @@ static rsRetVal addSess(ptcplstn_t *const pLstn, const int sock, prop_t *const p
 
     NULL_CHECK(peerName);
     NULL_CHECK(peerIP);
+    NULL_CHECK(peerPort);
 
     CHKmalloc(pSess = calloc(1, sizeof(ptcpsess_t)));
     INIT_ATOMIC_HELPER_MUT(pSess->mutWorkQueued);
@@ -1690,6 +1706,7 @@ static rsRetVal addSess(ptcplstn_t *const pLstn, const int sock, prop_t *const p
     pSess->bAtStrtOfFram = 1;
     pSess->peerName = peerName;
     pSess->peerIP = peerIP;
+    pSess->peerPort = peerPort;
     pSess->compressionMode = pLstn->pSrv->compressionMode;
     /* AUTO mode starts in sniff state; first DataRcvd() locks in the
      * effective compressionMode for the rest of the session. */
@@ -2098,27 +2115,36 @@ static rsRetVal ATTR_NONNULL() lstnActivity(ptcplstn_t *const pLstn) {
     int newSock = -1;
     prop_t *peerName;
     prop_t *peerIP;
+    prop_t *peerPort;
     rsRetVal localRet;
     DEFiRet;
 
     DBGPRINTF("imptcp: new connection on listen socket %d\n", pLstn->sock);
     while (glbl.GetGlobalInputTermState() == 0) {
-        localRet = AcceptConnReq(pLstn, &newSock, &peerName, &peerIP);
+        newSock = -1;
+        peerName = NULL;
+        peerIP = NULL;
+        peerPort = NULL;
+        localRet = AcceptConnReq(pLstn, &newSock, &peerName, &peerIP, &peerPort);
         DBGPRINTF("imptcp: AcceptConnReq on listen socket %d returned %d\n", pLstn->sock, localRet);
         if (glbl.GetGlobalInputTermState() == 1) {
             if (newSock != -1) {
                 close(newSock);
             }
+            if (peerName != NULL) prop.Destruct(&peerName);
+            if (peerIP != NULL) prop.Destruct(&peerIP);
+            if (peerPort != NULL) prop.Destruct(&peerPort);
             break;
         } else if (localRet == RS_RET_NO_MORE_DATA) {
             break;
         }
         CHKiRet(localRet);
-        localRet = addSess(pLstn, newSock, peerName, peerIP);
+        localRet = addSess(pLstn, newSock, peerName, peerIP, peerPort);
         if (localRet != RS_RET_OK) {
             close(newSock);
             prop.Destruct(&peerName);
             prop.Destruct(&peerIP);
+            prop.Destruct(&peerPort);
             ABORT_FINALIZE(localRet);
         }
     }

--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -161,6 +161,7 @@ static ratelimit_cfg_bucket_t *ratelimitCfgBucket(ratelimit_cfgs_t *const cfgs,
  * Allowed exceptions (no parse):
  * - %fromhost-ip%
  * - %fromhost%
+ * - %fromhost-port%
  * - %fromhost-ip%:%fromhost-port%
  * - %fromhost%:%fromhost-port%
  *
@@ -189,8 +190,11 @@ static enum ratelimit_ps_key_mode perSourceKeyModeFromTemplate(const struct temp
         if (entry->bComplexProcessing) {
             return RL_PS_KEY_TPL;
         }
-        if (entry->data.field.msgProp.id == PROP_FROMHOST_IP || entry->data.field.msgProp.id == PROP_FROMHOST) {
-            return (entry->data.field.msgProp.id == PROP_FROMHOST_IP) ? RL_PS_KEY_FROMHOST_IP : RL_PS_KEY_FROMHOST;
+        if (entry->data.field.msgProp.id == PROP_FROMHOST_IP || entry->data.field.msgProp.id == PROP_FROMHOST ||
+            entry->data.field.msgProp.id == PROP_FROMHOST_PORT) {
+            if (entry->data.field.msgProp.id == PROP_FROMHOST_IP) return RL_PS_KEY_FROMHOST_IP;
+            if (entry->data.field.msgProp.id == PROP_FROMHOST_PORT) return RL_PS_KEY_FROMHOST_PORT;
+            return RL_PS_KEY_FROMHOST;
         }
         return RL_PS_KEY_TPL;
     }
@@ -214,7 +218,7 @@ static enum ratelimit_ps_key_mode perSourceKeyModeFromTemplate(const struct temp
         if ((first->data.field.msgProp.id == PROP_FROMHOST_IP || first->data.field.msgProp.id == PROP_FROMHOST) &&
             third->data.field.msgProp.id == PROP_FROMHOST_PORT) {
             return (first->data.field.msgProp.id == PROP_FROMHOST_IP) ? RL_PS_KEY_FROMHOST_IP_PORT
-                                                                      : RL_PS_KEY_FROMHOST_PORT;
+                                                                      : RL_PS_KEY_FROMHOST_NAME_PORT;
         }
         return RL_PS_KEY_TPL;
     }
@@ -2705,12 +2709,15 @@ static rsRetVal ratelimitComputePerSourceKey(ratelimit_t *ratelimit, smsg_t *pMs
         case RL_PS_KEY_FROMHOST:
             CHKiRet(ratelimitGetRcvFromString(pMsg, PROP_FROMHOST, &ctx->key, &ctx->key_len, &ctx->free_host));
             break;
+        case RL_PS_KEY_FROMHOST_PORT:
+            CHKiRet(ratelimitGetRcvFromString(pMsg, PROP_FROMHOST_PORT, &ctx->key, &ctx->key_len, &ctx->free_port));
+            break;
         case RL_PS_KEY_FROMHOST_IP_PORT:
             CHKiRet(ratelimitGetRcvFromString(pMsg, PROP_FROMHOST_IP, &host, &host_len, &ctx->free_host));
             CHKiRet(ratelimitGetRcvFromString(pMsg, PROP_FROMHOST_PORT, &port, &port_len, &ctx->free_port));
             CHKiRet(ratelimitComposePerSourceHostPort(ctx, host, host_len, port, port_len));
             break;
-        case RL_PS_KEY_FROMHOST_PORT:
+        case RL_PS_KEY_FROMHOST_NAME_PORT:
             CHKiRet(ratelimitGetRcvFromString(pMsg, PROP_FROMHOST, &host, &host_len, &ctx->free_host));
             CHKiRet(ratelimitGetRcvFromString(pMsg, PROP_FROMHOST_PORT, &port, &port_len, &ctx->free_port));
             CHKiRet(ratelimitComposePerSourceHostPort(ctx, host, host_len, port, port_len));

--- a/runtime/ratelimit.h
+++ b/runtime/ratelimit.h
@@ -47,8 +47,9 @@ enum ratelimit_ps_key_mode {
     RL_PS_KEY_TPL = 0,
     RL_PS_KEY_FROMHOST_IP,
     RL_PS_KEY_FROMHOST,
+    RL_PS_KEY_FROMHOST_PORT,
     RL_PS_KEY_FROMHOST_IP_PORT,
-    RL_PS_KEY_FROMHOST_PORT
+    RL_PS_KEY_FROMHOST_NAME_PORT
 };
 
 typedef enum ratelimit_scope_e { RATELIMIT_SCOPE_INPUT = 0, RATELIMIT_SCOPE_OUTPUT } ratelimit_scope_t;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -894,10 +894,15 @@ TESTS_RATELIMIT = \
 	imuxsock_ratelimit_name.sh
 
 TESTS_RATELIMIT_YAML = \
-	imudp-persource-ratelimit-policy.sh
+	imudp-persource-ratelimit-policy.sh \
+	imtcp-persource-port-keys.sh
 
 TESTS_RATELIMIT_IMPTCP_YAML = \
-	imptcp-persource-ratelimit-policy.sh
+	imptcp-persource-ratelimit-policy.sh \
+	imptcp-persource-port-keys.sh
+
+TESTS_IMPTCP_FROMHOST_PORT = \
+	imptcp-fromhost-port.sh
 
 TESTS_IMTCP_IMPSTATS = \
 	imtcp-impstats.sh
@@ -2302,6 +2307,8 @@ EXTRA_DIST += $(TESTS_IMTCP_IMPSTATS)
 EXTRA_DIST += $(TESTS_RATELIMIT)
 EXTRA_DIST += $(TESTS_RATELIMIT_YAML)
 EXTRA_DIST += $(TESTS_RATELIMIT_IMPTCP_YAML)
+EXTRA_DIST += $(TESTS_IMPTCP_FROMHOST_PORT)
+EXTRA_DIST += ratelimit-persource-port-keys-common.sh
 EXTRA_DIST += $(TESTS_SNMP_MINIMAL)
 EXTRA_DIST += $(TESTS_SNMP_FULL)
 EXTRA_DIST += $(TESTS_MMUTF8FIX)
@@ -3311,6 +3318,7 @@ if ENABLE_IMPTCP
 # need to be disabled if we do not have this module
 TESTS += $(TESTS_IMPTCP)
 TESTS += $(TESTS_IMPTCP_STREAM_ALWAYS)
+TESTS += $(TESTS_IMPTCP_FROMHOST_PORT)
 if HAVE_LIBYAML
 TESTS += $(TESTS_RATELIMIT_IMPTCP_YAML)
 endif # HAVE_LIBYAML

--- a/tests/imptcp-fromhost-port.sh
+++ b/tests/imptcp-fromhost-port.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+## Verify that imptcp attaches the accepted peer's numeric source port to
+## every message. The tcpflood port file is obtained with getsockname(), and
+## exact comparison after synchronized shutdown proves property correctness.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=4
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+generate_conf
+add_conf '
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp" address="127.0.0.1" port="0"
+      listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%fromhost-port%\n")
+if $msg contains "msgnum:" then
+  action(type="omfile" template="outfmt" file="'"$RSYSLOG_OUT_LOG"'")
+'
+startup
+tcpflood -p"$(cat "${RSYSLOG_DYNNAME}.tcpflood_port")" -m"$NUMMESSAGES" \
+	-w "${RSYSLOG_DYNNAME}.tcpflood-source-port"
+shutdown_when_empty
+wait_shutdown
+SOURCE_PORT=$(cat "${RSYSLOG_DYNNAME}.tcpflood-source-port")
+EXPECTED=$(printf '%s\n%s\n%s\n%s' "$SOURCE_PORT" "$SOURCE_PORT" "$SOURCE_PORT" "$SOURCE_PORT")
+export EXPECTED
+cmp_exact
+exit_test

--- a/tests/imptcp-persource-port-keys.sh
+++ b/tests/imptcp-persource-port-keys.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+## Run the shared exact port-key ratelimit test through imptcp.
+export PORT_KEY_MODULE=imptcp
+. ${srcdir:=.}/ratelimit-persource-port-keys-common.sh

--- a/tests/imtcp-persource-port-keys.sh
+++ b/tests/imtcp-persource-port-keys.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+## Run the shared exact port-key ratelimit test through imtcp.
+export PORT_KEY_MODULE=imtcp
+. ${srcdir:=.}/ratelimit-persource-port-keys-common.sh

--- a/tests/ratelimit-persource-port-keys-common.sh
+++ b/tests/ratelimit-persource-port-keys-common.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+## Verify the three exact port-based per-source key modes for a TCP input.
+## The first tcpflood run uses two simultaneous connections and the second
+## uses 32; both deterministically send two messages per connection. A limit
+## of one must therefore emit exactly one message for each of 34 distinct
+## numeric peer ports. The impstats oracle also proves that none of the exact
+## modes used generic template or
+## message-parse evaluation, even though the syslog-header hostname is set to
+## an unrelated value.
+: "${PORT_KEY_MODULE:?wrapper must select imtcp or imptcp}"
+. ${srcdir:=.}/diag.sh init
+require_plugin impstats
+export STATSFILE="$RSYSLOG_DYNNAME.stats"
+
+for mode in port ip_port host_port; do
+	policy="$(pwd)/${RSYSLOG_DYNNAME}.${mode}.yaml"
+	case "$mode" in
+		port) template=PortKey ;;
+		ip_port) template=IpPortKey ;;
+		host_port) template=HostPortKey ;;
+	esac
+	cat >"$policy" <<EOF
+perSource:
+  enabled: true
+  keyTemplate: "$template"
+  default:
+    max: 1
+    window: 1h
+EOF
+done
+
+generate_conf
+add_conf '
+template(name="PortKey" type="string" string="%fromhost-port%")
+template(name="IpPortKey" type="string" string="%fromhost-ip%:%fromhost-port%")
+template(name="HostPortKey" type="string" string="%fromhost%:%fromhost-port%")
+ratelimit(name="port" policy="'"$(pwd)/${RSYSLOG_DYNNAME}.port.yaml"'")
+ratelimit(name="ip_port" policy="'"$(pwd)/${RSYSLOG_DYNNAME}.ip_port.yaml"'")
+ratelimit(name="host_port" policy="'"$(pwd)/${RSYSLOG_DYNNAME}.host_port.yaml"'")
+
+module(load="../plugins/'"$PORT_KEY_MODULE"'/.libs/'"$PORT_KEY_MODULE"'")
+module(load="../plugins/impstats/.libs/impstats" log.file="'"$STATSFILE"'" interval="1")
+
+ruleset(name="port_rules") {
+  action(type="omfile" file="'"$RSYSLOG_DYNNAME"'.port.out"
+         template="PortKey")
+}
+ruleset(name="ip_port_rules") {
+  action(type="omfile" file="'"$RSYSLOG_DYNNAME"'.ip_port.out"
+         template="IpPortKey")
+}
+ruleset(name="host_port_rules") {
+  action(type="omfile" file="'"$RSYSLOG_DYNNAME"'.host_port.out"
+         template="HostPortKey")
+}
+
+input(type="'"$PORT_KEY_MODULE"'" address="127.0.0.1" port="0"
+      listenPortFileName="'"$RSYSLOG_DYNNAME"'.port.listen"
+      ruleset="port_rules" ratelimit.name="port")
+input(type="'"$PORT_KEY_MODULE"'" address="127.0.0.1" port="0"
+      listenPortFileName="'"$RSYSLOG_DYNNAME"'.ip_port.listen"
+      ruleset="ip_port_rules" ratelimit.name="ip_port")
+input(type="'"$PORT_KEY_MODULE"'" address="127.0.0.1" port="0"
+      listenPortFileName="'"$RSYSLOG_DYNNAME"'.host_port.listen"
+      ruleset="host_port_rules" ratelimit.name="host_port")
+'
+startup
+
+for mode in port ip_port host_port; do
+	tcpflood -p"$(cat "${RSYSLOG_DYNNAME}.${mode}.listen")" -c2 -Y -m4 \
+		-h"header-${mode}" >/dev/null
+	wait_file_lines "${RSYSLOG_DYNNAME}.${mode}.out" 2 30
+done
+for mode in port ip_port host_port; do
+	tcpflood -p"$(cat "${RSYSLOG_DYNNAME}.${mode}.listen")" -c32 -Y -m64 \
+		-h"other-header-${mode}" >/dev/null
+done
+sleep 2
+shutdown_when_empty
+wait_shutdown
+
+for mode in port ip_port host_port; do
+	output="${RSYSLOG_DYNNAME}.${mode}.out"
+	if [ "$(wc -l <"$output")" -ne 34 ]; then
+		echo "FAIL: $PORT_KEY_MODULE $mode did not allow one message per connection"
+		cat "$output"
+		error_exit 1
+	fi
+	if [ "$(sort -u "$output" | wc -l)" -ne 34 ]; then
+		echo "FAIL: $PORT_KEY_MODULE $mode did not produce 34 distinct port keys"
+		cat "$output"
+		error_exit 1
+	fi
+	if sed 's/.*://' "$output" | grep -Ev '^[0-9]+$' | grep -q .; then
+		echo "FAIL: $PORT_KEY_MODULE $mode emitted a non-numeric peer port"
+		cat "$output"
+		error_exit 1
+	fi
+	stats=$(grep "ratelimit.${mode}.per_source" "$STATSFILE" | tail -1)
+	tpl_evals=$(printf '%s\n' "$stats" | grep -o 'per_source_key_tpl_evals=[0-9]*' | sed 's/.*=//')
+	parse_evals=$(printf '%s\n' "$stats" | grep -o 'per_source_key_parse_evals=[0-9]*' | sed 's/.*=//')
+	if [ "${tpl_evals:-1}" -ne 0 ] || [ "${parse_evals:-1}" -ne 0 ]; then
+		echo "FAIL: $PORT_KEY_MODULE $mode used generic key evaluation: $stats"
+		error_exit 1
+	fi
+done
+
+exit_test


### PR DESCRIPTION
## Summary

- populate the immutable `fromhost-port` receive property in imptcp, matching imtcp
- recognize exact `%fromhost-port%` per-source keys and bypass generic template evaluation/parsing
- add reproducible paired imtcp/imptcp benchmarks with exact delivery validation
- cover port-only, IP/port, and hostname/port keys with 2 and 32 real TCP connections

## Why

Port-based per-source ratelimiting previously took the generic template path,
and imptcp did not populate the receive-port property at all. This made exact
port keys slower than the existing source-property shortcuts and prevented the
same configuration from behaving consistently across the two TCP inputs.

## Performance evidence

Two independent sessions used one calibration and eleven alternating measured
pairs per workload. The retained port-only shortcut improved median throughput
by 22–26% for imtcp with 32 connections and 8–10% for imptcp with 32
connections. Its weakest workload was imptcp with 128 connections at -1.22%
and -2.34%, within the -3% guardrail. Short-connection churn at `maxStates=64`
improved by 17–20% for imtcp and 7–10% for imptcp.

The separately measured inline tuple-buffer experiment failed its performance
gate and was removed. Full normalized results and environment details are in
`benchmarks/ratelimit-port-keys/RESULTS.md`.

## Validation

- C formatting, Python style, shellcheck, and diff checks passed
- focused imtcp/imptcp/imudp per-source, property, reload, eviction, repeat,
  top-N, and legacy tests passed
- host imrelp focused run was unavailable in the minimal host configuration;
  the Ubuntu container was built with RELP and covered the hosted family
- mock distcheck: 939 total, 934 pass, 5 skip, 0 fail/error
- Ubuntu 26.04 CI-equivalent suite: 1,453 total, 1,420 pass, 33 skip, 0 fail/error
- Clang 21 static analyzer: no bugs found
- local Cubic review: no issues found
- image digest: `sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`

## Testing limits

Loopback connections provide real distinct ephemeral ports but do not model
NAT, proxies, or separate remote machines. Tests assert numeric uniqueness,
not fixed ephemeral values. Port reuse timing and every IPv6/TLS environment
remain covered by existing lifecycle/churn and transport tests rather than a
fully forced matrix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

