### PR TITLE
stringbuf: harden empty string replacement

### DIFF
--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -407,7 +407,13 @@ rsRetVal rsCStrSetSzStr(cstr_t *const __restrict__ pThis, uchar *const __restric
             pThis->iBufSize = newlen + 1;
         }
         pThis->iStrLen = newlen;
-        memcpy(pThis->pBuf, pszNew, pThis->iStrLen);
+        if (pThis->iStrLen == 0) {
+            if (pThis->pBuf != NULL) {
+                pThis->pBuf[0] = '\0';
+            }
+        } else {
+            memcpy(pThis->pBuf, pszNew, pThis->iStrLen);
+        }
     }
 
     return RS_RET_OK;

--- a/tests/unit/stringbuf_test.c
+++ b/tests/unit/stringbuf_test.c
@@ -175,11 +175,26 @@ static int test_destructive_convert_semantics(void) {
 static int test_setszstr_requires_finalize(void) {
     cstr_t *str = NULL;
 
+    /* Empty non-NULL input must remain valid even when no backing buffer has
+     * been allocated yet. UBSan rejects passing that NULL buffer to memcpy,
+     * including when the requested copy length is zero. */
     CHECK(rsCStrConstruct(&str) == RS_RET_OK);
+    CHECK(rsCStrSetSzStr(str, (uchar *)"") == RS_RET_OK);
+    cstrFinalize(str);
+    CHECK(rsCStrLen(str) == 0);
+    CHECK(strcmp((char *)rsCStrGetSzStrNoNULL(str), "") == 0);
+
     CHECK(rsCStrSetSzStr(str, (uchar *)"new-value") == RS_RET_OK);
     cstrFinalize(str);
     CHECK(rsCStrLen(str) == strlen("new-value"));
     CHECK(strcmp((char *)rsCStrGetSzStrNoNULL(str), "new-value") == 0);
+
+    /* Reusing the allocated buffer for an empty string must not expose the
+     * previous value through the NUL-terminated string view. */
+    CHECK(rsCStrSetSzStr(str, (uchar *)"") == RS_RET_OK);
+    cstrFinalize(str);
+    CHECK(rsCStrLen(str) == 0);
+    CHECK(strcmp((char *)rsCStrGetSzStrNoNULL(str), "") == 0);
 
     CHECK(rsCStrSetSzStr(str, NULL) == RS_RET_OK);
     cstrFinalize(str);


### PR DESCRIPTION
## Summary

- avoid calling `memcpy` when the replacement string has length zero
- preserve the supported NULL-buffer representation for a fresh empty string
- terminate retained storage when an allocated string is replaced with an empty value, so the old bytes are not exposed through the string view
- cover fresh, populated, reused, and NULL reset behavior in the string-buffer unit test

## Classification

This is robustness hardening. The C library call requires valid pointer arguments even when the copy count is zero, and a reused target buffer also needs an explicit terminator to represent the new empty value. No production crash or security impact has been demonstrated.

## Validation

- `devtools/format-code.sh --git-changed --check --check-if-available`
- `git diff --check`
- `devtools/local-validation-plan.sh --run`
  - Ubuntu 26.04 CI-equivalent lane: 1,529 total; 1,500 passed; 29 skipped; 0 failed/errors
  - clang static analyzer: no bugs found
  - local Cubic review: no issues found

Container image: `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`). Default local concurrency was used.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

