### PR TITLE
ci: use Amazon Linux minimal package transaction

### DIFF
--- a/.github/workflows/amazonlinux2023_daily_stable.yml
+++ b/.github/workflows/amazonlinux2023_daily_stable.yml
@@ -484,7 +484,9 @@ jobs:
       EXPECTED_EVR: ${{ needs.build.outputs.expected_evr }}
     steps:
       - name: Install container prerequisites
-        run: dnf -q -y install ca-certificates curl gnupg2 python3 rpm tar
+        run: |
+          dnf -q -y install tar
+          dnf -q -y swap gnupg2-minimal gnupg2
 
       - name: Checkout archive automation
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
The official Amazon Linux 2023 container already contains curl-minimal and gnupg2-minimal, so installing the full packages conflicts. Install only tar, then use the native dnf swap transaction to replace gnupg2-minimal with gnupg2 because repository verification requires gpgv.

The exact transaction passed in a fresh amazonlinux:2023 container. actionlint, flake coverage, and zizmor passed. Two earlier full 1,535-test gates plus analyzer and Cubic were green; the final broad rerun had three unrelated parallel test flakes, all of which passed when rerun sequentially.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

