### PR TITLE
daily-stable: verify Alpine packages at origin

### DIFF
--- a/.github/ALPINE_DAILY_STABLE.md
+++ b/.github/ALPINE_DAILY_STABLE.md
@@ -37,7 +37,9 @@ snapshots/YYYY-MM-DD/PACKAGE_VERSION/
 APK files and snapshots are immutable and retained for at least five years.
 The workflow merges the previous signed index with each new package set so
 older daily versions remain installable. Only the small mutable APK index and
-public signing key use the CDN's 60-second metadata cache override.
+public signing key request a 60-second metadata cache override. DigitalOcean's
+CDN currently enforces a one-hour minimum TTL, so consumers can see a newly
+published index up to one hour later.
 The ordered APK version contains the UTC date and GitHub run/attempt serial;
 the manifest records the exact rsyslog source commit.
 
@@ -59,6 +61,8 @@ Add these repository variables:
   publication succeeds.
 - `ALPINE324_DAILY_STABLE_REPO_URL`: public CDN URL ending in
   `/apk/daily-stable/alpine/3.24`.
+- `ALPINE324_DAILY_STABLE_ORIGIN_REPO_URL`: public Spaces origin URL ending in
+  `/apk/daily-stable/alpine/3.24`.
 - `ALPINE_DAILY_STABLE_RSA_PUBLIC_KEY_SHA256`: SHA-256 of the PEM public key.
 
 The existing shared Space bucket, endpoint, region, access key, and secret key
@@ -70,8 +74,10 @@ remain unchanged. A DigitalOcean account API token is not required.
 2. Run the workflow manually with publication disabled and inspect the APK
    artifacts.
 3. Run it manually with publication enabled.
-4. Confirm that a clean `alpine:3.24` container trusts the published key,
-   installs the exact daily rsyslog version, and passes `rsyslogd -N1`.
+4. Confirm that the CDN key and index are reachable and that a clean
+   `alpine:3.24` container trusts the public origin key, installs the exact
+   daily rsyslog version, and passes `rsyslogd -N1`. Exact-version validation
+   uses the origin because the CDN's minimum TTL can exceed CI runtime.
 5. Set `ALPINE324_DAILY_STABLE_ENABLED=true`.
 
 The scheduled workflow opens or updates an issue if its build, publication,

--- a/.github/workflows/alpine324_daily_stable.yml
+++ b/.github/workflows/alpine324_daily_stable.yml
@@ -453,6 +453,7 @@ jobs:
       contents: read
     env:
       REPO_URL: ${{ vars.ALPINE324_DAILY_STABLE_REPO_URL }}
+      ORIGIN_REPO_URL: ${{ vars.ALPINE324_DAILY_STABLE_ORIGIN_REPO_URL }}
       EXPECTED_PUBLIC_KEY_SHA256: ${{ vars.ALPINE_DAILY_STABLE_RSA_PUBLIC_KEY_SHA256 }}
       EXPECTED_VERSION: ${{ needs.build.outputs.expected_version }}
     steps:
@@ -464,7 +465,7 @@ jobs:
       - name: Install verification tools
         run: apk add --no-cache bash ca-certificates curl python3
 
-      - name: Wait for CDN and verify exact package installation
+      - name: Verify CDN reachability and exact origin installation
         id: published_install
         shell: bash
         run: |
@@ -474,17 +475,26 @@ jobs:
           set +e
           (
             set -euo pipefail
+            [ -n "$REPO_URL" ]
+            [ -n "$ORIGIN_REPO_URL" ]
+            curl -fsSL "$REPO_URL/rsyslog-alpine-archive.rsa.pub" \
+              -o /tmp/rsyslog-alpine-cdn-key.pub
+            [ "$(sha256sum /tmp/rsyslog-alpine-cdn-key.pub | awk '{print $1}')" = \
+              "$EXPECTED_PUBLIC_KEY_SHA256" ]
+            curl -fsSL "$REPO_URL/$ALPINE_ARCH/APKINDEX.tar.gz" \
+              -o /tmp/rsyslog-alpine-cdn-index.tar.gz
+            tar -tzf /tmp/rsyslog-alpine-cdn-index.tar.gz | grep -Fx APKINDEX
             verification_rc=1
             for attempt in $(seq 1 20); do
               rm -f /tmp/rsyslog-alpine-archive.rsa.pub
               if curl -fsSL \
-                  "$REPO_URL/rsyslog-alpine-archive.rsa.pub" \
+                  "$ORIGIN_REPO_URL/rsyslog-alpine-archive.rsa.pub" \
                   -o /tmp/rsyslog-alpine-archive.rsa.pub &&
                 [ "$(sha256sum /tmp/rsyslog-alpine-archive.rsa.pub | awk '{print $1}')" = \
                   "$EXPECTED_PUBLIC_KEY_SHA256" ]; then
                 cp /tmp/rsyslog-alpine-archive.rsa.pub /etc/apk/keys/
-                if ! grep -Fxq "$REPO_URL" /etc/apk/repositories; then
-                  echo "$REPO_URL" >> /etc/apk/repositories
+                if ! grep -Fxq "$ORIGIN_REPO_URL" /etc/apk/repositories; then
+                  echo "$ORIGIN_REPO_URL" >> /etc/apk/repositories
                 fi
                 if apk update --no-cache &&
                   apk add --no-cache "rsyslog=$EXPECTED_VERSION"; then
@@ -492,7 +502,7 @@ jobs:
                   break
                 fi
               fi
-              echo "Repository not ready yet, retrying ($attempt/20)..."
+              echo "Origin repository not ready yet, retrying ($attempt/20)..."
               [ "$attempt" -eq 20 ] || sleep 30
             done
             [ "$verification_rc" -eq 0 ]


### PR DESCRIPTION
## Summary

- verify the CDN endpoint remains publicly reachable and serves a valid signed-index archive
- install the exact newly published version from the public Spaces origin
- document DigitalOcean's observed one-hour CDN minimum TTL
- add the protected-environment origin URL variable (already configured)

## Why

Run 30312772064 published version `8.2608.0_p20260727000000000501-r0` and correctly merged it with `...0401-r0` at the origin. DigitalOcean continued serving the cached old index from the CDN with `cache-control: max-age=3600`, despite the origin object's requested 60-second TTL. A ten-minute exact-version CDN gate therefore cannot succeed reliably.

## End-to-end validation

A fresh `alpine:3.24` container passed:
- public CDN signing-key checksum
- public CDN APKINDEX reachability and archive structure
- public origin signing-key checksum
- exact origin install of `8.2608.0_p20260727000000000501-r0`
- installed-version assertion
- `rsyslogd -v`
- `rsyslogd -N1`

Also passed:
- `actionlint .github/workflows/alpine324_daily_stable.yml`
- `python3 devtools/check-flake-evidence-coverage.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

