### PR TITLE
packaging: order daily version after Debian baseline

### DIFF
--- a/devtools/release/debian-daily-stable.sh
+++ b/devtools/release/debian-daily-stable.sh
@@ -44,6 +44,17 @@ short_commit_sha() {
   git rev-parse --short=12 HEAD
 }
 
+daily_version() {
+  local base="$1"
+  local date="$2"
+  local run="$3"
+  local attempt="$4"
+  local short_sha="$5"
+
+  printf '%s+daily%s.%s.%s+git%s-1adiscon1\n' \
+    "$base" "$date" "$run" "$attempt" "$short_sha"
+}
+
 cmd_version() {
   local base date short_sha run attempt version
 
@@ -56,7 +67,7 @@ cmd_version() {
   short_sha="$(short_commit_sha)"
   run="${GITHUB_RUN_NUMBER:-0}"
   attempt="${GITHUB_RUN_ATTEMPT:-1}"
-  version="${base}~daily${date}.${run}.${attempt}+git${short_sha}-1adiscon1"
+  version="$(daily_version "$base" "$date" "$run" "$attempt" "$short_sha")"
 
   printf '%s\n' "$version"
 
@@ -508,12 +519,19 @@ build_self_test_deb() {
 
 cmd_self_test() (
   local tmp_dir repo_dir first_artifacts second_artifacts fingerprint
+  local test_version
   local cleanup_command
 
-  for tool in apt-ftparchive curl dpkg-deb gpg gpgv xz; do
+  for tool in apt-ftparchive curl dpkg dpkg-deb gpg gpgv xz; do
     command -v "$tool" >/dev/null 2>&1 ||
       die "$tool is required for self-test"
   done
+
+  test_version="$(
+    daily_version 8.2606.0 20260725 9 1 31720a4787d4
+  )"
+  dpkg --compare-versions "$test_version" gt 8.2606.0-4 ||
+    die "daily version must sort after the Debian packaging baseline"
 
   tmp_dir="$(mktemp -d)"
   printf -v cleanup_command 'rm -rf -- %q' "$tmp_dir"


### PR DESCRIPTION
## Summary

- make generated daily versions sort after the Debian packaging baseline
- retain monotonic date, run, attempt, and source revision components
- add a self-test assertion for Debian version ordering

## Failure reproduced

Manual non-publishing workflow run 30167350139 failed because `dch` considered `8.2606.0~daily...` older than `8.2606.0-4`.

## Validation

- shell syntax and ShellCheck
- archive self-test
- exact `dch` reproduction against `8.2606.0-4`
- Ubuntu 26.04 change-gated suite: 1346 passed, 33 skipped, one unrelated disk-queue test failed and passed on focused rerun
- clang static analyzer: no bugs found
- local Cubic: no issues found

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

