### PR TITLE
packaging: prevent stale repository metadata

### DIFF
--- a/.github/DEBIAN_DAILY_STABLE.md
+++ b/.github/DEBIAN_DAILY_STABLE.md
@@ -51,7 +51,12 @@ uploaded first, signed mutable metadata last, and `InRelease` last of all.
 Create one public-read Standard Spaces bucket with object versioning enabled.
 Give the workflow a bucket-scoped read/write Spaces key; do not give it a
 DigitalOcean account API token. Enable the Spaces CDN and route the final
-package hostname to it.
+package hostname to it. The workflows set DigitalOcean's object metadata
+`max-age` override in addition to HTTP `Cache-Control`: 60 seconds for mutable
+repository metadata and one year for immutable package and snapshot objects.
+After first enabling that override, purge previously cached repository metadata
+once in the DigitalOcean control panel so old one-hour cache entries do not
+delay the first verification run.
 
 Configure these GitHub repository variables:
 

--- a/.github/workflows/debian_daily_stable.yml
+++ b/.github/workflows/debian_daily_stable.yml
@@ -477,7 +477,7 @@ jobs:
               --endpoint-url "$SPACE_ENDPOINT" \
               --acl public-read \
               --cache-control 'public,max-age=31536000,immutable' \
-              --metadata "sha256=$local_hash" \
+              --metadata "sha256=$local_hash,max-age=31536000" \
               "$path" \
               "s3://$SPACE_BUCKET/$key"
           }
@@ -505,6 +505,7 @@ jobs:
               --endpoint-url "$SPACE_ENDPOINT" \
               --acl public-read \
               --cache-control 'public,max-age=60,must-revalidate' \
+              --metadata 'max-age=60' \
               "$path" \
               "s3://$SPACE_BUCKET/$SPACE_PREFIX/$relative_path"
           }

--- a/.github/workflows/el10_daily_stable.yml
+++ b/.github/workflows/el10_daily_stable.yml
@@ -414,7 +414,7 @@ jobs:
             aws s3 cp --only-show-errors --endpoint-url "$SPACE_ENDPOINT" \
               --acl public-read \
               --cache-control 'public,max-age=31536000,immutable' \
-              --metadata "sha256=$local_hash" \
+              --metadata "sha256=$local_hash,max-age=31536000" \
               "$path" "s3://$SPACE_BUCKET/$key"
           }
           while IFS= read -r -d '' path; do
@@ -433,6 +433,7 @@ jobs:
             aws s3 cp --only-show-errors --endpoint-url "$SPACE_ENDPOINT" \
               --acl public-read \
               --cache-control 'public,max-age=60,must-revalidate' \
+              --metadata 'max-age=60' \
               "$path" "s3://$SPACE_BUCKET/$SPACE_PREFIX/$relative_path"
           }
           upload_metadata rpm-repo/rsyslog-archive-keyring.asc
@@ -483,7 +484,7 @@ jobs:
           persist-credentials: false
 
       - name: Install verification tools
-        run: dnf -y install ca-certificates curl gnupg2 rpm
+        run: dnf -y install ca-certificates curl gnupg2 python3 rpm
 
       - name: Wait for CDN and verify signed metadata
         id: published_metadata

--- a/.github/workflows/ubuntu_daily_stable.yml
+++ b/.github/workflows/ubuntu_daily_stable.yml
@@ -478,7 +478,7 @@ jobs:
               --endpoint-url "$SPACE_ENDPOINT" \
               --acl public-read \
               --cache-control 'public,max-age=31536000,immutable' \
-              --metadata "sha256=$local_hash" \
+              --metadata "sha256=$local_hash,max-age=31536000" \
               "$path" \
               "s3://$SPACE_BUCKET/$key"
           }
@@ -506,6 +506,7 @@ jobs:
               --endpoint-url "$SPACE_ENDPOINT" \
               --acl public-read \
               --cache-control 'public,max-age=60,must-revalidate' \
+              --metadata 'max-age=60' \
               "$path" \
               "s3://$SPACE_BUCKET/$SPACE_PREFIX/$relative_path"
           }

--- a/devtools/release/rpm-daily-stable.sh
+++ b/devtools/release/rpm-daily-stable.sh
@@ -361,7 +361,7 @@ cmd_verify_repo() {
   local arch="$2"
   local expected_evr="$3"
   local expected_fingerprint="$4"
-  local verify_dir actual_fingerprint
+  local verify_dir actual_fingerprint primary_href
 
   verify_dir="$(mktemp -d)"
   trap 'rm -rf "$verify_dir"' RETURN
@@ -384,6 +384,69 @@ cmd_verify_repo() {
     "$repo_url/$arch/repodata/repomd.xml.asc" --output "$verify_dir/repomd.xml.asc"
   gpgv --keyring "$verify_dir/keyring.gpg" \
     "$verify_dir/repomd.xml.asc" "$verify_dir/repomd.xml"
+  primary_href="$(
+    python3 - "$verify_dir/repomd.xml" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+root = ET.parse(sys.argv[1]).getroot()
+namespace = {"repo": "http://linux.duke.edu/metadata/repo"}
+location = root.find("repo:data[@type='primary']/repo:location", namespace)
+if location is None or not location.get("href"):
+    raise SystemExit("primary package metadata is missing from repomd.xml")
+print(location.get("href"))
+PY
+  )"
+  case "$primary_href" in
+    repodata/*/../* | repodata/../* | repodata/*/./*)
+      die "unsafe primary metadata path in repomd.xml: $primary_href"
+      ;;
+    repodata/*) ;;
+    *) die "unsafe primary metadata path in repomd.xml: $primary_href" ;;
+  esac
+  curl --fail --silent --show-error --location \
+    "$repo_url/$arch/$primary_href" --output "$verify_dir/primary.xml.gz"
+  python3 - "$verify_dir/repomd.xml" "$verify_dir/primary.xml.gz" \
+    "$expected_evr" <<'PY'
+import gzip
+import hashlib
+import sys
+import xml.etree.ElementTree as ET
+
+repomd_path = sys.argv[1]
+metadata_path = sys.argv[2]
+expected_evr = sys.argv[3]
+repo_namespace = {"repo": "http://linux.duke.edu/metadata/repo"}
+common_namespace = {"common": "http://linux.duke.edu/metadata/common"}
+repomd = ET.parse(repomd_path).getroot()
+primary = repomd.find("repo:data[@type='primary']", repo_namespace)
+checksum = primary.find("repo:checksum", repo_namespace) if primary is not None else None
+if checksum is None or not checksum.get("type") or not checksum.text:
+    raise SystemExit("primary package metadata checksum is missing from repomd.xml")
+try:
+    with open(metadata_path, "rb") as package_metadata:
+        digest = hashlib.new(checksum.get("type"), package_metadata.read()).hexdigest()
+except ValueError as error:
+    raise SystemExit(f"unsupported primary metadata checksum: {error}") from error
+if digest != checksum.text.strip():
+    raise SystemExit("primary package metadata checksum does not match repomd.xml")
+available = set()
+with gzip.open(metadata_path, "rb") as metadata:
+    for _, element in ET.iterparse(metadata, events=("end",)):
+        if element.tag != "{http://linux.duke.edu/metadata/common}package":
+            continue
+        name = element.findtext("common:name", namespaces=common_namespace)
+        if name == "rsyslog":
+            version = element.find("common:version", common_namespace)
+            if version is not None:
+                available.add(f"{version.get('ver')}-{version.get('rel')}")
+        element.clear()
+if expected_evr not in available:
+    versions = ", ".join(sorted(available)) or "none"
+    raise SystemExit(
+        f"expected rsyslog EVR {expected_evr} is absent; available EVRs: {versions}"
+    )
+PY
   printf 'Verified signed repository metadata for %s (%s)\n' \
     "$expected_evr" "$arch"
 


### PR DESCRIPTION
## Summary

- set the DigitalOcean-specific `max-age` object metadata for Debian, Ubuntu, and EL package archive uploads
- require EL10 readiness metadata to contain the exact expected rsyslog EVR and verify primary metadata against signed checksums
- explicitly install Python in every EL10 verifier and document the one-time transition purge

## Why

DigitalOcean Spaces CDN ignored the ordinary object `Cache-Control` for its edge TTL and continued serving signed `.2.1` metadata after `.3.1` was published. The provider-specific metadata reduces mutable edge caching to 60 seconds while immutable packages remain cached for one year.

## Validation

- PR-ready Ubuntu 26.04 container gate: 1535 total, 1506 passed, 29 skipped, 0 failed
- clang static analyzer: no bugs found
- local Cubic review: no issues found
- actionlint, shellcheck, flake-evidence checker, and pinned zizmor: passed
- exact signed repository verifier passed in CentOS Stream 10, Rocky 10, AlmaLinux 10, and Oracle Linux 10
- absent-EVR test correctly rejected stale signed metadata and listed retained EVRs
- live Spaces/CDN probe stored `x-amz-meta-max-age: 60` and returned a 60-second CDN policy; probe object removed

The EL10 schedule remains disabled until the post-merge production E2E run is green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

