### PR TITLE
imptcp: guard regex framing match at line start

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1053,7 +1053,7 @@ static rsRetVal ATTR_NONNULL() processDataRcvd_regexFraming(ptcpsess_t *const __
         pThis->iCurrLine = pThis->iMsg;
     } else {
         const int isMatch = !regexec(&inst->start_preg, (char *)pThis->pMsg + pThis->iCurrLine, 0, NULL, 0);
-        if (isMatch) {
+        if (pThis->iCurrLine > 0 && isMatch) {
             DBGPRINTF("regex match (%d), framing line: %s\n", pThis->iCurrLine, pThis->pMsg);
             memmove(pThis->pMsg_save, pThis->pMsg + pThis->iCurrLine, ustrlen(pThis->pMsg + pThis->iCurrLine) + 1);
             pThis->iMsg = pThis->iCurrLine - 1;

--- a/tests/imptcp_framing_regex-oversize.sh
+++ b/tests/imptcp_framing_regex-oversize.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released  under ASL 2.0
+# Regression coverage for regex-framed imptcp oversize recovery. The configured
+# 256-byte limit forces the recovery path; clean shutdown plus the two internal
+# diagnostics prove that recovery completed without corrupting parser state.
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
@@ -40,6 +43,6 @@ NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag multi
 line3
 NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test4'
 cmp_exact
-content_check-regex "assuming end of frame" ${RSYSLOG2_OUT_LOG}
-content_check-regex "message too long" ${RSYSLOG2_OUT_LOG}
+content_check --regex "assuming end of frame" "${RSYSLOG2_OUT_LOG}"
+content_check --regex "message too long" "${RSYSLOG2_OUT_LOG}"
 exit_test


### PR DESCRIPTION
## Summary

- reject an invalid zero-offset regex-framing transition in `imptcp`
- make the existing oversize regex-framing test assert its diagnostics with the supported testbench helper
- document the regression-test oracle

## Root cause

After regex-framing oversize recovery, a zero line offset could be treated as a valid delimiter match. Subtracting one from that offset produced an invalid negative message length before submission.

The fix mirrors the guard already used by the shared `imtcp` parser.

## Impact

This prevents a configuration-dependent remote denial of service for `imptcp` listeners using the non-default `framing.delimiter.regex` option.

## Validation

- focused `imptcp_framing_regex-oversize.sh`
- Ubuntu 26.04 static analyzer
- change-gated Ubuntu 26.04 container check
- focused ASan/UBSan imptcp regression
- formatting and diff checks

The broad sanitizer suite had one unrelated `imfile-logrotate-async` timeout; the affected `imptcp` test passed under sanitizers.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

