### PR TITLE
packaging: make RPM metadata verification EL10-compatible

### DIFF
--- a/devtools/release/rpm-daily-stable.sh
+++ b/devtools/release/rpm-daily-stable.sh
@@ -373,8 +373,11 @@ cmd_verify_repo() {
   )"
   [ "$actual_fingerprint" = "$expected_fingerprint" ] ||
     die "archive key fingerprint $actual_fingerprint does not match expected fingerprint"
-  gpg --batch --no-default-keyring --keyring "$verify_dir/keyring.gpg" \
-    --import "$verify_dir/key.asc" >/dev/null 2>&1
+  # EL10 GnuPG creates a .kbx file when importing into a custom keyring, while
+  # gpgv opens the literal path it is given. Dearmor the public key so every
+  # supported verifier gets the same keyring format and filename.
+  gpg --batch --yes --dearmor --output "$verify_dir/keyring.gpg" \
+    "$verify_dir/key.asc"
   curl --fail --silent --show-error --location \
     "$repo_url/$arch/repodata/repomd.xml" --output "$verify_dir/repomd.xml"
   curl --fail --silent --show-error --location \


### PR DESCRIPTION
## Summary

Fix the public metadata verification reached by production E2E run [30286859515](https://github.com/rsyslog/rsyslog/actions/runs/30286859515). EL10 GnuPG imports a custom keyring as `keyring.gpg.kbx`, but `gpgv` opens the literal `keyring.gpg` path. Dearmoring the public key directly creates the deterministic keyring file expected by `gpgv`.

The run successfully built, signed, and published the complete first EL10 repository before the verifier issue was reached.

## Validation

- reproduced the failure exactly in Rocky Linux 10
- signed public metadata verification passes with the fix on CentOS Stream 10, Rocky Linux 10, AlmaLinux 10, and Oracle Linux 10
- public `.repo` import, exact EVR installation, `rsyslogd -v`, and `rsyslogd -N1` pass on all four targets
- exact public EVR: `8.2608.0-0.daily20260727.2.1.gitc21ceea63930.adiscon1.el10`
- `bash -n` and shellcheck passed
- formal Ubuntu 26.04 gate: 1,380 total, 1,347 passed, 33 expected skips, zero failures/errors
- clang static analyzer: no bugs found
- local Cubic: no issues found

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

