### PR TITLE
daily-stable: fix Alpine snapshot ownership

### DIFF
--- a/.github/workflows/alpine324_daily_stable.yml
+++ b/.github/workflows/alpine324_daily_stable.yml
@@ -370,6 +370,7 @@ jobs:
                 /runner-temp/rsyslog-alpine-archive.rsa \
                 alpine-daily-stable-artifacts/rsyslog-alpine-archive.rsa.pub
             '
+          sudo chown -R "$(id -u):$(id -g)" apk-repo
 
       - name: Generate snapshot
         env:


### PR DESCRIPTION
## Summary

- return the container-generated APK repository tree to the GitHub runner user
- allow immutable snapshot metadata to be created before publication
- preserve signing, archive layout, and upload semantics

## Validation

- reproduced the hosted failure in run 30309914798: `apk-repo` was root-owned after index generation
- `actionlint .github/workflows/alpine324_daily_stable.yml`
- `python3 devtools/check-flake-evidence-coverage.py`
- PR-ready Ubuntu 26.04 container gate: 1535 total, 1506 pass, 29 skip, 0 fail
- static analyzer: no bugs found
- Cubic repeated the fixed ownership condition at the newly added `chown` line; treated as a false positive

After merge, the Alpine workflow will be rerun with publication enabled and verified from a clean Alpine 3.24 container.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

