### PR TITLE
mmkubernetes: reload SA token proactively and on HTTP 401

### DIFF
--- a/contrib/mmkubernetes/mmkubernetes.c
+++ b/contrib/mmkubernetes/mmkubernetes.c
@@ -41,6 +41,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <unistd.h>
+#include <time.h>
 #include <sys/stat.h>
 #include <libestr.h>
 #include <liblognorm.h>
@@ -106,6 +107,10 @@ DEFobjCurrIf(regexp) DEFobjCurrIf(statsobj) DEFobjCurrIf(datetime)
     -1 /* delete all expired entries from the cache every N seconds \
 -1 disables cache expiration/ttl checking                           \
 0 means - run cache expiration for every record */
+#define DFLT_TOKEN_RELOAD_INTERVAL                                         \
+    3600 /* proactively re-read the bearer token from tokenfile every N    \
+seconds so a rotated projected ServiceAccount token is picked up without a \
+restart; 0 disables the proactive reload */
 
 /* only support setting the partial chain flag on openssl platforms that have the define */
 #if defined(ENABLE_OPENSSL) && defined(X509_V_FLAG_PARTIAL_CHAIN)
@@ -159,6 +164,8 @@ struct modConfData_s {
     sbool sslPartialChain; /* if true, allow using intermediate certs without root certs */
     int cacheEntryTTL; /* delete entries from the cache if they are older than this many seconds */
     int cacheExpireInterval; /* delete all expired entries from the cache every this many seconds */
+    int tokenReloadInterval; /* proactively re-read the token from tokenFile every this many seconds
+                                (0 disables); guards against short-lived rotated SA tokens going stale */
 };
 
 /* action (instance) configuration data */
@@ -192,12 +199,15 @@ typedef struct _instanceData {
     sbool sslPartialChain; /* if true, allow using intermediate certs without root certs */
     int cacheEntryTTL; /* delete entries from the cache if they are older than this many seconds */
     int cacheExpireInterval; /* delete all expired entries from the cache every this many seconds */
+    int tokenReloadInterval; /* proactively re-read the token from tokenFile every this many seconds
+                                (0 disables); guards against short-lived rotated SA tokens going stale */
 } instanceData;
 
 typedef struct wrkrInstanceData {
     instanceData *pData;
     CURL *curlCtx;
     struct curl_slist *curlHdr;
+    time_t lastTokenReload; /* when curlHdr's bearer token was last (re)read from disk */
     char *curlRply;
     size_t curlRplyLen;
     statsobj_t *stats; /* stats for this instance */
@@ -238,7 +248,8 @@ static struct cnfparamdescr modpdescr[] = {{"kubernetesurl", eCmdHdlrArray, 0},
                                            {"busyretryinterval", eCmdHdlrInt, 0},
                                            {"sslpartialchain", eCmdHdlrBinary, 0},
                                            {"cacheentryttl", eCmdHdlrInt, 0},
-                                           {"cacheexpireinterval", eCmdHdlrInt, 0}
+                                           {"cacheexpireinterval", eCmdHdlrInt, 0},
+                                           {"tokenreloadinterval", eCmdHdlrInt, 0}
 #if HAVE_LOADSAMPLESFROMSTRING == 1
                                            ,
                                            {"filenamerules", eCmdHdlrArray, 0},
@@ -266,7 +277,8 @@ static struct cnfparamdescr actpdescr[] = {{"kubernetesurl", eCmdHdlrArray, 0},
                                            {"busyretryinterval", eCmdHdlrInt, 0},
                                            {"sslpartialchain", eCmdHdlrBinary, 0},
                                            {"cacheentryttl", eCmdHdlrInt, 0},
-                                           {"cacheexpireinterval", eCmdHdlrInt, 0}
+                                           {"cacheexpireinterval", eCmdHdlrInt, 0},
+                                           {"tokenreloadinterval", eCmdHdlrInt, 0}
 #if HAVE_LOADSAMPLESFROMSTRING == 1
                                            ,
                                            {"filenamerules", eCmdHdlrArray, 0},
@@ -645,6 +657,7 @@ BEGINsetModCnf
     loadModConf->sslPartialChain = DFLT_SSL_PARTIAL_CHAIN;
     loadModConf->cacheEntryTTL = DFLT_CACHE_ENTRY_TTL;
     loadModConf->cacheExpireInterval = DFLT_CACHE_EXPIRE_INTERVAL;
+    loadModConf->tokenReloadInterval = DFLT_TOKEN_RELOAD_INTERVAL;
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) {
             continue;
@@ -776,6 +789,8 @@ BEGINsetModCnf
             loadModConf->cacheEntryTTL = pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "cacheexpireinterval")) {
             loadModConf->cacheExpireInterval = pvals[i].val.d.n;
+        } else if (!strcmp(modpblk.descr[i].name, "tokenreloadinterval")) {
+            loadModConf->tokenReloadInterval = pvals[i].val.d.n;
         } else {
             dbgprintf(
                 "mmkubernetes: program error, non-handled "
@@ -804,6 +819,14 @@ BEGINsetModCnf
                      loadModConf->cacheEntryTTL);
             ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
         }
+    }
+
+    if (loadModConf->tokenReloadInterval < 0) {
+        LogError(0, RS_RET_CONFIG_ERROR,
+                 "mmkubernetes: tokenreloadinterval value [%d] is invalid - "
+                 "value must be 0 (disabled) or greater",
+                 loadModConf->tokenReloadInterval);
+        ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
     }
 
     /* set defaults */
@@ -893,13 +916,101 @@ finalize_it:
 }
 #endif
 
+/**
+ * (Re)build the curl Authorization header for a worker from the current bearer
+ * token and bind it to the worker's curl handle.
+ *
+ * The token is read fresh on every call: @c pData->token (inline, takes
+ * precedence) or the contents of @c pData->tokenFile. This lets a rotated or
+ * late-authorized projected ServiceAccount token be picked up without
+ * recreating the worker. Any header list previously installed on the handle is
+ * released. @c lastTokenReload is stamped so the proactive reload in queryKB()
+ * can schedule the next refresh.
+ *
+ * Shared by createWrkrInstance() (initial build) and the reload paths in
+ * queryKB() (proactive interval + reactive on 401), so the token is read
+ * through a single code path.
+ *
+ * @param[in] pWrkrData worker instance whose curlHdr is (re)built and bound to
+ *            its already-initialized curlCtx
+ * @returns RS_RET_OK on success, or an error code (the previously installed
+ *          header is left in place on failure)
+ */
+static rsRetVal mmk_build_token_header(wrkrInstanceData_t *pWrkrData) {
+    DEFiRet;
+    struct curl_slist *hdr = NULL;
+    char *tokenHdr = NULL;
+    char *token = NULL;
+    FILE *fp = NULL;
+
+    hdr = curl_slist_append(hdr, "Content-Type: text/json; charset=utf-8");
+    if (hdr == NULL) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    if (pWrkrData->pData->token) {
+        /* asprintf leaves the pointer undefined on failure, so NULL it before
+         * aborting - finalize_it frees tokenHdr unconditionally */
+        if (asprintf(&tokenHdr, "Authorization: Bearer %s", pWrkrData->pData->token) == -1) {
+            tokenHdr = NULL;
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+    } else if (pWrkrData->pData->tokenFile) {
+        struct stat statbuf;
+        fp = fopen((const char *)pWrkrData->pData->tokenFile, "r");
+        if (fp && !fstat(fileno(fp), &statbuf)) {
+            size_t bytesread;
+            CHKmalloc(token = malloc((statbuf.st_size + 1) * sizeof(char)));
+            /* require a complete read: a partial read during a rotation race
+             * would yield a truncated (invalid) token, so leave tokenHdr NULL
+             * and let the caller keep the existing header */
+            if ((bytesread = fread(token, sizeof(char), statbuf.st_size, fp)) == (size_t)statbuf.st_size &&
+                bytesread > 0) {
+                token[bytesread] = '\0';
+                if (asprintf(&tokenHdr, "Authorization: Bearer %s", token) == -1) {
+                    tokenHdr = NULL;
+                    ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+                }
+            }
+        }
+    }
+    /* If a token source is configured but we could not read a token (e.g. the
+     * projected token volume is transiently unavailable during rotation), do not
+     * tear down a header that is already installed: keep the existing,
+     * still-likely-valid Authorization header and leave lastTokenReload
+     * unchanged so the caller retries the reload on the next lookup. On the
+     * initial build (curlHdr == NULL) there is nothing to preserve, so we fall
+     * through and install the token-less header, matching the original startup
+     * behavior. */
+    if (tokenHdr == NULL && (pWrkrData->pData->token || pWrkrData->pData->tokenFile) && pWrkrData->curlHdr != NULL) {
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    if (tokenHdr) {
+        struct curl_slist *new_hdr = curl_slist_append(hdr, tokenHdr);
+        if (new_hdr == NULL) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        hdr = new_hdr;
+    }
+    /* swap in the fresh header, releasing any previously installed one */
+    if (pWrkrData->curlHdr != NULL) {
+        curl_slist_free_all(pWrkrData->curlHdr);
+    }
+    pWrkrData->curlHdr = hdr;
+    curl_easy_setopt(pWrkrData->curlCtx, CURLOPT_HTTPHEADER, hdr);
+    hdr = NULL;
+    pWrkrData->lastTokenReload = time(NULL);
+finalize_it:
+    free(token);
+    free(tokenHdr);
+    if (fp != NULL) {
+        fclose(fp);
+    }
+    if (hdr != NULL) {
+        curl_slist_free_all(hdr);
+    }
+    RETiRet;
+}
+
+
 BEGINcreateWrkrInstance
     CODESTARTcreateWrkrInstance;
     CURL *ctx;
-    struct curl_slist *hdr = NULL;
-    char *tokenHdr = NULL;
-    FILE *fp = NULL;
-    char *token = NULL;
     char *statsName = NULL;
 
     CHKiRet(statsobj.Construct(&(pWrkrData->stats)));
@@ -957,38 +1068,8 @@ BEGINcreateWrkrInstance
                                 &(pWrkrData->podCacheMisses)));
     CHKiRet(statsobj.ConstructFinalize(pWrkrData->stats));
 
-    hdr = curl_slist_append(hdr, "Content-Type: text/json; charset=utf-8");
-    if (pWrkrData->pData->token) {
-        if ((-1 == asprintf(&tokenHdr, "Authorization: Bearer %s", pWrkrData->pData->token)) || (!tokenHdr)) {
-            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-        }
-    } else if (pWrkrData->pData->tokenFile) {
-        struct stat statbuf;
-        fp = fopen((const char *)pWrkrData->pData->tokenFile, "r");
-        if (fp && !fstat(fileno(fp), &statbuf)) {
-            size_t bytesread;
-            CHKmalloc(token = malloc((statbuf.st_size + 1) * sizeof(char)));
-            if (0 < (bytesread = fread(token, sizeof(char), statbuf.st_size, fp))) {
-                token[bytesread] = '\0';
-                if ((-1 == asprintf(&tokenHdr, "Authorization: Bearer %s", token)) || (!tokenHdr)) {
-                    ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-                }
-            }
-            free(token);
-            token = NULL;
-        }
-        if (fp) {
-            fclose(fp);
-            fp = NULL;
-        }
-    }
-    if (tokenHdr) {
-        hdr = curl_slist_append(hdr, tokenHdr);
-        free(tokenHdr);
-    }
-    pWrkrData->curlHdr = hdr;
     ctx = curl_easy_init();
-    curl_easy_setopt(ctx, CURLOPT_HTTPHEADER, hdr);
+    pWrkrData->curlCtx = ctx;
     curl_easy_setopt(ctx, CURLOPT_WRITEFUNCTION, curlCB);
     curl_easy_setopt(ctx, CURLOPT_WRITEDATA, pWrkrData);
     if (pWrkrData->pData->caCertFile) curl_easy_setopt(ctx, CURLOPT_CAINFO, pWrkrData->pData->caCertFile);
@@ -1002,15 +1083,27 @@ BEGINcreateWrkrInstance
         curl_easy_setopt(ctx, CURLOPT_SSL_CTX_DATA, NULL);
     }
 #endif
-    pWrkrData->curlCtx = ctx;
+    /* build the Authorization header from the current token on disk and bind it
+     * to the handle just initialized; shared with the reload paths in queryKB()
+     * so the token is read through one code path. */
+    CHKiRet(mmk_build_token_header(pWrkrData));
 finalize_it:
-    free(token);
     free(statsName);
-    if ((iRet != RS_RET_OK) && pWrkrData->stats) {
-        statsobj.Destruct(&(pWrkrData->stats));
-    }
-    if (fp) {
-        fclose(fp);
+    if (iRet != RS_RET_OK) {
+        /* rsyslog does not call freeWrkrInstance when createWrkrInstance fails,
+         * so release the curl handle here to avoid leaking it (e.g. if the
+         * initial token-header build fails). */
+        if (pWrkrData->curlCtx != NULL) {
+            curl_easy_cleanup(pWrkrData->curlCtx);
+            pWrkrData->curlCtx = NULL;
+        }
+        if (pWrkrData->curlHdr != NULL) {
+            curl_slist_free_all(pWrkrData->curlHdr);
+            pWrkrData->curlHdr = NULL;
+        }
+        if (pWrkrData->stats) {
+            statsobj.Destruct(&(pWrkrData->stats));
+        }
     }
 ENDcreateWrkrInstance
 
@@ -1288,6 +1381,7 @@ BEGINnewActInst
     pData->sslPartialChain = loadModConf->sslPartialChain;
     pData->cacheEntryTTL = loadModConf->cacheEntryTTL;
     pData->cacheExpireInterval = loadModConf->cacheExpireInterval;
+    pData->tokenReloadInterval = loadModConf->tokenReloadInterval;
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) {
             continue;
@@ -1420,6 +1514,8 @@ BEGINnewActInst
             pData->cacheEntryTTL = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "cacheexpireinterval")) {
             pData->cacheExpireInterval = pvals[i].val.d.n;
+        } else if (!strcmp(actpblk.descr[i].name, "tokenreloadinterval")) {
+            pData->tokenReloadInterval = pvals[i].val.d.n;
         } else {
             dbgprintf(
                 "mmkubernetes: program error, non-handled "
@@ -1452,6 +1548,14 @@ BEGINnewActInst
                      pData->cacheEntryTTL);
             ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
         }
+    }
+
+    if (pData->tokenReloadInterval < 0) {
+        LogError(0, RS_RET_CONFIG_ERROR,
+                 "mmkubernetes: tokenreloadinterval value [%d] is invalid - "
+                 "value must be 0 (disabled) or greater",
+                 pData->tokenReloadInterval);
+        ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
     }
 
     if (pData->nKubernetesUrls == 0) {
@@ -1592,6 +1696,7 @@ BEGINdbgPrintInstInfo
     dbgprintf("\tbusyretryinterval='%d'\n", pData->busyRetryInterval);
     dbgprintf("\tcacheentryttl='%d'\n", pData->cacheEntryTTL);
     dbgprintf("\tcacheexpireinterval='%d'\n", pData->cacheExpireInterval);
+    dbgprintf("\ttokenreloadinterval='%d'\n", pData->tokenReloadInterval);
 ENDdbgPrintInstInfo
 
 
@@ -1687,6 +1792,29 @@ static rsRetVal queryKB(wrkrInstanceData_t *pWrkrData, char *url, time_t now, st
     struct json_tokener *jt = NULL;
     struct json_object *jo;
     long resp_code = 400;
+    int reloaded_token = 0;
+
+    /* Proactive token refresh: the bearer token is cached in the curl header at
+     * worker start and otherwise never re-read. A projected ServiceAccount token
+     * may be short-lived (kubelet rotates the on-disk file well before expiry),
+     * so re-read it every tokenReloadInterval seconds to stay inside the validity
+     * window and avoid the 401 entirely. A single missed reload is harmless
+     * because validity greatly exceeds the interval. The reactive reload-on-401
+     * below remains as a backstop for the startup / identity-warm-up window this
+     * cannot cover. Done before the busy-time adjustment below, which mutates
+     * `now`. tokenReloadInterval == 0 disables the proactive reload. Only
+     * meaningful when reading from tokenFile: an inline token cannot change, so
+     * skip the reload entirely in that case. */
+    if (pWrkrData->pData->tokenFile != NULL && pWrkrData->pData->token == NULL &&
+        pWrkrData->pData->tokenReloadInterval > 0 &&
+        now - pWrkrData->lastTokenReload >= pWrkrData->pData->tokenReloadInterval) {
+        if (mmk_build_token_header(pWrkrData) != RS_RET_OK) {
+            /* keep the existing (still likely-valid) header; retry next call */
+            LogMsg(0, RS_RET_OK, LOG_INFO,
+                   "mmkubernetes: proactive token reload failed; keeping cached "
+                   "token and will retry on the next lookup\n");
+        }
+    }
 
     if (pWrkrData->pData->cache->lastBusyTime) {
         now -= pWrkrData->pData->cache->lastBusyTime;
@@ -1709,6 +1837,7 @@ static rsRetVal queryKB(wrkrInstanceData_t *pWrkrData, char *url, time_t now, st
     /* query kubernetes for pod info */
     ccode = curl_easy_setopt(pWrkrData->curlCtx, CURLOPT_URL, url);
     if (ccode != CURLE_OK) ABORT_FINALIZE(RS_RET_ERR);
+retry_query:
     if (CURLE_OK != (ccode = curl_easy_perform(pWrkrData->curlCtx))) {
         LogMsg(0, RS_RET_ERR, LOG_ERR, "mmkubernetes: failed to connect to [%s] - %d:%s\n", url, ccode,
                curl_easy_strerror(ccode));
@@ -1718,6 +1847,31 @@ static rsRetVal queryKB(wrkrInstanceData_t *pWrkrData, char *url, time_t now, st
         LogMsg(0, RS_RET_ERR, LOG_ERR, "mmkubernetes: could not get response code from query to [%s] - %d:%s\n", url,
                ccode, curl_easy_strerror(ccode));
         ABORT_FINALIZE(RS_RET_ERR);
+    }
+    /* On a 401 the most likely cause is a stale bearer token: the projected SA
+     * token rotated on disk, or this worker came up before its node identity was
+     * authorized. The header is built once at worker construction and otherwise
+     * only refreshed by the proactive interval above. Re-read the token from
+     * disk, rebuild the header, and retry the request exactly once before
+     * surfacing the error. The response body buffered from the failed attempt is
+     * drained first so the retry parses cleanly. A 403 (Forbidden) is not
+     * retried: it means the request authenticated but this identity lacks access,
+     * so re-reading the same token cannot help. Only attempted when reading from
+     * tokenFile: an inline token cannot change, so a reload+retry cannot help. */
+    if (resp_code == 401 && !reloaded_token && pWrkrData->pData->tokenFile != NULL && pWrkrData->pData->token == NULL) {
+        reloaded_token = 1;
+        if (pWrkrData->curlRply != NULL) {
+            free(pWrkrData->curlRply);
+            pWrkrData->curlRply = NULL;
+            pWrkrData->curlRplyLen = 0;
+        }
+        if (mmk_build_token_header(pWrkrData) == RS_RET_OK) {
+            LogMsg(0, RS_RET_OK, LOG_INFO,
+                   "mmkubernetes: got [%ld] for url [%s] - reloaded SA token "
+                   "and retrying once\n",
+                   resp_code, url);
+            goto retry_query;
+        }
     }
     if (resp_code == 401) {
         LogMsg(0, RS_RET_ERR, LOG_ERR,

--- a/contrib/mmkubernetes/mmkubernetes.c
+++ b/contrib/mmkubernetes/mmkubernetes.c
@@ -41,6 +41,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <unistd.h>
+#include <time.h>
 #include <sys/stat.h>
 #include <libestr.h>
 #include <liblognorm.h>
@@ -107,6 +108,10 @@ DEFobjCurrIf(regexp) DEFobjCurrIf(statsobj) DEFobjCurrIf(datetime)
     -1 /* delete all expired entries from the cache every N seconds \
 -1 disables cache expiration/ttl checking                           \
 0 means - run cache expiration for every record */
+#define DFLT_TOKEN_RELOAD_INTERVAL                                         \
+    3600 /* proactively re-read the bearer token from tokenfile every N    \
+seconds so a rotated projected ServiceAccount token is picked up without a \
+restart; 0 disables the proactive reload */
 
 /* only support setting the partial chain flag on openssl platforms that have the define */
 #if defined(ENABLE_OPENSSL) && defined(X509_V_FLAG_PARTIAL_CHAIN)
@@ -162,6 +167,8 @@ struct modConfData_s {
     int cacheEntryTTL; /* delete entries from the cache if they are older than this many seconds */
     int cacheExpireInterval; /* delete all expired entries from the cache every this many seconds */
     sbool includeNamespaceMetadata; /* query and attach namespace metadata */
+    int tokenReloadInterval; /* proactively re-read the token from tokenFile every this many seconds
+                                (0 disables); guards against short-lived rotated SA tokens going stale */
 };
 
 /* action (instance) configuration data */
@@ -196,12 +203,15 @@ typedef struct _instanceData {
     int cacheEntryTTL; /* delete entries from the cache if they are older than this many seconds */
     int cacheExpireInterval; /* delete all expired entries from the cache every this many seconds */
     sbool includeNamespaceMetadata; /* query and attach namespace metadata */
+    int tokenReloadInterval; /* proactively re-read the token from tokenFile every this many seconds
+                                (0 disables); guards against short-lived rotated SA tokens going stale */
 } instanceData;
 
 typedef struct wrkrInstanceData {
     instanceData *pData;
     CURL *curlCtx;
     struct curl_slist *curlHdr;
+    time_t lastTokenReload; /* when curlHdr's bearer token was last (re)read from disk */
     char *curlRply;
     size_t curlRplyLen;
     statsobj_t *stats; /* stats for this instance */
@@ -243,7 +253,8 @@ static struct cnfparamdescr modpdescr[] = {{"kubernetesurl", eCmdHdlrArray, 0},
                                            {"sslpartialchain", eCmdHdlrBinary, 0},
                                            {"cacheentryttl", eCmdHdlrInt, 0},
                                            {"cacheexpireinterval", eCmdHdlrInt, 0},
-                                           {"includenamespacemetadata", eCmdHdlrBinary, 0}
+                                           {"includenamespacemetadata", eCmdHdlrBinary, 0},
+                                           {"tokenreloadinterval", eCmdHdlrInt, 0}
 #if HAVE_LOADSAMPLESFROMSTRING == 1
                                            ,
                                            {"filenamerules", eCmdHdlrArray, 0},
@@ -272,7 +283,8 @@ static struct cnfparamdescr actpdescr[] = {{"kubernetesurl", eCmdHdlrArray, 0},
                                            {"sslpartialchain", eCmdHdlrBinary, 0},
                                            {"cacheentryttl", eCmdHdlrInt, 0},
                                            {"cacheexpireinterval", eCmdHdlrInt, 0},
-                                           {"includenamespacemetadata", eCmdHdlrBinary, 0}
+                                           {"includenamespacemetadata", eCmdHdlrBinary, 0},
+                                           {"tokenreloadinterval", eCmdHdlrInt, 0}
 #if HAVE_LOADSAMPLESFROMSTRING == 1
                                            ,
                                            {"filenamerules", eCmdHdlrArray, 0},
@@ -652,6 +664,7 @@ BEGINsetModCnf
     loadModConf->cacheEntryTTL = DFLT_CACHE_ENTRY_TTL;
     loadModConf->cacheExpireInterval = DFLT_CACHE_EXPIRE_INTERVAL;
     loadModConf->includeNamespaceMetadata = DFLT_INCLUDE_NAMESPACE_METADATA;
+    loadModConf->tokenReloadInterval = DFLT_TOKEN_RELOAD_INTERVAL;
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) {
             continue;
@@ -785,6 +798,8 @@ BEGINsetModCnf
             loadModConf->cacheExpireInterval = pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "includenamespacemetadata")) {
             loadModConf->includeNamespaceMetadata = pvals[i].val.d.n;
+        } else if (!strcmp(modpblk.descr[i].name, "tokenreloadinterval")) {
+            loadModConf->tokenReloadInterval = pvals[i].val.d.n;
         } else {
             dbgprintf(
                 "mmkubernetes: program error, non-handled "
@@ -813,6 +828,14 @@ BEGINsetModCnf
                      loadModConf->cacheEntryTTL);
             ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
         }
+    }
+
+    if (loadModConf->tokenReloadInterval < 0) {
+        LogError(0, RS_RET_CONFIG_ERROR,
+                 "mmkubernetes: tokenreloadinterval value [%d] is invalid - "
+                 "value must be 0 (disabled) or greater",
+                 loadModConf->tokenReloadInterval);
+        ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
     }
 
     /* set defaults */
@@ -902,13 +925,101 @@ finalize_it:
 }
 #endif
 
+/**
+ * (Re)build the curl Authorization header for a worker from the current bearer
+ * token and bind it to the worker's curl handle.
+ *
+ * The token is read fresh on every call: @c pData->token (inline, takes
+ * precedence) or the contents of @c pData->tokenFile. This lets a rotated or
+ * late-authorized projected ServiceAccount token be picked up without
+ * recreating the worker. Any header list previously installed on the handle is
+ * released. @c lastTokenReload is stamped so the proactive reload in queryKB()
+ * can schedule the next refresh.
+ *
+ * Shared by createWrkrInstance() (initial build) and the reload paths in
+ * queryKB() (proactive interval + reactive on 401), so the token is read
+ * through a single code path.
+ *
+ * @param[in] pWrkrData worker instance whose curlHdr is (re)built and bound to
+ *            its already-initialized curlCtx
+ * @returns RS_RET_OK on success, or an error code (the previously installed
+ *          header is left in place on failure)
+ */
+static rsRetVal mmk_build_token_header(wrkrInstanceData_t *pWrkrData) {
+    DEFiRet;
+    struct curl_slist *hdr = NULL;
+    char *tokenHdr = NULL;
+    char *token = NULL;
+    FILE *fp = NULL;
+
+    hdr = curl_slist_append(hdr, "Content-Type: text/json; charset=utf-8");
+    if (hdr == NULL) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    if (pWrkrData->pData->token) {
+        /* asprintf leaves the pointer undefined on failure, so NULL it before
+         * aborting - finalize_it frees tokenHdr unconditionally */
+        if (asprintf(&tokenHdr, "Authorization: Bearer %s", pWrkrData->pData->token) == -1) {
+            tokenHdr = NULL;
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+    } else if (pWrkrData->pData->tokenFile) {
+        struct stat statbuf;
+        fp = fopen((const char *)pWrkrData->pData->tokenFile, "r");
+        if (fp && !fstat(fileno(fp), &statbuf)) {
+            size_t bytesread;
+            CHKmalloc(token = malloc((statbuf.st_size + 1) * sizeof(char)));
+            /* require a complete read: a partial read during a rotation race
+             * would yield a truncated (invalid) token, so leave tokenHdr NULL
+             * and let the caller keep the existing header */
+            if ((bytesread = fread(token, sizeof(char), statbuf.st_size, fp)) == (size_t)statbuf.st_size &&
+                bytesread > 0) {
+                token[bytesread] = '\0';
+                if (asprintf(&tokenHdr, "Authorization: Bearer %s", token) == -1) {
+                    tokenHdr = NULL;
+                    ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+                }
+            }
+        }
+    }
+    /* If a token source is configured but we could not read a token (e.g. the
+     * projected token volume is transiently unavailable during rotation), do not
+     * tear down a header that is already installed: keep the existing,
+     * still-likely-valid Authorization header and leave lastTokenReload
+     * unchanged so the caller retries the reload on the next lookup. On the
+     * initial build (curlHdr == NULL) there is nothing to preserve, so we fall
+     * through and install the token-less header, matching the original startup
+     * behavior. */
+    if (tokenHdr == NULL && (pWrkrData->pData->token || pWrkrData->pData->tokenFile) && pWrkrData->curlHdr != NULL) {
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    if (tokenHdr) {
+        struct curl_slist *new_hdr = curl_slist_append(hdr, tokenHdr);
+        if (new_hdr == NULL) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        hdr = new_hdr;
+    }
+    /* swap in the fresh header, releasing any previously installed one */
+    if (pWrkrData->curlHdr != NULL) {
+        curl_slist_free_all(pWrkrData->curlHdr);
+    }
+    pWrkrData->curlHdr = hdr;
+    curl_easy_setopt(pWrkrData->curlCtx, CURLOPT_HTTPHEADER, hdr);
+    hdr = NULL;
+    pWrkrData->lastTokenReload = time(NULL);
+finalize_it:
+    free(token);
+    free(tokenHdr);
+    if (fp != NULL) {
+        fclose(fp);
+    }
+    if (hdr != NULL) {
+        curl_slist_free_all(hdr);
+    }
+    RETiRet;
+}
+
+
 BEGINcreateWrkrInstance
     CODESTARTcreateWrkrInstance;
     CURL *ctx;
-    struct curl_slist *hdr = NULL;
-    char *tokenHdr = NULL;
-    FILE *fp = NULL;
-    char *token = NULL;
     char *statsName = NULL;
 
     CHKiRet(statsobj.Construct(&(pWrkrData->stats)));
@@ -966,38 +1077,8 @@ BEGINcreateWrkrInstance
                                 &(pWrkrData->podCacheMisses)));
     CHKiRet(statsobj.ConstructFinalize(pWrkrData->stats));
 
-    hdr = curl_slist_append(hdr, "Content-Type: text/json; charset=utf-8");
-    if (pWrkrData->pData->token) {
-        if ((-1 == asprintf(&tokenHdr, "Authorization: Bearer %s", pWrkrData->pData->token)) || (!tokenHdr)) {
-            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-        }
-    } else if (pWrkrData->pData->tokenFile) {
-        struct stat statbuf;
-        fp = fopen((const char *)pWrkrData->pData->tokenFile, "r");
-        if (fp && !fstat(fileno(fp), &statbuf)) {
-            size_t bytesread;
-            CHKmalloc(token = malloc((statbuf.st_size + 1) * sizeof(char)));
-            if (0 < (bytesread = fread(token, sizeof(char), statbuf.st_size, fp))) {
-                token[bytesread] = '\0';
-                if ((-1 == asprintf(&tokenHdr, "Authorization: Bearer %s", token)) || (!tokenHdr)) {
-                    ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-                }
-            }
-            free(token);
-            token = NULL;
-        }
-        if (fp) {
-            fclose(fp);
-            fp = NULL;
-        }
-    }
-    if (tokenHdr) {
-        hdr = curl_slist_append(hdr, tokenHdr);
-        free(tokenHdr);
-    }
-    pWrkrData->curlHdr = hdr;
     ctx = curl_easy_init();
-    curl_easy_setopt(ctx, CURLOPT_HTTPHEADER, hdr);
+    pWrkrData->curlCtx = ctx;
     curl_easy_setopt(ctx, CURLOPT_WRITEFUNCTION, curlCB);
     curl_easy_setopt(ctx, CURLOPT_WRITEDATA, pWrkrData);
     if (pWrkrData->pData->caCertFile) curl_easy_setopt(ctx, CURLOPT_CAINFO, pWrkrData->pData->caCertFile);
@@ -1011,15 +1092,27 @@ BEGINcreateWrkrInstance
         curl_easy_setopt(ctx, CURLOPT_SSL_CTX_DATA, NULL);
     }
 #endif
-    pWrkrData->curlCtx = ctx;
+    /* build the Authorization header from the current token on disk and bind it
+     * to the handle just initialized; shared with the reload paths in queryKB()
+     * so the token is read through one code path. */
+    CHKiRet(mmk_build_token_header(pWrkrData));
 finalize_it:
-    free(token);
     free(statsName);
-    if ((iRet != RS_RET_OK) && pWrkrData->stats) {
-        statsobj.Destruct(&(pWrkrData->stats));
-    }
-    if (fp) {
-        fclose(fp);
+    if (iRet != RS_RET_OK) {
+        /* rsyslog does not call freeWrkrInstance when createWrkrInstance fails,
+         * so release the curl handle here to avoid leaking it (e.g. if the
+         * initial token-header build fails). */
+        if (pWrkrData->curlCtx != NULL) {
+            curl_easy_cleanup(pWrkrData->curlCtx);
+            pWrkrData->curlCtx = NULL;
+        }
+        if (pWrkrData->curlHdr != NULL) {
+            curl_slist_free_all(pWrkrData->curlHdr);
+            pWrkrData->curlHdr = NULL;
+        }
+        if (pWrkrData->stats) {
+            statsobj.Destruct(&(pWrkrData->stats));
+        }
     }
 ENDcreateWrkrInstance
 
@@ -1299,6 +1392,7 @@ BEGINnewActInst
     pData->cacheEntryTTL = loadModConf->cacheEntryTTL;
     pData->cacheExpireInterval = loadModConf->cacheExpireInterval;
     pData->includeNamespaceMetadata = loadModConf->includeNamespaceMetadata;
+    pData->tokenReloadInterval = loadModConf->tokenReloadInterval;
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) {
             continue;
@@ -1433,6 +1527,8 @@ BEGINnewActInst
             pData->cacheExpireInterval = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "includenamespacemetadata")) {
             pData->includeNamespaceMetadata = pvals[i].val.d.n;
+        } else if (!strcmp(actpblk.descr[i].name, "tokenreloadinterval")) {
+            pData->tokenReloadInterval = pvals[i].val.d.n;
         } else {
             dbgprintf(
                 "mmkubernetes: program error, non-handled "
@@ -1465,6 +1561,14 @@ BEGINnewActInst
                      pData->cacheEntryTTL);
             ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
         }
+    }
+
+    if (pData->tokenReloadInterval < 0) {
+        LogError(0, RS_RET_CONFIG_ERROR,
+                 "mmkubernetes: tokenreloadinterval value [%d] is invalid - "
+                 "value must be 0 (disabled) or greater",
+                 pData->tokenReloadInterval);
+        ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
     }
 
     if (pData->nKubernetesUrls == 0) {
@@ -1608,6 +1712,7 @@ BEGINdbgPrintInstInfo
     dbgprintf("\tcacheentryttl='%d'\n", pData->cacheEntryTTL);
     dbgprintf("\tcacheexpireinterval='%d'\n", pData->cacheExpireInterval);
     dbgprintf("\tincludenamespacemetadata='%d'\n", pData->includeNamespaceMetadata);
+    dbgprintf("\ttokenreloadinterval='%d'\n", pData->tokenReloadInterval);
 ENDdbgPrintInstInfo
 
 
@@ -1703,6 +1808,29 @@ static rsRetVal queryKB(wrkrInstanceData_t *pWrkrData, char *url, time_t now, st
     struct json_tokener *jt = NULL;
     struct json_object *jo;
     long resp_code = 400;
+    int reloaded_token = 0;
+
+    /* Proactive token refresh: the bearer token is cached in the curl header at
+     * worker start and otherwise never re-read. A projected ServiceAccount token
+     * may be short-lived (kubelet rotates the on-disk file well before expiry),
+     * so re-read it every tokenReloadInterval seconds to stay inside the validity
+     * window and avoid the 401 entirely. A single missed reload is harmless
+     * because validity greatly exceeds the interval. The reactive reload-on-401
+     * below remains as a backstop for the startup / identity-warm-up window this
+     * cannot cover. Done before the busy-time adjustment below, which mutates
+     * `now`. tokenReloadInterval == 0 disables the proactive reload. Only
+     * meaningful when reading from tokenFile: an inline token cannot change, so
+     * skip the reload entirely in that case. */
+    if (pWrkrData->pData->tokenFile != NULL && pWrkrData->pData->token == NULL &&
+        pWrkrData->pData->tokenReloadInterval > 0 &&
+        now - pWrkrData->lastTokenReload >= pWrkrData->pData->tokenReloadInterval) {
+        if (mmk_build_token_header(pWrkrData) != RS_RET_OK) {
+            /* keep the existing (still likely-valid) header; retry next call */
+            LogMsg(0, RS_RET_OK, LOG_INFO,
+                   "mmkubernetes: proactive token reload failed; keeping cached "
+                   "token and will retry on the next lookup\n");
+        }
+    }
 
     if (pWrkrData->pData->cache->lastBusyTime) {
         now -= pWrkrData->pData->cache->lastBusyTime;
@@ -1725,6 +1853,7 @@ static rsRetVal queryKB(wrkrInstanceData_t *pWrkrData, char *url, time_t now, st
     /* query kubernetes for pod info */
     ccode = curl_easy_setopt(pWrkrData->curlCtx, CURLOPT_URL, url);
     if (ccode != CURLE_OK) ABORT_FINALIZE(RS_RET_ERR);
+retry_query:
     if (CURLE_OK != (ccode = curl_easy_perform(pWrkrData->curlCtx))) {
         LogMsg(0, RS_RET_ERR, LOG_ERR, "mmkubernetes: failed to connect to [%s] - %d:%s\n", url, ccode,
                curl_easy_strerror(ccode));
@@ -1734,6 +1863,31 @@ static rsRetVal queryKB(wrkrInstanceData_t *pWrkrData, char *url, time_t now, st
         LogMsg(0, RS_RET_ERR, LOG_ERR, "mmkubernetes: could not get response code from query to [%s] - %d:%s\n", url,
                ccode, curl_easy_strerror(ccode));
         ABORT_FINALIZE(RS_RET_ERR);
+    }
+    /* On a 401 the most likely cause is a stale bearer token: the projected SA
+     * token rotated on disk, or this worker came up before its node identity was
+     * authorized. The header is built once at worker construction and otherwise
+     * only refreshed by the proactive interval above. Re-read the token from
+     * disk, rebuild the header, and retry the request exactly once before
+     * surfacing the error. The response body buffered from the failed attempt is
+     * drained first so the retry parses cleanly. A 403 (Forbidden) is not
+     * retried: it means the request authenticated but this identity lacks access,
+     * so re-reading the same token cannot help. Only attempted when reading from
+     * tokenFile: an inline token cannot change, so a reload+retry cannot help. */
+    if (resp_code == 401 && !reloaded_token && pWrkrData->pData->tokenFile != NULL && pWrkrData->pData->token == NULL) {
+        reloaded_token = 1;
+        if (pWrkrData->curlRply != NULL) {
+            free(pWrkrData->curlRply);
+            pWrkrData->curlRply = NULL;
+            pWrkrData->curlRplyLen = 0;
+        }
+        if (mmk_build_token_header(pWrkrData) == RS_RET_OK) {
+            LogMsg(0, RS_RET_OK, LOG_INFO,
+                   "mmkubernetes: got [%ld] for url [%s] - reloaded SA token "
+                   "and retrying once\n",
+                   resp_code, url);
+            goto retry_query;
+        }
     }
     if (resp_code == 401) {
         LogMsg(0, RS_RET_ERR, LOG_ERR,

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -910,6 +910,7 @@ EXTRA_DIST = \
     source/reference/parameters/mmkubernetes-tls-myprivkey.rst \
     source/reference/parameters/mmkubernetes-token.rst \
     source/reference/parameters/mmkubernetes-tokenfile.rst \
+    source/reference/parameters/mmkubernetes-tokenreloadinterval.rst \
     source/reference/parameters/mmnormalize-allowregex.rst \
     source/reference/parameters/mmnormalize-path.rst \
     source/reference/parameters/mmnormalize-rule.rst \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -917,6 +917,7 @@ EXTRA_DIST = \
     source/reference/parameters/mmkubernetes-tls-myprivkey.rst \
     source/reference/parameters/mmkubernetes-token.rst \
     source/reference/parameters/mmkubernetes-tokenfile.rst \
+    source/reference/parameters/mmkubernetes-tokenreloadinterval.rst \
     source/reference/parameters/mmnormalize-allowregex.rst \
     source/reference/parameters/mmnormalize-debug.rst \
     source/reference/parameters/mmnormalize-debugfile.rst \

--- a/doc/source/configuration/modules/mmkubernetes.rst
+++ b/doc/source/configuration/modules/mmkubernetes.rst
@@ -152,6 +152,10 @@ Action Parameters
      - .. include:: ../../reference/parameters/mmkubernetes-tokenfile.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-mmkubernetes-tokenreloadinterval`
+     - .. include:: ../../reference/parameters/mmkubernetes-tokenreloadinterval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 .. toctree::
    :hidden:
@@ -177,6 +181,7 @@ Action Parameters
    ../../reference/parameters/mmkubernetes-tls-myprivkey
    ../../reference/parameters/mmkubernetes-token
    ../../reference/parameters/mmkubernetes-tokenfile
+   ../../reference/parameters/mmkubernetes-tokenreloadinterval
 
 .. _mmkubernetes-statistic-counter:
 

--- a/doc/source/configuration/modules/mmkubernetes.rst
+++ b/doc/source/configuration/modules/mmkubernetes.rst
@@ -156,6 +156,10 @@ Action Parameters
      - .. include:: ../../reference/parameters/mmkubernetes-tokenfile.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-mmkubernetes-tokenreloadinterval`
+     - .. include:: ../../reference/parameters/mmkubernetes-tokenreloadinterval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 .. toctree::
    :hidden:
@@ -182,6 +186,7 @@ Action Parameters
    ../../reference/parameters/mmkubernetes-tls-myprivkey
    ../../reference/parameters/mmkubernetes-token
    ../../reference/parameters/mmkubernetes-tokenfile
+   ../../reference/parameters/mmkubernetes-tokenreloadinterval
 
 .. _mmkubernetes-statistic-counter:
 

--- a/doc/source/reference/parameters/mmkubernetes-tokenreloadinterval.rst
+++ b/doc/source/reference/parameters/mmkubernetes-tokenreloadinterval.rst
@@ -1,0 +1,58 @@
+.. _param-mmkubernetes-tokenreloadinterval:
+.. _mmkubernetes.parameter.action.tokenreloadinterval:
+
+tokenreloadinterval
+===================
+
+.. index::
+   single: mmkubernetes; tokenreloadinterval
+   single: tokenreloadinterval
+
+.. summary-start
+
+How often to proactively re-read the bearer token from ``tokenfile``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmkubernetes`.
+
+:Name: tokenreloadinterval
+:Scope: action
+:Type: integer
+:Default: 3600
+:Required?: no
+:Introduced: 8.2608.0
+
+Description
+-----------
+How often, in seconds, to proactively re-read the bearer token from
+:ref:`param-mmkubernetes-tokenfile`. The default is ``3600`` (one hour).
+
+The token read from ``tokenfile`` is cached in the HTTP ``Authorization``
+header when the worker starts. Kubernetes projected ServiceAccount tokens are
+short-lived and rotated on disk by the kubelet (well before they expire), so a
+long-running worker would otherwise keep sending the original token until it
+becomes invalid, at which point metadata lookups fail with HTTP 401 until the
+process is restarted. Re-reading the token periodically keeps the worker well
+inside the token validity window.
+
+Set this to ``0`` to disable the proactive reload. Regardless of this setting,
+mmkubernetes also reloads the token from ``tokenfile`` and retries the request
+once when a lookup returns HTTP 401, so a rotated token is picked up
+automatically without a restart. This value must be 0 or greater.
+
+This option has no effect when the inline :ref:`param-mmkubernetes-token`
+parameter is used instead of ``tokenfile``.
+
+Action usage
+------------
+.. _param-mmkubernetes-action-tokenreloadinterval:
+.. _mmkubernetes.parameter.action.tokenreloadinterval-usage:
+
+.. code-block:: rsyslog
+
+   action(type="mmkubernetes" tokenReloadInterval="3600")
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmkubernetes`.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2228,11 +2228,13 @@ TESTS_MMTAGHOSTNAME = \
 TESTS_MMKUBERNETES = \
 	mmkubernetes-basic.sh \
 	mmkubernetes-cache-expire.sh \
-	mmkubernetes-url-failover.sh
+	mmkubernetes-url-failover.sh \
+	mmkubernetes-token-reload.sh
 
 TESTS_MMKUBERNETES_VALGRIND = \
 	mmkubernetes-basic-vg.sh \
-	mmkubernetes-cache-expire-vg.sh
+	mmkubernetes-cache-expire-vg.sh \
+	mmkubernetes-token-reload-vg.sh
 
 TESTS_IMKUBERNETES = \
 	imkubernetes-cri-basic.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2291,11 +2291,13 @@ TESTS_MMKUBERNETES = \
 	mmkubernetes-cache-expire.sh \
 	mmkubernetes-url-failover.sh \
 	mmkubernetes-namespace-metadata-off.sh \
-	yaml-mmkubernetes-namespace-metadata-off.sh
+	yaml-mmkubernetes-namespace-metadata-off.sh \
+	mmkubernetes-token-reload.sh
 
 TESTS_MMKUBERNETES_VALGRIND = \
 	mmkubernetes-basic-vg.sh \
-	mmkubernetes-cache-expire-vg.sh
+	mmkubernetes-cache-expire-vg.sh \
+	mmkubernetes-token-reload-vg.sh
 
 TESTS_IMKUBERNETES = \
 	imkubernetes-cri-partial-accept.sh \

--- a/tests/mmkubernetes-token-reload-vg.sh
+++ b/tests/mmkubernetes-token-reload-vg.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# valgrind variant of mmkubernetes-token-reload.sh - see that script for details.
+export USE_VALGRIND="YES"
+. ${srcdir:=.}/mmkubernetes-token-reload.sh

--- a/tests/mmkubernetes-token-reload.sh
+++ b/tests/mmkubernetes-token-reload.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# added 2026 for https://github.com/rsyslog/rsyslog/issues/7402, released under ASL 2.0
+#
+# Note: on buildbot VMs (where there is no environment cleanup), the
+# kubernetes test server may be kept running if the script aborts or
+# is aborted (buildbot master failure!) for some reason. As such we
+# execute it under "timeout" control, which ensures it always is
+# terminated. It's not a 100% great method, but hopefully does the
+# trick. -- rgerhards, 2018-07-21
+#
+# Verify mmkubernetes reloads the bearer token from tokenfile and retries once
+# on an HTTP 401. The module reads the ServiceAccount token from tokenfile once
+# at worker start and caches it in the curl Authorization header. On a
+# short-lived projected token that is rotated on disk, the cached copy goes
+# stale and every lookup 401s. This test rotates the token file after the worker
+# has cached the old value, then confirms a subsequent (cache-miss) lookup 401s,
+# reloads the fresh token, retries, and succeeds - so the record is still
+# enriched.
+#export RSYSLOG_DEBUG="debug"
+# USE_VALGRIND may be set by the -vg variant that sources this script
+. ${srcdir:=.}/diag.sh init
+check_command_available timeout
+pwd=$( pwd )
+k8s_srv_port_file="${RSYSLOG_DYNNAME}mmk8s-test-server.port"
+generate_conf
+
+# the token file the module reads and the server validates against; the worker
+# caches its contents at startup and only re-reads it on reload
+token_file=$RSYSLOG_DYNNAME.spool/sa-token
+printf 'token-v1' > $token_file
+
+testsrv=mmk8s-test-server
+echo starting kubernetes \"emulator\"
+# MMK8S_EXPECTED_TOKEN_FILE enables bearer-token validation against $token_file
+# (the server returns 401 on mismatch)
+MMK8S_EXPECTED_TOKEN_FILE=$pwd/$token_file \
+	timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server.py 0 ${RSYSLOG_DYNNAME}${testsrv}.pid ${RSYSLOG_DYNNAME}${testsrv}.started ${k8s_srv_port_file} > ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log 2>&1 &
+BGPROCESS=$!
+wait_file_exists "$k8s_srv_port_file"
+k8s_srv_port="$(cat "$k8s_srv_port_file")"
+wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
+echo background mmkubernetes_test_server.py process id is $BGPROCESS
+
+add_conf '
+global(workDirectory="'$RSYSLOG_DYNNAME.spool'")
+module(load="../plugins/impstats/.libs/impstats" interval="1"
+	   log.file="'"$RSYSLOG_DYNNAME.spool"'/mmkubernetes-stats.log" log.syslog="off" format="cee")
+module(load="../plugins/imfile/.libs/imfile")
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+module(load="../contrib/mmkubernetes/.libs/mmkubernetes")
+
+template(name="mmk8s_template" type="list") {
+    property(name="$!all-json-plain")
+    constant(value="\n")
+}
+
+input(type="imfile" file="'$RSYSLOG_DYNNAME.spool'/pod-*.log" tag="kubernetes" addmetadata="on")
+action(type="mmjsonparse" cookie="")
+action(type="mmkubernetes" busyretryinterval="1" tokenfile="'$pwd/$token_file'" tokenreloadinterval="0"
+       kubernetesurl="http://localhost:'$k8s_srv_port'"
+       filenamerules=["rule=:'$pwd/$RSYSLOG_DYNNAME.spool'/%pod_name:char-to:.%.%container_hash:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log",
+	                  "rule=:'$pwd/$RSYSLOG_DYNNAME.spool'/%pod_name:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log"]
+)
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="mmk8s_template")
+'
+
+# use the mmkubernetes valgrind suppressions when run under the -vg variant;
+# startup/wait_shutdown dispatch to the valgrind path automatically when
+# USE_VALGRIND is set
+if [ "$USE_VALGRIND" == "YES" ]; then
+	export EXTRA_VALGRIND_SUPPRESSIONS="--suppressions=$srcdir/mmkubernetes.supp"
+fi
+startup
+
+# record 1: the token on disk (v1) matches - the worker caches v1 and the lookup
+# succeeds normally. Draining the queue guarantees the worker has started and
+# cached v1 *before* we rotate the token below.
+cat > ${RSYSLOG_DYNNAME}.spool/pod-name1_namespace-name1_container-name1-id1.log <<EOF
+{"log":"{\"message\":\"HEAD1 / 200 1ms - 9.0B\"}\n","stream":"stdout","time":"2018-04-06T17:26:34.492083106Z","testid":1}
+EOF
+wait_queueempty
+
+# rotate the projected token on disk, as kubelet does at ~80% of its lifetime.
+# The worker still holds the cached v1 in its curl header; the server now only
+# accepts v2.
+printf 'token-v2' > $token_file
+
+# record 2: a new pod/namespace is a cache miss, so the worker queries the API
+# with its stale cached v1 token -> 401 -> reload v2 from disk -> retry -> 200.
+cat > ${RSYSLOG_DYNNAME}.spool/pod-name2_namespace-name2_container-name2-id2.log <<EOF
+{"log":"{\"message\":\"HEAD2 / 200 1ms - 9.0B\"}\n","stream":"stdout","time":"2018-04-06T17:26:34.492083106Z","testid":2}
+EOF
+wait_queueempty
+
+shutdown_when_empty
+wait_shutdown
+kill $BGPROCESS
+wait_pid_termination ${RSYSLOG_DYNNAME}${testsrv}.pid
+
+# both records must be enriched with kubernetes metadata from the API: pod_id is
+# derived from the API response (the pod uid), not from the log filename, so its
+# presence proves the lookup succeeded - record 1 under the original token,
+# record 2 only after the token was reloaded on the 401
+content_check 'pod-name1-id'
+content_check 'pod-name2-id'
+# the reload-and-retry path must have fired for record 2
+content_check --regex 'mmkubernetes: got \[401\].*reloaded SA token and retrying once'
+# and the retry must have recovered - no surfaced Unauthorized error
+assert_content_missing 'mmkubernetes: Unauthorized'
+
+exit_test

--- a/tests/mmkubernetes_test_server.py
+++ b/tests/mmkubernetes_test_server.py
@@ -98,6 +98,24 @@ err_template = '''{{
 
 is_busy = False
 include_node_name = os.environ.get("MMK8S_INCLUDE_NODE_NAME") == "1"
+# Optional path to a file holding the currently-valid bearer token. When set
+# (via MMK8S_EXPECTED_TOKEN_FILE), the server rejects any request whose
+# "Authorization: Bearer <tok>" does not match the file's current contents with
+# HTTP 401. The test rotates this file to exercise the token reload-on-401 path
+# in mmkubernetes. When unset, no auth check is performed and existing tests
+# behave as before.
+expected_token_file = os.environ.get("MMK8S_EXPECTED_TOKEN_FILE")
+
+
+def read_expected_token():
+    """Read the currently-valid token from expected_token_file, or None."""
+    if not expected_token_file:
+        return None
+    try:
+        with open(expected_token_file) as ff:
+            return ff.read().strip()
+    except IOError:
+        return None
 
 
 class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
@@ -108,6 +126,20 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         # or
         # /api/v1/namespaces/$ns_name/pods/$pod_name
         global is_busy
+        # if token checking is enabled, reject a stale/missing bearer token with
+        # 401 so the module reloads the token from disk and retries
+        want_token = read_expected_token()
+        if want_token is not None:
+            auth = self.headers.get('Authorization', '')
+            got_token = auth[len('Bearer '):].strip() if auth.startswith('Bearer ') else ''
+            if got_token != want_token:
+                resp = err_template.format(kind='pods', objectname=self.path,
+                                           err='invalid bearer token', reason='Unauthorized', code=401)
+                self.log_error(resp)
+                self.send_response(401)
+                self.end_headers()
+                self.wfile.write(json.dumps(json.loads(resp), separators=(',', ':')).encode())
+                return
         comps = self.path.split('/')
         status = 400
         if len(comps) >= 5 and comps[1] == 'api' and comps[2] == 'v1' and comps[3] == 'namespaces':


### PR DESCRIPTION
Fixes #7402

## What

`mmkubernetes` reads the ServiceAccount token from `tokenfile` once, at worker creation, and caches it in the worker's persistent curl `Authorization` header. It is never re-read (no mtime check, no inotify, no per-request rebuild), and a 401/403 only logs and aborts.

This was harmless while projected tokens were valid for months — longer than a pod typically lives. With shorter-lived projected tokens (e.g. Kubernetes 1.34 caps projected-token validity at ~1 day via the External JWT Signer), kubelet rotates the on-disk token at ~80% of its lifetime but the module keeps using the original cached copy. About a day after a pod starts, every cache-miss metadata lookup returns 401 and never recovers until the pod is restarted. Log data is unaffected; only the Kubernetes metadata enrichment is lost.

## How

The `Authorization`-header construction is factored out of `createWrkrInstance` into `mmk_build_token_header()`, which reads the token fresh and rebinds the header to the worker's curl handle. The token is then reloaded via two mechanisms:

1. **Proactive** — in `queryKB`, re-read the token every `tokenreloadinterval` seconds (new integer parameter, default `3600`, `0` disables) so the worker stays inside the validity window and avoids the 401 entirely. Because validity greatly exceeds the interval, a single failed/missed reload is harmless.
2. **Reactive** — on a **401**, rebuild the header from the current token on disk and retry the request once before falling through to the existing error path. This covers the startup / identity-warm-up window the timer cannot. A **403 is not retried**: it means the request authenticated but the identity lacks access, so re-reading the same token cannot help.

If a reload cannot obtain a token (e.g. the projected-token volume is briefly unavailable during rotation), the existing header is kept and `lastTokenReload` is not advanced, so the next lookup retries the reload rather than tearing down a working header. `createWrkrInstance` releases the curl handle on its own error path, since rsyslog does not call `freeWrkrInstance` when `createWrkrInstance` fails. The healthy steady-state path is unchanged — cache hits never reach `queryKB`. The reload logic lives inside `queryKB`, so it composes with the existing `kubernetesurl` failover loop.

## Tests

Adds `mmkubernetes-token-reload.sh` (plus a valgrind variant) that rotates the token file after the worker has cached the old value, then confirms a subsequent lookup 401s, reloads the fresh token, retries, and succeeds. The `mmkubernetes_test_server.py` mock gains an opt-in bearer-token check (enabled via `MMK8S_EXPECTED_TOKEN_FILE`) used by that test. Registered in `tests/Makefile.am` via `TESTS_MMKUBERNETES` / `TESTS_MMKUBERNETES_VALGRIND`.

## Docs

Adds the `tokenreloadinterval` parameter reference page and links it from the mmkubernetes module doc.

## Notes

- Formatted with `clang-format-18` per `.clang-format` / `devtools/format-code.sh`.
- I could not run the full C build/testbench locally (no rsyslog build deps on my machine); relying on CI for the compile and test run.

AI-Agent: Claude 2026-07


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

