### PR TITLE
imtcp: release completed zlib decoder state

### DIFF
--- a/doc/source/reference/parameters/imtcp-maxsessions.rst
+++ b/doc/source/reference/parameters/imtcp-maxsessions.rst
@@ -31,6 +31,14 @@ before the first $InputTCPServerRun directive.
 
 The same-named input parameter can override this module setting.
 
+Each session owns its framing, transport, TLS, and optional decompressor state.
+Consequently, unusually large values multiply the memory retained by idle or
+incomplete connections.  A zlib ``stream:always`` session has a bounded history
+window of at most 32 KiB plus decoder bookkeeping; completed zlib streams release
+that decoder state immediately, but incomplete streams retain it until the
+connection closes.  Size ``MaxSessions`` for the listener's expected concurrency
+and available memory.
+
 
 Module usage
 ------------
@@ -65,4 +73,3 @@ Historic names/directives for compatibility. Do not use in new configs.
 See also
 --------
 See also :doc:`../../configuration/modules/imtcp`.
-

--- a/doc/source/reference/parameters/imtcp-maxsessions.rst
+++ b/doc/source/reference/parameters/imtcp-maxsessions.rst
@@ -33,10 +33,10 @@ The same-named input parameter can override this module setting.
 
 Each session owns its framing, transport, TLS, and optional decompressor state.
 Consequently, unusually large values multiply the memory retained by idle or
-incomplete connections.  A zlib ``stream:always`` session has a bounded history
+incomplete connections. A zlib ``stream:always`` session has a bounded history
 window of at most 32 KiB plus decoder bookkeeping; completed zlib streams release
 that decoder state immediately, but incomplete streams retain it until the
-connection closes.  Size ``MaxSessions`` for the listener's expected concurrency
+connection closes. Size ``MaxSessions`` for the listener's expected concurrency
 and available memory.
 
 

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -173,14 +173,19 @@ static void release_zstd_window_reservation(tcps_sess_t *const pThis) {
 }
 #endif
 
+static void release_zlib_decoder(tcps_sess_t *const pThis) {
+    if (!pThis->zipInitDone) return;
+
+    inflateEnd(&pThis->zstrm);
+    memset(&pThis->zstrm, 0, sizeof(pThis->zstrm));
+    pThis->zipInitDone = 0;
+}
+
 
 /* destructor for the tcps_sess object */
 BEGINobjDestruct(tcps_sess) /* be sure to specify the object type also in END and CODESTART macros! */
     CODESTARTobjDestruct(tcps_sess);
-    if (pThis->zipInitDone) {
-        inflateEnd(&pThis->zstrm);
-        pThis->zipInitDone = 0;
-    }
+    release_zlib_decoder(pThis);
 #ifdef ENABLE_LIBZSTD
     if (pThis->zstdDctx != NULL) {
         ZSTD_freeDCtx((ZSTD_DCtx *)pThis->zstdDctx);
@@ -939,6 +944,8 @@ static rsRetVal DataRcvdCompressedZlib(tcps_sess_t *const pThis,
                                            "data after end of zlib stream");
                 ABORT_FINALIZE(RS_RET_ZLIB_ERR);
             }
+            release_zlib_decoder(pThis);
+            DBGPRINTF("tcps_sess: released zlib decoder after stream completion\n");
             break;
         }
 
@@ -953,6 +960,7 @@ static rsRetVal DataRcvdCompressedZlib(tcps_sess_t *const pThis,
     } while (pThis->zstrm.avail_in != 0 || pThis->zstrm.avail_out == 0);
 
 finalize_it:
+    if (iRet != RS_RET_OK) release_zlib_decoder(pThis);
     RETiRet;
 }
 
@@ -1112,8 +1120,7 @@ static rsRetVal finishCompressedStream(tcps_sess_t *pThis) {
             FINALIZE;
         }
         logCompressedStreamFailure(pThis, "detected truncated compressed stream", "zlib stream ended before trailer");
-        inflateEnd(&pThis->zstrm);
-        pThis->zipInitDone = 0;
+        release_zlib_decoder(pThis);
         ABORT_FINALIZE(RS_RET_ZLIB_ERR);
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -834,6 +834,7 @@ TESTS_IMTCP = \
 
 TESTS_IMTCP_STREAM_ALWAYS_ZLIB = \
 	imtcp-stream-always-zlib-basic.sh \
+	imtcp-stream-always-zlib-completion-release.sh \
 	imtcp-stream-always-zlib-flushoff.sh \
 	imtcp-stream-always-zlib-corrupt.sh \
 	imtcp-stream-always-zlib-truncated.sh \
@@ -2170,7 +2171,8 @@ sndrcv_gzip.log: sndrcv_failover.log
 sndrcv_udp_nonstdpt.log: sndrcv_gzip.log
 sndrcv_udp_nonstdpt_v6.log: sndrcv_udp_nonstdpt.log
 imtcp-stream-always-zlib-basic.log: sndrcv_udp_nonstdpt_v6.log
-imtcp-stream-always-zlib-flushoff.log: imtcp-stream-always-zlib-basic.log
+imtcp-stream-always-zlib-completion-release.log: imtcp-stream-always-zlib-basic.log
+imtcp-stream-always-zlib-flushoff.log: imtcp-stream-always-zlib-completion-release.log
 imtcp-stream-always-zlib-corrupt.log: imtcp-stream-always-zlib-flushoff.log
 imtcp-stream-always-zlib-truncated.log: imtcp-stream-always-zlib-corrupt.log
 imtcp-stream-always-zlib-fragmented-ratio.log: imtcp-stream-always-zlib-truncated.log

--- a/tests/imtcp-stream-always-zlib-completion-release.sh
+++ b/tests/imtcp-stream-always-zlib-completion-release.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# added 2026-07-21 by Codex, released under ASL 2.0
+# Verifies that imtcp releases a completed zlib inflater while its TCP socket
+# remains open. The debug lifecycle marker proves inflateEnd() already ran;
+# the delivered message and the diagnostic caused by a subsequent byte prove
+# that same socket remained open after cleanup. Polling allows ten seconds for
+# a loaded CI runner, while those state markers—not elapsed time—are the oracle.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+check_command_available python3
+export NUMMESSAGES=1
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+export RSYSLOG_DEBUG="debug nostdout"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
+
+generate_conf
+add_conf '
+global(processInternalMessages="on")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	compression.mode="stream:always"
+	compression.driver="zlib")
+
+template(name="outfmt" type="string" string="%msg%\n")
+if $syslogtag contains "rsyslogd" then {
+	action(type="omfile" file="'$RSYSLOG2_OUT_LOG'")
+	stop
+}
+if $msg contains "zlib-completion-release" then
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+python3 - "$TCPFLOOD_PORT" "$RSYSLOG_DEBUGLOG" "$RSYSLOG_OUT_LOG" "$RSYSLOG2_OUT_LOG" <<'PY'
+import socket
+import sys
+import time
+import zlib
+
+
+port = int(sys.argv[1])
+debug_path = sys.argv[2]
+output_path = sys.argv[3]
+diagnostic_path = sys.argv[4]
+release_marker = b"released zlib decoder after stream completion"
+message_marker = b"zlib-completion-release"
+trailing_data_marker = b"data after end of zlib stream"
+
+
+def wait_for(path, marker, deadline):
+    while time.monotonic() < deadline:
+        try:
+            with open(path, "rb") as stream:
+                if marker in stream.read():
+                    return
+        except FileNotFoundError:
+            pass
+        time.sleep(0.05)
+    raise SystemExit(f"timed out waiting for {marker!r} in {path}")
+
+
+payload = b"<129>Mar 10 01:00:00 127.0.0.1 tag: zlib-completion-release\n"
+with socket.create_connection(("127.0.0.1", port)) as connection:
+    connection.sendall(zlib.compress(payload))
+    deadline = time.monotonic() + 10
+    wait_for(debug_path, release_marker, deadline)
+    wait_for(output_path, message_marker, deadline)
+    connection.sendall(b"x")
+    wait_for(diagnostic_path, trailing_data_marker, deadline)
+PY
+
+shutdown_when_empty
+wait_shutdown
+wait_file_lines
+content_check "zlib-completion-release"
+content_check "released zlib decoder after stream completion" "$RSYSLOG_DEBUGLOG"
+content_check "data after end of zlib stream" "$RSYSLOG2_OUT_LOG"
+exit_test

--- a/tests/imtcp-stream-always-zlib-completion-release.sh
+++ b/tests/imtcp-stream-always-zlib-completion-release.sh
@@ -54,11 +54,21 @@ trailing_data_marker = b"data after end of zlib stream"
 
 
 def wait_for(path, marker, deadline):
+    offset = 0
+    tail = b""
     while time.monotonic() < deadline:
         try:
             with open(path, "rb") as stream:
-                if marker in stream.read():
+                stream.seek(0, 2)
+                if stream.tell() < offset:
+                    offset = 0
+                    tail = b""
+                stream.seek(offset)
+                chunk = stream.read()
+                offset = stream.tell()
+                if marker in tail + chunk:
                     return
+                tail = (tail + chunk)[1 - len(marker):]
         except FileNotFoundError:
             pass
         time.sleep(0.05)

--- a/tests/imtcp-stream-always-zlib-completion-release.sh
+++ b/tests/imtcp-stream-always-zlib-completion-release.sh
@@ -6,7 +6,8 @@
 # that same socket remained open after cleanup. Polling allows ten seconds for
 # a loaded CI runner, while those state markers—not elapsed time—are the oracle.
 . ${srcdir:=.}/diag.sh init
-if [ "$(uname)" = "Darwin" ] && [[ "$CFLAGS" == *"sanitize=thread"* ]]; then
+if [ "$(uname)" = "Darwin" ] &&
+	{ [[ "${CFLAGS:-}" == *"sanitize=thread"* ]] || [ -n "${TSAN_OPTIONS:-}" ]; }; then
 	echo "test skipped on macOS TSAN: lifecycle oracle requires debug logging, which exposes a known debug.c race"
 	exit 77
 fi

--- a/tests/imtcp-stream-always-zlib-completion-release.sh
+++ b/tests/imtcp-stream-always-zlib-completion-release.sh
@@ -6,6 +6,10 @@
 # that same socket remained open after cleanup. Polling allows ten seconds for
 # a loaded CI runner, while those state markers—not elapsed time—are the oracle.
 . ${srcdir:=.}/diag.sh init
+if [ "$(uname)" = "Darwin" ] && [[ "$CFLAGS" == *"sanitize=thread"* ]]; then
+	echo "test skipped on macOS TSAN: lifecycle oracle requires debug logging, which exposes a known debug.c race"
+	exit 77
+fi
 require_plugin imtcp
 check_command_available python3
 export NUMMESSAGES=1


### PR DESCRIPTION
## Summary

- release each imtcp zlib inflater immediately when its compressed stream reaches Z_STREAM_END, even if the TCP socket remains open
- centralize inflater teardown in an idempotent helper used by completion, error, truncated-close, and destruction paths
- add a lifecycle regression test and document the bounded per-session zlib memory behavior

## Why

A zlib history window is bounded, so it does not need the configurable aggregate budget introduced for zstd. However, completed streams previously retained their decoder state until the TCP connection closed. With many long-lived completed connections, that memory remained allocated despite imtcp rejecting all data after the stream trailer.

This is intentionally narrow: there is no new configuration, shared counter, lock, quota, or concurrency coupling. Incomplete zlib streams retain their decoder until completion or connection teardown.

## Validation

- clang-format-18 apply and read-only check
- bash syntax, shellcheck, checkbashisms, and test antipattern scan
- HTML documentation build and mock distcheck
- focused zlib basic, completion, corrupt, and truncated tests
- completion regression under Valgrind
- focused Clang ASan/UBSan and imtcp no-epoll lanes
- Clang static analyzer: no bugs found
- local Cubic review: no issues found
- post-rebase Ubuntu 26.04 container build and focused regression: passed

Two complete 1,392-test local PR-ready runs each encountered a different unrelated load-sensitive failure; both failing tests passed immediately in isolation, and every imtcp zlib/zstd test passed in both broad runs. The evidence is recorded in https://github.com/rsyslog/rsyslog/issues/7406.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

