### PR TITLE
fix Alpine APK artifact verification

### DIFF
--- a/devtools/release/alpine-daily-stable.sh
+++ b/devtools/release/alpine-daily-stable.sh
@@ -137,16 +137,15 @@ cmd_verify_artifacts() {
 	local artifact_dir="$1"
 	local expected_version="$2"
 	local arch="$3"
-	local base_apk actual_version
+	local base_apk
 
 	base_apk="$(find "$artifact_dir" -maxdepth 1 -type f \
 		-name "rsyslog-${expected_version}.apk" -print -quit)"
 	[ -n "$base_apk" ] ||
 		die "base rsyslog APK for $expected_version is absent"
-	actual_version="$(apk info --legacy-info --description "$base_apk" 2>/dev/null |
-		sed -n '1s/^rsyslog-//p')"
-	[ "$actual_version" = "$expected_version" ] ||
-		die "built APK version $actual_version does not match $expected_version"
+	if ! apk verify "$base_apk"; then
+		die "base rsyslog APK failed signature or integrity verification"
+	fi
 	find "$artifact_dir" -maxdepth 1 -type f -name '*.apk' -print -quit |
 		grep -q . || die "no APK artifacts were produced"
 	[ "$(apk --print-arch)" = "$arch" ] ||


### PR DESCRIPTION
### Motivation

The first merged hosted Alpine build produced and signed all APKs, then failed silently in the post-build legacy apk info pipeline.

### Change

- retain the exact expected versioned filename check
- replace the stderr-suppressed legacy metadata query with Alpine native apk verify
- report a clear signature/integrity failure

### Validation

- bash syntax and shellcheck passed
- the exact verifier passed in a clean alpine:3.24 container against all locally built packages signed by the production archive key
- apk verify reported the expected base package OK
- the underlying workflow passed the full Ubuntu 26.04 container gate before this targeted follow-up: 1506 passed, 29 skipped, 0 failed; scan-build and local Cubic found no issues

Failed hosted run: https://github.com/rsyslog/rsyslog/actions/runs/30308649562

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

