### PR TITLE
packaging: add Ubuntu 26.04 daily archive

### DIFF
--- a/.github/scripts/debian_package_build.sh
+++ b/.github/scripts/debian_package_build.sh
@@ -90,6 +90,7 @@ install_prereqs() {
     g++ \
     git \
     libtool \
+    libdistro-info-perl \
     libyaml-dev \
     make \
     pkg-config \

--- a/.github/ubuntu-daily-stable-26.04-policy.yml
+++ b/.github/ubuntu-daily-stable-26.04-policy.yml
@@ -1,0 +1,34 @@
+{
+  "allowed_patch_skips": [
+    {
+      "patch": "Increase-timeouts-in-imfile-basic-2GB-file-and-imfile-tru.patch",
+      "reason": "Ubuntu 26.04 carries the 2 GiB imfile timeout increase that current upstream already includes with later test updates."
+    },
+    {
+      "patch": "gnusort-in-tests.patch",
+      "reason": "Ubuntu 26.04 carries an armhf GNU sort test workaround whose patch context is superseded by later upstream testbench changes."
+    },
+    {
+      "patch": "fix-curl-ftbfs.patch",
+      "reason": "Ubuntu 26.04 carries upstream curl compatibility commit b1302a17, which is already part of current main."
+    },
+    {
+      "patch": "imptcp-security.patch",
+      "reason": "Ubuntu 26.04 backports the imptcp regex-framing denial-of-service fix already present in current main."
+    },
+    {
+      "patch": "CVE-2026-61548.patch",
+      "reason": "Ubuntu 26.04 backports custom structured-data container handling already present in current main."
+    }
+  ],
+  "supplemental_build_deps": [],
+  "control_replacements": [
+    {
+      "pattern": "Build-Depends: debhelper-compat \\(= 13\\),",
+      "replacement": "Build-Depends: debhelper-compat (= 13),\\n               libyaml-dev,\\n               libprotobuf-c-dev,\\n               protobuf-c-compiler,\\n               libsnappy-dev,",
+      "reason": "Current upstream adds YAML configuration and native impstats push support whose build dependencies postdate Ubuntu 26.04's rsyslog source package."
+    }
+  ],
+  "install_manifest_additions": [],
+  "not_installed_paths": []
+}

--- a/.github/workflows/collect_flake_evidence.yml
+++ b/.github/workflows/collect_flake_evidence.yml
@@ -14,6 +14,7 @@ name: collect flake evidence
       - imhttp Prometheus scrape
       - impstats push to VictoriaMetrics
       - debian daily stable
+      - ubuntu daily stable
     types: [completed]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/ubuntu_daily_stable.yml
+++ b/.github/workflows/ubuntu_daily_stable.yml
@@ -1,0 +1,726 @@
+# Copyright 2026 Rainer Gerhards and Others
+#
+# https://github.com/rsyslog/rsyslog
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: ubuntu daily stable
+
+'on':
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: rsyslog source branch, tag, or commit to package
+        required: true
+        default: main
+        type: string
+      publish_to_archive:
+        description: Publish to the configured DigitalOcean Spaces archive
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    - cron: '23 4 * * *'
+
+concurrency:
+  group: ubuntu-daily-stable
+  cancel-in-progress: false
+
+env:
+  DEBIAN_CI_POLICY_FILE: .github/ubuntu-daily-stable-26.04-policy.yml
+  DEBIAN_CI_HELPER: .github/scripts/debian_package_build.sh
+  DEBIAN_DAILY_STABLE_HELPER: devtools/release/debian-daily-stable.sh
+  DEBIAN_BUILD_ROOT: /tmp/rsyslog-ubuntu-daily-stable-build
+  DEBIAN_SUITE: resolute
+  DEBIAN_COMPONENT: main
+  DEBIAN_ARCH: amd64
+  PACKAGE_CHANNEL: daily-stable
+  PACKAGE_DISTRO: ubuntu
+  PACKAGE_DISTRO_LABEL: Ubuntu
+  PACKAGE_DISTRO_VERSION: '26.04'
+  SPACE_PREFIX: apt/daily-stable/ubuntu/26.04
+
+jobs:
+  preflight:
+    name: preflight
+    runs-on: ubuntu-24.04
+    if: github.repository == 'rsyslog/rsyslog'
+    permissions:
+      contents: read
+    outputs:
+      should_run: ${{ steps.decision.outputs.should_run }}
+      should_publish: ${{ steps.decision.outputs.should_publish }}
+      source_ref: ${{ steps.decision.outputs.source_ref }}
+    steps:
+      - name: Decide whether this run is active
+        id: decision
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_PUBLISH: ${{ inputs.publish_to_archive }}
+          MANUAL_SOURCE_REF: ${{ inputs.source_ref }}
+          SCHEDULE_ENABLED: ${{ vars.UBUNTU_DAILY_STABLE_ENABLED }}
+        run: |
+          set -euo pipefail
+          should_run=false
+          should_publish=false
+          source_ref=main
+
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              should_run=true
+              source_ref="${MANUAL_SOURCE_REF:-main}"
+              if [ "${MANUAL_PUBLISH:-false}" = "true" ]; then
+                should_publish=true
+              fi
+              ;;
+            schedule)
+              if [ "${SCHEDULE_ENABLED:-false}" = "true" ]; then
+                should_run=true
+                should_publish=true
+              fi
+              ;;
+          esac
+
+          {
+            echo "should_run=$should_run"
+            echo "should_publish=$should_publish"
+            echo "source_ref=$source_ref"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: build Ubuntu 26.04 amd64 packages
+    needs: preflight
+    if: needs.preflight.outputs.should_run == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    container:
+      image: ubuntu:26.04
+      options: --user root
+    permissions:
+      contents: read
+    outputs:
+      archive_date: ${{ steps.version.outputs.archive_date }}
+      version: ${{ steps.version.outputs.version }}
+      source_sha: ${{ steps.source.outputs.source_sha }}
+    steps:
+      - name: Bootstrap container tools
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            git \
+            python3
+
+      - name: Checkout archive automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Checkout source to package
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          path: rsyslog-source
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.source_ref }}
+
+      - name: Record packaged source revision
+        id: source
+        run: |
+          set -euo pipefail
+          source_sha="$(git -C rsyslog-source rev-parse HEAD)"
+          {
+            echo "source_sha=$source_sha"
+            echo "SOURCE_GIT_SHA=$source_sha"
+            echo "RSYSLOG_SOURCE_DIR=$GITHUB_WORKSPACE/rsyslog-source"
+          } | tee -a "$GITHUB_ENV" >> "$GITHUB_OUTPUT"
+
+      - name: Install prerequisites
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" install_prereqs
+          apt-get install -y --no-install-recommends \
+            apt-utils \
+            curl \
+            gnupg \
+            xz-utils
+
+      - name: Test incremental archive generation
+        id: archive_self_test
+        run: |
+          devtools/ci-flake-phase.sh run ubuntu-archive-self-test custom -- \
+            "$GITHUB_WORKSPACE/$DEBIAN_DAILY_STABLE_HELPER" self-test
+
+      - name: Generate daily package version
+        id: version
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_DAILY_STABLE_HELPER" version
+
+      - name: Load Ubuntu CI policy
+        run: |
+          mkdir -p "$DEBIAN_BUILD_ROOT"
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" load_policy \
+            "$GITHUB_WORKSPACE/$DEBIAN_CI_POLICY_FILE" \
+            "$DEBIAN_BUILD_ROOT/debian-ci-policy"
+
+      - name: Fetch Ubuntu packaging baseline
+        id: packaging
+        run: |
+          baseline_version_file="$DEBIAN_BUILD_ROOT/debian-packaging-version"
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" \
+            fetch_debian_release_packaging \
+            "$DEBIAN_BUILD_ROOT/debian-packaging" \
+            "$baseline_version_file"
+          baseline_version="$(cat "$baseline_version_file")"
+          echo "baseline_version=$baseline_version" >> "$GITHUB_OUTPUT"
+
+      - name: Apply packaging baseline policy
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" apply_control_replacements \
+            "$DEBIAN_BUILD_ROOT/debian-packaging/control" \
+            "$DEBIAN_BUILD_ROOT/debian-ci-policy/control_replacements.tsv" \
+            "$DEBIAN_BUILD_ROOT/debian-ci-policy/control_replacements.reasons.txt"
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" \
+            apply_install_manifest_additions \
+            "$DEBIAN_BUILD_ROOT/debian-packaging" \
+            "$DEBIAN_BUILD_ROOT/debian-ci-policy/install_manifest_additions.tsv"
+
+      - name: Install Ubuntu build dependencies
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" install_build_deps \
+            "$DEBIAN_BUILD_ROOT/debian-packaging/control" \
+            "$DEBIAN_BUILD_ROOT/debian-ci-policy/supplemental_build_deps.txt"
+
+      - name: Generate rsyslog dist tarball
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" run_dist_build \
+            "$GITHUB_WORKSPACE/rsyslog-source"
+
+      - name: Locate rsyslog dist tarball
+        run: |
+          dist_tarball="$(
+            "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" find_dist_tarball \
+              "$GITHUB_WORKSPACE/rsyslog-source"
+          )"
+          echo "DIST_TARBALL=$dist_tarball" >> "$GITHUB_ENV"
+
+      - name: Unpack tarball and inject Ubuntu packaging
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" unpack_source_tree \
+            "$GITHUB_WORKSPACE/rsyslog-source" \
+            "$DIST_TARBALL" \
+            "$DEBIAN_BUILD_ROOT/debian-packaging" \
+            "$DEBIAN_BUILD_ROOT/debian-src"
+
+      - name: Stamp daily stable changelog
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_DAILY_STABLE_HELPER" stamp-changelog \
+            "$DEBIAN_BUILD_ROOT/debian-src" \
+            "$VERSION"
+
+      - name: Apply Ubuntu CI policy
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" apply_not_installed_policy \
+            "$DEBIAN_BUILD_ROOT/debian-src" \
+            "$DEBIAN_BUILD_ROOT/debian-ci-policy/not_installed_paths.txt" \
+            "$DEBIAN_BUILD_ROOT/debian-ci-policy/not_installed_paths.reasons.txt"
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" resolve_patch_policy \
+            "$DEBIAN_BUILD_ROOT/debian-src" \
+            "$DEBIAN_BUILD_ROOT/debian-ci-policy/allowed_patch_skips.txt" \
+            "$DEBIAN_BUILD_ROOT/debian-ci-policy/allowed_patch_skips.reasons.txt" \
+            strict
+
+      - name: Build source and binary packages
+        id: package_build
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          devtools/ci-flake-phase.sh run ubuntu-package-build custom -- \
+            "$GITHUB_WORKSPACE/$DEBIAN_DAILY_STABLE_HELPER" build-package \
+              "$GITHUB_WORKSPACE/rsyslog-source" \
+              "$DEBIAN_BUILD_ROOT/debian-src" \
+              "$DIST_TARBALL" \
+              "$GITHUB_WORKSPACE/ubuntu-daily-stable-artifacts" \
+              "$VERSION" \
+              "$DEBIAN_BUILD_ROOT/ubuntu-daily-stable-build.log"
+
+      - name: Upload failure evidence
+        if: >-
+          ${{
+            failure() &&
+            (steps.archive_self_test.outcome == 'failure' ||
+             steps.package_build.outcome == 'failure')
+          }}
+        uses: ./.github/actions/upload-flake-evidence
+        with:
+          job-name: Ubuntu 26.04 daily stable package build
+
+      - name: Generate artifact manifest
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_DAILY_STABLE_HELPER" manifest \
+            "$GITHUB_WORKSPACE/ubuntu-daily-stable-artifacts" \
+            "$VERSION" \
+            "$DEBIAN_SUITE" \
+            "$DEBIAN_ARCH" \
+            "$PACKAGE_CHANNEL" \
+            "$PACKAGE_DISTRO" \
+            "$PACKAGE_DISTRO_VERSION"
+
+      - name: Upload Ubuntu package artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ubuntu-daily-stable-${{ steps.version.outputs.version }}
+          path: ubuntu-daily-stable-artifacts/
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Summarize build
+        env:
+          BASELINE_VERSION: ${{ steps.packaging.outputs.baseline_version }}
+          SOURCE_REF: ${{ needs.preflight.outputs.source_ref }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "### Ubuntu daily stable build"
+            echo
+            echo "- Version: \`$VERSION\`"
+            echo "- Source ref: \`$SOURCE_REF\`"
+            echo "- Source commit: \`$SOURCE_GIT_SHA\`"
+            echo "- Ubuntu packaging baseline: \`rsyslog $BASELINE_VERSION\`"
+            echo "- Target: Ubuntu 26.04 (\`$DEBIAN_SUITE\`), \`$DEBIAN_ARCH\`"
+            echo "- Archive prefix: \`$SPACE_PREFIX\`"
+            echo
+            echo "Artifacts:"
+            find ubuntu-daily-stable-artifacts -maxdepth 1 -type f \
+              -printf '%f\n' | sort |
+            while IFS= read -r artifact; do
+              printf -- "- \`%s\`\n" "$artifact"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: publish DigitalOcean Spaces APT archive
+    needs:
+      - preflight
+      - build
+    if: needs.preflight.outputs.should_publish == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: debian-daily-stable
+    permissions:
+      contents: read
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.DEBIAN_DAILY_STABLE_SPACE_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DEBIAN_DAILY_STABLE_SPACE_SECRET_KEY }}
+      AWS_DEFAULT_REGION: ${{ vars.DEBIAN_DAILY_STABLE_SPACE_REGION }}
+      SPACE_BUCKET: ${{ vars.DEBIAN_DAILY_STABLE_SPACE_BUCKET }}
+      SPACE_ENDPOINT: ${{ vars.DEBIAN_DAILY_STABLE_SPACE_ENDPOINT }}
+      DEBIAN_DAILY_STABLE_GPG_PRIVATE_KEY: ${{ secrets.DEBIAN_DAILY_STABLE_GPG_PRIVATE_KEY }}
+      DEBIAN_DAILY_STABLE_GPG_PASSPHRASE: ${{ secrets.DEBIAN_DAILY_STABLE_GPG_PASSPHRASE }}
+    steps:
+      - name: Checkout archive automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Prepare repository and Spaces tools
+        run: |
+          command -v aws
+          aws --version
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            apt-utils \
+            gnupg \
+            xz-utils
+
+      - name: Validate archive configuration
+        run: |
+          set -euo pipefail
+          for variable in \
+            AWS_ACCESS_KEY_ID \
+            AWS_SECRET_ACCESS_KEY \
+            AWS_DEFAULT_REGION \
+            SPACE_BUCKET \
+            SPACE_ENDPOINT \
+            DEBIAN_DAILY_STABLE_GPG_PRIVATE_KEY; do
+            [ -n "${!variable:-}" ] || {
+              echo "$variable is empty" >&2
+              exit 1
+            }
+          done
+
+      - name: Download Ubuntu package artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ubuntu-daily-stable-${{ needs.build.outputs.version }}
+          path: ubuntu-daily-stable-artifacts
+
+      - name: Verify artifact checksums
+        run: |
+          cd ubuntu-daily-stable-artifacts
+          sha256sum -c SHA256SUMS
+
+      - name: Import archive signing key
+        run: |
+          set -euo pipefail
+          install -m 700 -d "$HOME/.gnupg"
+          printf '%s\n' "$DEBIAN_DAILY_STABLE_GPG_PRIVATE_KEY" |
+            gpg --batch --import
+          gpg --batch --list-secret-keys
+
+      - name: Download current indexes
+        run: |
+          set -euo pipefail
+          mkdir -p "apt-repo/dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/binary-$DEBIAN_ARCH"
+          mkdir -p "apt-repo/dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/source"
+
+          download_if_present() {
+            local relative_path="$1"
+            local key="$SPACE_PREFIX/$relative_path"
+            local remote_key
+
+            remote_key="$(
+              aws s3api list-objects-v2 \
+                --endpoint-url "$SPACE_ENDPOINT" \
+                --bucket "$SPACE_BUCKET" \
+                --prefix "$key" \
+                --max-keys 1 \
+                --query 'Contents[0].Key' \
+                --output text
+            )"
+            if [ "$remote_key" = "$key" ]; then
+              aws s3 cp \
+                --endpoint-url "$SPACE_ENDPOINT" \
+                "s3://$SPACE_BUCKET/$key" \
+                "apt-repo/$relative_path"
+            fi
+          }
+
+          download_if_present \
+            "dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/binary-$DEBIAN_ARCH/Packages.xz"
+          download_if_present \
+            "dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/source/Sources.xz"
+
+      - name: Generate signed incremental APT repository
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_DAILY_STABLE_HELPER" generate-repo \
+            "$GITHUB_WORKSPACE/ubuntu-daily-stable-artifacts" \
+            "$GITHUB_WORKSPACE/apt-repo" \
+            "$DEBIAN_SUITE" \
+            "$DEBIAN_COMPONENT" \
+            "$DEBIAN_ARCH"
+
+      - name: Prepare immutable build snapshot
+        env:
+          ARCHIVE_DATE: ${{ needs.build.outputs.archive_date }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          snapshot_dir="apt-repo/snapshots/$ARCHIVE_DATE/$VERSION"
+          mkdir -p "$snapshot_dir"
+          find ubuntu-daily-stable-artifacts -maxdepth 1 -type f \
+            \( -name 'manifest.json' -o -name 'SHA256SUMS' \
+               -o -name '*.changes' -o -name '*.buildinfo' \
+               -o -name 'build.log' \) \
+            -exec cp -a {} "$snapshot_dir/" \;
+
+      - name: Publish immutable packages and snapshots
+        run: |
+          set -euo pipefail
+
+          upload_immutable() {
+            local path="$1"
+            local relative_path="${path#apt-repo/}"
+            local key="$SPACE_PREFIX/$relative_path"
+            local remote_key local_hash remote_hash
+
+            remote_key="$(
+              aws s3api list-objects-v2 \
+                --endpoint-url "$SPACE_ENDPOINT" \
+                --bucket "$SPACE_BUCKET" \
+                --prefix "$key" \
+                --max-keys 1 \
+                --query 'Contents[0].Key' \
+                --output text
+            )"
+            local_hash="$(sha256sum "$path" | awk '{print $1}')"
+            if [ "$remote_key" = "$key" ]; then
+              remote_hash="$(
+                aws s3 cp \
+                  --quiet \
+                  --endpoint-url "$SPACE_ENDPOINT" \
+                  "s3://$SPACE_BUCKET/$key" - |
+                  sha256sum | awk '{print $1}'
+              )"
+              [ "$remote_hash" = "$local_hash" ] || {
+                echo "immutable archive collision at $key" >&2
+                exit 1
+              }
+              return
+            fi
+
+            aws s3 cp \
+              --only-show-errors \
+              --endpoint-url "$SPACE_ENDPOINT" \
+              --acl public-read \
+              --cache-control 'public,max-age=31536000,immutable' \
+              --metadata "sha256=$local_hash" \
+              "$path" \
+              "s3://$SPACE_BUCKET/$key"
+          }
+
+          while IFS= read -r -d '' path; do
+            upload_immutable "$path"
+          done < <(
+            find apt-repo/pool apt-repo/snapshots \
+              "apt-repo/dists/$DEBIAN_SUITE" \
+              -type f \
+              \( -path '*/pool/*' -o -path '*/snapshots/*' \
+                 -o -path '*/by-hash/*' \) \
+              -print0
+          )
+
+      - name: Publish archive key and mutable metadata
+        run: |
+          set -euo pipefail
+
+          upload_metadata() {
+            local path="$1"
+            local relative_path="${path#apt-repo/}"
+            aws s3 cp \
+              --only-show-errors \
+              --endpoint-url "$SPACE_ENDPOINT" \
+              --acl public-read \
+              --cache-control 'public,max-age=60,must-revalidate' \
+              "$path" \
+              "s3://$SPACE_BUCKET/$SPACE_PREFIX/$relative_path"
+          }
+
+          upload_metadata apt-repo/rsyslog-archive-keyring.asc
+          while IFS= read -r -d '' path; do
+            upload_metadata "$path"
+          done < <(
+            find "apt-repo/dists/$DEBIAN_SUITE" -type f \
+              ! -path '*/by-hash/*' \
+              ! -name Release \
+              ! -name Release.gpg \
+              ! -name InRelease \
+              -print0
+          )
+          upload_metadata "apt-repo/dists/$DEBIAN_SUITE/Release"
+          upload_metadata "apt-repo/dists/$DEBIAN_SUITE/Release.gpg"
+          upload_metadata "apt-repo/dists/$DEBIAN_SUITE/InRelease"
+
+  verify:
+    name: verify published Ubuntu 26.04 repository
+    needs:
+      - preflight
+      - build
+      - publish
+    if: needs.preflight.outputs.should_publish == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    container:
+      image: ubuntu:26.04
+      options: --user root
+    defaults:
+      run:
+        shell: bash
+    environment: debian-daily-stable
+    permissions:
+      contents: read
+    env:
+      REPO_URL: ${{ vars.UBUNTU_DAILY_STABLE_REPO_URL }}
+      EXPECTED_GPG_FINGERPRINT: ${{ vars.DEBIAN_DAILY_STABLE_GPG_FINGERPRINT }}
+    steps:
+      - name: Checkout archive automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install verification tools
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            curl \
+            gnupg \
+            gpgv \
+            python3 \
+            xz-utils
+
+      - name: Wait for CDN and verify signed metadata
+        id: published_metadata
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          [ -n "$REPO_URL" ] || {
+            echo "UBUNTU_DAILY_STABLE_REPO_URL is empty" >&2
+            exit 1
+          }
+          [ -n "$EXPECTED_GPG_FINGERPRINT" ] || {
+            echo "DEBIAN_DAILY_STABLE_GPG_FINGERPRINT is empty" >&2
+            exit 1
+          }
+          devtools/ci-flake-phase.sh begin ubuntu-published-metadata custom
+          set +e
+          verification_rc=1
+          for attempt in $(seq 1 20); do
+            if "$GITHUB_WORKSPACE/$DEBIAN_DAILY_STABLE_HELPER" verify-repo \
+              "$REPO_URL" \
+              "$DEBIAN_SUITE" \
+              "$DEBIAN_COMPONENT" \
+              "$DEBIAN_ARCH" \
+              "$VERSION" \
+              "$EXPECTED_GPG_FINGERPRINT" \
+              true; then
+              verification_rc=0
+              break
+            fi
+            echo "Repository not ready yet, retrying ($attempt/20)..."
+            if [ "$attempt" -lt 20 ]; then
+              sleep 30
+            fi
+          done
+          set -e
+          devtools/ci-flake-phase.sh end \
+            ubuntu-published-metadata custom "$verification_rc"
+          if [ "$verification_rc" -ne 0 ]; then
+            echo "Repository verification did not succeed before timeout." >&2
+            exit "$verification_rc"
+          fi
+
+      - name: Install and smoke-test the published package
+        id: published_install
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p .ci/flake-evidence/logs
+          devtools/ci-flake-phase.sh begin ubuntu-published-install custom
+          set +e
+          (
+            set -euo pipefail
+            curl -fsSL "$REPO_URL/rsyslog-archive-keyring.asc" |
+              gpg --dearmor -o /usr/share/keyrings/rsyslog-archive-keyring.gpg
+            echo "deb [signed-by=/usr/share/keyrings/rsyslog-archive-keyring.gpg] $REPO_URL $DEBIAN_SUITE $DEBIAN_COMPONENT" \
+              > /etc/apt/sources.list.d/rsyslog-daily-stable.list
+            apt-get update
+            apt-get install -y "rsyslog=$VERSION"
+            installed_version="$(dpkg-query -W -f='${Version}\n' rsyslog)"
+            [ "$installed_version" = "$VERSION" ] || {
+              echo "installed rsyslog version $installed_version does not match $VERSION" >&2
+              exit 1
+            }
+            rsyslogd -v
+            rsyslogd -N1
+          ) 2>&1 | tee .ci/flake-evidence/logs/ubuntu-published-install.log
+          install_status=$?
+          set -e
+          devtools/ci-flake-phase.sh end \
+            ubuntu-published-install custom "$install_status"
+          exit "$install_status"
+
+      - name: Upload publication failure evidence
+        if: >-
+          ${{
+            failure() &&
+            (steps.published_metadata.outcome == 'failure' ||
+             steps.published_install.outcome == 'failure')
+          }}
+        uses: ./.github/actions/upload-flake-evidence
+        with:
+          job-name: Ubuntu 26.04 daily stable publication verification
+
+  report_failure:
+    name: report failure
+    needs:
+      - preflight
+      - build
+      - publish
+      - verify
+    if: >-
+      always() &&
+      github.event_name == 'schedule' &&
+      (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Create or update failure issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+          PREFLIGHT_RESULT: ${{ needs.preflight.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+        with:
+          script: |
+            const version = process.env.VERSION || `run-${context.runId}`;
+            const title = '[ubuntu-daily-stable] package archive failure';
+            const body = [
+              `Automated Ubuntu daily stable failed for \`${version}\`.`,
+              '',
+              `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `Workflow commit: ${context.sha}`,
+              '',
+              'Job results:',
+              `- preflight: ${process.env.PREFLIGHT_RESULT}`,
+              `- build: ${process.env.BUILD_RESULT}`,
+              `- publish: ${process.env.PUBLISH_RESULT}`,
+              `- verify: ${process.env.VERIFY_RESULT}`,
+              '',
+              'Inspect the workflow artifacts and logs, then rerun the workflow manually after fixing the cause.'
+            ].join('\n');
+
+            const {owner, repo} = context.repo;
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100
+            });
+            const issue = existing.find(item => item.title === title && !item.pull_request);
+            if (issue) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body
+              });
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body
+            });
+            try {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: created.data.number,
+                labels: ['release', 'packaging', 'daily-stable', 'automated']
+              });
+            } catch (error) {
+              core.warning(`Could not add labels: ${error.message}`);
+            }

--- a/devtools/check-flake-evidence-coverage.py
+++ b/devtools/check-flake-evidence-coverage.py
@@ -34,6 +34,7 @@ EXPECTED_UPLOADS = {
     "imhttp_prometheus_scrape.yml": 1,
     "impstats_push_victoriametrics.yml": 1,
     "debian_daily_stable.yml": 2,
+    "ubuntu_daily_stable.yml": 2,
 }
 TEST_COMMAND_RE = re.compile(r"run-ci\.sh|make\s+[^\n]*\b(?:check|distcheck)\b|devtools/test-[^\s]+\.sh")
 UPLOAD_RE = re.compile(

--- a/devtools/release/debian-daily-stable.sh
+++ b/devtools/release/debian-daily-stable.sh
@@ -85,6 +85,8 @@ cmd_version() {
 cmd_stamp_changelog() {
   local source_dir="$1"
   local version="$2"
+  local suite="${DEBIAN_SUITE:-trixie}"
+  local distro_label="${PACKAGE_DISTRO_LABEL:-Debian}"
 
   [ -d "$source_dir/debian" ] ||
     die "missing debian directory: $source_dir/debian"
@@ -92,8 +94,8 @@ cmd_stamp_changelog() {
   cd "$source_dir"
   export DEBEMAIL="${DEBEMAIL:-release-bot@adiscon.com}"
   export DEBFULLNAME="${DEBFULLNAME:-Adiscon package maintainers}"
-  dch --force-distribution --distribution trixie --newversion "$version" \
-    "Automated rsyslog Debian daily stable build."
+  dch --force-distribution --distribution "$suite" --newversion "$version" \
+    "Automated rsyslog $distro_label daily stable build."
 }
 
 cmd_build_package() {
@@ -401,7 +403,7 @@ cmd_generate_repo() {
       -o "APT::FTPArchive::Release::Architectures=$arch" \
       -o "APT::FTPArchive::Release::Components=$component" \
       -o "APT::FTPArchive::Release::Acquire-By-Hash=yes" \
-      -o "APT::FTPArchive::Release::Description=rsyslog Debian daily stable packages" \
+      -o "APT::FTPArchive::Release::Description=rsyslog ${PACKAGE_DISTRO_LABEL:-Debian} daily stable packages" \
       release "dists/$suite" > "dists/$suite/Release"
   )
 
@@ -519,7 +521,7 @@ build_self_test_deb() {
 
 cmd_self_test() (
   local tmp_dir repo_dir first_artifacts second_artifacts fingerprint
-  local test_version
+  local test_suite test_version
   local cleanup_command
 
   for tool in apt-ftparchive curl dpkg dpkg-deb gpg gpgv xz; do
@@ -530,6 +532,7 @@ cmd_self_test() (
   test_version="$(
     daily_version 8.2606.0 20260725 9 1 31720a4787d4
   )"
+  test_suite="${DEBIAN_SUITE:-trixie}"
   dpkg --compare-versions "$test_version" gt 8.2606.0-4 ||
     die "daily version must sort after the Debian packaging baseline"
 
@@ -549,20 +552,20 @@ cmd_self_test() (
   fingerprint="$(secret_key_fingerprint)"
 
   build_self_test_deb "$first_artifacts" "1.0~daily1"
-  cmd_generate_repo "$first_artifacts" "$repo_dir" trixie main amd64
-  cmd_verify_repo "file://$repo_dir" trixie main amd64 \
+  cmd_generate_repo "$first_artifacts" "$repo_dir" "$test_suite" main amd64
+  cmd_verify_repo "file://$repo_dir" "$test_suite" main amd64 \
     "1.0~daily1" "$fingerprint"
 
   build_self_test_deb "$second_artifacts" "1.0~daily2"
-  cmd_generate_repo "$second_artifacts" "$repo_dir" trixie main amd64
-  cmd_verify_repo "file://$repo_dir" trixie main amd64 \
+  cmd_generate_repo "$second_artifacts" "$repo_dir" "$test_suite" main amd64
+  cmd_verify_repo "file://$repo_dir" "$test_suite" main amd64 \
     "1.0~daily1" "$fingerprint"
-  cmd_verify_repo "file://$repo_dir" trixie main amd64 \
+  cmd_verify_repo "file://$repo_dir" "$test_suite" main amd64 \
     "1.0~daily2" "$fingerprint"
 
   rm -rf "$tmp_dir"
   trap - EXIT
-  echo "Debian daily stable archive self-test passed."
+  echo "${PACKAGE_DISTRO_LABEL:-Debian} daily stable archive self-test passed."
 )
 
 command="${1:-}"


### PR DESCRIPTION
Adds an opt-in Ubuntu 26.04 (resolute) daily-stable archive workflow.

The workflow builds current `main` with Ubuntu 26.04's native source-package
`debian/` definitions, then publishes immutable packages and snapshots under:

```
apt/daily-stable/ubuntu/26.04/
```

It verifies the public signed archive and installs the exact produced rsyslog
version in a clean Ubuntu 26.04 container. Scheduled execution remains gated by
`UBUNTU_DAILY_STABLE_ENABLED`; it will be enabled only after the first
production end-to-end run succeeds.

Validation:

- Exact Ubuntu package build passed: `8.2608.0+daily20260727.0.2+gite056d89d54e6-1adiscon1`
- Signed local APT repository verification and exact `apt-get install` passed
- Clean Ubuntu 26.04 `rsyslogd -v` and `rsyslogd -N1` passed
- Local CI container: 1,535 total; 1,506 passed; 29 expected skips; 0 failures/errors
- Static analyzer: no bugs found
- Cubic: no issues found
- actionlint, shellcheck, Python style, flake-evidence coverage, pinned zizmor,
  JSON parse, and `git diff --check`: passed

Container image:
`rsyslog/rsyslog_dev_base_ubuntu:26.04`
`sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`

Local concurrency:

- build/check: 10/10
- static analyzer: 20

No service-lane relaxations were applied to the broad test run.
