### PR TITLE
imfile: fix delay.message microsecond conversion

### DIFF
--- a/doc/source/reference/parameters/imfile-delay-message.rst
+++ b/doc/source/reference/parameters/imfile-delay-message.rst
@@ -43,13 +43,9 @@ drop messages when rate limits are exceeded, ``delay.message`` slows down proces
 without message loss. This makes it suitable for scenarios where all messages must
 be preserved but bandwidth sharing is required.
 
-.. note::
-   The delay value is specified in **microseconds**, but the current implementation
-   has a known issue where the seconds and microseconds components are swapped
-   internally. For values less than 1,000,000 microseconds (1 second), the actual
-   delay will be much longer than documented. For example, ``delay.message="1000"``
-   (intended as 1 ms) currently results in approximately a 1000-second delay.
-   Users should be aware of this behavior when configuring this parameter.
+The value is converted into whole seconds and remaining microseconds before
+rsyslog sleeps. For example, ``delay.message="1000"`` adds a 1 millisecond
+delay, while ``delay.message="1500000"`` adds a 1.5 second delay.
 
 Input usage
 -----------
@@ -64,11 +60,6 @@ Input usage
          delay.message="1000")
 
 The above example configures a delay value of 1000 microseconds.
-
-.. note::
-   Due to a known implementation issue, small delay values (less than 1,000,000)
-   may result in much longer delays than expected. See the Description section
-   above for details.
 
 Notes
 -----

--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -1648,14 +1648,14 @@ static rsRetVal ATTR_NONNULL(1, 2)
                 continue;
             } else if (localRet != RS_RET_OK) {
                 if (inst->delay_perMsg) {
-                    srSleep(inst->delay_perMsg % 1000000, inst->delay_perMsg / 1000000);
+                    srSleep(inst->delay_perMsg / 1000000, inst->delay_perMsg % 1000000);
                 }
                 ABORT_FINALIZE(localRet);
             }
         }
 
         if (inst->delay_perMsg) {
-            srSleep(inst->delay_perMsg % 1000000, inst->delay_perMsg / 1000000);
+            srSleep(inst->delay_perMsg / 1000000, inst->delay_perMsg % 1000000);
         }
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2042,6 +2042,7 @@ TESTS_IMFILE_EXTENDED = \
 TESTS_IMFILE = \
 	imfile-basic.sh \
 	imfile-basic-legacy.sh \
+	imfile-delay-message.sh \
 	imfile-discard-truncated-line.sh \
 	imfile-truncate-line.sh \
 	imfile-file-not-found-error.sh \

--- a/tests/imfile-delay-message.sh
+++ b/tests/imfile-delay-message.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Regression test for imfile delay.message microsecond conversion.
+# A 1000-microsecond delay must deliver one line within 10 seconds. The
+# generous bound is not a performance assertion: it tolerates loaded CI hosts
+# while deterministically rejecting the old swapped-argument behavior, which
+# sleeps for about 1000 seconds.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1
+generate_conf
+add_conf '
+module(load="../plugins/imfile/.libs/imfile")
+input(type="imfile"
+      File="./'$RSYSLOG_DYNNAME'.input"
+      Tag="file:"
+      delay.message="1000")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+if $msg contains "msgnum:" then
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+touch "$RSYSLOG_DYNNAME.input"
+startup
+./inputfilegen -m "$NUMMESSAGES" >> "$RSYSLOG_DYNNAME.input"
+wait_file_lines "$RSYSLOG_OUT_LOG" "$NUMMESSAGES" 10
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test


### PR DESCRIPTION
## Summary

Fix `imfile` passing the seconds and microseconds components of `delay.message` to `srSleep()` in reverse order. A value of 1000 microseconds previously became an approximately 1000-second wait; it now correctly becomes 1 millisecond.

Both sleep sites use the documented microsecond conversion, the obsolete documentation warning is removed, and a focused regression test covers the sub-second case. The older 2018 report in #3116 described the same swapped-unit root cause: `delay.message="100"` became an approximately 100-second pause, making input appear stalled.

Closes: https://github.com/rsyslog/rsyslog/issues/7348
Closes: https://github.com/rsyslog/rsyslog/issues/3116

## Validation

- focused `imfile-delay-message.sh`: passes with the fix
- mutation check: restoring the swapped arguments fails the regression within its 10-second oracle
- `devtools/format-code.sh --git-changed --check --check-if-available`: passes
- `shellcheck`: passes
- local Cubic: no issues
- `devtools/local-validation-plan.sh --run`: passes on the committed source tree
  - Ubuntu 26.04: 1,462 total, 1,429 passed, 33 skipped, 0 failed
  - static analyzer: no bugs found
  - final local Cubic: no issues found
  - image: `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`)
  - concurrency: `RSYSLOG_LOCAL_CHECK_JOBS=10`, `RSYSLOG_LOCAL_BUILD_JOBS=10`

With the help of AI-Agents: Codex

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
