### PR TITLE
daily-stable: run Alpine verifier with Bash

### DIFF
--- a/.github/workflows/alpine324_daily_stable.yml
+++ b/.github/workflows/alpine324_daily_stable.yml
@@ -462,10 +462,11 @@ jobs:
           persist-credentials: false
 
       - name: Install verification tools
-        run: apk add --no-cache bash ca-certificates curl
+        run: apk add --no-cache bash ca-certificates curl python3
 
       - name: Wait for CDN and verify exact package installation
         id: published_install
+        shell: bash
         run: |
           set -euo pipefail
           mkdir -p .ci/flake-evidence/logs


### PR DESCRIPTION
## Summary

- run the published-archive verifier with Bash so `PIPESTATUS` is available
- install Python in the clean Alpine verifier so failure-evidence collection can run

## End-to-end evidence

Hosted run 30312032738 successfully published the signed APK archive and its clean Alpine 3.24 container:
- verified the public signing key
- installed exact version `8.2608.0_p20260727000000000401-r0`
- passed `rsyslogd -v` and `rsyslogd -N1`

The job then failed only while reading Bash `PIPESTATUS` under BusyBox `sh`.

The corrected step was reproduced in a fresh local `alpine:3.24` container against the public CDN, including key checksum, exact install/version assertion, both rsyslog checks, and the Bash pipeline-status assertion.

Also passed:
- `actionlint .github/workflows/alpine324_daily_stable.yml`
- `python3 devtools/check-flake-evidence-coverage.py`

The immediately preceding ownership fix passed the full Ubuntu 26.04 local gate: 1535 total, 1506 pass, 29 skip, 0 fail; static analyzer found no bugs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

