### PR TITLE
packaging: harden daily schedule preflight

### DIFF
--- a/.github/ALPINE_DAILY_STABLE.md
+++ b/.github/ALPINE_DAILY_STABLE.md
@@ -55,10 +55,16 @@ Add this environment secret:
 - `ALPINE_DAILY_STABLE_RSA_PRIVATE_KEY`: PEM-encoded RSA private key used by
   `abuild` to sign APK packages and their APKINDEX.
 
-Add these repository variables:
+Add this repository variable:
 
 - `ALPINE324_DAILY_STABLE_ENABLED`: `true` only after the first end-to-end
   publication succeeds.
+
+The scheduled workflow fails preflight if this switch is missing or is not
+exactly `true` or `false`, so a configuration error cannot appear successful.
+
+Add these variables to the `debian-daily-stable` environment:
+
 - `ALPINE324_DAILY_STABLE_REPO_URL`: public CDN URL ending in
   `/apk/daily-stable/alpine/3.24`.
 - `ALPINE324_DAILY_STABLE_ORIGIN_REPO_URL`: public Spaces origin URL ending in

--- a/.github/AMAZONLINUX_DAILY_STABLE.md
+++ b/.github/AMAZONLINUX_DAILY_STABLE.md
@@ -63,10 +63,16 @@ already held by the protected `debian-daily-stable` GitHub Environment. Despite
 its legacy name, that environment is the security boundary for the shared
 package archive and is not limited to Debian.
 
-Add these environment variables:
+Add this repository variable:
 
 - `AMAZONLINUX2023_DAILY_STABLE_ENABLED`: `true` only after the first complete
   publication succeeds.
+
+The scheduled workflow fails preflight if this switch is missing or is not
+exactly `true` or `false`, so a configuration error cannot appear successful.
+
+Add these variables to the `debian-daily-stable` environment:
+
 - `AMAZONLINUX2023_DAILY_STABLE_REPO_URL`: public CDN URL ending in
   `/rpm/daily-stable/amazonlinux/2023`.
 - `AMAZONLINUX2023_DAILY_STABLE_ORIGIN_REPO_URL`: public Spaces origin URL

--- a/.github/DEBIAN_DAILY_STABLE.md
+++ b/.github/DEBIAN_DAILY_STABLE.md
@@ -71,6 +71,10 @@ Configure these GitHub repository variables:
 - `DEBIAN_DAILY_STABLE_GPG_FINGERPRINT`: full fingerprint of the archive
   signing key.
 
+All daily-package schedule switches are repository variables. A scheduled
+workflow fails preflight, and therefore reports a failure issue, if its switch
+is missing or is not exactly `true` or `false`.
+
 Create a protected `debian-daily-stable` GitHub Environment and add:
 
 - `DEBIAN_DAILY_STABLE_SPACE_ACCESS_KEY`

--- a/.github/FEDORA_DAILY_STABLE.md
+++ b/.github/FEDORA_DAILY_STABLE.md
@@ -62,10 +62,16 @@ already held by the protected `debian-daily-stable` GitHub Environment. Despite
 its legacy name, that environment is the security boundary for the shared
 package archive and is not limited to Debian.
 
-Add these environment variables:
+Add this repository variable:
 
 - `FEDORA44_DAILY_STABLE_ENABLED`: `true` only after the first complete
   publication succeeds.
+
+The scheduled workflow fails preflight if this switch is missing or is not
+exactly `true` or `false`, so a configuration error cannot appear successful.
+
+Add these variables to the `debian-daily-stable` environment:
+
 - `FEDORA44_DAILY_STABLE_REPO_URL`: public CDN URL ending in
   `/rpm/daily-stable/fedora/44`.
 - `FEDORA44_DAILY_STABLE_ORIGIN_REPO_URL`: public Spaces origin URL

--- a/.github/OPENSUSE_DAILY_STABLE.md
+++ b/.github/OPENSUSE_DAILY_STABLE.md
@@ -72,10 +72,16 @@ already held by the protected `debian-daily-stable` GitHub Environment. Despite
 its legacy name, that environment is the security boundary for the shared
 package archive and is not limited to Debian.
 
-Add these environment variables:
+Add this repository variable:
 
 - `OPENSUSE_LEAP160_DAILY_STABLE_ENABLED`: `true` only after the first complete
   publication succeeds.
+
+The scheduled workflow fails preflight if this switch is missing or is not
+exactly `true` or `false`, so a configuration error cannot appear successful.
+
+Add these variables to the `debian-daily-stable` environment:
+
 - `OPENSUSE_LEAP160_DAILY_STABLE_REPO_URL`: public CDN URL ending in
   `/rpm/daily-stable/opensuse/leap/16.0`.
 - `OPENSUSE_LEAP160_DAILY_STABLE_ORIGIN_REPO_URL`: public Spaces origin URL

--- a/.github/workflows/alpine324_daily_stable.yml
+++ b/.github/workflows/alpine324_daily_stable.yml
@@ -74,10 +74,18 @@ jobs:
               fi
               ;;
             schedule)
-              if [ "${SCHEDULE_ENABLED:-false}" = true ]; then
-                should_run=true
-                should_publish=true
-              fi
+              case "${SCHEDULE_ENABLED:-}" in
+                true)
+                  should_run=true
+                  should_publish=true
+                  ;;
+                false)
+                  ;;
+                *)
+                  echo "::error::ALPINE324_DAILY_STABLE_ENABLED must be a repository variable set to true or false"
+                  exit 1
+                  ;;
+              esac
               ;;
           esac
           {

--- a/.github/workflows/amazonlinux2023_daily_stable.yml
+++ b/.github/workflows/amazonlinux2023_daily_stable.yml
@@ -73,10 +73,18 @@ jobs:
               fi
               ;;
             schedule)
-              if [ "${SCHEDULE_ENABLED:-false}" = true ]; then
-                should_run=true
-                should_publish=true
-              fi
+              case "${SCHEDULE_ENABLED:-}" in
+                true)
+                  should_run=true
+                  should_publish=true
+                  ;;
+                false)
+                  ;;
+                *)
+                  echo "::error::AMAZONLINUX2023_DAILY_STABLE_ENABLED must be a repository variable set to true or false"
+                  exit 1
+                  ;;
+              esac
               ;;
           esac
           {

--- a/.github/workflows/debian_daily_stable.yml
+++ b/.github/workflows/debian_daily_stable.yml
@@ -84,10 +84,18 @@ jobs:
               fi
               ;;
             schedule)
-              if [ "${SCHEDULE_ENABLED:-false}" = "true" ]; then
-                should_run=true
-                should_publish=true
-              fi
+              case "${SCHEDULE_ENABLED:-}" in
+                true)
+                  should_run=true
+                  should_publish=true
+                  ;;
+                false)
+                  ;;
+                *)
+                  echo "::error::DEBIAN_DAILY_STABLE_ENABLED must be a repository variable set to true or false"
+                  exit 1
+                  ;;
+              esac
               ;;
           esac
 

--- a/.github/workflows/el10_daily_stable.yml
+++ b/.github/workflows/el10_daily_stable.yml
@@ -74,10 +74,18 @@ jobs:
               fi
               ;;
             schedule)
-              if [ "${SCHEDULE_ENABLED:-false}" = true ]; then
-                should_run=true
-                should_publish=true
-              fi
+              case "${SCHEDULE_ENABLED:-}" in
+                true)
+                  should_run=true
+                  should_publish=true
+                  ;;
+                false)
+                  ;;
+                *)
+                  echo "::error::EL10_DAILY_STABLE_ENABLED must be a repository variable set to true or false"
+                  exit 1
+                  ;;
+              esac
               ;;
           esac
           {

--- a/.github/workflows/fedora44_daily_stable.yml
+++ b/.github/workflows/fedora44_daily_stable.yml
@@ -73,10 +73,18 @@ jobs:
               fi
               ;;
             schedule)
-              if [ "${SCHEDULE_ENABLED:-false}" = true ]; then
-                should_run=true
-                should_publish=true
-              fi
+              case "${SCHEDULE_ENABLED:-}" in
+                true)
+                  should_run=true
+                  should_publish=true
+                  ;;
+                false)
+                  ;;
+                *)
+                  echo "::error::FEDORA44_DAILY_STABLE_ENABLED must be a repository variable set to true or false"
+                  exit 1
+                  ;;
+              esac
               ;;
           esac
           {

--- a/.github/workflows/opensuse_leap160_daily_stable.yml
+++ b/.github/workflows/opensuse_leap160_daily_stable.yml
@@ -73,10 +73,18 @@ jobs:
               fi
               ;;
             schedule)
-              if [ "${SCHEDULE_ENABLED:-false}" = true ]; then
-                should_run=true
-                should_publish=true
-              fi
+              case "${SCHEDULE_ENABLED:-}" in
+                true)
+                  should_run=true
+                  should_publish=true
+                  ;;
+                false)
+                  ;;
+                *)
+                  echo "::error::OPENSUSE_LEAP160_DAILY_STABLE_ENABLED must be a repository variable set to true or false"
+                  exit 1
+                  ;;
+              esac
               ;;
           esac
           {

--- a/.github/workflows/ubuntu_daily_stable.yml
+++ b/.github/workflows/ubuntu_daily_stable.yml
@@ -85,10 +85,18 @@ jobs:
               fi
               ;;
             schedule)
-              if [ "${SCHEDULE_ENABLED:-false}" = "true" ]; then
-                should_run=true
-                should_publish=true
-              fi
+              case "${SCHEDULE_ENABLED:-}" in
+                true)
+                  should_run=true
+                  should_publish=true
+                  ;;
+                false)
+                  ;;
+                *)
+                  echo "::error::UBUNTU_DAILY_STABLE_ENABLED must be a repository variable set to true or false"
+                  exit 1
+                  ;;
+              esac
               ;;
           esac
 


### PR DESCRIPTION
## Summary

- make all seven daily-package schedule switches repository-level operational variables
- reject missing or invalid switch values during scheduled preflight
- preserve protected-environment scoping for archive URLs and credentials
- document the shared configuration principle

## Why

Six scheduled workflows silently skipped because their enable switches existed only in the protected environment, which the preflight job does not enter. Empty values were treated as disabled, producing false-green runs and no failure issue.

## Validation

- actionlint: passed for all seven workflows
- zizmor 1.25.2 strict collection: passed, no findings
- flake-evidence coverage checker: passed
- extracted preflight scripts: true, false, missing, and manual-publish cases passed for all seven workflows
- real scheduled reruns: Ubuntu 26.04, EL10, Alpine 3.24, Amazon Linux 2023, Fedora 44, and openSUSE Leap 16.0 all built, published, installed, and smoke-tested successfully; Debian 13 had already passed today
- Ubuntu 26.04 broad local suite: 1505 passed, 29 skipped, with one unrelated flaky failure on each of two attempts; segmented-da-idle-cleanup-failure.sh and omfwd-suspended-no-early-commit.sh each passed immediate isolated reruns
- local Cubic: unavailable because the installed CLI subscription is expired

## Operational configuration

All seven repository-level enable switches are currently set to true. Duplicate environment-scoped switches will be removed after merge; archive configuration and credentials remain protected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

