### PR TITLE
packaging: handle empty first-run RPM metadata

### DIFF
--- a/devtools/release/rpm-daily-stable.sh
+++ b/devtools/release/rpm-daily-stable.sh
@@ -289,7 +289,9 @@ create_repo_generation() {
   rm -rf "$output_dir"
   mkdir -p "$output_dir/Packages"
   cp -a "$new_dir/Packages/." "$output_dir/Packages/"
-  if [ -d "$previous_dir/repodata" ]; then
+  # An S3 sync of a missing first-run prefix can still leave an empty local
+  # repodata directory. Only merge when it contains an actual repository.
+  if [ -f "$previous_dir/repodata/repomd.xml" ]; then
     mergerepo_c --all --omit-baseurl \
       --repo "file://$previous_dir" \
       --repo "file://$new_dir" \


### PR DESCRIPTION
## Summary

Fix the first EL10 archive publication discovered by production E2E run [30284521846](https://github.com/rsyslog/rsyslog/actions/runs/30284521846). An `aws s3 sync` of a missing prefix leaves an empty local `repodata/` directory; repository generation must require `repomd.xml` before treating that directory as an existing repository.

No objects were uploaded by the failed run because failure occurred before both publication steps.

## Validation

- reproduced the failure with the production run artifacts
- patched first-run generation passed in a disposable Ubuntu 24.04 publisher-equivalent container using the actual production RPM/SRPM set and a throwaway signing key
- both x86_64 and SRPM `repomd.xml` signatures verified
- rerunning over the generated repository passed the normal incremental merge path
- `bash -n` and shellcheck passed
- formal Ubuntu 26.04 gate clean on committed HEAD: 1,380 total, 1,347 passed, 33 expected skips, zero failures/errors
- one unrelated timing-sensitive mbedTLS test failed in the first gate attempt, passed immediately in isolation, and passed in the clean full rerun
- clang static analyzer: no bugs found
- local Cubic: no issues found

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

