### PR TITLE
ci: run Debian verifier with Bash

### DIFF
--- a/.github/workflows/debian_daily_stable.yml
+++ b/.github/workflows/debian_daily_stable.yml
@@ -536,6 +536,9 @@ jobs:
     container:
       image: debian:trixie
       options: --user root
+    defaults:
+      run:
+        shell: bash
     environment: debian-daily-stable
     permissions:
       contents: read
@@ -626,11 +629,11 @@ jobs:
             rsyslogd -v
             rsyslogd -N1
           ) 2>&1 | tee .ci/flake-evidence/logs/debian-published-install.log
-          install_status=("${PIPESTATUS[@]}")
+          install_status=$?
           set -e
           devtools/ci-flake-phase.sh end \
-            debian-published-install custom "${install_status[0]}"
-          exit "${install_status[0]}"
+            debian-published-install custom "$install_status"
+          exit "$install_status"
 
       - name: Upload publication failure evidence
         if: >-


### PR DESCRIPTION
## Summary

- explicitly run the Debian 13 publication verifier with Bash
- preserve the smoke-test pipeline result as a scalar status
- fix the false failure that occurred after the package had installed and validated successfully

## Production-path evidence

Run 30190064370 successfully:

- built current `main` with Debian 13 package definitions
- published immutable packages, retained snapshot, and signed APT metadata to DigitalOcean Spaces
- verified the public signed repository metadata
- installed exact version `8.2608.0+daily20260726.13.1+git19a1f4ed9d8d-1adiscon1`
- passed `rsyslogd -v`
- passed `rsyslogd -N1`

The job then failed only because the container runner invoked the step as `sh`, which rejected the Bash array used to read `PIPESTATUS`.

## Validation

- exact success and forced-failure pipeline paths in clean `debian:trixie`: pass
- actionlint: pass
- flake-evidence workflow coverage: pass
- zizmor 1.24.1 strict collection: no findings
- local Cubic review: no issues found
- broad CI-equivalent run: stopped after unrelated mmkubernetes/imfile failures and hung TLS/Kafka tests; previous parent patch completed 1,535 tests and static analysis clean

With the help of AI-Agents: Codex

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

