### PR TITLE
security: clarify daily stable disclosure path

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -114,6 +114,18 @@ hardening are still fixed, but normally flow through daily stable and the next
 scheduled stable release, with advisory text documenting the affected
 configuration and mitigations.
 
+For a confirmed issue limited to an optional component or explicitly enabled,
+uncommon configuration, with primarily denial-of-service impact and no known
+active exploitation, maintainers normally use the ordinary reviewed daily
+stable workflow. Once the fix is validated, maintainers normally give
+distribution security contacts a short embargoed notification before making
+the daily stable package and concise advisory public. This coordination period
+typically lasts no more than two days. The validated fix may remain on a
+private maintainer branch during that period and is merged publicly when the
+embargo ends. The next scheduled stable release then includes the same fix.
+Maintainers may choose a different path when the specific exposure or
+downstream impact warrants it.
+
 ## Optional and Contributed Modules
 
 rsyslog includes many optional plugins and contributed modules. Some are widely


### PR DESCRIPTION
## Summary

Clarify that confirmed, narrowly scoped issues in optional components or uncommon configurations—primarily denial-of-service issues without known active exploitation—normally use the regular daily-stable release path.

The policy now states that distribution security contacts normally receive a short, embargoed notice after the fix is validated. The fix may remain private during that period; the daily package and concise advisory are published after it, normally within two days. The next scheduled stable release includes the same fix. Maintainers retain discretion for broader exposure or downstream impact.

## Validation

- `git diff --check`
- Manual text review of `SECURITY.md`

No build or container validation was run because this is a documentation-only policy change.