### PR TITLE
queue: preserve DA child work during shutdown

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -2593,10 +2593,15 @@ rsRetVal ATTR_NONNULL(1) qqueueShutdownWorkers(qqueue_t *const pThis) {
     CHKiRet(tryShutdownWorkersWithinQueueTimeout(pThis));
 
     pthread_mutex_lock(pThis->mut);
-    int physQueueSize;
-    physQueueSize = getPhysicalQueueSize(pThis);
+    const int parent_phys_queue_size = getPhysicalQueueSize(pThis);
+    const int child_phys_queue_size = pThis->pqDA == NULL ? 0 : getPhysicalQueueSize(pThis->pqDA);
     pthread_mutex_unlock(pThis->mut);
-    if (physQueueSize > 0) {
+    /* The DA transfer worker can empty the memory parent while the disk child
+     * still owns queued or in-flight work.  Skipping the action-completion
+     * phase in that state sends the child directly to cancellation, which can
+     * discard an action at the cancellation boundary.  Parent and child share
+     * the queue mutex, so inspect both at one stable point. */
+    if (parent_phys_queue_size > 0 || child_phys_queue_size > 0) {
         CHKiRet(tryShutdownWorkersWithinActionTimeout(pThis));
     }
 

--- a/tests/segmented-da-tcp-spill-exact.sh
+++ b/tests/segmented-da-tcp-spill-exact.sh
@@ -69,11 +69,12 @@ if [ $? -ne 0 ] || ! tcpflood_marker_is_valid "$SENDER_MARKER"; then
 	error_exit 1 "tcpflood did not complete cleanly"
 fi
 wait_queueempty
-# A full line count followed by sequence validation proves every delayed TCP
-# record was framed, persisted, forwarded, and drained exactly once.
-wait_file_lines --abort-on-oversize "$RECEIVER_FILE" "$NUMMESSAGES" 120
+# Main-queue emptiness may precede completion of batches already owned by DA
+# child workers. Shutdown is the downstream completion barrier and also closes
+# omfwd's TCP stream, allowing the receiver to consume the final records.
 shutdown_when_empty
 wait_shutdown
+wait_file_lines --abort-on-oversize "$RECEIVER_FILE" "$NUMMESSAGES" 120
 rm -f "$RECEIVER_KEEP_FILE"
 wait "$RECEIVER_PID" || error_exit 1 "minitcpsrv did not exit cleanly"
 cut -d: -f2 "$RECEIVER_FILE" >"$RSYSLOG_OUT_LOG"

--- a/tests/testsuites/segmented-da-idle-crash-driver.sh
+++ b/tests/testsuites/segmented-da-idle-crash-driver.sh
@@ -11,7 +11,7 @@
 : "${SEGDISK_IDLE_FAULT_POINT:?SEGDISK_IDLE_FAULT_POINT is required}"
 SEGDISK_IDLE_FAULT_REPEATS=${SEGDISK_IDLE_FAULT_REPEATS:-1}
 export NUMMESSAGES=$((1000 * SEGDISK_IDLE_FAULT_REPEATS))
-export RSTB_IMDIAG_INJECT_DELAY_MODE=none
+export RSTB_IMDIAG_INJECT_DELAY_MODE=no
 SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
 
 write_conf() {
@@ -19,7 +19,7 @@ write_conf() {
 	add_conf '
 global(workDirectory="'"$SPOOL_DIR"'")
 main_queue(queue.type="LinkedList" queue.filename="mainq"
-	queue.diskQueueType="segmentedDisk" queue.diskQueueIdleTimeout="0"
+	queue.diskQueueType="segmentedDisk" queue.diskQueueIdleTimeout="5000"
 	queue.size="50" queue.highWatermark="10" queue.lowWatermark="5"
 	queue.dequeueBatchSize="1" queue.dequeueSlowdown="2"
 	queue.checkpointInterval="1" queue.saveOnShutdown="on")
@@ -31,13 +31,17 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 for ((cycle = 0; cycle < SEGDISK_IDLE_FAULT_REPEATS; ++cycle)); do
 	write_conf
 	startup
+	# Submit the bulk of the cycle before arming the crash. An immediate idle
+	# cleanup can otherwise terminate a slow TSAN instance while imdiag is still
+	# injecting, and never-accepted messages look like queue loss after restart.
+	injectmsg $((cycle * 1000)) 999
 	set_segmented_disk_fault "$SEGDISK_IDLE_FAULT_POINT"
 	export RSTB_EXPECT_NO_PROPER_TERMINATION=YES
 	crashed_pid=$(getpid)
-	# Every cycle appends a distinct range. This rematerializes the store if an
-	# earlier interrupted cleanup completed during restart and proves the armed
-	# fault state survives the unmaterialized child representation.
-	injectmsg $((cycle * 1000)) 1000 || true
+	# The final record rematerializes the store if an earlier interrupted cleanup
+	# completed during restart and gives the armed fault a fresh idle transition.
+	# Its response may race with the intentional SIGKILL.
+	injectmsg $((cycle * 1000 + 999)) 1 || true
 	for _ in {1..600}; do
 		kill -0 "$crashed_pid" 2>/dev/null || break
 		./msleep 100


### PR DESCRIPTION
## What changed

- keep the disk-assisted child queue in the graceful action-completion phase when the parent queue has already drained
- make the TCP spill test wait for the sender shutdown barrier before checking the receiver's final count
- arm the idle-cleanup crash only after bulk injection and use the last record to create the tested idle transition
- correct the invalid immediate-input delay mode used by the idle-crash driver

## Root cause

The shutdown decision inspected only the parent queue's physical size. A disk-assisted child could still own queued or in-flight work after the parent reached zero, so shutdown skipped the action-completion phase and proceeded to hard cancellation.

Two test synchronization gaps amplified the symptoms: the TCP test treated an empty main queue as downstream delivery completion, and the idle-crash test could kill rsyslog while the bulk input was still being accepted.

## Impact

This preserves disk-assisted child work during shutdown and removes timing-dependent missing-output failures in the segmented DA tests without changing ordinary queue processing.

## Validation

- current `main`: all three archived failure scenarios passed locally and in an Ubuntu 26.04 Clang 21 TSAN reproduction attempt
- patched branch: 24/24 concurrent focused TSAN stress runs passed
- Ubuntu 26.04 change-gated validation: 1,526 total, 1,497 passed, 29 expected skips, 0 failures/errors
- static analyzer: no bugs found
- Cubic review: no issues found
- `devtools/format-code.sh --git-changed`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

