### PR TITLE
ci: install Amazon Linux checkout prerequisites

### DIFF
--- a/.github/workflows/amazonlinux2023_daily_stable.yml
+++ b/.github/workflows/amazonlinux2023_daily_stable.yml
@@ -483,13 +483,13 @@ jobs:
       EXPECTED_GPG_FINGERPRINT: ${{ vars.DEBIAN_DAILY_STABLE_GPG_FINGERPRINT }}
       EXPECTED_EVR: ${{ needs.build.outputs.expected_evr }}
     steps:
+      - name: Install container prerequisites
+        run: dnf -q -y install ca-certificates curl gnupg2 python3 rpm tar
+
       - name: Checkout archive automation
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - name: Install verification tools
-        run: dnf -q -y install ca-certificates curl gnupg2 python3 rpm
 
       - name: Verify CDN and exact origin installation
         id: published_install


### PR DESCRIPTION
Install tar and the existing verification dependencies before actions/checkout in the minimal Amazon Linux 2023 verification container. This fixes the end-to-end archive run, which successfully built, signed, and published the RPM repository but could not start checkout because tar was absent.

Validated with actionlint, flake-evidence coverage, zizmor, the full 1,535-test Ubuntu 26.04 container gate, clang static analyzer, and local Cubic review.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

