### PR TITLE
ci: use Debian 13 package definitions

### DIFF
--- a/.github/debian-daily-stable-13-policy.yml
+++ b/.github/debian-daily-stable-13-policy.yml
@@ -1,0 +1,28 @@
+{
+  "allowed_patch_skips": [
+    {
+      "patch": "Increase-timeouts-in-imfile-basic-2GB-file-and-imfile-tru.patch",
+      "reason": "Debian 13 carries the 2 GiB imfile timeout increase that current upstream already includes with later test updates."
+    },
+    {
+      "patch": "Revert-queue-emit-better-warning-messages-on-queue-param-.patch",
+      "reason": "Debian 13 carries the queue warning revert that current upstream already includes, followed by later queue changes."
+    }
+  ],
+  "supplemental_build_deps": [],
+  "control_replacements": [
+    {
+      "pattern": "Build-Depends: debhelper-compat \\(= 13\\),",
+      "replacement": "Build-Depends: debhelper-compat (= 13),\\n               libyaml-dev,\\n               libprotobuf-c-dev,\\n               protobuf-c-compiler,\\n               libsnappy-dev,",
+      "reason": "Current upstream adds YAML configuration and native impstats push support whose build dependencies postdate Debian 13's rsyslog source package."
+    }
+  ],
+  "install_manifest_additions": [
+    {
+      "manifest": "rsyslog.install",
+      "path": "usr/lib/${DEB_HOST_MULTIARCH}/rsyslog/mmleefparse.so",
+      "reason": "Current upstream adds mmleefparse after Debian 13's rsyslog install manifest; it belongs in the core package with the other message-modification modules."
+    }
+  ],
+  "not_installed_paths": []
+}

--- a/.github/scripts/debian_package_build.sh
+++ b/.github/scripts/debian_package_build.sh
@@ -57,6 +57,19 @@ with open(replacements_path, "w", encoding="utf-8") as replacements_fh, \
             continue
         replacements_fh.write(f"{pattern}\t{replacement}\n")
         reasons_fh.write(f"{pattern}\t{reason}\n")
+
+manifest_path = os.path.join(out_dir, "install_manifest_additions.tsv")
+manifest_reasons_path = os.path.join(out_dir, "install_manifest_additions.reasons.txt")
+with open(manifest_path, "w", encoding="utf-8") as manifest_fh, \
+        open(manifest_reasons_path, "w", encoding="utf-8") as reasons_fh:
+    for entry in policy.get("install_manifest_additions", []):
+        manifest = entry.get("manifest", "").strip()
+        path = entry.get("path", "").strip()
+        reason = entry.get("reason", "").strip()
+        if not manifest or not path:
+            continue
+        manifest_fh.write(f"{manifest}\t{path}\n")
+        reasons_fh.write(f"{manifest}:{path}\t{reason}\n")
 PY
 }
 
@@ -104,6 +117,72 @@ fetch_debian_packaging() {
   cp -r "$clone_dir/debian" "$target_dir"
 }
 
+enable_debian_source_repositories() {
+  local deb822_files=(/etc/apt/sources.list.d/*.sources)
+
+  if [ -e "${deb822_files[0]}" ]; then
+    python3 - "${deb822_files[@]}" <<'PY'
+import pathlib
+import sys
+
+for name in sys.argv[1:]:
+    path = pathlib.Path(name)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    updated = []
+    for line in lines:
+        if line.startswith("Types:"):
+            types = line.removeprefix("Types:").split()
+            if "deb" in types and "deb-src" not in types:
+                types.append("deb-src")
+            line = f"Types: {' '.join(types)}"
+        updated.append(line)
+    path.write_text("\n".join(updated) + "\n", encoding="utf-8")
+PY
+  elif [ -f /etc/apt/sources.list ]; then
+    sed -n 's/^deb[[:space:]]\+/deb-src /p' /etc/apt/sources.list \
+      > /etc/apt/sources.list.d/rsyslog-deb-src.list
+  fi
+
+  apt-get update
+  apt-cache showsrc rsyslog >/dev/null 2>&1 || {
+    echo "ERROR: target Debian release does not provide rsyslog source metadata" >&2
+    return 1
+  }
+}
+
+fetch_debian_release_packaging() {
+  local target_dir="$1"
+  local version_file="$2"
+  local source_root
+  local source_dir
+  local packaging_version
+
+  source_root="$(mktemp -d)"
+  rm -rf "$target_dir"
+
+  enable_debian_source_repositories
+  (
+    cd "$source_root"
+    apt-get source --only-source rsyslog
+  )
+
+  source_dir="$(
+    find "$source_root" -mindepth 1 -maxdepth 1 -type d \
+      -name 'rsyslog-*' -print -quit
+  )"
+  if [ -z "$source_dir" ] || [ ! -d "$source_dir/debian" ]; then
+    echo "ERROR: could not extract the target Debian release's rsyslog source package" >&2
+    return 1
+  fi
+
+  packaging_version="$(
+    dpkg-parsechangelog -l "$source_dir/debian/changelog" -S Version
+  )"
+  cp -r "$source_dir/debian" "$target_dir"
+  printf '%s\n' "$packaging_version" > "$version_file"
+  rm -rf "$source_root"
+}
+
 apply_control_replacements() {
   local control_file="$1"
   local replacements_file="$2"
@@ -140,6 +219,34 @@ PY
     record_policy_items "$reasons_file" "$findings_dir" \
       "allowed_packaging_drift" "Update Debian control replacement for"
   fi
+}
+
+apply_install_manifest_additions() {
+  local packaging_dir="$1"
+  local additions_file="$2"
+  local manifest
+  local path
+  local target
+
+  [ -s "$additions_file" ] || return 0
+
+  while IFS=$'\t' read -r manifest path; do
+    [ -n "$manifest" ] && [ -n "$path" ] || continue
+    case "$manifest" in
+      */*|.*)
+        echo "ERROR: invalid Debian install manifest name: $manifest" >&2
+        return 1
+        ;;
+    esac
+    target="$packaging_dir/$manifest"
+    [ -f "$target" ] || {
+      echo "ERROR: missing Debian install manifest: $target" >&2
+      return 1
+    }
+    if ! grep -Fqx "$path" "$target"; then
+      printf '%s\n' "$path" >> "$target"
+    fi
+  done < "$additions_file"
 }
 
 run_dist_build() {
@@ -288,7 +395,7 @@ resolve_patch_policy() {
     quilt pop -a >/dev/null 2>&1 || true
 
     set +e
-    quilt push -a > /tmp/quilt-push.log 2>&1
+    quilt push --fuzz=0 -a > /tmp/quilt-push.log 2>&1
     rc=$?
     set -e
     cat /tmp/quilt-push.log
@@ -438,7 +545,9 @@ case "${1:-}" in
   load_policy) shift; load_policy "$@" ;;
   install_prereqs) shift; install_prereqs "$@" ;;
   fetch_debian_packaging) shift; fetch_debian_packaging "$@" ;;
+  fetch_debian_release_packaging) shift; fetch_debian_release_packaging "$@" ;;
   apply_control_replacements) shift; apply_control_replacements "$@" ;;
+  apply_install_manifest_additions) shift; apply_install_manifest_additions "$@" ;;
   run_dist_build) shift; run_dist_build "$@" ;;
   find_dist_tarball) shift; find_dist_tarball "$@" ;;
   unpack_source_tree) shift; unpack_source_tree "$@" ;;

--- a/.github/workflows/debian_daily_stable.yml
+++ b/.github/workflows/debian_daily_stable.yml
@@ -23,7 +23,7 @@ name: debian daily stable
       source_ref:
         description: rsyslog source branch, tag, or commit to package
         required: true
-        default: v8-stable
+        default: main
         type: string
       publish_to_archive:
         description: Publish to the configured DigitalOcean Spaces archive
@@ -38,11 +38,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DEBIAN_CI_POLICY_FILE: .github/debian-ci-policy.yml
+  DEBIAN_CI_POLICY_FILE: .github/debian-daily-stable-13-policy.yml
   DEBIAN_CI_HELPER: .github/scripts/debian_package_build.sh
   DEBIAN_DAILY_STABLE_HELPER: devtools/release/debian-daily-stable.sh
-  DEBIAN_PACKAGING_REPO: https://salsa.debian.org/debian/rsyslog.git
-  DEBIAN_PACKAGING_BRANCH: debian/latest
   DEBIAN_BUILD_ROOT: /tmp/rsyslog-debian-daily-stable-build
   DEBIAN_SUITE: trixie
   DEBIAN_COMPONENT: main
@@ -75,12 +73,12 @@ jobs:
           set -euo pipefail
           should_run=false
           should_publish=false
-          source_ref=v8-stable
+          source_ref=main
 
           case "$EVENT_NAME" in
             workflow_dispatch)
               should_run=true
-              source_ref="${MANUAL_SOURCE_REF:-v8-stable}"
+              source_ref="${MANUAL_SOURCE_REF:-main}"
               if [ "${MANUAL_PUBLISH:-false}" = "true" ]; then
                 should_publish=true
               fi
@@ -175,11 +173,15 @@ jobs:
             "$DEBIAN_BUILD_ROOT/debian-ci-policy"
 
       - name: Fetch Debian packaging baseline
+        id: packaging
         run: |
-          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" fetch_debian_packaging \
-            "$DEBIAN_PACKAGING_REPO" \
-            "$DEBIAN_PACKAGING_BRANCH" \
-            "$DEBIAN_BUILD_ROOT/debian-packaging"
+          baseline_version_file="$DEBIAN_BUILD_ROOT/debian-packaging-version"
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" \
+            fetch_debian_release_packaging \
+            "$DEBIAN_BUILD_ROOT/debian-packaging" \
+            "$baseline_version_file"
+          baseline_version="$(cat "$baseline_version_file")"
+          echo "baseline_version=$baseline_version" >> "$GITHUB_OUTPUT"
 
       - name: Apply packaging baseline policy
         run: |
@@ -187,6 +189,10 @@ jobs:
             "$DEBIAN_BUILD_ROOT/debian-packaging/control" \
             "$DEBIAN_BUILD_ROOT/debian-ci-policy/control_replacements.tsv" \
             "$DEBIAN_BUILD_ROOT/debian-ci-policy/control_replacements.reasons.txt"
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" \
+            apply_install_manifest_additions \
+            "$DEBIAN_BUILD_ROOT/debian-packaging" \
+            "$DEBIAN_BUILD_ROOT/debian-ci-policy/install_manifest_additions.tsv"
 
       - name: Install Debian build dependencies
         run: |
@@ -283,6 +289,7 @@ jobs:
 
       - name: Summarize build
         env:
+          BASELINE_VERSION: ${{ steps.packaging.outputs.baseline_version }}
           SOURCE_REF: ${{ needs.preflight.outputs.source_ref }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -292,6 +299,7 @@ jobs:
             echo "- Version: \`$VERSION\`"
             echo "- Source ref: \`$SOURCE_REF\`"
             echo "- Source commit: \`$SOURCE_GIT_SHA\`"
+            echo "- Debian packaging baseline: \`rsyslog $BASELINE_VERSION\`"
             echo "- Target: Debian 13 (\`$DEBIAN_SUITE\`), \`$DEBIAN_ARCH\`"
             echo "- Archive prefix: \`$SPACE_PREFIX\`"
             echo
@@ -547,6 +555,8 @@ jobs:
             ca-certificates \
             curl \
             gnupg \
+            gpgv \
+            python3 \
             xz-utils
 
       - name: Wait for CDN and verify signed metadata


### PR DESCRIPTION
## Summary

- build daily-stable packages from current rsyslog `main`
- obtain the packaging definitions from Debian 13 source repositories
- keep Debian-13-specific backport adjustments in an explicit policy
- verify Debian patch application with zero fuzz
- include dependencies and modules added by current upstream

## End-to-end validation

- fetched Debian 13 rsyslog source package baseline `8.2504.0-1`
- built source and binary packages from current rsyslog source
- installed the exact generated package in a fresh Debian 13 container
- verified `rsyslogd -v` reports `8.2608.0.daily`
- verified `rsyslogd -N1` succeeds
- verified the newly added `mmleefparse.so` is installed

## Local PR-ready validation

- Ubuntu 26.04 CI-equivalent suite: 1,535 total, 1,506 pass, 29 skip, 0 fail
- clang static analyzer: no bugs found
- actionlint, shellcheck, zizmor, flake-evidence coverage, JSON parsing, and diff checks: pass
- local Cubic review: no issues found

With the help of AI-Agents: Codex

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

