### PR TITLE
tests: cover invalid template parameters

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,6 +24,9 @@ EXTRA_DIST += $(TESTS_TEMPLATE_REGEX_BOUNDS) $(TESTS_TEMPLATE_REGEX_BOUNDS_LIBYA
 TESTS_RSCRIPT_OBJECT_STRINGS = rscript-object-string-escapes.sh
 EXTRA_DIST += $(TESTS_RSCRIPT_OBJECT_STRINGS)
 
+TESTS_TEMPLATE_PARAMETER_ERRORS = template-parameter-errors.sh
+EXTRA_DIST += $(TESTS_TEMPLATE_PARAMETER_ERRORS)
+
 TESTS_SEGMENTED_DISK_QUEUE = \
 	segmented-diskqueue-config.sh \
 	segmented-diskqueue.sh \
@@ -284,6 +287,7 @@ TESTS_DEFAULT = \
 	template-json.sh \
 	$(TESTS_RSCRIPT_OBJECT_STRINGS) \
 	template-property-transformations.sh \
+	$(TESTS_TEMPLATE_PARAMETER_ERRORS) \
         template-pure-json.sh \
 	template-jsonf-nested.sh \
 	template-jsonf-nested-fallback-flat.sh \

--- a/tests/template-parameter-errors.sh
+++ b/tests/template-parameter-errors.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Exercise malformed legacy property-replacer parameters one configuration at
+# a time. Each case must make rsyslogd -N1 fail under abortOnUncleanConfig and
+# emit its specific parser diagnostic; separate invocations prove that an
+# earlier rejected template cannot hide later cases.
+# The long decimal literals deliberately overflow parser integers; they are
+# configuration data, not fixed network ports.
+. ${srcdir:=.}/diag.sh init
+
+run_invalid_parameter() {
+	local name="$1"
+	local parameter="$2"
+	local expected="$3"
+	local cfg="${RSYSLOG_DYNNAME}.${name}.conf"
+	local log="${RSYSLOG_DYNNAME}.${name}.log"
+
+	cat >"$cfg" <<CONF_EOF
+global(abortOnUncleanConfig="on")
+template(name="$name" type="string" string="$parameter")
+CONF_EOF
+
+	if ../tools/rsyslogd -C -N1 -f"$cfg" -M"$RSYSLOG_MODDIR" >"$log" 2>&1; then
+		error_exit 1 "config check unexpectedly succeeded for $name"
+	fi
+	content_check "$expected" "$log"
+}
+
+while IFS='|' read -r name parameter expected; do
+	run_invalid_parameter "$name" "$parameter" "$expected"
+done <<'CASES'
+invalid_option|%msg:::bogus-option%|template error: invalid field option 'bogus-option' specified - ignored
+conflict_csv|%msg:::json,csv%|one option out of (json, jsonf, jsonr, jsonfr, csv) - csv ignored
+conflict_json|%msg:::csv,json%|one option out of (json, jsonf, jsonr, jsonfr, csv) - json ignored
+conflict_jsonf|%msg:::csv,jsonf%|one option out of (json, jsonf, jsonr, jsonfr, csv) - jsonf ignored
+conflict_jsonr|%msg:::csv,jsonr%|one option out of (json, jsonf, jsonr, jsonfr, csv) - jsonr ignored
+conflict_jsonfr|%msg:::csv,jsonfr%|one option out of (json, jsonf, jsonr, jsonfr, csv) - jsonfr ignored
+delimiter_nondigit|%msg:F,x:2%|invalid character in frompos after "F,"
+delimiter_overflow|%msg:F,999999999999999999999999:2%|delimiter value in template is too large
+delimiter_nonascii|%msg:F,256:2%|non-USASCII delimiter character value 256
+delimiter_tail|%msg:F,44x:2%|invalid character 'x' in frompos after "F,"
+invalid_after_f|%msg:Fx:2%|invalid character in frompos after "F"
+frompos_overflow|%msg:999999999999999999999999:2%|frompos value in template is too large
+field_number_overflow|%msg:F,44:999999999999999999999999%|field number in template is too large
+field_topos_overflow|%msg:F,44:2,999999999999999999999999%|topos value in template is too large
+topos_overflow|%msg:1:999999999999999999999999%|topos value in template is too large
+CASES
+
+exit_test


### PR DESCRIPTION
## Summary

- add a table-driven negative test for legacy property-replacer parameters
- validate each malformed template in a separate `rsyslogd -N1` invocation
- cover conflicting formats, unknown options, invalid delimiters, and integer overflows
- register and distribute the test through the normal Automake testbench

## Why

A valid template configuration can exercise many transformations in one daemon run, but a rejected parameter makes that approach unsuitable for error paths. Separate configuration checks ensure that an earlier failure cannot hide later cases while keeping the test compact and deterministic.

## Coverage

Unioning the focused trace with the preceding full-suite trace adds 28 previously uncovered `runtime/template.c` lines: 7 in `doOptions` and 17 in `do_Parameter`. The projected full-suite coverage becomes approximately 79.0% for `template.c`, 93.0% for `doOptions`, and 70.0% for `do_Parameter`.

## Validation

- focused Ubuntu 26.04 test: pass, 15 cases
- focused coverage run using the regular Ubuntu 26.04 profile plus `--enable-coverage`: pass
- shell syntax and warning-level ShellCheck: pass
- test antipattern audit: only documented integer-overflow literals matched the fixed-port heuristic
- MOCK-OK `make distcheck -j60`: pass
- repository PR-ready `testbench-plumbing` validation with build/check jobs 60/60: pass
- Ubuntu 26.04 static analyzer: pass
- local Cubic review: no issues found


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

