### PR TITLE
fix(packaging): provision clean RPM workflow prerequisites

### DIFF
--- a/.github/workflows/fedora44_daily_stable.yml
+++ b/.github/workflows/fedora44_daily_stable.yml
@@ -484,7 +484,7 @@ jobs:
     steps:
       - name: Install container prerequisites
         run: |
-          dnf -q -y install tar
+          dnf -q -y install python3 tar
           dnf -q -y swap gnupg2-minimal gnupg2
 
       - name: Checkout archive automation

--- a/.github/workflows/opensuse_leap160_daily_stable.yml
+++ b/.github/workflows/opensuse_leap160_daily_stable.yml
@@ -175,6 +175,9 @@ jobs:
               zypper -n install findutils gzip python3 rpm-build tar
               zypper -n modifyrepo --enable openSUSE:repo-oss-source
               zypper -n refresh openSUSE:repo-oss-source
+              # Keep the official source RPM for provenance and extraction;
+              # --build-deps-only does not download it on a clean runner.
+              zypper -n source-install --download-only --no-build-deps rsyslog
               zypper -n source-install --build-deps-only rsyslog
               # These four are already native conditional BuildRequires, but
               # zypper source-install does not resolve them on Leap 16.0.


### PR DESCRIPTION
The first real RPM daily-stable runs exposed two clean-runner prerequisite gaps:\n\n- openSUSE: zypper source-install --build-deps-only installs dependencies but does not retain the official source RPM that the workflow hashes and extracts. Add an explicit source-only download transaction first.\n- Fedora: the minimal verification container lacked Python, which the shared RPM metadata verifier and failure-evidence action require. Install python3 with the other verifier prerequisites.\n\nBoth changes preserve the distro-native package definitions and repository policy.\n\nValidation:\n- pristine opensuse/leap:16.0 container retained rsyslog-8.2502.0-160000.3.1.src.rpm in the expected zypper cache\n- freshly published Fedora archive passed signed metadata validation, exact rsyslog/rsyslog-crypto/rsyslog-openssl installation in a clean fedora:44 container, rsyslogd -v, and rsyslogd -N1\n- actionlint passed\n- flake-evidence coverage checker passed\n- zizmor 1.25.2 passed\n- Ubuntu 26.04 PR-ready run: 1535 total, 1506 passed, 29 skipped, 0 failed\n- static analyzer: no bugs found\n- local Cubic: no issues found\n\nFollow-up to #7442, #7443, and failed real runs:\n- https://github.com/rsyslog/rsyslog/actions/runs/30341638993\n- https://github.com/rsyslog/rsyslog/actions/runs/30341756987