### PR TITLE
tests: avoid UDP port race in rfctag replacer test

### DIFF
--- a/tests/proprepltest-rfctag-udp.sh
+++ b/tests/proprepltest-rfctag-udp.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
+# Verify UDP RFC-tag truncation to 32 characters via property replacer.
+# The imudp listener owns an OS-assigned port before tcpflood sends, preventing
+# parallel UDP tests from sharing a preselected port; the ordered truncated tag
+# output is the pass/fail oracle.
 . ${srcdir:=.}/diag.sh init
 generate_conf
+PORT_RCVR_FILE="$RSYSLOG_DYNNAME.imudp.port"
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="'$TCPFLOOD_PORT'")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'")
 
 template(name="outfmt" type="string" string="+%syslogtag:1:32%+\n")
 
@@ -14,6 +19,7 @@ template(name="outfmt" type="string" string="+%syslogtag:1:32%+\n")
 
 '
 startup
+assign_tcpflood_port "$PORT_RCVR_FILE"
 tcpflood -m1 -T "udp" -M "\"<167>Mar  6 16:57:54 172.20.245.8 TAG: Rest of message...\""
 tcpflood -m1 -T "udp" -M "\"<167>Mar  6 16:57:54 172.20.245.8 0 Rest of message...\""
 tcpflood -m1 -T "udp" -M "\"<167>Mar  6 16:57:54 172.20.245.8 01234567890123456789012345678901 Rest of message...\""


### PR DESCRIPTION
Why: Daily full-distro CI showed proprepltest-rfctag-udp can fail when parallel UDP tests race on a preselected port.

Impact: Test-only change; RFC-tag truncation assertions stay the same, but the UDP listener no longer uses a racy port.

Before/After: Before, tcpflood sent to a port chosen before imudp bound it. After, imudp binds port 0 and reports the owned port before tcpflood sends.

Technical Overview: Mirror the #7364 deflake for the leftover proprepltest-rfctag-udp case. Configure imudp with address 127.0.0.1, port 0, and listenPortFileName. After startup, read the assigned listener port with assign_tcpflood_port. Keep the original truncated-tag expected output. Refresh the test header to document the parser invariant, race prevention, and oracle.

Closes: https://github.com/rsyslog/rsyslog/issues/7404

With the help of AI-Agents: Composer

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

