### PR TITLE
ci: use hosted AWS CLI for package publishing

### DIFF
--- a/.github/workflows/debian_daily_stable.yml
+++ b/.github/workflows/debian_daily_stable.yml
@@ -328,12 +328,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install repository and Spaces tools
+      - name: Prepare repository and Spaces tools
         run: |
+          command -v aws
+          aws --version
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             apt-utils \
-            awscli \
             gnupg \
             xz-utils
 


### PR DESCRIPTION
## Summary
- use the AWS CLI v2 bundled with the GitHub Ubuntu 24.04 runner
- fail early if the hosted aws command is unavailable
- retain apt installation of the repository-generation and signing tools

## Why
The first real end-to-end Debian daily-stable run built all packages, then failed before upload because Ubuntu 24.04 has no installable awscli apt candidate.

## Validation
- full local validation plan
  - Ubuntu 26.04 CI-equivalent suite: 1,535 total, 1,506 pass, 29 skip, 0 fail
  - static analyzer: no bugs found
  - Cubic: no issues found
- actionlint
- flake-evidence coverage checker
- zizmor strict collection
- git diff check

After merge, the publisher will be rerun to verify DigitalOcean upload, public signed metadata, exact-version Debian 13 installation, and rsyslog smoke tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

