### PR TITLE
mmkubernetes: make namespace metadata optional

### DIFF
--- a/contrib/mmkubernetes/mmkubernetes.c
+++ b/contrib/mmkubernetes/mmkubernetes.c
@@ -102,6 +102,7 @@ DEFobjCurrIf(regexp) DEFobjCurrIf(statsobj) DEFobjCurrIf(datetime)
 #define DFLT_BUSY_RETRY_INTERVAL 5 /* retry every 5 seconds */
 #define DFLT_SSL_PARTIAL_CHAIN 0 /* disallow X509_V_FLAG_PARTIAL_CHAIN by default */
 #define DFLT_CACHE_ENTRY_TTL 3600 /* delete entries from the cache older than 3600 seconds */
+#define DFLT_INCLUDE_NAMESPACE_METADATA 1
 #define DFLT_CACHE_EXPIRE_INTERVAL                                  \
     -1 /* delete all expired entries from the cache every N seconds \
 -1 disables cache expiration/ttl checking                           \
@@ -119,6 +120,7 @@ DEFobjCurrIf(regexp) DEFobjCurrIf(statsobj) DEFobjCurrIf(datetime)
 
 static struct cache_s {
     const uchar *kbUrl;
+    sbool includeNamespaceMetadata;
     struct hashtable *mdHt;
     struct hashtable *nsHt;
     pthread_mutex_t *cacheMtx;
@@ -159,6 +161,7 @@ struct modConfData_s {
     sbool sslPartialChain; /* if true, allow using intermediate certs without root certs */
     int cacheEntryTTL; /* delete entries from the cache if they are older than this many seconds */
     int cacheExpireInterval; /* delete all expired entries from the cache every this many seconds */
+    sbool includeNamespaceMetadata; /* query and attach namespace metadata */
 };
 
 /* action (instance) configuration data */
@@ -192,6 +195,7 @@ typedef struct _instanceData {
     sbool sslPartialChain; /* if true, allow using intermediate certs without root certs */
     int cacheEntryTTL; /* delete entries from the cache if they are older than this many seconds */
     int cacheExpireInterval; /* delete all expired entries from the cache every this many seconds */
+    sbool includeNamespaceMetadata; /* query and attach namespace metadata */
 } instanceData;
 
 typedef struct wrkrInstanceData {
@@ -238,7 +242,8 @@ static struct cnfparamdescr modpdescr[] = {{"kubernetesurl", eCmdHdlrArray, 0},
                                            {"busyretryinterval", eCmdHdlrInt, 0},
                                            {"sslpartialchain", eCmdHdlrBinary, 0},
                                            {"cacheentryttl", eCmdHdlrInt, 0},
-                                           {"cacheexpireinterval", eCmdHdlrInt, 0}
+                                           {"cacheexpireinterval", eCmdHdlrInt, 0},
+                                           {"includenamespacemetadata", eCmdHdlrBinary, 0}
 #if HAVE_LOADSAMPLESFROMSTRING == 1
                                            ,
                                            {"filenamerules", eCmdHdlrArray, 0},
@@ -266,7 +271,8 @@ static struct cnfparamdescr actpdescr[] = {{"kubernetesurl", eCmdHdlrArray, 0},
                                            {"busyretryinterval", eCmdHdlrInt, 0},
                                            {"sslpartialchain", eCmdHdlrBinary, 0},
                                            {"cacheentryttl", eCmdHdlrInt, 0},
-                                           {"cacheexpireinterval", eCmdHdlrInt, 0}
+                                           {"cacheexpireinterval", eCmdHdlrInt, 0},
+                                           {"includenamespacemetadata", eCmdHdlrBinary, 0}
 #if HAVE_LOADSAMPLESFROMSTRING == 1
                                            ,
                                            {"filenamerules", eCmdHdlrArray, 0},
@@ -645,6 +651,7 @@ BEGINsetModCnf
     loadModConf->sslPartialChain = DFLT_SSL_PARTIAL_CHAIN;
     loadModConf->cacheEntryTTL = DFLT_CACHE_ENTRY_TTL;
     loadModConf->cacheExpireInterval = DFLT_CACHE_EXPIRE_INTERVAL;
+    loadModConf->includeNamespaceMetadata = DFLT_INCLUDE_NAMESPACE_METADATA;
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) {
             continue;
@@ -776,6 +783,8 @@ BEGINsetModCnf
             loadModConf->cacheEntryTTL = pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "cacheexpireinterval")) {
             loadModConf->cacheExpireInterval = pvals[i].val.d.n;
+        } else if (!strcmp(modpblk.descr[i].name, "includenamespacemetadata")) {
+            loadModConf->includeNamespaceMetadata = pvals[i].val.d.n;
         } else {
             dbgprintf(
                 "mmkubernetes: program error, non-handled "
@@ -1059,6 +1068,7 @@ static struct cache_s *cacheNew(instanceData *pData) {
     need_mutex_destroy = 1;
     datetime.GetTime(&now);
     cache->kbUrl = pData->kubernetesUrl;
+    cache->includeNamespaceMetadata = pData->includeNamespaceMetadata;
     cache->expirationTime = 0;
     if (pData->cacheExpireInterval > -1)
         cache->expirationTime = pData->cacheExpireInterval + pData->cacheEntryTTL + now;
@@ -1288,6 +1298,7 @@ BEGINnewActInst
     pData->sslPartialChain = loadModConf->sslPartialChain;
     pData->cacheEntryTTL = loadModConf->cacheEntryTTL;
     pData->cacheExpireInterval = loadModConf->cacheExpireInterval;
+    pData->includeNamespaceMetadata = loadModConf->includeNamespaceMetadata;
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) {
             continue;
@@ -1420,6 +1431,8 @@ BEGINnewActInst
             pData->cacheEntryTTL = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "cacheexpireinterval")) {
             pData->cacheExpireInterval = pvals[i].val.d.n;
+        } else if (!strcmp(actpblk.descr[i].name, "includenamespacemetadata")) {
+            pData->includeNamespaceMetadata = pvals[i].val.d.n;
         } else {
             dbgprintf(
                 "mmkubernetes: program error, non-handled "
@@ -1493,7 +1506,9 @@ BEGINnewActInst
 
     /* get the cache for this url */
     for (i = 0; caches[i] != NULL; i++) {
-        if (!strcmp((char *)pData->kubernetesUrl, (char *)caches[i]->kbUrl)) break;
+        if (!strcmp((char *)pData->kubernetesUrl, (char *)caches[i]->kbUrl) &&
+            pData->includeNamespaceMetadata == caches[i]->includeNamespaceMetadata)
+            break;
     }
     if (caches[i] != NULL) {
         pData->cache = caches[i];
@@ -1592,6 +1607,7 @@ BEGINdbgPrintInstInfo
     dbgprintf("\tbusyretryinterval='%d'\n", pData->busyRetryInterval);
     dbgprintf("\tcacheentryttl='%d'\n", pData->cacheEntryTTL);
     dbgprintf("\tcacheexpireinterval='%d'\n", pData->cacheExpireInterval);
+    dbgprintf("\tincludenamespacemetadata='%d'\n", pData->includeNamespaceMetadata);
 ENDdbgPrintInstInfo
 
 
@@ -1856,10 +1872,12 @@ BEGINdoAction
     if (jMetadata == NULL) {
         struct json_object *jReply = NULL, *jo2 = NULL, *jNsMeta = NULL, *jPodData = NULL;
 
-        /* check cache for namespace metadata */
-        jNsMeta = cache_entry_get_nsmd(pWrkrData, (const char *)ns, now);
+        /* Namespace metadata is optional. The namespace name parsed from the
+         * input path remains part of the basic pod identity either way. */
+        if (pWrkrData->pData->includeNamespaceMetadata)
+            jNsMeta = cache_entry_get_nsmd(pWrkrData, (const char *)ns, now);
 
-        if (jNsMeta == NULL) {
+        if (pWrkrData->pData->includeNamespaceMetadata && jNsMeta == NULL) {
             /* query kubernetes for namespace info */
             if ((-1 == asprintf(&apiPath, "/api/v1/namespaces/%s", ns)) || (!apiPath)) {
                 pthread_mutex_unlock(pWrkrData->pData->cache->cacheMtx);

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -908,6 +908,7 @@ EXTRA_DIST = \
     source/reference/parameters/mmkubernetes-filenamerulebase.rst \
     source/reference/parameters/mmkubernetes-filenamerules.rst \
     source/reference/parameters/mmkubernetes-kubernetesurl.rst \
+    source/reference/parameters/mmkubernetes-includenamespacemetadata.rst \
     source/reference/parameters/mmkubernetes-skipverifyhost.rst \
     source/reference/parameters/mmkubernetes-srcmetadatapath.rst \
     source/reference/parameters/mmkubernetes-sslpartialchain.rst \

--- a/doc/source/configuration/modules/mmkubernetes.rst
+++ b/doc/source/configuration/modules/mmkubernetes.rst
@@ -120,6 +120,10 @@ Action Parameters
      - .. include:: ../../reference/parameters/mmkubernetes-kubernetesurl.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-mmkubernetes-includenamespacemetadata`
+     - .. include:: ../../reference/parameters/mmkubernetes-includenamespacemetadata.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-mmkubernetes-skipverifyhost`
      - .. include:: ../../reference/parameters/mmkubernetes-skipverifyhost.rst
         :start-after: .. summary-start
@@ -169,6 +173,7 @@ Action Parameters
    ../../reference/parameters/mmkubernetes-filenamerulebase
    ../../reference/parameters/mmkubernetes-filenamerules
    ../../reference/parameters/mmkubernetes-kubernetesurl
+   ../../reference/parameters/mmkubernetes-includenamespacemetadata
    ../../reference/parameters/mmkubernetes-skipverifyhost
    ../../reference/parameters/mmkubernetes-srcmetadatapath
    ../../reference/parameters/mmkubernetes-sslpartialchain

--- a/doc/source/reference/parameters/mmkubernetes-includenamespacemetadata.rst
+++ b/doc/source/reference/parameters/mmkubernetes-includenamespacemetadata.rst
@@ -1,0 +1,62 @@
+.. meta::
+   :description: Control whether mmkubernetes queries and adds Kubernetes namespace metadata.
+   :keywords: rsyslog, mmkubernetes, namespace, metadata, Kubernetes
+
+.. _param-mmkubernetes-includenamespacemetadata:
+.. _mmkubernetes.parameter.action.includenamespacemetadata:
+
+includeNamespaceMetadata
+========================
+
+.. index::
+   single: mmkubernetes; includeNamespaceMetadata
+   single: includeNamespaceMetadata
+
+.. summary-start
+
+Controls whether mmkubernetes queries and adds namespace metadata.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmkubernetes`.
+
+:Name: includeNamespaceMetadata
+:Scope: module, action
+:Type: boolean
+:Default: on
+:Required?: no
+:Introduced: 8.2608.0
+
+Description
+-----------
+
+When set to ``off``, mmkubernetes does not query the Kubernetes namespace API
+and does not add ``namespace_id``, ``namespace_labels``,
+``namespace_annotations``, or the namespace ``creation_timestamp``. The
+``namespace_name`` parsed from the input metadata is still added because it is
+needed to identify and query the pod.
+
+Disabling namespace metadata can reduce Kubernetes API traffic and avoids
+collecting namespace labels and annotations when they are not needed. Pod
+metadata collection is unchanged.
+
+Action usage
+------------
+
+.. code-block:: rsyslog
+
+   action(type="mmkubernetes" includeNamespaceMetadata="off")
+
+YAML usage
+----------
+
+.. code-block:: yaml
+
+   actions:
+     - type: mmkubernetes
+       includeNamespaceMetadata: off
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/mmkubernetes`.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2256,7 +2256,9 @@ TESTS_MMTAGHOSTNAME = \
 TESTS_MMKUBERNETES = \
 	mmkubernetes-basic.sh \
 	mmkubernetes-cache-expire.sh \
-	mmkubernetes-url-failover.sh
+	mmkubernetes-url-failover.sh \
+	mmkubernetes-namespace-metadata-off.sh \
+	yaml-mmkubernetes-namespace-metadata-off.sh
 
 TESTS_MMKUBERNETES_VALGRIND = \
 	mmkubernetes-basic-vg.sh \

--- a/tests/mmkubernetes-namespace-metadata-off.sh
+++ b/tests/mmkubernetes-namespace-metadata-off.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Verify includeNamespaceMetadata="off" skips the namespace API lookup while
+# retaining parsed namespace identity and pod metadata. The output fields and
+# absence of a namespace-only request in the test-server log are the oracle.
+# The two-minute server timeout is hang protection; readiness and cleanup use
+# PID/port files rather than timing assumptions.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+check_command_available timeout
+require_plugin mmkubernetes ../contrib/mmkubernetes
+
+pwd=$(pwd)
+testsrv=mmk8s-test-server
+k8s_srv_port_file="${RSYSLOG_DYNNAME}${testsrv}.port"
+generate_conf
+
+timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server.py 0 \
+	${RSYSLOG_DYNNAME}${testsrv}.pid \
+	${RSYSLOG_DYNNAME}${testsrv}.started \
+	${k8s_srv_port_file} > ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log 2>&1 &
+BGPROCESS=$!
+wait_file_exists "$k8s_srv_port_file"
+k8s_srv_port="$(cat "$k8s_srv_port_file")"
+wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
+
+add_conf '
+global(workDirectory="'$RSYSLOG_DYNNAME.spool'")
+module(load="../plugins/imfile/.libs/imfile")
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+module(load="../contrib/mmkubernetes/.libs/mmkubernetes")
+input(type="imfile" file="'$RSYSLOG_DYNNAME.spool'/pod-*.log" tag="kubernetes" addmetadata="on")
+action(type="mmjsonparse" cookie="")
+action(type="mmkubernetes" token="dummy"
+       kubernetesurl="http://localhost:'$k8s_srv_port'"
+       includeNamespaceMetadata="off"
+       filenamerules=["rule=:'$pwd/$RSYSLOG_DYNNAME.spool'/%pod_name:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log"])
+template(name="outfmt" type="string" string="%$!all-json-plain%\n")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+cat > ${RSYSLOG_DYNNAME}.spool/pod-name2578_namespace-name2578_container-name2578-id2578.log <<EOF
+{"message":"namespace metadata disabled","testid":2578}
+EOF
+
+startup
+wait_queueempty
+shutdown_when_empty
+wait_shutdown
+kill $BGPROCESS
+wait_pid_termination ${RSYSLOG_DYNNAME}${testsrv}.pid
+
+$PYTHON - "$RSYSLOG_OUT_LOG" "${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log" <<'PY'
+import json
+import sys
+
+record = next(item for item in map(json.loads, open(sys.argv[1])) if item.get("testid") == 2578)
+kubernetes = record["kubernetes"]
+assert kubernetes["namespace_name"] == "namespace-name2578", kubernetes
+assert kubernetes["pod_id"] == "pod-name2578-id", kubernetes
+for field in ("namespace_id", "namespace_labels", "namespace_annotations", "creation_timestamp"):
+    assert field not in kubernetes, (field, kubernetes)
+server_log = open(sys.argv[2]).read()
+assert "/api/v1/namespaces/namespace-name2578 HTTP" not in server_log, server_log
+assert "/api/v1/namespaces/namespace-name2578/pods/pod-name2578 HTTP" in server_log, server_log
+PY
+if [ $? -ne 0 ]; then
+	cat ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log
+	cat "$RSYSLOG_OUT_LOG"
+	error_exit 1
+fi
+
+exit_test

--- a/tests/yaml-mmkubernetes-namespace-metadata-off.sh
+++ b/tests/yaml-mmkubernetes-namespace-metadata-off.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Verify includeNamespaceMetadata=off reaches mmkubernetes through the YAML
+# frontend. The retained pod metadata and absent namespace metadata are the
+# observable parity oracle. The two-minute server timeout is hang protection;
+# readiness and cleanup use PID/port files rather than timing assumptions.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+check_command_available timeout
+require_yaml_support
+require_plugin mmkubernetes ../contrib/mmkubernetes
+
+pwd=$(pwd)
+testsrv=mmk8s-test-server
+k8s_srv_port_file="${RSYSLOG_DYNNAME}${testsrv}.port"
+generate_conf --yaml-only
+
+timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server.py 0 \
+	${RSYSLOG_DYNNAME}${testsrv}.pid \
+	${RSYSLOG_DYNNAME}${testsrv}.started \
+	${k8s_srv_port_file} > ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log 2>&1 &
+BGPROCESS=$!
+wait_file_exists "$k8s_srv_port_file"
+k8s_srv_port="$(cat "$k8s_srv_port_file")"
+wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
+
+add_yaml_conf 'modules:'
+add_yaml_conf '  - load: "../plugins/imfile/.libs/imfile"'
+add_yaml_conf '  - load: "../plugins/mmjsonparse/.libs/mmjsonparse"'
+add_yaml_conf '  - load: "../contrib/mmkubernetes/.libs/mmkubernetes"'
+add_yaml_conf 'inputs:'
+add_yaml_conf '  - type: imfile'
+add_yaml_conf '    file: "'$RSYSLOG_DYNNAME.spool'/pod-*.log"'
+add_yaml_conf '    tag: kubernetes'
+add_yaml_conf '    addmetadata: on'
+add_yaml_conf '    ruleset: main'
+add_yaml_conf 'templates:'
+add_yaml_conf '  - name: outfmt'
+add_yaml_conf '    type: string'
+add_yaml_conf '    string: "%$!all-json-plain%\n"'
+add_yaml_conf 'rulesets:'
+add_yaml_conf '  - name: main'
+add_yaml_conf '    statements:'
+add_yaml_conf '      - type: mmjsonparse'
+add_yaml_conf '        cookie: ""'
+add_yaml_conf '      - type: mmkubernetes'
+add_yaml_conf '        token: dummy'
+add_yaml_conf '        kubernetesurl: "http://localhost:'$k8s_srv_port'"'
+add_yaml_conf '        includenamespacemetadata: off'
+add_yaml_conf '        filenamerules:'
+add_yaml_conf '          - "rule=:'$pwd/$RSYSLOG_DYNNAME.spool'/%pod_name:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log"'
+add_yaml_conf '      - type: omfile'
+add_yaml_conf '        file: "'$RSYSLOG_OUT_LOG'"'
+add_yaml_conf '        template: outfmt'
+
+cat > ${RSYSLOG_DYNNAME}.spool/pod-name2578_namespace-name2578_container-name2578-id2578.log <<EOF
+{"message":"namespace metadata disabled via yaml","testid":2578}
+EOF
+
+startup
+wait_queueempty
+shutdown_when_empty
+wait_shutdown
+kill $BGPROCESS
+wait_pid_termination ${RSYSLOG_DYNNAME}${testsrv}.pid
+
+$PYTHON - "$RSYSLOG_OUT_LOG" <<'PY'
+import json
+import sys
+
+record = next(item for item in map(json.loads, open(sys.argv[1])) if item.get("testid") == 2578)
+kubernetes = record["kubernetes"]
+assert kubernetes["namespace_name"] == "namespace-name2578", kubernetes
+assert kubernetes["pod_id"] == "pod-name2578-id", kubernetes
+for field in ("namespace_id", "namespace_labels", "namespace_annotations", "creation_timestamp"):
+    assert field not in kubernetes, (field, kubernetes)
+PY
+if [ $? -ne 0 ]; then
+	cat ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log
+	cat "$RSYSLOG_OUT_LOG"
+	error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
Closes: https://github.com/rsyslog/rsyslog/issues/2578

## Summary

- add a default-on `includeNamespaceMetadata` module/action option
- skip namespace API queries and namespace-only fields when disabled
- keep pod enrichment and the parsed `namespace_name` unchanged
- keep caches isolated between actions with different namespace settings
- document the option and cover RainerScript/YAML parity

Thanks to @richm for the precise report and the good comparison with Fluentd's `include_namespace_metadata` option. That analysis directly shaped this default-on, opt-out implementation.

## Compatibility

The default remains `on`, so existing configurations and enriched output are unchanged. Setting the option to `off` only suppresses namespace API traffic and namespace-derived ID, labels, annotations, and creation timestamp.

## Validation

- Ubuntu 26.04 change-gated `run-ci.sh`: 1,349 passed, 33 skipped, 0 failed (1,382 total)
- Ubuntu 26.04 clang static analyzer: no bugs found
- focused RainerScript and YAML regression tests: passed
- existing `mmkubernetes-basic.sh`: passed
- rendered Sphinx documentation build: passed
- documentation distribution check: passed
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j10`: passed
- clang-format gate and `git diff --check`: passed
- memory/resource and test/build prompt audits: no findings
- local Cubic review: no issues found

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

