### PR TITLE
macos: suppress libsystem_trace ASAN false positive

### DIFF
--- a/.github/workflows/run_macos_weekly.yml
+++ b/.github/workflows/run_macos_weekly.yml
@@ -109,7 +109,8 @@ jobs:
           if [ "${{ matrix.sanitizer }}" = "asan" ]; then
             export ASAN_OPTIONS=":halt_on_error=1:\
               check_initialization_order=1:strict_init_order=1:\
-              detect_stack_use_after_return=1:print_stacktrace=1"
+              detect_stack_use_after_return=1:print_stacktrace=1:\
+              suppressions=$PWD/tests/asan-macos.supp"
           elif [ "${{ matrix.sanitizer }}" = "tsan" ]; then
             export TSAN_OPTIONS=":halt_on_error=1:\
               detect_deadlocks=1:history_size=7:suppressions=$PWD/tests/tsan-rt.supp"

--- a/tests/asan-macos.supp
+++ b/tests/asan-macos.supp
@@ -1,0 +1,4 @@
+# Apple libsystem_trace false positive under ASAN during getaddrinfo init
+# (os_log_create -> _os_trace_get_image_info strcmp into a global redzone).
+# Seen on macos-15 arm64 weekly ASAN in omfwd-rebind-tcp (#7428).
+interceptor_via_fun:_os_trace_get_image_info


### PR DESCRIPTION
Weekly macOS ASAN failed omfwd-rebind-tcp on an Apple
libsystem_trace interceptor false positive during
getaddrinfo/os_log init, not an rsyslog memory bug.
Add a narrow ASAN suppression for
_os_trace_get_image_info and wire it into the weekly
macOS ASAN job.

Closes: https://github.com/rsyslog/rsyslog/issues/7428