### PR TITLE
omazuredce: avoid duplicate transaction replay

### DIFF
--- a/plugins/omazuredce/omazuredce.c
+++ b/plugins/omazuredce/omazuredce.c
@@ -1136,7 +1136,12 @@ BEGINendTransaction
     CHKiRet(retryPendingAsyncFlushUnlocked(pWrkrData));
     /* Always flush at transaction end so queue commit never races ahead of HTTP delivery. */
     if (pWrkrData->recordCount > 0) {
-        CHKiRet(flushBatchUnlocked(pWrkrData));
+        iRet = flushBatchUnlocked(pWrkrData);
+        if (iRet != RS_RET_OK) {
+            /* actionCommit() retains and replays the transaction parameters; drop only our private copy. */
+            resetBatch(pWrkrData);
+            FINALIZE;
+        }
     }
     if (pthread_mutex_unlock(&pWrkrData->batchLock) != 0) {
         lockHeld = 0;

--- a/tests/omazuredce-interrupt.sh
+++ b/tests/omazuredce-interrupt.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
+# Exercise a retryable synchronous Azure DCE post failure followed by recovery.
+# The oracle sums successful batch record counts after queue drain: it must equal
+# NUMMESSAGES exactly, proving action-engine replay did not append duplicate records.
+# A trap owns the background fault injector and removes its firewall rules. The
+# 180-second wait is hang protection for credentialed Azure calls on loaded CI.
 echo This test must be run as root [connection interruption requires iptables]
 echo "For variables to be passed use --preserve-env=AZURE_DCE_CLIENT_ID,AZURE_DCE_CLIENT_SECRET,AZURE_DCE_TENANT_ID,AZURE_DCE_URL,AZURE_DCE_DCR_ID,AZURE_DCE_TABLE_NAME"
 if [ "$EUID" -ne 0 ]; then
@@ -183,6 +188,14 @@ content_check "omazuredce: posted batch records="
 post_count=$(grep -c -F "omazuredce: posted batch records=" < "$RSYSLOG_OUT_LOG")
 if [ "${post_count:=0}" -lt 2 ]; then
 	echo "FAIL: expected multiple successful omazuredce batch posts after interruption, got $post_count"
+	cat -n "$RSYSLOG_OUT_LOG"
+	error_exit 1
+fi
+
+posted_records=$(sed -n 's/.*omazuredce: posted batch records=\([0-9][0-9]*\).*/\1/p' "$RSYSLOG_OUT_LOG" |
+	awk '{ total += $1 } END { print total + 0 }')
+if [ "$posted_records" -ne "$NUMMESSAGES" ]; then
+	echo "FAIL: expected exactly $NUMMESSAGES posted records after retry, got $posted_records"
 	cat -n "$RSYSLOG_OUT_LOG"
 	error_exit 1
 fi


### PR DESCRIPTION
## Summary

- make the action engine the sole owner of synchronous transaction replay
- clear only `omazuredce`'s private batch after a retryable transaction-end upload failure
- extend the interruption test with an exact successful-record-count oracle

## Why

Rsyslog provides at-least-once delivery, so duplicates can be an expected consequence of uncertain delivery outcomes. In this path, however, a synchronous failure left the same uncommitted records in both the action engine and the module-private batch. Replaying the transaction could then append the records to that retained batch and amplify duplicates unnecessarily.

The action engine already retains the transaction parameters and replays them after a retryable return. Dropping only the module-private copy establishes one owner for synchronous retry state while preserving the existing at-least-once contract.

Timer-originated asynchronous retry state is unchanged.

## Validation

- C formatting check, `git diff --check`, `bash -n`, and ShellCheck passed
- mock distcheck passed
- Ubuntu 26.04 change-gated CI: 1,389 total, 1,345 passed, 44 skipped, 0 failed
- Ubuntu 26.04 clang static analyzer: no bugs found
- Ubuntu 26.04 ThreadSanitizer lane: 1,262 total, 1,214 passed, 48 skipped, 0 failed
- local Cubic review completed; its conditional retry-ownership concern was checked against `actionCommit()` and `actionTryRemoveHardErrorsFromBatch()`, which retain and replay the original transaction parameters

The credential-free `omazuredce-no-dcr-id.sh` test passed. Azure-backed tests, including the modified interruption test, were skipped because credentials were not available locally.

With the help of AI-Agents: Codex


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

