### PR TITLE
packaging: add openSUSE Leap 16 daily archive

### DIFF
--- a/.github/OPENSUSE_DAILY_STABLE.md
+++ b/.github/OPENSUSE_DAILY_STABLE.md
@@ -1,0 +1,100 @@
+# openSUSE daily stable package archive
+
+The `opensuse leap 16.0 daily stable` workflow builds current rsyslog `main`
+for openSUSE Leap 16.0 on `x86_64`. Every run enables Leap's official disabled
+source repository and downloads its current rsyslog source RPM. That native
+spec, configuration, systemd unit, feature choices, file ownership, and
+subpackage split are the packaging authority. The source RPM's NEVRA and
+SHA-256 are recorded with each build.
+
+The explicit current-source deltas are recorded in
+`opensuse-leap160-daily-stable-policy.yml`. Current main additionally needs
+`libyaml-devel`, `protobuf-c-devel`, and `snappy-devel`, and generates the core
+`mmleefparse.so` module which the older native spec does not list. The workflow
+adds only those declared deltas. It also explicitly installs four conditional
+native BuildRequires (`libnet-devel`, `librdkafka-devel`, `net-snmp-devel`, and
+`qpid-proton-devel`) which Leap's `zypper source-install` does not resolve, so
+the native feature set is not silently reduced.
+
+Leap packages documentation separately. Each run therefore builds the current
+main-branch HTML and source documentation and replaces the native documentation
+source tarball, preserving the `rsyslog-doc` package without shipping stale
+documentation. The native Leap spec has no `%check` phase; the workflow keeps
+that distro definition and compensates with a signed repository check followed
+by a clean exact-version install and rsyslog configuration validation. If Leap
+adds a downstream patch, the build stops for review instead of silently
+dropping it.
+
+Package construction does not run for pull requests. Manual dispatch remains
+available for bootstrap and recovery. The schedule is inactive until a manual
+publication and clean openSUSE installation test pass.
+
+## Archive layout and retention
+
+The repository URL ends in:
+
+```text
+/rpm/daily-stable/opensuse/leap/16.0
+```
+
+The binary and source repositories are below that path:
+
+```text
+x86_64/Packages/*.rpm
+x86_64/repodata/
+SRPMS/Packages/*.src.rpm
+SRPMS/repodata/
+```
+
+Every publication also records its manifest, checksums, prepared spec, and
+build log below:
+
+```text
+snapshots/YYYY-MM-DD/EVR/
+```
+
+RPMs and snapshots are immutable and retained for at least five years. Each
+new repository generation merges prior signed metadata so old daily versions
+remain installable. The EVR contains the UTC date, GitHub run and attempt,
+and source commit. Only repository metadata, the public key, and the consumer
+`.repo` file are mutable.
+
+DigitalOcean's CDN currently enforces an observed one-hour minimum TTL even
+when objects request a shorter cache lifetime. The workflow therefore verifies
+that the CDN serves a valid signed repository, while exact newly published
+version installation uses the public Spaces origin. Consumers continue to use
+the CDN and can see a new daily version up to one hour later.
+
+## Signing and configuration
+
+The archive reuses the OpenPGP signing key and DigitalOcean Spaces credentials
+already held by the protected `debian-daily-stable` GitHub Environment. Despite
+its legacy name, that environment is the security boundary for the shared
+package archive and is not limited to Debian.
+
+Add these environment variables:
+
+- `OPENSUSE_LEAP160_DAILY_STABLE_ENABLED`: `true` only after the first complete
+  publication succeeds.
+- `OPENSUSE_LEAP160_DAILY_STABLE_REPO_URL`: public CDN URL ending in
+  `/rpm/daily-stable/opensuse/leap/16.0`.
+- `OPENSUSE_LEAP160_DAILY_STABLE_ORIGIN_REPO_URL`: public Spaces origin URL
+  ending in `/rpm/daily-stable/opensuse/leap/16.0`.
+
+No new private key, DigitalOcean account API token, or bucket permission is
+required.
+
+## End-to-end activation
+
+1. Set the CDN and public-origin repository variables while leaving the
+   schedule flag unset or false.
+2. Run the workflow manually with publication disabled and inspect the RPMs.
+3. Run it manually with publication enabled.
+4. Confirm the CDN metadata signature and clean-install the exact new EVR of
+   `rsyslog`, `rsyslog-module-ossl`, and `rsyslog-doc` from the public origin in
+   `opensuse/leap:16.0`; verify all installed EVRs, `rsyslogd -v`, and
+   `rsyslogd -N1`.
+5. Set `OPENSUSE_LEAP160_DAILY_STABLE_ENABLED=true`.
+
+The scheduled workflow opens or updates an issue if its build, publication,
+or installation verification fails.

--- a/.github/opensuse-leap160-daily-stable-policy.yml
+++ b/.github/opensuse-leap160-daily-stable-policy.yml
@@ -1,0 +1,19 @@
+{
+  "supplemental_build_requires": [
+    {
+      "package": "libyaml-devel",
+      "reason": "Current upstream enables YAML configuration support by default."
+    },
+    {
+      "package": "protobuf-c-devel",
+      "reason": "Current upstream enables impstats push support and needs the protobuf-c compiler and headers."
+    },
+    {
+      "package": "snappy-devel",
+      "reason": "Current upstream impstats push support uses Snappy compression."
+    }
+  ],
+  "supplemental_core_files": [
+    "%{rsyslog_module_dir_nodeps}/mmleefparse.so"
+  ]
+}

--- a/.github/workflows/collect_flake_evidence.yml
+++ b/.github/workflows/collect_flake_evidence.yml
@@ -19,6 +19,7 @@ name: collect flake evidence
       - alpine 3.24 daily stable
       - amazon linux 2023 daily stable
       - fedora 44 daily stable
+      - opensuse leap 16.0 daily stable
     types: [completed]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/opensuse_leap160_daily_stable.yml
+++ b/.github/workflows/opensuse_leap160_daily_stable.yml
@@ -1,0 +1,655 @@
+# Copyright 2026 Rainer Gerhards and Others
+#
+# https://github.com/rsyslog/rsyslog
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+---
+name: opensuse leap 16.0 daily stable
+
+'on':
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: rsyslog source branch, tag, or commit to package
+        required: true
+        default: main
+        type: string
+      publish_to_archive:
+        description: Publish to the configured DigitalOcean Spaces archive
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    - cron: '17 6 * * *'
+
+concurrency:
+  group: opensuse-leap160-daily-stable
+  cancel-in-progress: false
+
+env:
+  OPENSUSE_DAILY_STABLE_HELPER: devtools/release/opensuse-daily-stable.sh
+  OPENSUSE_POLICY_FILE: .github/opensuse-leap160-daily-stable-policy.yml
+  RPM_ARCH: x86_64
+  PACKAGE_CHANNEL: daily-stable
+  PACKAGE_DISTRO: opensuse-leap
+  PACKAGE_DISTRO_VERSION: '16.0'
+  SPACE_PREFIX: rpm/daily-stable/opensuse/leap/16.0
+
+jobs:
+  preflight:
+    name: preflight
+    runs-on: ubuntu-24.04
+    if: github.repository == 'rsyslog/rsyslog'
+    permissions:
+      contents: read
+    outputs:
+      should_run: ${{ steps.decision.outputs.should_run }}
+      should_publish: ${{ steps.decision.outputs.should_publish }}
+      source_ref: ${{ steps.decision.outputs.source_ref }}
+    steps:
+      - name: Decide whether this run is active
+        id: decision
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_PUBLISH: ${{ inputs.publish_to_archive }}
+          MANUAL_SOURCE_REF: ${{ inputs.source_ref }}
+          SCHEDULE_ENABLED: ${{ vars.OPENSUSE_LEAP160_DAILY_STABLE_ENABLED }}
+        run: |
+          set -euo pipefail
+          should_run=false
+          should_publish=false
+          source_ref=main
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              should_run=true
+              source_ref="${MANUAL_SOURCE_REF:-main}"
+              if [ "${MANUAL_PUBLISH:-false}" = true ]; then
+                should_publish=true
+              fi
+              ;;
+            schedule)
+              if [ "${SCHEDULE_ENABLED:-false}" = true ]; then
+                should_run=true
+                should_publish=true
+              fi
+              ;;
+          esac
+          {
+            echo "should_run=$should_run"
+            echo "should_publish=$should_publish"
+            echo "source_ref=$source_ref"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: build openSUSE Leap 16.0 x86_64 packages
+    needs: preflight
+    if: needs.preflight.outputs.should_run == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 150
+    permissions:
+      contents: read
+    outputs:
+      archive_date: ${{ steps.version.outputs.archive_date }}
+      expected_evr: ${{ steps.version.outputs.expected_evr }}
+      source_sha: ${{ steps.source.outputs.source_sha }}
+    steps:
+      - name: Checkout archive automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Checkout source to package
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          path: rsyslog-source
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.source_ref }}
+
+      - name: Record packaged source revision
+        id: source
+        run: |
+          set -euo pipefail
+          source_sha="$(git -C rsyslog-source rev-parse HEAD)"
+          {
+            echo "source_sha=$source_sha"
+            echo "SOURCE_GIT_SHA=$source_sha"
+            echo "RSYSLOG_SOURCE_DIR=$GITHUB_WORKSPACE/rsyslog-source"
+          } | tee -a "$GITHUB_ENV" >> "$GITHUB_OUTPUT"
+
+      - name: Generate daily package version
+        id: version
+        run: "$OPENSUSE_DAILY_STABLE_HELPER version"
+
+      - name: Generate rsyslog dist tarball
+        run: |
+          RSYSLOG_HOME="$GITHUB_WORKSPACE/rsyslog-source" \
+            RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 \
+            devtools/devcontainer.sh --rm \
+              .github/scripts/debian_package_build.sh run_dist_build \
+              /rsyslog
+          dist_tarball="$(
+            find rsyslog-source -maxdepth 1 -type f \
+              -name 'rsyslog-*.tar.gz' -print -quit
+          )"
+          [ -n "$dist_tarball" ]
+          echo "DIST_TARBALL=$GITHUB_WORKSPACE/$dist_tarball" >> "$GITHUB_ENV"
+
+      - name: Generate current rsyslog documentation tarball
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          rsyslog-source/doc/tools/build-doc-linux.sh \
+            --clean --format html --jobs "$(nproc)"
+          doc_tarball="$GITHUB_WORKSPACE/rsyslog-doc-$VERSION.tar.gz"
+          tar -C rsyslog-source/doc -czf "$doc_tarball" \
+            build source LICENSE README.md
+          echo "DOC_TARBALL=$doc_tarball" >> "$GITHUB_ENV"
+
+      - name: Fetch native baseline and build openSUSE RPMs
+        id: package_build
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          RELEASE: ${{ steps.version.outputs.release }}
+          EXPECTED_EVR: ${{ steps.version.outputs.expected_evr }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/opensuse-leap160-build"
+          devtools/ci-flake-phase.sh begin opensuse-leap160-package-build custom
+          set +e
+          docker run --rm \
+            -e OPENSUSE_DAILY_STABLE_HELPER \
+            -e OPENSUSE_POLICY_FILE -e EXPECTED_EVR -e RELEASE -e VERSION \
+            -e "DIST_TARBALL=/workspace/rsyslog-source/$(basename "$DIST_TARBALL")" \
+            -e "DOC_TARBALL=/workspace/$(basename "$DOC_TARBALL")" \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -v "$RUNNER_TEMP:/runner-temp" \
+            -w /workspace \
+            opensuse/leap:16.0 bash -lc '
+              set -euo pipefail
+              zypper -n install findutils gzip python3 rpm-build tar
+              zypper -n modifyrepo --enable openSUSE:repo-oss-source
+              zypper -n refresh openSUSE:repo-oss-source
+              zypper -n source-install --build-deps-only rsyslog
+              # These four are already native conditional BuildRequires, but
+              # zypper source-install does not resolve them on Leap 16.0.
+              zypper -n install libnet-devel librdkafka-devel \
+                net-snmp-devel qpid-proton-devel \
+                libyaml-devel protobuf-c-devel snappy-devel
+              mkdir -p /runner-temp/opensuse-leap160-baseline/rpmbuild
+              baseline_srpm="$(
+                find /var/cache/zypp/packages -type f \
+                  -name "rsyslog-*.src.rpm" -print -quit
+              )"
+              [ -n "$baseline_srpm" ]
+              rpm -qp --qf "%{NAME}-%{VERSION}-%{RELEASE}.src\n" \
+                "$baseline_srpm" \
+                > /runner-temp/opensuse-leap160-baseline-nevra
+              sha256sum "$baseline_srpm" | awk "{print \$1}" \
+                > /runner-temp/opensuse-leap160-baseline-sha256
+              rpm -ivh \
+                --define "_topdir /runner-temp/opensuse-leap160-baseline/rpmbuild" \
+                "$baseline_srpm" >/dev/null
+              "$OPENSUSE_DAILY_STABLE_HELPER" prepare-sources \
+                /runner-temp/opensuse-leap160-baseline/rpmbuild \
+                "$DIST_TARBALL" \
+                "$DOC_TARBALL" \
+                /runner-temp/opensuse-leap160-prepared \
+                "$OPENSUSE_POLICY_FILE" \
+                "$VERSION" \
+                "$RELEASE"
+              "$OPENSUSE_DAILY_STABLE_HELPER" build-package \
+                /runner-temp/opensuse-leap160-prepared \
+                /runner-temp/opensuse-leap160-artifacts \
+                /runner-temp/opensuse-leap160-build.log \
+                "$EXPECTED_EVR" \
+                x86_64
+            '
+          build_status=$?
+          set -e
+          devtools/ci-flake-phase.sh end \
+            opensuse-leap160-package-build custom "$build_status"
+          if [ "$build_status" -eq 0 ]; then
+            sudo chown -R "$(id -u):$(id -g)" \
+              "$RUNNER_TEMP/opensuse-leap160-artifacts" \
+              "$RUNNER_TEMP/opensuse-leap160-build.log" \
+              "$RUNNER_TEMP/opensuse-leap160-baseline-nevra" \
+              "$RUNNER_TEMP/opensuse-leap160-baseline-sha256"
+            cp -a "$RUNNER_TEMP/opensuse-leap160-artifacts" \
+              opensuse-leap160-daily-stable-artifacts
+            {
+              echo "baseline_nevra=$(cat "$RUNNER_TEMP/opensuse-leap160-baseline-nevra")"
+              echo "baseline_sha256=$(cat "$RUNNER_TEMP/opensuse-leap160-baseline-sha256")"
+            } >> "$GITHUB_OUTPUT"
+          fi
+          exit "$build_status"
+
+      - name: Upload package-build failure evidence
+        if: failure() && steps.package_build.outcome == 'failure'
+        uses: ./.github/actions/upload-flake-evidence
+        with:
+          job-name: openSUSE Leap 16.0 daily stable package build
+
+      - name: Generate artifact manifest
+        env:
+          EXPECTED_EVR: ${{ steps.version.outputs.expected_evr }}
+        run: |
+          "$OPENSUSE_DAILY_STABLE_HELPER" manifest \
+            opensuse-leap160-daily-stable-artifacts \
+            "$EXPECTED_EVR" \
+            "$RPM_ARCH" \
+            "$PACKAGE_CHANNEL" \
+            "$PACKAGE_DISTRO" \
+            "$PACKAGE_DISTRO_VERSION"
+
+      - name: Upload openSUSE package artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: opensuse-leap160-daily-stable-${{ steps.version.outputs.expected_evr }}
+          path: opensuse-leap160-daily-stable-artifacts/
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Summarize build
+        env:
+          BASELINE_NEVRA: ${{ steps.package_build.outputs.baseline_nevra }}
+          BASELINE_SHA256: ${{ steps.package_build.outputs.baseline_sha256 }}
+          EXPECTED_EVR: ${{ steps.version.outputs.expected_evr }}
+          SOURCE_REF: ${{ needs.preflight.outputs.source_ref }}
+        run: |
+          {
+            echo '### openSUSE Leap 16.0 daily stable build'
+            echo
+            echo "- EVR: \`$EXPECTED_EVR\`"
+            echo "- Source ref: \`$SOURCE_REF\`"
+            echo "- Source commit: \`$SOURCE_GIT_SHA\`"
+            echo "- openSUSE source RPM: \`$BASELINE_NEVRA\`"
+            echo "- Baseline SHA-256: \`$BASELINE_SHA256\`"
+            echo "- Archive prefix: \`$SPACE_PREFIX\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: publish DigitalOcean Spaces openSUSE RPM archive
+    needs: [preflight, build]
+    if: needs.preflight.outputs.should_publish == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    # This legacy-named environment is the security boundary for the shared
+    # package archive, not a Debian-only destination.
+    environment: debian-daily-stable
+    permissions:
+      contents: read
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.DEBIAN_DAILY_STABLE_SPACE_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DEBIAN_DAILY_STABLE_SPACE_SECRET_KEY }}
+      AWS_DEFAULT_REGION: ${{ vars.DEBIAN_DAILY_STABLE_SPACE_REGION }}
+      SPACE_BUCKET: ${{ vars.DEBIAN_DAILY_STABLE_SPACE_BUCKET }}
+      SPACE_ENDPOINT: ${{ vars.DEBIAN_DAILY_STABLE_SPACE_ENDPOINT }}
+      REPO_URL: ${{ vars.OPENSUSE_LEAP160_DAILY_STABLE_REPO_URL }}
+      ARCHIVE_GPG_PRIVATE_KEY: ${{ secrets.DEBIAN_DAILY_STABLE_GPG_PRIVATE_KEY }}
+      ARCHIVE_GPG_PASSPHRASE: ${{ secrets.DEBIAN_DAILY_STABLE_GPG_PASSPHRASE }}
+      ARCHIVE_GPG_FINGERPRINT: ${{ vars.DEBIAN_DAILY_STABLE_GPG_FINGERPRINT }}
+    steps:
+      - name: Checkout archive automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install RPM repository tools
+        run: |
+          command -v aws
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            createrepo-c gnupg rpm
+
+      - name: Validate archive configuration
+        run: |
+          set -euo pipefail
+          for variable in \
+            AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION \
+            SPACE_BUCKET SPACE_ENDPOINT REPO_URL ARCHIVE_GPG_PRIVATE_KEY \
+            ARCHIVE_GPG_FINGERPRINT; do
+            [ -n "${!variable:-}" ] || {
+              echo "$variable is empty" >&2
+              exit 1
+            }
+          done
+
+      - name: Download openSUSE package artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: opensuse-leap160-daily-stable-${{ needs.build.outputs.expected_evr }}
+          path: opensuse-leap160-daily-stable-artifacts
+
+      - name: Verify artifact checksums
+        run: |
+          cd opensuse-leap160-daily-stable-artifacts
+          sha256sum -c SHA256SUMS
+
+      - name: Import signing key and unlock its agent
+        run: |
+          set -euo pipefail
+          install -m 700 -d "$HOME/.gnupg"
+          echo allow-preset-passphrase > "$HOME/.gnupg/gpg-agent.conf"
+          gpgconf --kill gpg-agent || true
+          printf '%s\n' "$ARCHIVE_GPG_PRIVATE_KEY" | gpg --batch --import
+          keygrip="$(
+            gpg --batch --with-colons --with-keygrip --list-secret-keys \
+              "$ARCHIVE_GPG_FINGERPRINT" |
+              awk -F: '$1 == "grp" { print $10; exit }'
+          )"
+          [ -n "$keygrip" ]
+          preset_tool="$(command -v gpg-preset-passphrase || true)"
+          for candidate in \
+            /usr/lib/gnupg2/gpg-preset-passphrase \
+            /usr/lib/gnupg/gpg-preset-passphrase; do
+            if [ -z "$preset_tool" ] && [ -x "$candidate" ]; then
+              preset_tool="$candidate"
+            fi
+          done
+          [ -n "$preset_tool" ]
+          printf '%s' "$ARCHIVE_GPG_PASSPHRASE" |
+            "$preset_tool" --preset "$keygrip"
+          passphrase_file="$RUNNER_TEMP/archive-gpg-passphrase"
+          install -m 600 /dev/null "$passphrase_file"
+          printf '%s' "$ARCHIVE_GPG_PASSPHRASE" > "$passphrase_file"
+          echo "GPG_PASSPHRASE_FILE=$passphrase_file" >> "$GITHUB_ENV"
+
+      - name: Sign binary and source RPMs
+        run: |
+          "$OPENSUSE_DAILY_STABLE_HELPER" sign-rpms \
+            opensuse-leap160-daily-stable-artifacts \
+            "$ARCHIVE_GPG_FINGERPRINT"
+
+      - name: Download current repository metadata
+        run: |
+          set -euo pipefail
+          mkdir -p "rpm-repo/$RPM_ARCH" rpm-repo/SRPMS
+          for repo_subdir in "$RPM_ARCH" SRPMS; do
+            aws s3 sync \
+              --only-show-errors \
+              --endpoint-url "$SPACE_ENDPOINT" \
+              "s3://$SPACE_BUCKET/$SPACE_PREFIX/$repo_subdir/repodata" \
+              "rpm-repo/$repo_subdir/repodata"
+          done
+
+      - name: Generate signed incremental RPM repositories
+        run: |
+          "$OPENSUSE_DAILY_STABLE_HELPER" generate-repo \
+            opensuse-leap160-daily-stable-artifacts \
+            rpm-repo \
+            "$RPM_ARCH" \
+            "$ARCHIVE_GPG_FINGERPRINT" \
+            "$GPG_PASSPHRASE_FILE"
+
+      - name: Generate signed artifact manifest and snapshot
+        env:
+          ARCHIVE_DATE: ${{ needs.build.outputs.archive_date }}
+          EXPECTED_EVR: ${{ needs.build.outputs.expected_evr }}
+        run: |
+          "$OPENSUSE_DAILY_STABLE_HELPER" manifest \
+            opensuse-leap160-daily-stable-artifacts \
+            "$EXPECTED_EVR" "$RPM_ARCH" "$PACKAGE_CHANNEL" \
+            "$PACKAGE_DISTRO" "$PACKAGE_DISTRO_VERSION"
+          snapshot_dir="rpm-repo/snapshots/$ARCHIVE_DATE/$EXPECTED_EVR"
+          mkdir -p "$snapshot_dir"
+          cp -a opensuse-leap160-daily-stable-artifacts/manifest.json \
+            opensuse-leap160-daily-stable-artifacts/SHA256SUMS \
+            opensuse-leap160-daily-stable-artifacts/build.log \
+            opensuse-leap160-daily-stable-artifacts/rsyslog.spec \
+            "$snapshot_dir/"
+
+      - name: Generate repository configuration
+        run: |
+          cat > rpm-repo/rsyslog-daily-stable-opensuse-leap160.repo <<EOF
+          [rsyslog-daily-stable]
+          name=rsyslog daily stable for openSUSE Leap 16.0 - \$basearch
+          baseurl=$REPO_URL/\$basearch
+          enabled=1
+          gpgcheck=1
+          repo_gpgcheck=1
+          pkg_gpgcheck=1
+          gpgkey=$REPO_URL/rsyslog-archive-keyring.asc
+          EOF
+
+      - name: Publish immutable RPMs and snapshots
+        run: |
+          set -euo pipefail
+          upload_immutable() {
+            local path="$1"
+            local relative_path="${path#rpm-repo/}"
+            local key="$SPACE_PREFIX/$relative_path"
+            local local_hash remote_hash remote_key
+            remote_key="$(
+              aws s3api list-objects-v2 \
+                --endpoint-url "$SPACE_ENDPOINT" --bucket "$SPACE_BUCKET" \
+                --prefix "$key" --max-keys 1 \
+                --query 'Contents[0].Key' --output text
+            )"
+            local_hash="$(sha256sum "$path" | awk '{print $1}')"
+            if [ "$remote_key" = "$key" ]; then
+              remote_hash="$(
+                aws s3 cp --quiet --endpoint-url "$SPACE_ENDPOINT" \
+                  "s3://$SPACE_BUCKET/$key" - | sha256sum | awk '{print $1}'
+              )"
+              [ "$remote_hash" = "$local_hash" ] || {
+                echo "immutable archive collision at $key" >&2
+                exit 1
+              }
+              return
+            fi
+            aws s3 cp --only-show-errors --endpoint-url "$SPACE_ENDPOINT" \
+              --acl public-read \
+              --cache-control 'public,max-age=31536000,immutable' \
+              --metadata "sha256=$local_hash,max-age=31536000" \
+              "$path" "s3://$SPACE_BUCKET/$key"
+          }
+          while IFS= read -r -d '' path; do
+            upload_immutable "$path"
+          done < <(
+            find "rpm-repo/$RPM_ARCH/Packages" rpm-repo/SRPMS/Packages \
+              rpm-repo/snapshots -type f -print0
+          )
+
+      - name: Publish archive key and mutable metadata
+        run: |
+          set -euo pipefail
+          upload_metadata() {
+            local path="$1"
+            local relative_path="${path#rpm-repo/}"
+            aws s3 cp --only-show-errors --endpoint-url "$SPACE_ENDPOINT" \
+              --acl public-read \
+              --cache-control 'public,max-age=60,must-revalidate' \
+              --metadata 'max-age=60' \
+              "$path" "s3://$SPACE_BUCKET/$SPACE_PREFIX/$relative_path"
+          }
+          upload_metadata rpm-repo/rsyslog-archive-keyring.asc
+          upload_metadata rpm-repo/rsyslog-daily-stable-opensuse-leap160.repo
+          for repo_subdir in "$RPM_ARCH" SRPMS; do
+            while IFS= read -r -d '' path; do
+              upload_metadata "$path"
+            done < <(
+              find "rpm-repo/$repo_subdir/repodata" -type f \
+                ! -name repomd.xml ! -name repomd.xml.asc -print0
+            )
+            upload_metadata "rpm-repo/$repo_subdir/repodata/repomd.xml"
+            upload_metadata "rpm-repo/$repo_subdir/repodata/repomd.xml.asc"
+          done
+
+  verify:
+    name: verify published openSUSE Leap 16.0 repository
+    needs: [preflight, build, publish]
+    if: needs.preflight.outputs.should_publish == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    container:
+      image: opensuse/leap:16.0
+      options: --user root
+    environment: debian-daily-stable
+    permissions:
+      contents: read
+    env:
+      REPO_URL: ${{ vars.OPENSUSE_LEAP160_DAILY_STABLE_REPO_URL }}
+      ORIGIN_REPO_URL: ${{ vars.OPENSUSE_LEAP160_DAILY_STABLE_ORIGIN_REPO_URL }}
+      EXPECTED_GPG_FINGERPRINT: ${{ vars.DEBIAN_DAILY_STABLE_GPG_FINGERPRINT }}
+      EXPECTED_EVR: ${{ needs.build.outputs.expected_evr }}
+    steps:
+      - name: Install container prerequisites
+        run: |
+          zypper -n install curl gpg2 python3 rpm tar
+
+      - name: Checkout archive automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Verify CDN and exact origin installation
+        id: published_install
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .ci/flake-evidence/logs
+          devtools/ci-flake-phase.sh begin \
+            opensuse-leap160-published-install custom
+          set +e
+          (
+            set -euo pipefail
+            for variable in REPO_URL ORIGIN_REPO_URL EXPECTED_EVR \
+              EXPECTED_GPG_FINGERPRINT; do
+              [ -n "${!variable:-}" ]
+            done
+            verify_dir="$(mktemp -d)"
+            curl -fsSL "$REPO_URL/rsyslog-archive-keyring.asc" \
+              -o "$verify_dir/key.asc"
+            actual_fingerprint="$(
+              gpg --batch --show-keys --with-colons "$verify_dir/key.asc" |
+                awk -F: '$1 == "fpr" { print $10; exit }'
+            )"
+            [ "$actual_fingerprint" = "$EXPECTED_GPG_FINGERPRINT" ]
+            gpg --batch --yes --dearmor \
+              --output "$verify_dir/keyring.gpg" "$verify_dir/key.asc"
+            curl -fsSL "$REPO_URL/$RPM_ARCH/repodata/repomd.xml" \
+              -o "$verify_dir/repomd.xml"
+            curl -fsSL "$REPO_URL/$RPM_ARCH/repodata/repomd.xml.asc" \
+              -o "$verify_dir/repomd.xml.asc"
+            gpgv --keyring "$verify_dir/keyring.gpg" \
+              "$verify_dir/repomd.xml.asc" "$verify_dir/repomd.xml"
+            rm -rf "$verify_dir"
+
+            verification_rc=1
+            for attempt in $(seq 1 20); do
+              if "$OPENSUSE_DAILY_STABLE_HELPER" verify-repo \
+                "$ORIGIN_REPO_URL" "$RPM_ARCH" "$EXPECTED_EVR" \
+                "$EXPECTED_GPG_FINGERPRINT"; then
+                verification_rc=0
+                break
+              fi
+              echo "Origin repository not ready yet, retrying ($attempt/20)..."
+              [ "$attempt" -eq 20 ] || sleep 30
+            done
+            [ "$verification_rc" -eq 0 ]
+
+            curl -fsSL "$ORIGIN_REPO_URL/rsyslog-archive-keyring.asc" \
+              -o /tmp/rsyslog-archive-keyring.asc
+            rpm --import /tmp/rsyslog-archive-keyring.asc
+            # Zypper, not this shell, expands the literal $basearch token.
+            # shellcheck disable=SC2016
+            printf '%s\n' \
+              '[rsyslog-daily-stable]' \
+              'name=rsyslog daily stable for openSUSE Leap 16.0 - $basearch' \
+              "baseurl=$ORIGIN_REPO_URL/\$basearch" \
+              'enabled=1' \
+              'autorefresh=1' \
+              'gpgcheck=1' \
+              'repo_gpgcheck=1' \
+              'pkg_gpgcheck=1' \
+              "gpgkey=$ORIGIN_REPO_URL/rsyslog-archive-keyring.asc" \
+              > /etc/zypp/repos.d/rsyslog-daily-stable.repo
+            zypper --gpg-auto-import-keys -n refresh rsyslog-daily-stable
+            zypper -n install --oldpackage \
+              "rsyslog=$EXPECTED_EVR" \
+              "rsyslog-module-ossl=$EXPECTED_EVR" \
+              "rsyslog-doc=$EXPECTED_EVR"
+            for package in rsyslog rsyslog-module-ossl rsyslog-doc; do
+              installed_evr="$(
+                rpm -q --qf '%{VERSION}-%{RELEASE}\n' "$package"
+              )"
+              [ "$installed_evr" = "$EXPECTED_EVR" ]
+            done
+            rsyslogd -v
+            rsyslogd -N1
+          ) 2>&1 | tee \
+            .ci/flake-evidence/logs/opensuse-leap160-published-install.log
+          install_status=${PIPESTATUS[0]}
+          set -e
+          devtools/ci-flake-phase.sh end \
+            opensuse-leap160-published-install custom "$install_status"
+          exit "$install_status"
+
+      - name: Upload publication failure evidence
+        if: failure() && steps.published_install.outcome == 'failure'
+        uses: ./.github/actions/upload-flake-evidence
+        with:
+          job-name: openSUSE Leap 16.0 daily stable verification
+
+  report_failure:
+    name: report failure
+    needs: [preflight, build, publish, verify]
+    if: >-
+      always() &&
+      github.event_name == 'schedule' &&
+      (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Create or update failure issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          VERSION: ${{ needs.build.outputs.expected_evr }}
+          PREFLIGHT_RESULT: ${{ needs.preflight.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+        with:
+          script: |
+            const version = process.env.VERSION || `run-${context.runId}`;
+            const title = '[opensuse-leap160-daily-stable] package archive failure';
+            const body = [
+              `Automated openSUSE Leap 16.0 daily stable failed for \`${version}\`.`,
+              '',
+              `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `Workflow commit: ${context.sha}`,
+              '',
+              'Job results:',
+              `- preflight: ${process.env.PREFLIGHT_RESULT}`,
+              `- build: ${process.env.BUILD_RESULT}`,
+              `- publish: ${process.env.PUBLISH_RESULT}`,
+              `- verify: ${process.env.VERIFY_RESULT}`
+            ].join('\n');
+            const {owner, repo} = context.repo;
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', per_page: 100
+            });
+            const issue = existing.find(item => item.title === title && !item.pull_request);
+            if (issue) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issue.number, body
+              });
+              return;
+            }
+            const created = await github.rest.issues.create({owner, repo, title, body});
+            try {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: created.data.number,
+                labels: ['release', 'packaging', 'daily-stable', 'automated']
+              });
+            } catch (error) {
+              core.warning(`Could not add labels: ${error.message}`);
+            }

--- a/devtools/release/opensuse-daily-stable.sh
+++ b/devtools/release/opensuse-daily-stable.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+	cat >&2 <<'EOF'
+Usage: opensuse-daily-stable.sh <command> [args...]
+
+Commands:
+  version
+  prepare-sources <baseline-root> <dist-tarball> <doc-tarball> <output-dir> <policy-file> <version> <release>
+  build-package <prepared-dir> <artifact-dir> <build-log> <expected-evr> <arch>
+  sign-rpms <artifact-dir> <fingerprint>
+  generate-repo <artifact-dir> <repo-dir> <arch> <fingerprint> <passphrase-file>
+  verify-repo <repo-url> <arch> <expected-evr> <expected-fingerprint>
+  manifest <artifact-dir> <expected-evr> <arch> <channel> <distro> <distro-version>
+EOF
+}
+
+die() {
+	echo "ERROR: $*" >&2
+	exit 1
+}
+
+base_version() {
+	local configure_file script_dir
+
+	script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	configure_file="${RSYSLOG_SOURCE_DIR:-$script_dir/../..}/configure.ac"
+	sed -n 's/AC_INIT(\[rsyslog\],\[\([^]]*\)\].*/\1/p' "$configure_file" |
+		sed 's/\.daily$//'
+}
+
+short_commit_sha() {
+	local candidate="${SOURCE_GIT_SHA:-${GITHUB_SHA:-}}"
+
+	if [ -n "$candidate" ] &&
+		printf '%s\n' "$candidate" | grep -Eq '^[0-9a-fA-F]{12,64}$'; then
+		printf '%.12s\n' "$candidate" | tr '[:upper:]' '[:lower:]'
+		return
+	fi
+
+	git rev-parse --verify HEAD >/dev/null 2>&1 ||
+		die "could not determine git commit"
+	git rev-parse --short=12 HEAD
+}
+
+cmd_version() {
+	local version date run attempt short_sha release expected_evr
+
+	version="$(base_version)"
+	[ -n "$version" ] || die "could not determine base version"
+	date="${RSYSLOG_BUILD_DATE:-$(date -u +%Y%m%d)}"
+	printf '%s\n' "$date" | grep -Eq '^[0-9]{8}$' ||
+		die "RSYSLOG_BUILD_DATE must use YYYYMMDD"
+	run="${GITHUB_RUN_NUMBER:-0}"
+	attempt="${GITHUB_RUN_ATTEMPT:-1}"
+	short_sha="$(short_commit_sha)"
+	release="0.daily${date}.${run}.${attempt}.git${short_sha}.adiscon1.lp160"
+	expected_evr="${version}-${release}"
+
+	printf '%s\n' "$expected_evr"
+	if [ -n "${GITHUB_OUTPUT:-}" ]; then
+		{
+			printf 'version=%s\n' "$version"
+			printf 'release=%s\n' "$release"
+			printf 'expected_evr=%s\n' "$expected_evr"
+			printf 'archive_date=%s-%s-%s\n' \
+				"${date:0:4}" "${date:4:2}" "${date:6:2}"
+		} >> "$GITHUB_OUTPUT"
+	fi
+}
+
+cmd_prepare_sources() {
+	local baseline_root="$1"
+	local dist_tarball="$2"
+	local doc_tarball="$3"
+	local output_dir="$4"
+	local policy_file="$5"
+	local version="$6"
+	local release="$7"
+	local baseline_spec baseline_sources spec_file tmp_dir source_root
+
+	baseline_spec="$baseline_root/SPECS/rsyslog.spec"
+	baseline_sources="$baseline_root/SOURCES"
+	[ -f "$baseline_spec" ] || die "missing openSUSE spec: $baseline_spec"
+	[ -d "$baseline_sources" ] || die "missing openSUSE sources: $baseline_sources"
+	[ -f "$dist_tarball" ] || die "missing dist tarball: $dist_tarball"
+	[ -f "$doc_tarball" ] || die "missing documentation tarball: $doc_tarball"
+	[ -f "$policy_file" ] || die "missing openSUSE policy: $policy_file"
+
+	rm -rf "$output_dir"
+	mkdir -p "$output_dir/SOURCES" "$output_dir/SPECS"
+	cp -a "$baseline_sources/." "$output_dir/SOURCES/"
+	cp "$baseline_spec" "$output_dir/SPECS/rsyslog.spec"
+	spec_file="$output_dir/SPECS/rsyslog.spec"
+
+	tmp_dir="$(mktemp -d)"
+	trap 'rm -rf "$tmp_dir"' RETURN
+	tar -xzf "$dist_tarball" -C "$tmp_dir"
+	source_root="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+	[ -n "$source_root" ] || die "dist tarball has no source directory"
+	[ "$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1 ] ||
+		die "dist tarball must contain exactly one source directory"
+	mv "$source_root" "$tmp_dir/rsyslog-$version"
+	tar -C "$tmp_dir" -czf "$output_dir/SOURCES/rsyslog-$version.tar.gz" \
+		"rsyslog-$version"
+	cp "$doc_tarball" "$output_dir/SOURCES/rsyslog-doc-$version.tar.gz"
+
+	python3 - "$spec_file" "$policy_file" "$version" "$release" <<'PY'
+import json
+import pathlib
+import re
+import sys
+from datetime import datetime, timezone
+
+spec_path = pathlib.Path(sys.argv[1])
+policy_path = pathlib.Path(sys.argv[2])
+version = sys.argv[3]
+release = sys.argv[4]
+spec = spec_path.read_text(encoding="utf-8")
+policy = json.loads(policy_path.read_text(encoding="utf-8"))
+
+if re.search(r"(?m)^Patch\d*:\s*", spec):
+    raise SystemExit("openSUSE baseline gained patches; review them before packaging main")
+
+build_requires = policy.get("supplemental_build_requires", [])
+packages = [entry.get("package", "").strip() for entry in build_requires]
+if any(not package for package in packages):
+    raise SystemExit("policy contains an empty supplemental BuildRequires package")
+for package in packages:
+    if re.search(rf"(?m)^BuildRequires:\s*{re.escape(package)}(?:\s|$)", spec):
+        continue
+    spec, count = re.subn(
+        r"(?m)^(BuildRequires:\s*bison\s*)$",
+        rf"\1\nBuildRequires: {package}",
+        spec,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit(f"could not insert supplemental BuildRequires: {package}")
+
+core_files = policy.get("supplemental_core_files", [])
+if any(not path.strip() for path in core_files):
+    raise SystemExit("policy contains an empty supplemental core file")
+for path in core_files:
+    if re.search(rf"(?m)^{re.escape(path)}\s*$", spec):
+        continue
+    spec, count = re.subn(
+        r"(?m)^(%\{rsyslog_module_dir_nodeps\}/lmzlibw\.so\s*)$",
+        rf"\1\n{path}",
+        spec,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit(f"could not add supplemental core file: {path}")
+
+spec, macro_count = re.subn(
+    r"(?m)^# drop this with next release when doc tarball version lines up\n"
+    r"%define rsyslog_major .*\n%define rsyslog_patch .*\n",
+    "",
+    spec,
+)
+spec, version_count = re.subn(r"(?m)^Version:\s*.*$", f"Version:        {version}", spec)
+spec, release_count = re.subn(
+    r"(?m)^Release:\s*.*$", f"Release:        {release}", spec
+)
+spec, source_count = re.subn(
+    r"(?m)^Source0:\s*.*$", "Source0:        %{name}-%{version}.tar.gz", spec
+)
+spec, doc_source_count = re.subn(
+    r"(?m)^Source14:\s*.*$", "Source14:       rsyslog-doc-%{version}.tar.gz", spec
+)
+if (macro_count, version_count, release_count, source_count, doc_source_count) != (1, 1, 1, 1, 1):
+    raise SystemExit("openSUSE spec version/source fields did not match exactly once")
+
+stamp = datetime.now(timezone.utc).strftime("%a %b %d %Y")
+entry = (
+    f"%changelog\n* {stamp} Adiscon package maintainers "
+    f"<release-bot@adiscon.com> - {version}-{release}\n"
+    "- Automated rsyslog openSUSE Leap 16.0 daily stable build.\n\n"
+)
+spec, changelog_count = re.subn(r"(?m)^%changelog\s*$", entry.rstrip(), spec, count=1)
+if changelog_count != 1:
+    raise SystemExit("openSUSE spec has no unique %changelog marker")
+
+spec_path.write_text(spec, encoding="utf-8")
+PY
+
+	rm -rf "$tmp_dir"
+	trap - RETURN
+}
+
+cmd_build_package() {
+	local prepared_dir="$1"
+	local artifact_dir="$2"
+	local build_log="$3"
+	local expected_evr="$4"
+	local arch="$5"
+	local build_root srpm rpm_file actual_evr rc
+
+	command -v rpmbuild >/dev/null || die "rpmbuild is not installed"
+	rm -rf "$artifact_dir"
+	mkdir -p "$artifact_dir/srpm" "$artifact_dir/rpms"
+
+	set +e
+	rpmbuild -bs --define "_topdir $prepared_dir" \
+		"$prepared_dir/SPECS/rsyslog.spec" 2>&1 | tee "$build_log"
+	rc=${PIPESTATUS[0]}
+	set -e
+	[ "$rc" -eq 0 ] || return "$rc"
+
+	srpm="$(find "$prepared_dir/SRPMS" -maxdepth 1 -type f -name '*.src.rpm' -print -quit)"
+	[ -n "$srpm" ] || die "rpmbuild did not produce a source RPM"
+	cp "$srpm" "$artifact_dir/srpm/"
+
+	build_root="$(mktemp -d)"
+	trap 'rm -rf "$build_root"' RETURN
+	mkdir -p "$build_root/BUILD" "$build_root/BUILDROOT" "$build_root/RPMS" \
+		"$build_root/SOURCES" "$build_root/SPECS" "$build_root/SRPMS"
+	set +e
+	rpmbuild --rebuild --define "_topdir $build_root" "$srpm" \
+		2>&1 | tee -a "$build_log"
+	rc=${PIPESTATUS[0]}
+	set -e
+	[ "$rc" -eq 0 ] || return "$rc"
+
+	find "$build_root/RPMS" -type f -name '*.rpm' -exec cp -a {} "$artifact_dir/rpms/" \;
+	rpm_file="$(find "$artifact_dir/rpms" -maxdepth 1 -type f \
+		-name 'rsyslog-[0-9]*.rpm' ! -name '*-debuginfo-*' ! -name '*-debugsource-*' \
+		-print -quit)"
+	[ -n "$rpm_file" ] || die "rpmbuild did not produce the base rsyslog RPM"
+	[ "$(rpm -qp --qf '%{ARCH}\n' "$rpm_file")" = "$arch" ] ||
+		die "base RPM architecture does not match $arch"
+	actual_evr="$(rpm -qp --qf '%{VERSION}-%{RELEASE}\n' "$rpm_file")"
+	[ "$actual_evr" = "$expected_evr" ] ||
+		die "built RPM EVR $actual_evr does not match $expected_evr"
+
+	cp "$build_log" "$artifact_dir/build.log"
+	cp "$prepared_dir/SPECS/rsyslog.spec" "$artifact_dir/rsyslog.spec"
+	rm -rf "$build_root"
+	trap - RETURN
+}
+
+command="${1:-}"
+case "$command" in
+	version)
+		shift
+		cmd_version "$@"
+		;;
+	prepare-sources)
+		shift
+		cmd_prepare_sources "$@"
+		;;
+	build-package)
+		shift
+		cmd_build_package "$@"
+		;;
+	sign-rpms | generate-repo | verify-repo | manifest)
+		exec "$(dirname "$0")/rpm-daily-stable.sh" "$@"
+		;;
+	*)
+		usage
+		exit 2
+		;;
+esac


### PR DESCRIPTION
## Summary

- build current rsyslog main with the official openSUSE Leap 16.0 source RPM definitions
- preserve Leap feature choices, configuration, systemd unit, ownership, and full native subpackage split
- regenerate current documentation while retaining the native `rsyslog-doc` package
- publish signed immutable daily RPM/SRPM generations to DigitalOcean Spaces
- verify signed CDN metadata and exact packages in a clean Leap 16.0 container
- report scheduled failures through a deduplicated GitHub issue

## Validation

- native Leap 16.0 RPM build produced the full distro package set
- clean Leap 16.0 exact-EVR install of rsyslog, rsyslog-module-ossl, and rsyslog-doc
- `rsyslogd -v` and `rsyslogd -N1`
- PR-ready Ubuntu 26.04 gate: 1,535 tests, 0 failures
- clang static analyzer: no bugs found
- ShellCheck, actionlint, flake-evidence coverage, and pinned zizmor 1.25.2
- local Cubic complete-diff review assessed; its AWS CLI warning is covered by the pinned GitHub-hosted runner image and the same proven archive workflows

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

