### PR TITLE
packaging: add native ARM daily builds

### DIFF
--- a/.github/ALPINE_DAILY_STABLE.md
+++ b/.github/ALPINE_DAILY_STABLE.md
@@ -1,7 +1,7 @@
 # Alpine daily stable package archive
 
 The `alpine 3.24 daily stable` workflow builds current rsyslog `main` for
-Alpine Linux 3.24 on `x86_64`. It starts with Alpine's official
+Alpine Linux 3.24 on `x86_64` and `aarch64`. It starts with Alpine's official
 `3.24-stable` `main/rsyslog` APKBUILD and replaces only the upstream source
 and daily version. This preserves Alpine's configure choices, dependencies,
 subpackage split, OpenRC integration, and default configuration.
@@ -20,19 +20,25 @@ The repository URL ends in:
 /apk/daily-stable/alpine/3.24
 ```
 
-The current `x86_64` repository is below that path:
+The architecture repositories are below that path:
 
 ```text
 x86_64/APKINDEX.tar.gz
 x86_64/*.apk
+aarch64/APKINDEX.tar.gz
+aarch64/*.apk
 ```
 
 Every publication also records its manifest, checksums, prepared APKBUILD,
 and build log below:
 
 ```text
-snapshots/YYYY-MM-DD/PACKAGE_VERSION/
+snapshots/YYYY-MM-DD/PACKAGE_VERSION/x86_64/
+snapshots/YYYY-MM-DD/PACKAGE_VERSION/aarch64/
 ```
+
+Each APK is built and installed on a native runner of the matching
+architecture.
 
 APK files and snapshots are immutable and retained for at least five years.
 The workflow merges the previous signed index with each new package set so
@@ -81,8 +87,9 @@ remain unchanged. A DigitalOcean account API token is not required.
    artifacts.
 3. Run it manually with publication enabled.
 4. Confirm that the CDN key and index are reachable and that a clean
-   `alpine:3.24` container trusts the public origin key, installs the exact
-   daily rsyslog version, and passes `rsyslogd -N1`. Exact-version validation
+   native `alpine:3.24` containers for both architectures trust the public
+   origin key, install the exact daily rsyslog version, and pass
+   `rsyslogd -N1`. Exact-version validation
    uses the origin because the CDN's minimum TTL can exceed CI runtime.
 5. Set `ALPINE324_DAILY_STABLE_ENABLED=true`.
 

--- a/.github/AMAZONLINUX_DAILY_STABLE.md
+++ b/.github/AMAZONLINUX_DAILY_STABLE.md
@@ -1,7 +1,7 @@
 # Amazon Linux daily stable package archive
 
 The `amazon linux 2023 daily stable` workflow builds current rsyslog `main`
-for Amazon Linux 2023 on `x86_64`. It downloads Amazon's current official
+for Amazon Linux 2023 on `x86_64` and `aarch64`. It downloads Amazon's current official
 rsyslog source RPM from the `amazonlinux-source` repository on every run and
 uses that spec, configuration, systemd unit, dependency choices, and
 subpackage split as the packaging authority. The source RPM's NEVRA and
@@ -33,6 +33,8 @@ The binary and source repositories are below that path:
 ```text
 x86_64/Packages/*.rpm
 x86_64/repodata/
+aarch64/Packages/*.rpm
+aarch64/repodata/
 SRPMS/Packages/*.src.rpm
 SRPMS/repodata/
 ```
@@ -41,8 +43,12 @@ Every publication also records its manifest, checksums, prepared spec, and
 build log below:
 
 ```text
-snapshots/YYYY-MM-DD/EVR/
+snapshots/YYYY-MM-DD/EVR/x86_64/
+snapshots/YYYY-MM-DD/EVR/aarch64/
 ```
+
+Each binary package is built and installed on a native runner of the matching
+architecture.
 
 RPMs and snapshots are immutable and retained for at least five years. Each
 new repository generation merges prior signed metadata so old daily versions
@@ -88,7 +94,8 @@ required.
 2. Run the workflow manually with publication disabled and inspect the RPMs.
 3. Run it manually with publication enabled.
 4. Confirm the CDN metadata signature and clean-install the exact new EVR from
-   the public origin in `amazonlinux:2023`; verify all installed EVRs,
+   the public origin in native `amazonlinux:2023` containers for both
+   architectures; verify all installed EVRs,
    `rsyslogd -v`, and `rsyslogd -N1`.
 5. Set `AMAZONLINUX2023_DAILY_STABLE_ENABLED=true`.
 

--- a/.github/DEBIAN_DAILY_STABLE.md
+++ b/.github/DEBIAN_DAILY_STABLE.md
@@ -1,7 +1,7 @@
 # Debian daily stable package archive
 
-The `debian daily stable` workflow builds rsyslog from `v8-stable` for Debian
-13 (`trixie`) on `amd64`. Package construction does not run for pull requests;
+The `debian daily stable` workflow builds current rsyslog `main` for Debian 13
+(`trixie`) on `amd64` and `arm64`. Package construction does not run for pull requests;
 the repository's workflow lint and security checks still validate workflow
 changes without consuming a full Debian package-build runner. Manual dispatch
 remains available for bootstrap and recovery. Scheduled publishing remains
@@ -27,14 +27,19 @@ The initial repository URL ends in:
 /apt/daily-stable/debian/13
 ```
 
-This leaves room for later channels, Debian and Ubuntu versions, RPM-based
-distributions, and additional architectures. Debian packages and source
+This leaves room for later channels, Debian and Ubuntu versions, and RPM-based
+distributions. Debian packages and source
 artifacts use immutable paths below `pool/`. Every run also records its
 manifest, checksums, build information, and build log below:
 
 ```text
-snapshots/YYYY-MM-DD/PACKAGE_VERSION/
+snapshots/YYYY-MM-DD/PACKAGE_VERSION/amd64/
+snapshots/YYYY-MM-DD/PACKAGE_VERSION/arm64/
 ```
+
+Signed APT indexes are published under both `binary-amd64/` and
+`binary-arm64/`. Each package is built and installed on a native runner of the
+matching architecture.
 
 The APT indexes retain every published package version. The Space must not have
 a lifecycle rule that removes package-pool, by-hash, or snapshot objects before

--- a/.github/FEDORA_DAILY_STABLE.md
+++ b/.github/FEDORA_DAILY_STABLE.md
@@ -1,7 +1,7 @@
 # Fedora daily stable package archive
 
 The `fedora 44 daily stable` workflow builds current rsyslog `main` for
-Fedora 44 on `x86_64`. It downloads Fedora's current official rsyslog source
+Fedora 44 on `x86_64` and `aarch64`. It downloads Fedora's current official rsyslog source
 RPM from the Fedora 44 repositories on every run and
 uses that spec, configuration, systemd unit, dependency choices, and
 subpackage split as the packaging authority. The source RPM's NEVRA and
@@ -32,6 +32,8 @@ The binary and source repositories are below that path:
 ```text
 x86_64/Packages/*.rpm
 x86_64/repodata/
+aarch64/Packages/*.rpm
+aarch64/repodata/
 SRPMS/Packages/*.src.rpm
 SRPMS/repodata/
 ```
@@ -40,8 +42,12 @@ Every publication also records its manifest, checksums, prepared spec, and
 build log below:
 
 ```text
-snapshots/YYYY-MM-DD/EVR/
+snapshots/YYYY-MM-DD/EVR/x86_64/
+snapshots/YYYY-MM-DD/EVR/aarch64/
 ```
+
+Each binary package is built and installed on a native runner of the matching
+architecture.
 
 RPMs and snapshots are immutable and retained for at least five years. Each
 new repository generation merges prior signed metadata so old daily versions
@@ -87,7 +93,8 @@ required.
 2. Run the workflow manually with publication disabled and inspect the RPMs.
 3. Run it manually with publication enabled.
 4. Confirm the CDN metadata signature and clean-install the exact new EVR from
-   the public origin in `fedora:44`; verify all installed EVRs,
+   the public origin in native `fedora:44` containers for both architectures;
+   verify all installed EVRs,
    `rsyslogd -v`, and `rsyslogd -N1`.
 5. Set `FEDORA44_DAILY_STABLE_ENABLED=true`.
 

--- a/.github/OPENSUSE_DAILY_STABLE.md
+++ b/.github/OPENSUSE_DAILY_STABLE.md
@@ -1,7 +1,7 @@
 # openSUSE daily stable package archive
 
 The `opensuse leap 16.0 daily stable` workflow builds current rsyslog `main`
-for openSUSE Leap 16.0 on `x86_64`. Every run enables Leap's official disabled
+for openSUSE Leap 16.0 on `x86_64` and `aarch64`. Every run enables Leap's official disabled
 source repository and downloads its current rsyslog source RPM. That native
 spec, configuration, systemd unit, feature choices, file ownership, and
 subpackage split are the packaging authority. The source RPM's NEVRA and
@@ -42,6 +42,8 @@ The binary and source repositories are below that path:
 ```text
 x86_64/Packages/*.rpm
 x86_64/repodata/
+aarch64/Packages/*.rpm
+aarch64/repodata/
 SRPMS/Packages/*.src.rpm
 SRPMS/repodata/
 ```
@@ -50,8 +52,12 @@ Every publication also records its manifest, checksums, prepared spec, and
 build log below:
 
 ```text
-snapshots/YYYY-MM-DD/EVR/
+snapshots/YYYY-MM-DD/EVR/x86_64/
+snapshots/YYYY-MM-DD/EVR/aarch64/
 ```
+
+Each binary package is built and installed on a native runner of the matching
+architecture.
 
 RPMs and snapshots are immutable and retained for at least five years. Each
 new repository generation merges prior signed metadata so old daily versions
@@ -98,8 +104,8 @@ required.
 3. Run it manually with publication enabled.
 4. Confirm the CDN metadata signature and clean-install the exact new EVR of
    `rsyslog`, `rsyslog-module-ossl`, and `rsyslog-doc` from the public origin in
-   `opensuse/leap:16.0`; verify all installed EVRs, `rsyslogd -v`, and
-   `rsyslogd -N1`.
+   native `opensuse/leap:16.0` containers for both architectures; verify all
+   installed EVRs, `rsyslogd -v`, and `rsyslogd -N1`.
 5. Set `OPENSUSE_LEAP160_DAILY_STABLE_ENABLED=true`.
 
 The scheduled workflow opens or updates an issue if its build, publication,

--- a/.github/workflows/alpine324_daily_stable.yml
+++ b/.github/workflows/alpine324_daily_stable.yml
@@ -36,7 +36,7 @@ env:
   ALPINE_POLICY_FILE: .github/alpine324-daily-stable-policy.yml
   PACKAGE_FEATURE_CONTRACT: .github/daily-stable-package-features.yml
   ALPINE_BRANCH: 3.24-stable
-  ALPINE_ARCH: x86_64
+  PACKAGE_REPOSITORY_ARCHITECTURES: x86_64 aarch64
   PACKAGE_CHANNEL: daily-stable
   PACKAGE_DISTRO: alpine
   PACKAGE_DISTRO_VERSION: '3.24'
@@ -96,14 +96,24 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   build:
-    name: build Alpine 3.24 x86_64 packages
+    name: build Alpine 3.24 ${{ matrix.arch }} packages
     needs: preflight
     if: needs.preflight.outputs.should_run == 'true'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 150
     environment: debian-daily-stable
     permissions:
       contents: read
+    env:
+      ALPINE_ARCH: ${{ matrix.arch }}
     outputs:
       archive_date: ${{ steps.version.outputs.archive_date }}
       expected_version: ${{ steps.version.outputs.expected_version }}
@@ -149,11 +159,24 @@ jobs:
 
       - name: Generate rsyslog dist tarball
         run: |
-          RSYSLOG_HOME="$GITHUB_WORKSPACE/rsyslog-source" \
-            RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 \
-            devtools/devcontainer.sh --rm \
+          case "$ALPINE_ARCH" in
+            x86_64)
+              RSYSLOG_HOME="$GITHUB_WORKSPACE/rsyslog-source" \
+                RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 \
+                devtools/devcontainer.sh --rm \
+                  .github/scripts/debian_package_build.sh run_dist_build \
+                  /rsyslog
+              ;;
+            aarch64)
+              sudo apt-get update
+              sudo apt-get install -y --no-install-recommends \
+                autoconf autoconf-archive automake bison build-essential \
+                flex gawk git libestr-dev libfastjson-dev libsystemd-dev \
+                libtool libyaml-dev pkg-config python3-docutils zlib1g-dev
               .github/scripts/debian_package_build.sh run_dist_build \
-              /rsyslog
+                "$GITHUB_WORKSPACE/rsyslog-source"
+              ;;
+          esac
           dist_tarball="$(find rsyslog-source -maxdepth 1 -type f \
             -name 'rsyslog-*.tar.gz' -print -quit)"
           [ -n "$dist_tarball" ]
@@ -273,7 +296,7 @@ jobs:
       - name: Upload Alpine package artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: alpine324-daily-stable-${{ steps.version.outputs.expected_version }}
+          name: alpine324-daily-stable-${{ steps.version.outputs.expected_version }}-${{ matrix.arch }}
           path: alpine-daily-stable-artifacts/
           retention-days: 14
           if-no-files-found: error
@@ -329,33 +352,42 @@ jobs:
             }
           done
 
-      - name: Download Alpine package artifacts
+      - name: Download Alpine x86_64 package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: alpine324-daily-stable-${{ needs.build.outputs.expected_version }}
-          path: alpine-daily-stable-artifacts
+          name: alpine324-daily-stable-${{ needs.build.outputs.expected_version }}-x86_64
+          path: alpine-daily-stable-artifacts/x86_64
+
+      - name: Download Alpine aarch64 package artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: alpine324-daily-stable-${{ needs.build.outputs.expected_version }}-aarch64
+          path: alpine-daily-stable-artifacts/aarch64
 
       - name: Verify artifact checksums
         run: |
-          cd alpine-daily-stable-artifacts
-          sha256sum -c SHA256SUMS
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            (cd "alpine-daily-stable-artifacts/$arch" && sha256sum -c SHA256SUMS)
+          done
 
       - name: Download current repository index
         run: |
           set -euo pipefail
-          mkdir -p current-repository
-          index_key="$SPACE_PREFIX/$ALPINE_ARCH/APKINDEX.tar.gz"
-          remote_key="$(
-            aws s3api list-objects-v2 \
-              --endpoint-url "$SPACE_ENDPOINT" --bucket "$SPACE_BUCKET" \
-              --prefix "$index_key" --max-keys 1 \
-              --query 'Contents[0].Key' --output text
-          )"
-          if [ "$remote_key" = "$index_key" ]; then
-            aws s3 cp --only-show-errors --endpoint-url "$SPACE_ENDPOINT" \
-              "s3://$SPACE_BUCKET/$index_key" \
-              current-repository/APKINDEX.tar.gz
-          fi
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            mkdir -p "current-repository/$arch"
+            index_key="$SPACE_PREFIX/$arch/APKINDEX.tar.gz"
+            remote_key="$(
+              aws s3api list-objects-v2 \
+                --endpoint-url "$SPACE_ENDPOINT" --bucket "$SPACE_BUCKET" \
+                --prefix "$index_key" --max-keys 1 \
+                --query 'Contents[0].Key' --output text
+            )"
+            if [ "$remote_key" = "$index_key" ]; then
+              aws s3 cp --only-show-errors --endpoint-url "$SPACE_ENDPOINT" \
+                "s3://$SPACE_BUCKET/$index_key" \
+                "current-repository/$arch/APKINDEX.tar.gz"
+            fi
+          done
 
       - name: Generate signed incremental APK repository
         env:
@@ -365,21 +397,23 @@ jobs:
           private_key="$RUNNER_TEMP/rsyslog-alpine-archive.rsa"
           install -m 600 /dev/null "$private_key"
           printf '%s\n' "$ALPINE_RSA_PRIVATE_KEY" > "$private_key"
-          docker run --rm \
-            -e ALPINE_ARCH -e ALPINE_DAILY_STABLE_HELPER \
-            -v "$GITHUB_WORKSPACE:/workspace" \
-            -v "$RUNNER_TEMP:/runner-temp" \
-            -w /workspace \
-            alpine:3.24 sh -lc '
-              set -euo pipefail
-              apk add --no-cache abuild bash >/dev/null
-              "$ALPINE_DAILY_STABLE_HELPER" generate-index \
-                alpine-daily-stable-artifacts \
-                current-repository/APKINDEX.tar.gz \
-                apk-repo "$ALPINE_ARCH" \
-                /runner-temp/rsyslog-alpine-archive.rsa \
-                alpine-daily-stable-artifacts/rsyslog-alpine-archive.rsa.pub
-            '
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            docker run --rm \
+              -e "ALPINE_ARCH=$arch" -e ALPINE_DAILY_STABLE_HELPER \
+              -v "$GITHUB_WORKSPACE:/workspace" \
+              -v "$RUNNER_TEMP:/runner-temp" \
+              -w /workspace \
+              alpine:3.24 sh -lc '
+                set -euo pipefail
+                apk add --no-cache abuild bash >/dev/null
+                "$ALPINE_DAILY_STABLE_HELPER" generate-index \
+                  "alpine-daily-stable-artifacts/$ALPINE_ARCH" \
+                  "current-repository/$ALPINE_ARCH/APKINDEX.tar.gz" \
+                  apk-repo "$ALPINE_ARCH" \
+                  /runner-temp/rsyslog-alpine-archive.rsa \
+                  "alpine-daily-stable-artifacts/$ALPINE_ARCH/rsyslog-alpine-archive.rsa.pub"
+              '
+          done
           sudo chown -R "$(id -u):$(id -g)" apk-repo
 
       - name: Generate snapshot
@@ -388,12 +422,15 @@ jobs:
           EXPECTED_VERSION: ${{ needs.build.outputs.expected_version }}
         run: |
           snapshot_dir="apk-repo/snapshots/$ARCHIVE_DATE/$EXPECTED_VERSION"
-          mkdir -p "$snapshot_dir"
-          cp -a alpine-daily-stable-artifacts/manifest.json \
-            alpine-daily-stable-artifacts/SHA256SUMS \
-            alpine-daily-stable-artifacts/build.log \
-            alpine-daily-stable-artifacts/APKBUILD \
-            "$snapshot_dir/"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            artifact_dir="alpine-daily-stable-artifacts/$arch"
+            mkdir -p "$snapshot_dir/$arch"
+            cp -a "$artifact_dir/manifest.json" \
+              "$artifact_dir/SHA256SUMS" \
+              "$artifact_dir/build.log" \
+              "$artifact_dir/APKBUILD" \
+              "$snapshot_dir/$arch/"
+          done
 
       - name: Publish immutable APKs and snapshots
         run: |
@@ -430,7 +467,8 @@ jobs:
           while IFS= read -r -d '' path; do
             upload_immutable "$path"
           done < <(
-            find "apk-repo/$ALPINE_ARCH" -maxdepth 1 -type f -name '*.apk' -print0
+            find apk-repo/x86_64 apk-repo/aarch64 \
+              -maxdepth 1 -type f -name '*.apk' -print0
             find apk-repo/snapshots -type f -print0
           )
 
@@ -447,13 +485,23 @@ jobs:
               "$path" "s3://$SPACE_BUCKET/$SPACE_PREFIX/$relative_path"
           }
           upload_metadata apk-repo/rsyslog-alpine-archive.rsa.pub
-          upload_metadata "apk-repo/$ALPINE_ARCH/APKINDEX.tar.gz"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            upload_metadata "apk-repo/$arch/APKINDEX.tar.gz"
+          done
 
   verify:
-    name: verify published Alpine 3.24 repository
+    name: verify published Alpine 3.24 ${{ matrix.arch }} repository
     needs: [preflight, build, publish]
     if: needs.preflight.outputs.should_publish == 'true'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     container:
       image: alpine:3.24
@@ -462,6 +510,7 @@ jobs:
     permissions:
       contents: read
     env:
+      ALPINE_ARCH: ${{ matrix.arch }}
       REPO_URL: ${{ vars.ALPINE324_DAILY_STABLE_REPO_URL }}
       ORIGIN_REPO_URL: ${{ vars.ALPINE324_DAILY_STABLE_ORIGIN_REPO_URL }}
       EXPECTED_PUBLIC_KEY_SHA256: ${{ vars.ALPINE_DAILY_STABLE_RSA_PUBLIC_KEY_SHA256 }}

--- a/.github/workflows/amazonlinux2023_daily_stable.yml
+++ b/.github/workflows/amazonlinux2023_daily_stable.yml
@@ -35,7 +35,7 @@ env:
   AMAZONLINUX_DAILY_STABLE_HELPER: devtools/release/amazonlinux-daily-stable.sh
   AMAZONLINUX_POLICY_FILE: .github/amazonlinux2023-daily-stable-policy.yml
   PACKAGE_FEATURE_CONTRACT: .github/daily-stable-package-features.yml
-  RPM_ARCH: x86_64
+  PACKAGE_REPOSITORY_ARCHITECTURES: x86_64 aarch64
   PACKAGE_CHANNEL: daily-stable
   PACKAGE_DISTRO: amazonlinux
   PACKAGE_DISTRO_VERSION: '2023'
@@ -95,13 +95,23 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   build:
-    name: build Amazon Linux 2023 x86_64 packages
+    name: build Amazon Linux 2023 ${{ matrix.arch }} packages
     needs: preflight
     if: needs.preflight.outputs.should_run == 'true'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 150
     permissions:
       contents: read
+    env:
+      RPM_ARCH: ${{ matrix.arch }}
     outputs:
       archive_date: ${{ steps.version.outputs.archive_date }}
       expected_evr: ${{ steps.version.outputs.expected_evr }}
@@ -137,11 +147,24 @@ jobs:
 
       - name: Generate rsyslog dist tarball
         run: |
-          RSYSLOG_HOME="$GITHUB_WORKSPACE/rsyslog-source" \
-            RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 \
-            devtools/devcontainer.sh --rm \
+          case "$RPM_ARCH" in
+            x86_64)
+              RSYSLOG_HOME="$GITHUB_WORKSPACE/rsyslog-source" \
+                RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 \
+                devtools/devcontainer.sh --rm \
+                  .github/scripts/debian_package_build.sh run_dist_build \
+                  /rsyslog
+              ;;
+            aarch64)
+              sudo apt-get update
+              sudo apt-get install -y --no-install-recommends \
+                autoconf autoconf-archive automake bison build-essential \
+                flex gawk git libestr-dev libfastjson-dev libsystemd-dev \
+                libtool libyaml-dev pkg-config python3-docutils zlib1g-dev
               .github/scripts/debian_package_build.sh run_dist_build \
-              /rsyslog
+                "$GITHUB_WORKSPACE/rsyslog-source"
+              ;;
+          esac
           dist_tarball="$(
             find rsyslog-source -maxdepth 1 -type f \
               -name 'rsyslog-*.tar.gz' -print -quit
@@ -162,7 +185,8 @@ jobs:
           set +e
           docker run --rm \
             -e AMAZONLINUX_DAILY_STABLE_HELPER -e PACKAGE_FEATURE_CONTRACT \
-            -e AMAZONLINUX_POLICY_FILE -e EXPECTED_EVR -e RELEASE -e VERSION \
+            -e AMAZONLINUX_POLICY_FILE -e EXPECTED_EVR -e RELEASE -e RPM_ARCH \
+            -e VERSION \
             -e "DIST_TARBALL=/workspace/rsyslog-source/$(basename "$DIST_TARBALL")" \
             -v "$GITHUB_WORKSPACE:/workspace" \
             -v "$RUNNER_TEMP:/runner-temp" \
@@ -203,7 +227,7 @@ jobs:
                 /runner-temp/amazonlinux2023-artifacts \
                 /runner-temp/amazonlinux2023-build.log \
                 "$EXPECTED_EVR" \
-                x86_64
+                "$RPM_ARCH"
             '
           build_status=$?
           set -e
@@ -245,7 +269,7 @@ jobs:
       - name: Upload Amazon Linux package artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: amazonlinux2023-daily-stable-${{ steps.version.outputs.expected_evr }}
+          name: amazonlinux2023-daily-stable-${{ steps.version.outputs.expected_evr }}-${{ matrix.arch }}
           path: amazonlinux2023-daily-stable-artifacts/
           retention-days: 14
           if-no-files-found: error
@@ -315,16 +339,23 @@ jobs:
             }
           done
 
-      - name: Download Amazon Linux package artifacts
+      - name: Download Amazon Linux x86_64 package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: amazonlinux2023-daily-stable-${{ needs.build.outputs.expected_evr }}
-          path: amazonlinux2023-daily-stable-artifacts
+          name: amazonlinux2023-daily-stable-${{ needs.build.outputs.expected_evr }}-x86_64
+          path: amazonlinux2023-daily-stable-artifacts/x86_64
+
+      - name: Download Amazon Linux aarch64 package artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: amazonlinux2023-daily-stable-${{ needs.build.outputs.expected_evr }}-aarch64
+          path: amazonlinux2023-daily-stable-artifacts/aarch64
 
       - name: Verify artifact checksums
         run: |
-          cd amazonlinux2023-daily-stable-artifacts
-          sha256sum -c SHA256SUMS
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            (cd "amazonlinux2023-daily-stable-artifacts/$arch" && sha256sum -c SHA256SUMS)
+          done
 
       - name: Import signing key and unlock its agent
         run: |
@@ -357,15 +388,17 @@ jobs:
 
       - name: Sign binary and source RPMs
         run: |
-          "$AMAZONLINUX_DAILY_STABLE_HELPER" sign-rpms \
-            amazonlinux2023-daily-stable-artifacts \
-            "$ARCHIVE_GPG_FINGERPRINT"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            "$AMAZONLINUX_DAILY_STABLE_HELPER" sign-rpms \
+              "amazonlinux2023-daily-stable-artifacts/$arch" \
+              "$ARCHIVE_GPG_FINGERPRINT"
+          done
 
       - name: Download current repository metadata
         run: |
           set -euo pipefail
-          mkdir -p "rpm-repo/$RPM_ARCH" rpm-repo/SRPMS
-          for repo_subdir in "$RPM_ARCH" SRPMS; do
+          for repo_subdir in $PACKAGE_REPOSITORY_ARCHITECTURES SRPMS; do
+            mkdir -p "rpm-repo/$repo_subdir"
             aws s3 sync \
               --only-show-errors \
               --endpoint-url "$SPACE_ENDPOINT" \
@@ -375,29 +408,34 @@ jobs:
 
       - name: Generate signed incremental RPM repositories
         run: |
-          "$AMAZONLINUX_DAILY_STABLE_HELPER" generate-repo \
-            amazonlinux2023-daily-stable-artifacts \
-            rpm-repo \
-            "$RPM_ARCH" \
-            "$ARCHIVE_GPG_FINGERPRINT" \
-            "$GPG_PASSPHRASE_FILE"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            "$AMAZONLINUX_DAILY_STABLE_HELPER" generate-repo \
+              "amazonlinux2023-daily-stable-artifacts/$arch" \
+              rpm-repo \
+              "$arch" \
+              "$ARCHIVE_GPG_FINGERPRINT" \
+              "$GPG_PASSPHRASE_FILE"
+          done
 
       - name: Generate signed artifact manifest and snapshot
         env:
           ARCHIVE_DATE: ${{ needs.build.outputs.archive_date }}
           EXPECTED_EVR: ${{ needs.build.outputs.expected_evr }}
         run: |
-          "$AMAZONLINUX_DAILY_STABLE_HELPER" manifest \
-            amazonlinux2023-daily-stable-artifacts \
-            "$EXPECTED_EVR" "$RPM_ARCH" "$PACKAGE_CHANNEL" \
-            "$PACKAGE_DISTRO" "$PACKAGE_DISTRO_VERSION"
           snapshot_dir="rpm-repo/snapshots/$ARCHIVE_DATE/$EXPECTED_EVR"
-          mkdir -p "$snapshot_dir"
-          cp -a amazonlinux2023-daily-stable-artifacts/manifest.json \
-            amazonlinux2023-daily-stable-artifacts/SHA256SUMS \
-            amazonlinux2023-daily-stable-artifacts/build.log \
-            amazonlinux2023-daily-stable-artifacts/rsyslog.spec \
-            "$snapshot_dir/"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            artifact_dir="amazonlinux2023-daily-stable-artifacts/$arch"
+            "$AMAZONLINUX_DAILY_STABLE_HELPER" manifest \
+              "$artifact_dir" \
+              "$EXPECTED_EVR" "$arch" "$PACKAGE_CHANNEL" \
+              "$PACKAGE_DISTRO" "$PACKAGE_DISTRO_VERSION"
+            mkdir -p "$snapshot_dir/$arch"
+            cp -a "$artifact_dir/manifest.json" \
+              "$artifact_dir/SHA256SUMS" \
+              "$artifact_dir/build.log" \
+              "$artifact_dir/rsyslog.spec" \
+              "$snapshot_dir/$arch/"
+          done
 
       - name: Generate repository configuration
         run: |
@@ -446,8 +484,8 @@ jobs:
           while IFS= read -r -d '' path; do
             upload_immutable "$path"
           done < <(
-            find "rpm-repo/$RPM_ARCH/Packages" rpm-repo/SRPMS/Packages \
-              rpm-repo/snapshots -type f -print0
+            find rpm-repo/x86_64/Packages rpm-repo/aarch64/Packages \
+              rpm-repo/SRPMS/Packages rpm-repo/snapshots -type f -print0
           )
 
       - name: Publish archive key and mutable metadata
@@ -464,7 +502,7 @@ jobs:
           }
           upload_metadata rpm-repo/rsyslog-archive-keyring.asc
           upload_metadata rpm-repo/rsyslog-daily-stable-amazonlinux2023.repo
-          for repo_subdir in "$RPM_ARCH" SRPMS; do
+          for repo_subdir in $PACKAGE_REPOSITORY_ARCHITECTURES SRPMS; do
             while IFS= read -r -d '' path; do
               upload_metadata "$path"
             done < <(
@@ -476,10 +514,18 @@ jobs:
           done
 
   verify:
-    name: verify published Amazon Linux 2023 repository
+    name: verify published Amazon Linux 2023 ${{ matrix.arch }} repository
     needs: [preflight, build, publish]
     if: needs.preflight.outputs.should_publish == 'true'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     container:
       image: amazonlinux:2023
@@ -488,6 +534,7 @@ jobs:
     permissions:
       contents: read
     env:
+      RPM_ARCH: ${{ matrix.arch }}
       REPO_URL: ${{ vars.AMAZONLINUX2023_DAILY_STABLE_REPO_URL }}
       ORIGIN_REPO_URL: ${{ vars.AMAZONLINUX2023_DAILY_STABLE_ORIGIN_REPO_URL }}
       EXPECTED_GPG_FINGERPRINT: ${{ vars.DEBIAN_DAILY_STABLE_GPG_FINGERPRINT }}

--- a/.github/workflows/debian_daily_stable.yml
+++ b/.github/workflows/debian_daily_stable.yml
@@ -45,7 +45,7 @@ env:
   DEBIAN_BUILD_ROOT: /tmp/rsyslog-debian-daily-stable-build
   DEBIAN_SUITE: trixie
   DEBIAN_COMPONENT: main
-  DEBIAN_ARCH: amd64
+  PACKAGE_REPOSITORY_ARCHITECTURES: amd64 arm64
   PACKAGE_CHANNEL: daily-stable
   PACKAGE_DISTRO: debian
   PACKAGE_DISTRO_VERSION: '13'
@@ -107,16 +107,26 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   build:
-    name: build Debian 13 amd64 packages
+    name: build Debian 13 ${{ matrix.arch }} packages
     needs: preflight
     if: needs.preflight.outputs.should_run == 'true'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     container:
       image: debian:trixie
       options: --user root
     permissions:
       contents: read
+    env:
+      DEBIAN_ARCH: ${{ matrix.arch }}
     outputs:
       archive_date: ${{ steps.version.outputs.archive_date }}
       version: ${{ steps.version.outputs.version }}
@@ -294,7 +304,7 @@ jobs:
       - name: Upload Debian package artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: debian-daily-stable-${{ steps.version.outputs.version }}
+          name: debian-daily-stable-${{ steps.version.outputs.version }}-${{ matrix.arch }}
           path: debian-daily-stable-artifacts/
           retention-days: 14
           if-no-files-found: error
@@ -374,16 +384,23 @@ jobs:
             }
           done
 
-      - name: Download Debian package artifacts
+      - name: Download Debian amd64 package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: debian-daily-stable-${{ needs.build.outputs.version }}
-          path: debian-daily-stable-artifacts
+          name: debian-daily-stable-${{ needs.build.outputs.version }}-amd64
+          path: debian-daily-stable-artifacts/amd64
+
+      - name: Download Debian arm64 package artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: debian-daily-stable-${{ needs.build.outputs.version }}-arm64
+          path: debian-daily-stable-artifacts/arm64
 
       - name: Verify artifact checksums
         run: |
-          cd debian-daily-stable-artifacts
-          sha256sum -c SHA256SUMS
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            (cd "debian-daily-stable-artifacts/$arch" && sha256sum -c SHA256SUMS)
+          done
 
       - name: Import archive signing key
         run: |
@@ -396,7 +413,9 @@ jobs:
       - name: Download current indexes
         run: |
           set -euo pipefail
-          mkdir -p "apt-repo/dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/binary-$DEBIAN_ARCH"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            mkdir -p "apt-repo/dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/binary-$arch"
+          done
           mkdir -p "apt-repo/dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/source"
 
           download_if_present() {
@@ -421,19 +440,23 @@ jobs:
             fi
           }
 
-          download_if_present \
-            "dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/binary-$DEBIAN_ARCH/Packages.xz"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            download_if_present \
+              "dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/binary-$arch/Packages.xz"
+          done
           download_if_present \
             "dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/source/Sources.xz"
 
       - name: Generate signed incremental APT repository
         run: |
-          "$GITHUB_WORKSPACE/$DEBIAN_DAILY_STABLE_HELPER" generate-repo \
-            "$GITHUB_WORKSPACE/debian-daily-stable-artifacts" \
-            "$GITHUB_WORKSPACE/apt-repo" \
-            "$DEBIAN_SUITE" \
-            "$DEBIAN_COMPONENT" \
-            "$DEBIAN_ARCH"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            "$GITHUB_WORKSPACE/$DEBIAN_DAILY_STABLE_HELPER" generate-repo \
+              "$GITHUB_WORKSPACE/debian-daily-stable-artifacts/$arch" \
+              "$GITHUB_WORKSPACE/apt-repo" \
+              "$DEBIAN_SUITE" \
+              "$DEBIAN_COMPONENT" \
+              "$arch"
+          done
 
       - name: Prepare immutable build snapshot
         env:
@@ -442,12 +465,14 @@ jobs:
         run: |
           set -euo pipefail
           snapshot_dir="apt-repo/snapshots/$ARCHIVE_DATE/$VERSION"
-          mkdir -p "$snapshot_dir"
-          find debian-daily-stable-artifacts -maxdepth 1 -type f \
-            \( -name 'manifest.json' -o -name 'SHA256SUMS' \
-               -o -name '*.changes' -o -name '*.buildinfo' \
-               -o -name 'build.log' \) \
-            -exec cp -a {} "$snapshot_dir/" \;
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            mkdir -p "$snapshot_dir/$arch"
+            find "debian-daily-stable-artifacts/$arch" -maxdepth 1 -type f \
+              \( -name 'manifest.json' -o -name 'SHA256SUMS' \
+                 -o -name '*.changes' -o -name '*.buildinfo' \
+                 -o -name 'build.log' \) \
+              -exec cp -a {} "$snapshot_dir/$arch/" \;
+          done
 
       - name: Publish immutable packages and snapshots
         run: |
@@ -538,13 +563,21 @@ jobs:
           upload_metadata "apt-repo/dists/$DEBIAN_SUITE/InRelease"
 
   verify:
-    name: verify published Debian 13 repository
+    name: verify published Debian 13 ${{ matrix.arch }} repository
     needs:
       - preflight
       - build
       - publish
     if: needs.preflight.outputs.should_publish == 'true'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     container:
       image: debian:trixie
@@ -556,6 +589,7 @@ jobs:
     permissions:
       contents: read
     env:
+      DEBIAN_ARCH: ${{ matrix.arch }}
       REPO_URL: ${{ vars.DEBIAN_DAILY_STABLE_REPO_URL }}
       EXPECTED_GPG_FINGERPRINT: ${{ vars.DEBIAN_DAILY_STABLE_GPG_FINGERPRINT }}
     steps:

--- a/.github/workflows/el10_daily_stable.yml
+++ b/.github/workflows/el10_daily_stable.yml
@@ -35,8 +35,7 @@ env:
   RPM_DAILY_STABLE_HELPER: devtools/release/rpm-daily-stable.sh
   RPM_POLICY_FILE: .github/el10-daily-stable-policy.yml
   PACKAGE_FEATURE_CONTRACT: .github/daily-stable-package-features.yml
-  RPM_MOCK_CONFIG: centos-stream+epel-10-x86_64
-  RPM_ARCH: x86_64
+  PACKAGE_REPOSITORY_ARCHITECTURES: x86_64 aarch64
   PACKAGE_CHANNEL: daily-stable
   PACKAGE_DISTRO: el
   PACKAGE_DISTRO_VERSION: '10'
@@ -96,13 +95,26 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   build:
-    name: build EL10 x86_64 packages
+    name: build EL10 ${{ matrix.arch }} packages
     needs: preflight
     if: needs.preflight.outputs.should_run == 'true'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            mock_config: centos-stream+epel-10-x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            mock_config: centos-stream+epel-10-aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 150
     permissions:
       contents: read
+    env:
+      RPM_ARCH: ${{ matrix.arch }}
+      RPM_MOCK_CONFIG: ${{ matrix.mock_config }}
     outputs:
       archive_date: ${{ steps.version.outputs.archive_date }}
       expected_evr: ${{ steps.version.outputs.expected_evr }}
@@ -147,11 +159,24 @@ jobs:
 
       - name: Generate rsyslog dist tarball
         run: |
-          RSYSLOG_HOME="$GITHUB_WORKSPACE/rsyslog-source" \
-            RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 \
-            devtools/devcontainer.sh --rm \
+          case "$RPM_ARCH" in
+            x86_64)
+              RSYSLOG_HOME="$GITHUB_WORKSPACE/rsyslog-source" \
+                RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 \
+                devtools/devcontainer.sh --rm \
+                  .github/scripts/debian_package_build.sh run_dist_build \
+                  /rsyslog
+              ;;
+            aarch64)
+              sudo apt-get update
+              sudo apt-get install -y --no-install-recommends \
+                autoconf autoconf-archive automake bison build-essential \
+                flex gawk git libestr-dev libfastjson-dev libsystemd-dev \
+                libtool libyaml-dev pkg-config python3-docutils zlib1g-dev
               .github/scripts/debian_package_build.sh run_dist_build \
-              /rsyslog
+                "$GITHUB_WORKSPACE/rsyslog-source"
+              ;;
+          esac
           dist_tarball="$(find rsyslog-source -maxdepth 1 -type f -name 'rsyslog-*.tar.gz' -print -quit)"
           [ -n "$dist_tarball" ]
           echo "DIST_TARBALL=$GITHUB_WORKSPACE/$dist_tarball" >> "$GITHUB_ENV"
@@ -169,7 +194,7 @@ jobs:
           set +e
           docker run --rm --privileged \
             -e EXPECTED_EVR -e RELEASE -e VERSION \
-            -e PACKAGE_FEATURE_CONTRACT -e RPM_DAILY_STABLE_HELPER \
+            -e PACKAGE_FEATURE_CONTRACT -e RPM_ARCH -e RPM_DAILY_STABLE_HELPER \
             -e RPM_MOCK_CONFIG -e RPM_POLICY_FILE \
             -e "DIST_TARBALL=/workspace/rsyslog-source/$(basename "$DIST_TARBALL")" \
             -v "$GITHUB_WORKSPACE:/workspace" \
@@ -193,7 +218,8 @@ jobs:
                 "$RPM_MOCK_CONFIG" \
                 /runner-temp/el10-artifacts \
                 /runner-temp/el10-build.log \
-                "$EXPECTED_EVR"
+                "$EXPECTED_EVR" \
+                "$RPM_ARCH"
             '
           build_status=$?
           set -e
@@ -227,7 +253,7 @@ jobs:
       - name: Upload EL10 package artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: el10-daily-stable-${{ steps.version.outputs.expected_evr }}
+          name: el10-daily-stable-${{ steps.version.outputs.expected_evr }}-${{ matrix.arch }}
           path: el10-daily-stable-artifacts/
           retention-days: 14
           if-no-files-found: error
@@ -300,16 +326,23 @@ jobs:
             }
           done
 
-      - name: Download EL10 package artifacts
+      - name: Download EL10 x86_64 package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: el10-daily-stable-${{ needs.build.outputs.expected_evr }}
-          path: el10-daily-stable-artifacts
+          name: el10-daily-stable-${{ needs.build.outputs.expected_evr }}-x86_64
+          path: el10-daily-stable-artifacts/x86_64
+
+      - name: Download EL10 aarch64 package artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: el10-daily-stable-${{ needs.build.outputs.expected_evr }}-aarch64
+          path: el10-daily-stable-artifacts/aarch64
 
       - name: Verify artifact checksums
         run: |
-          cd el10-daily-stable-artifacts
-          sha256sum -c SHA256SUMS
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            (cd "el10-daily-stable-artifacts/$arch" && sha256sum -c SHA256SUMS)
+          done
 
       - name: Import signing key and unlock its agent
         run: |
@@ -342,15 +375,17 @@ jobs:
 
       - name: Sign binary and source RPMs
         run: |
-          "$RPM_DAILY_STABLE_HELPER" sign-rpms \
-            el10-daily-stable-artifacts \
-            "$ARCHIVE_GPG_FINGERPRINT"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            "$RPM_DAILY_STABLE_HELPER" sign-rpms \
+              "el10-daily-stable-artifacts/$arch" \
+              "$ARCHIVE_GPG_FINGERPRINT"
+          done
 
       - name: Download current repository metadata
         run: |
           set -euo pipefail
-          mkdir -p "rpm-repo/$RPM_ARCH" rpm-repo/SRPMS
-          for repo_subdir in "$RPM_ARCH" SRPMS; do
+          for repo_subdir in $PACKAGE_REPOSITORY_ARCHITECTURES SRPMS; do
+            mkdir -p "rpm-repo/$repo_subdir"
             aws s3 sync \
               --only-show-errors \
               --endpoint-url "$SPACE_ENDPOINT" \
@@ -360,29 +395,34 @@ jobs:
 
       - name: Generate signed incremental RPM repositories
         run: |
-          "$RPM_DAILY_STABLE_HELPER" generate-repo \
-            el10-daily-stable-artifacts \
-            rpm-repo \
-            "$RPM_ARCH" \
-            "$ARCHIVE_GPG_FINGERPRINT" \
-            "$GPG_PASSPHRASE_FILE"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            "$RPM_DAILY_STABLE_HELPER" generate-repo \
+              "el10-daily-stable-artifacts/$arch" \
+              rpm-repo \
+              "$arch" \
+              "$ARCHIVE_GPG_FINGERPRINT" \
+              "$GPG_PASSPHRASE_FILE"
+          done
 
       - name: Generate signed artifact manifest and snapshot
         env:
           ARCHIVE_DATE: ${{ needs.build.outputs.archive_date }}
           EXPECTED_EVR: ${{ needs.build.outputs.expected_evr }}
         run: |
-          "$RPM_DAILY_STABLE_HELPER" manifest \
-            el10-daily-stable-artifacts \
-            "$EXPECTED_EVR" "$RPM_ARCH" "$PACKAGE_CHANNEL" \
-            "$PACKAGE_DISTRO" "$PACKAGE_DISTRO_VERSION"
           snapshot_dir="rpm-repo/snapshots/$ARCHIVE_DATE/$EXPECTED_EVR"
-          mkdir -p "$snapshot_dir"
-          cp -a el10-daily-stable-artifacts/manifest.json \
-            el10-daily-stable-artifacts/SHA256SUMS \
-            el10-daily-stable-artifacts/build.log \
-            el10-daily-stable-artifacts/rsyslog.spec \
-            "$snapshot_dir/"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            artifact_dir="el10-daily-stable-artifacts/$arch"
+            "$RPM_DAILY_STABLE_HELPER" manifest \
+              "$artifact_dir" \
+              "$EXPECTED_EVR" "$arch" "$PACKAGE_CHANNEL" \
+              "$PACKAGE_DISTRO" "$PACKAGE_DISTRO_VERSION"
+            mkdir -p "$snapshot_dir/$arch"
+            cp -a "$artifact_dir/manifest.json" \
+              "$artifact_dir/SHA256SUMS" \
+              "$artifact_dir/build.log" \
+              "$artifact_dir/rsyslog.spec" \
+              "$snapshot_dir/$arch/"
+          done
 
       - name: Generate repository configuration
         run: |
@@ -431,8 +471,8 @@ jobs:
           while IFS= read -r -d '' path; do
             upload_immutable "$path"
           done < <(
-            find "rpm-repo/$RPM_ARCH/Packages" rpm-repo/SRPMS/Packages \
-              rpm-repo/snapshots -type f -print0
+            find rpm-repo/x86_64/Packages rpm-repo/aarch64/Packages \
+              rpm-repo/SRPMS/Packages rpm-repo/snapshots -type f -print0
           )
 
       - name: Publish archive key and mutable metadata
@@ -449,7 +489,7 @@ jobs:
           }
           upload_metadata rpm-repo/rsyslog-archive-keyring.asc
           upload_metadata rpm-repo/rsyslog-daily-stable-el10.repo
-          for repo_subdir in "$RPM_ARCH" SRPMS; do
+          for repo_subdir in $PACKAGE_REPOSITORY_ARCHITECTURES SRPMS; do
             while IFS= read -r -d '' path; do
               upload_metadata "$path"
             done < <(
@@ -461,14 +501,19 @@ jobs:
           done
 
   verify:
-    name: verify ${{ matrix.name }} EL10 repository
+    name: verify ${{ matrix.name }} EL10 ${{ matrix.target.arch }} repository
     needs: [preflight, build, publish]
     if: needs.preflight.outputs.should_publish == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.target.runner }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
+        target:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
         include:
           - name: CentOS Stream
             image: quay.io/centos/centos:stream10
@@ -485,6 +530,7 @@ jobs:
     permissions:
       contents: read
     env:
+      RPM_ARCH: ${{ matrix.target.arch }}
       REPO_URL: ${{ vars.EL10_DAILY_STABLE_REPO_URL }}
       EXPECTED_GPG_FINGERPRINT: ${{ vars.DEBIAN_DAILY_STABLE_GPG_FINGERPRINT }}
       EXPECTED_EVR: ${{ needs.build.outputs.expected_evr }}

--- a/.github/workflows/fedora44_daily_stable.yml
+++ b/.github/workflows/fedora44_daily_stable.yml
@@ -35,7 +35,7 @@ env:
   FEDORA_DAILY_STABLE_HELPER: devtools/release/fedora-daily-stable.sh
   FEDORA_POLICY_FILE: .github/fedora44-daily-stable-policy.yml
   PACKAGE_FEATURE_CONTRACT: .github/daily-stable-package-features.yml
-  RPM_ARCH: x86_64
+  PACKAGE_REPOSITORY_ARCHITECTURES: x86_64 aarch64
   PACKAGE_CHANNEL: daily-stable
   PACKAGE_DISTRO: fedora
   PACKAGE_DISTRO_VERSION: '44'
@@ -95,13 +95,23 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   build:
-    name: build Fedora 44 x86_64 packages
+    name: build Fedora 44 ${{ matrix.arch }} packages
     needs: preflight
     if: needs.preflight.outputs.should_run == 'true'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 150
     permissions:
       contents: read
+    env:
+      RPM_ARCH: ${{ matrix.arch }}
     outputs:
       archive_date: ${{ steps.version.outputs.archive_date }}
       expected_evr: ${{ steps.version.outputs.expected_evr }}
@@ -137,11 +147,24 @@ jobs:
 
       - name: Generate rsyslog dist tarball
         run: |
-          RSYSLOG_HOME="$GITHUB_WORKSPACE/rsyslog-source" \
-            RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 \
-            devtools/devcontainer.sh --rm \
+          case "$RPM_ARCH" in
+            x86_64)
+              RSYSLOG_HOME="$GITHUB_WORKSPACE/rsyslog-source" \
+                RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 \
+                devtools/devcontainer.sh --rm \
+                  .github/scripts/debian_package_build.sh run_dist_build \
+                  /rsyslog
+              ;;
+            aarch64)
+              sudo apt-get update
+              sudo apt-get install -y --no-install-recommends \
+                autoconf autoconf-archive automake bison build-essential \
+                flex gawk git libestr-dev libfastjson-dev libsystemd-dev \
+                libtool libyaml-dev pkg-config python3-docutils zlib1g-dev
               .github/scripts/debian_package_build.sh run_dist_build \
-              /rsyslog
+                "$GITHUB_WORKSPACE/rsyslog-source"
+              ;;
+          esac
           dist_tarball="$(
             find rsyslog-source -maxdepth 1 -type f \
               -name 'rsyslog-*.tar.gz' -print -quit
@@ -162,7 +185,8 @@ jobs:
           set +e
           docker run --rm \
             -e FEDORA_DAILY_STABLE_HELPER -e PACKAGE_FEATURE_CONTRACT \
-            -e FEDORA_POLICY_FILE -e EXPECTED_EVR -e RELEASE -e VERSION \
+            -e FEDORA_POLICY_FILE -e EXPECTED_EVR -e RELEASE -e RPM_ARCH \
+            -e VERSION \
             -e "DIST_TARBALL=/workspace/rsyslog-source/$(basename "$DIST_TARBALL")" \
             -v "$GITHUB_WORKSPACE:/workspace" \
             -v "$RUNNER_TEMP:/runner-temp" \
@@ -202,7 +226,7 @@ jobs:
                 /runner-temp/fedora44-artifacts \
                 /runner-temp/fedora44-build.log \
                 "$EXPECTED_EVR" \
-                x86_64
+                "$RPM_ARCH"
             '
           build_status=$?
           set -e
@@ -244,7 +268,7 @@ jobs:
       - name: Upload Fedora package artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: fedora44-daily-stable-${{ steps.version.outputs.expected_evr }}
+          name: fedora44-daily-stable-${{ steps.version.outputs.expected_evr }}-${{ matrix.arch }}
           path: fedora44-daily-stable-artifacts/
           retention-days: 14
           if-no-files-found: error
@@ -314,16 +338,23 @@ jobs:
             }
           done
 
-      - name: Download Fedora package artifacts
+      - name: Download Fedora x86_64 package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: fedora44-daily-stable-${{ needs.build.outputs.expected_evr }}
-          path: fedora44-daily-stable-artifacts
+          name: fedora44-daily-stable-${{ needs.build.outputs.expected_evr }}-x86_64
+          path: fedora44-daily-stable-artifacts/x86_64
+
+      - name: Download Fedora aarch64 package artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: fedora44-daily-stable-${{ needs.build.outputs.expected_evr }}-aarch64
+          path: fedora44-daily-stable-artifacts/aarch64
 
       - name: Verify artifact checksums
         run: |
-          cd fedora44-daily-stable-artifacts
-          sha256sum -c SHA256SUMS
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            (cd "fedora44-daily-stable-artifacts/$arch" && sha256sum -c SHA256SUMS)
+          done
 
       - name: Import signing key and unlock its agent
         run: |
@@ -356,15 +387,17 @@ jobs:
 
       - name: Sign binary and source RPMs
         run: |
-          "$FEDORA_DAILY_STABLE_HELPER" sign-rpms \
-            fedora44-daily-stable-artifacts \
-            "$ARCHIVE_GPG_FINGERPRINT"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            "$FEDORA_DAILY_STABLE_HELPER" sign-rpms \
+              "fedora44-daily-stable-artifacts/$arch" \
+              "$ARCHIVE_GPG_FINGERPRINT"
+          done
 
       - name: Download current repository metadata
         run: |
           set -euo pipefail
-          mkdir -p "rpm-repo/$RPM_ARCH" rpm-repo/SRPMS
-          for repo_subdir in "$RPM_ARCH" SRPMS; do
+          for repo_subdir in $PACKAGE_REPOSITORY_ARCHITECTURES SRPMS; do
+            mkdir -p "rpm-repo/$repo_subdir"
             aws s3 sync \
               --only-show-errors \
               --endpoint-url "$SPACE_ENDPOINT" \
@@ -374,29 +407,34 @@ jobs:
 
       - name: Generate signed incremental RPM repositories
         run: |
-          "$FEDORA_DAILY_STABLE_HELPER" generate-repo \
-            fedora44-daily-stable-artifacts \
-            rpm-repo \
-            "$RPM_ARCH" \
-            "$ARCHIVE_GPG_FINGERPRINT" \
-            "$GPG_PASSPHRASE_FILE"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            "$FEDORA_DAILY_STABLE_HELPER" generate-repo \
+              "fedora44-daily-stable-artifacts/$arch" \
+              rpm-repo \
+              "$arch" \
+              "$ARCHIVE_GPG_FINGERPRINT" \
+              "$GPG_PASSPHRASE_FILE"
+          done
 
       - name: Generate signed artifact manifest and snapshot
         env:
           ARCHIVE_DATE: ${{ needs.build.outputs.archive_date }}
           EXPECTED_EVR: ${{ needs.build.outputs.expected_evr }}
         run: |
-          "$FEDORA_DAILY_STABLE_HELPER" manifest \
-            fedora44-daily-stable-artifacts \
-            "$EXPECTED_EVR" "$RPM_ARCH" "$PACKAGE_CHANNEL" \
-            "$PACKAGE_DISTRO" "$PACKAGE_DISTRO_VERSION"
           snapshot_dir="rpm-repo/snapshots/$ARCHIVE_DATE/$EXPECTED_EVR"
-          mkdir -p "$snapshot_dir"
-          cp -a fedora44-daily-stable-artifacts/manifest.json \
-            fedora44-daily-stable-artifacts/SHA256SUMS \
-            fedora44-daily-stable-artifacts/build.log \
-            fedora44-daily-stable-artifacts/rsyslog.spec \
-            "$snapshot_dir/"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            artifact_dir="fedora44-daily-stable-artifacts/$arch"
+            "$FEDORA_DAILY_STABLE_HELPER" manifest \
+              "$artifact_dir" \
+              "$EXPECTED_EVR" "$arch" "$PACKAGE_CHANNEL" \
+              "$PACKAGE_DISTRO" "$PACKAGE_DISTRO_VERSION"
+            mkdir -p "$snapshot_dir/$arch"
+            cp -a "$artifact_dir/manifest.json" \
+              "$artifact_dir/SHA256SUMS" \
+              "$artifact_dir/build.log" \
+              "$artifact_dir/rsyslog.spec" \
+              "$snapshot_dir/$arch/"
+          done
 
       - name: Generate repository configuration
         run: |
@@ -445,8 +483,8 @@ jobs:
           while IFS= read -r -d '' path; do
             upload_immutable "$path"
           done < <(
-            find "rpm-repo/$RPM_ARCH/Packages" rpm-repo/SRPMS/Packages \
-              rpm-repo/snapshots -type f -print0
+            find rpm-repo/x86_64/Packages rpm-repo/aarch64/Packages \
+              rpm-repo/SRPMS/Packages rpm-repo/snapshots -type f -print0
           )
 
       - name: Publish archive key and mutable metadata
@@ -463,7 +501,7 @@ jobs:
           }
           upload_metadata rpm-repo/rsyslog-archive-keyring.asc
           upload_metadata rpm-repo/rsyslog-daily-stable-fedora44.repo
-          for repo_subdir in "$RPM_ARCH" SRPMS; do
+          for repo_subdir in $PACKAGE_REPOSITORY_ARCHITECTURES SRPMS; do
             while IFS= read -r -d '' path; do
               upload_metadata "$path"
             done < <(
@@ -475,10 +513,18 @@ jobs:
           done
 
   verify:
-    name: verify published Fedora 44 repository
+    name: verify published Fedora 44 ${{ matrix.arch }} repository
     needs: [preflight, build, publish]
     if: needs.preflight.outputs.should_publish == 'true'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     container:
       image: fedora:44
@@ -487,6 +533,7 @@ jobs:
     permissions:
       contents: read
     env:
+      RPM_ARCH: ${{ matrix.arch }}
       REPO_URL: ${{ vars.FEDORA44_DAILY_STABLE_REPO_URL }}
       ORIGIN_REPO_URL: ${{ vars.FEDORA44_DAILY_STABLE_ORIGIN_REPO_URL }}
       EXPECTED_GPG_FINGERPRINT: ${{ vars.DEBIAN_DAILY_STABLE_GPG_FINGERPRINT }}

--- a/.github/workflows/opensuse_leap160_daily_stable.yml
+++ b/.github/workflows/opensuse_leap160_daily_stable.yml
@@ -35,7 +35,7 @@ env:
   OPENSUSE_DAILY_STABLE_HELPER: devtools/release/opensuse-daily-stable.sh
   OPENSUSE_POLICY_FILE: .github/opensuse-leap160-daily-stable-policy.yml
   PACKAGE_FEATURE_CONTRACT: .github/daily-stable-package-features.yml
-  RPM_ARCH: x86_64
+  PACKAGE_REPOSITORY_ARCHITECTURES: x86_64 aarch64
   PACKAGE_CHANNEL: daily-stable
   PACKAGE_DISTRO: opensuse-leap
   PACKAGE_DISTRO_VERSION: '16.0'
@@ -95,13 +95,23 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   build:
-    name: build openSUSE Leap 16.0 x86_64 packages
+    name: build openSUSE Leap 16.0 ${{ matrix.arch }} packages
     needs: preflight
     if: needs.preflight.outputs.should_run == 'true'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 150
     permissions:
       contents: read
+    env:
+      RPM_ARCH: ${{ matrix.arch }}
     outputs:
       archive_date: ${{ steps.version.outputs.archive_date }}
       expected_evr: ${{ steps.version.outputs.expected_evr }}
@@ -137,11 +147,24 @@ jobs:
 
       - name: Generate rsyslog dist tarball
         run: |
-          RSYSLOG_HOME="$GITHUB_WORKSPACE/rsyslog-source" \
-            RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 \
-            devtools/devcontainer.sh --rm \
+          case "$RPM_ARCH" in
+            x86_64)
+              RSYSLOG_HOME="$GITHUB_WORKSPACE/rsyslog-source" \
+                RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04 \
+                devtools/devcontainer.sh --rm \
+                  .github/scripts/debian_package_build.sh run_dist_build \
+                  /rsyslog
+              ;;
+            aarch64)
+              sudo apt-get update
+              sudo apt-get install -y --no-install-recommends \
+                autoconf autoconf-archive automake bison build-essential \
+                flex gawk git libestr-dev libfastjson-dev libsystemd-dev \
+                libtool libyaml-dev pkg-config python3-docutils zlib1g-dev
               .github/scripts/debian_package_build.sh run_dist_build \
-              /rsyslog
+                "$GITHUB_WORKSPACE/rsyslog-source"
+              ;;
+          esac
           dist_tarball="$(
             find rsyslog-source -maxdepth 1 -type f \
               -name 'rsyslog-*.tar.gz' -print -quit
@@ -173,7 +196,8 @@ jobs:
           set +e
           docker run --rm \
             -e OPENSUSE_DAILY_STABLE_HELPER -e PACKAGE_FEATURE_CONTRACT \
-            -e OPENSUSE_POLICY_FILE -e EXPECTED_EVR -e RELEASE -e VERSION \
+            -e OPENSUSE_POLICY_FILE -e EXPECTED_EVR -e RELEASE -e RPM_ARCH \
+            -e VERSION \
             -e "DIST_TARBALL=/workspace/rsyslog-source/$(basename "$DIST_TARBALL")" \
             -e "DOC_TARBALL=/workspace/$(basename "$DOC_TARBALL")" \
             -v "$GITHUB_WORKSPACE:/workspace" \
@@ -221,7 +245,7 @@ jobs:
                 /runner-temp/opensuse-leap160-artifacts \
                 /runner-temp/opensuse-leap160-build.log \
                 "$EXPECTED_EVR" \
-                x86_64
+                "$RPM_ARCH"
             '
           build_status=$?
           set -e
@@ -263,7 +287,7 @@ jobs:
       - name: Upload openSUSE package artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: opensuse-leap160-daily-stable-${{ steps.version.outputs.expected_evr }}
+          name: opensuse-leap160-daily-stable-${{ steps.version.outputs.expected_evr }}-${{ matrix.arch }}
           path: opensuse-leap160-daily-stable-artifacts/
           retention-days: 14
           if-no-files-found: error
@@ -333,16 +357,23 @@ jobs:
             }
           done
 
-      - name: Download openSUSE package artifacts
+      - name: Download openSUSE x86_64 package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: opensuse-leap160-daily-stable-${{ needs.build.outputs.expected_evr }}
-          path: opensuse-leap160-daily-stable-artifacts
+          name: opensuse-leap160-daily-stable-${{ needs.build.outputs.expected_evr }}-x86_64
+          path: opensuse-leap160-daily-stable-artifacts/x86_64
+
+      - name: Download openSUSE aarch64 package artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: opensuse-leap160-daily-stable-${{ needs.build.outputs.expected_evr }}-aarch64
+          path: opensuse-leap160-daily-stable-artifacts/aarch64
 
       - name: Verify artifact checksums
         run: |
-          cd opensuse-leap160-daily-stable-artifacts
-          sha256sum -c SHA256SUMS
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            (cd "opensuse-leap160-daily-stable-artifacts/$arch" && sha256sum -c SHA256SUMS)
+          done
 
       - name: Import signing key and unlock its agent
         run: |
@@ -375,15 +406,17 @@ jobs:
 
       - name: Sign binary and source RPMs
         run: |
-          "$OPENSUSE_DAILY_STABLE_HELPER" sign-rpms \
-            opensuse-leap160-daily-stable-artifacts \
-            "$ARCHIVE_GPG_FINGERPRINT"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            "$OPENSUSE_DAILY_STABLE_HELPER" sign-rpms \
+              "opensuse-leap160-daily-stable-artifacts/$arch" \
+              "$ARCHIVE_GPG_FINGERPRINT"
+          done
 
       - name: Download current repository metadata
         run: |
           set -euo pipefail
-          mkdir -p "rpm-repo/$RPM_ARCH" rpm-repo/SRPMS
-          for repo_subdir in "$RPM_ARCH" SRPMS; do
+          for repo_subdir in $PACKAGE_REPOSITORY_ARCHITECTURES SRPMS; do
+            mkdir -p "rpm-repo/$repo_subdir"
             aws s3 sync \
               --only-show-errors \
               --endpoint-url "$SPACE_ENDPOINT" \
@@ -393,29 +426,34 @@ jobs:
 
       - name: Generate signed incremental RPM repositories
         run: |
-          "$OPENSUSE_DAILY_STABLE_HELPER" generate-repo \
-            opensuse-leap160-daily-stable-artifacts \
-            rpm-repo \
-            "$RPM_ARCH" \
-            "$ARCHIVE_GPG_FINGERPRINT" \
-            "$GPG_PASSPHRASE_FILE"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            "$OPENSUSE_DAILY_STABLE_HELPER" generate-repo \
+              "opensuse-leap160-daily-stable-artifacts/$arch" \
+              rpm-repo \
+              "$arch" \
+              "$ARCHIVE_GPG_FINGERPRINT" \
+              "$GPG_PASSPHRASE_FILE"
+          done
 
       - name: Generate signed artifact manifest and snapshot
         env:
           ARCHIVE_DATE: ${{ needs.build.outputs.archive_date }}
           EXPECTED_EVR: ${{ needs.build.outputs.expected_evr }}
         run: |
-          "$OPENSUSE_DAILY_STABLE_HELPER" manifest \
-            opensuse-leap160-daily-stable-artifacts \
-            "$EXPECTED_EVR" "$RPM_ARCH" "$PACKAGE_CHANNEL" \
-            "$PACKAGE_DISTRO" "$PACKAGE_DISTRO_VERSION"
           snapshot_dir="rpm-repo/snapshots/$ARCHIVE_DATE/$EXPECTED_EVR"
-          mkdir -p "$snapshot_dir"
-          cp -a opensuse-leap160-daily-stable-artifacts/manifest.json \
-            opensuse-leap160-daily-stable-artifacts/SHA256SUMS \
-            opensuse-leap160-daily-stable-artifacts/build.log \
-            opensuse-leap160-daily-stable-artifacts/rsyslog.spec \
-            "$snapshot_dir/"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            artifact_dir="opensuse-leap160-daily-stable-artifacts/$arch"
+            "$OPENSUSE_DAILY_STABLE_HELPER" manifest \
+              "$artifact_dir" \
+              "$EXPECTED_EVR" "$arch" "$PACKAGE_CHANNEL" \
+              "$PACKAGE_DISTRO" "$PACKAGE_DISTRO_VERSION"
+            mkdir -p "$snapshot_dir/$arch"
+            cp -a "$artifact_dir/manifest.json" \
+              "$artifact_dir/SHA256SUMS" \
+              "$artifact_dir/build.log" \
+              "$artifact_dir/rsyslog.spec" \
+              "$snapshot_dir/$arch/"
+          done
 
       - name: Generate repository configuration
         run: |
@@ -465,8 +503,8 @@ jobs:
           while IFS= read -r -d '' path; do
             upload_immutable "$path"
           done < <(
-            find "rpm-repo/$RPM_ARCH/Packages" rpm-repo/SRPMS/Packages \
-              rpm-repo/snapshots -type f -print0
+            find rpm-repo/x86_64/Packages rpm-repo/aarch64/Packages \
+              rpm-repo/SRPMS/Packages rpm-repo/snapshots -type f -print0
           )
 
       - name: Publish archive key and mutable metadata
@@ -483,7 +521,7 @@ jobs:
           }
           upload_metadata rpm-repo/rsyslog-archive-keyring.asc
           upload_metadata rpm-repo/rsyslog-daily-stable-opensuse-leap160.repo
-          for repo_subdir in "$RPM_ARCH" SRPMS; do
+          for repo_subdir in $PACKAGE_REPOSITORY_ARCHITECTURES SRPMS; do
             while IFS= read -r -d '' path; do
               upload_metadata "$path"
             done < <(
@@ -495,10 +533,18 @@ jobs:
           done
 
   verify:
-    name: verify published openSUSE Leap 16.0 repository
+    name: verify published openSUSE Leap 16.0 ${{ matrix.arch }} repository
     needs: [preflight, build, publish]
     if: needs.preflight.outputs.should_publish == 'true'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     container:
       image: opensuse/leap:16.0
@@ -507,6 +553,7 @@ jobs:
     permissions:
       contents: read
     env:
+      RPM_ARCH: ${{ matrix.arch }}
       REPO_URL: ${{ vars.OPENSUSE_LEAP160_DAILY_STABLE_REPO_URL }}
       ORIGIN_REPO_URL: ${{ vars.OPENSUSE_LEAP160_DAILY_STABLE_ORIGIN_REPO_URL }}
       EXPECTED_GPG_FINGERPRINT: ${{ vars.DEBIAN_DAILY_STABLE_GPG_FINGERPRINT }}

--- a/.github/workflows/ubuntu_daily_stable.yml
+++ b/.github/workflows/ubuntu_daily_stable.yml
@@ -45,7 +45,7 @@ env:
   DEBIAN_BUILD_ROOT: /tmp/rsyslog-ubuntu-daily-stable-build
   DEBIAN_SUITE: resolute
   DEBIAN_COMPONENT: main
-  DEBIAN_ARCH: amd64
+  PACKAGE_REPOSITORY_ARCHITECTURES: amd64 arm64
   PACKAGE_CHANNEL: daily-stable
   PACKAGE_DISTRO: ubuntu
   PACKAGE_DISTRO_LABEL: Ubuntu
@@ -108,16 +108,26 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   build:
-    name: build Ubuntu 26.04 amd64 packages
+    name: build Ubuntu 26.04 ${{ matrix.arch }} packages
     needs: preflight
     if: needs.preflight.outputs.should_run == 'true'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     container:
       image: ubuntu:26.04
       options: --user root
     permissions:
       contents: read
+    env:
+      DEBIAN_ARCH: ${{ matrix.arch }}
     outputs:
       archive_date: ${{ steps.version.outputs.archive_date }}
       version: ${{ steps.version.outputs.version }}
@@ -295,7 +305,7 @@ jobs:
       - name: Upload Ubuntu package artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ubuntu-daily-stable-${{ steps.version.outputs.version }}
+          name: ubuntu-daily-stable-${{ steps.version.outputs.version }}-${{ matrix.arch }}
           path: ubuntu-daily-stable-artifacts/
           retention-days: 14
           if-no-files-found: error
@@ -375,16 +385,23 @@ jobs:
             }
           done
 
-      - name: Download Ubuntu package artifacts
+      - name: Download Ubuntu amd64 package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ubuntu-daily-stable-${{ needs.build.outputs.version }}
-          path: ubuntu-daily-stable-artifacts
+          name: ubuntu-daily-stable-${{ needs.build.outputs.version }}-amd64
+          path: ubuntu-daily-stable-artifacts/amd64
+
+      - name: Download Ubuntu arm64 package artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ubuntu-daily-stable-${{ needs.build.outputs.version }}-arm64
+          path: ubuntu-daily-stable-artifacts/arm64
 
       - name: Verify artifact checksums
         run: |
-          cd ubuntu-daily-stable-artifacts
-          sha256sum -c SHA256SUMS
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            (cd "ubuntu-daily-stable-artifacts/$arch" && sha256sum -c SHA256SUMS)
+          done
 
       - name: Import archive signing key
         run: |
@@ -397,7 +414,9 @@ jobs:
       - name: Download current indexes
         run: |
           set -euo pipefail
-          mkdir -p "apt-repo/dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/binary-$DEBIAN_ARCH"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            mkdir -p "apt-repo/dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/binary-$arch"
+          done
           mkdir -p "apt-repo/dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/source"
 
           download_if_present() {
@@ -422,19 +441,23 @@ jobs:
             fi
           }
 
-          download_if_present \
-            "dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/binary-$DEBIAN_ARCH/Packages.xz"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            download_if_present \
+              "dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/binary-$arch/Packages.xz"
+          done
           download_if_present \
             "dists/$DEBIAN_SUITE/$DEBIAN_COMPONENT/source/Sources.xz"
 
       - name: Generate signed incremental APT repository
         run: |
-          "$GITHUB_WORKSPACE/$DEBIAN_DAILY_STABLE_HELPER" generate-repo \
-            "$GITHUB_WORKSPACE/ubuntu-daily-stable-artifacts" \
-            "$GITHUB_WORKSPACE/apt-repo" \
-            "$DEBIAN_SUITE" \
-            "$DEBIAN_COMPONENT" \
-            "$DEBIAN_ARCH"
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            "$GITHUB_WORKSPACE/$DEBIAN_DAILY_STABLE_HELPER" generate-repo \
+              "$GITHUB_WORKSPACE/ubuntu-daily-stable-artifacts/$arch" \
+              "$GITHUB_WORKSPACE/apt-repo" \
+              "$DEBIAN_SUITE" \
+              "$DEBIAN_COMPONENT" \
+              "$arch"
+          done
 
       - name: Prepare immutable build snapshot
         env:
@@ -443,12 +466,14 @@ jobs:
         run: |
           set -euo pipefail
           snapshot_dir="apt-repo/snapshots/$ARCHIVE_DATE/$VERSION"
-          mkdir -p "$snapshot_dir"
-          find ubuntu-daily-stable-artifacts -maxdepth 1 -type f \
-            \( -name 'manifest.json' -o -name 'SHA256SUMS' \
-               -o -name '*.changes' -o -name '*.buildinfo' \
-               -o -name 'build.log' \) \
-            -exec cp -a {} "$snapshot_dir/" \;
+          for arch in $PACKAGE_REPOSITORY_ARCHITECTURES; do
+            mkdir -p "$snapshot_dir/$arch"
+            find "ubuntu-daily-stable-artifacts/$arch" -maxdepth 1 -type f \
+              \( -name 'manifest.json' -o -name 'SHA256SUMS' \
+                 -o -name '*.changes' -o -name '*.buildinfo' \
+                 -o -name 'build.log' \) \
+              -exec cp -a {} "$snapshot_dir/$arch/" \;
+          done
 
       - name: Publish immutable packages and snapshots
         run: |
@@ -539,13 +564,21 @@ jobs:
           upload_metadata "apt-repo/dists/$DEBIAN_SUITE/InRelease"
 
   verify:
-    name: verify published Ubuntu 26.04 repository
+    name: verify published Ubuntu 26.04 ${{ matrix.arch }} repository
     needs:
       - preflight
       - build
       - publish
     if: needs.preflight.outputs.should_publish == 'true'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     container:
       image: ubuntu:26.04
@@ -557,6 +590,7 @@ jobs:
     permissions:
       contents: read
     env:
+      DEBIAN_ARCH: ${{ matrix.arch }}
       REPO_URL: ${{ vars.UBUNTU_DAILY_STABLE_REPO_URL }}
       EXPECTED_GPG_FINGERPRINT: ${{ vars.DEBIAN_DAILY_STABLE_GPG_FINGERPRINT }}
     steps:

--- a/devtools/release/debian-daily-stable.sh
+++ b/devtools/release/debian-daily-stable.sh
@@ -377,7 +377,9 @@ cmd_generate_repo() {
 
   (
     cd "$repo_dir"
-    apt-ftparchive packages "pool/$component/r/rsyslog" > "$packages_file.new"
+    apt-ftparchive \
+      -o "APT::FTPArchive::Architecture=$arch" \
+      packages "pool/$component/r/rsyslog" > "$packages_file.new"
     if find "pool/$component/r/rsyslog" -maxdepth 1 -type f -name '*.dsc' |
        grep -q .; then
       apt-ftparchive sources "pool/$component/r/rsyslog" > "$sources_file.new"
@@ -403,7 +405,7 @@ cmd_generate_repo() {
       -o "APT::FTPArchive::Release::Label=rsyslog daily stable" \
       -o "APT::FTPArchive::Release::Suite=$suite" \
       -o "APT::FTPArchive::Release::Codename=$suite" \
-      -o "APT::FTPArchive::Release::Architectures=$arch" \
+      -o "APT::FTPArchive::Release::Architectures=${PACKAGE_REPOSITORY_ARCHITECTURES:-$arch}" \
       -o "APT::FTPArchive::Release::Components=$component" \
       -o "APT::FTPArchive::Release::Acquire-By-Hash=yes" \
       -o "APT::FTPArchive::Release::Description=rsyslog ${PACKAGE_DISTRO_LABEL:-Debian} daily stable packages" \
@@ -509,17 +511,18 @@ cmd_verify_repo() (
 build_self_test_deb() {
   local root="$1"
   local version="$2"
+  local arch="${3:-amd64}"
   local package_dir="$root/package-$version"
 
   install -m 755 -d "$package_dir/DEBIAN"
   {
     echo "Package: rsyslog"
     echo "Version: $version"
-    echo "Architecture: amd64"
+    echo "Architecture: $arch"
     echo "Maintainer: rsyslog test <test@example.invalid>"
     echo "Description: synthetic daily archive test package"
   } > "$package_dir/DEBIAN/control"
-  dpkg-deb --build "$package_dir" "$root/rsyslog_${version}_amd64.deb" >/dev/null
+  dpkg-deb --build "$package_dir" "$root/rsyslog_${version}_${arch}.deb" >/dev/null
 }
 
 cmd_self_test() (
@@ -554,16 +557,40 @@ cmd_self_test() (
     "rsyslog archive self-test <test@example.invalid>" rsa2048 sign 0 >/dev/null 2>&1
   fingerprint="$(secret_key_fingerprint)"
 
-  build_self_test_deb "$first_artifacts" "1.0~daily1"
+  export PACKAGE_REPOSITORY_ARCHITECTURES="amd64 arm64"
+  build_self_test_deb "$first_artifacts" "1.0~daily1" amd64
+  build_self_test_deb "$first_artifacts" "1.0~daily1" arm64
   cmd_generate_repo "$first_artifacts" "$repo_dir" "$test_suite" main amd64
+  cmd_generate_repo "$first_artifacts" "$repo_dir" "$test_suite" main arm64
   cmd_verify_repo "file://$repo_dir" "$test_suite" main amd64 \
     "1.0~daily1" "$fingerprint"
+  cmd_verify_repo "file://$repo_dir" "$test_suite" main arm64 \
+    "1.0~daily1" "$fingerprint"
+  xz -dc "$repo_dir/dists/$test_suite/main/binary-amd64/Packages.xz" |
+    grep -Fxq 'Architecture: amd64' ||
+    die "amd64 package index is missing its native package"
+  if xz -dc "$repo_dir/dists/$test_suite/main/binary-amd64/Packages.xz" |
+     grep -Fxq 'Architecture: arm64'; then
+    die "amd64 package index contains an arm64 package"
+  fi
+  xz -dc "$repo_dir/dists/$test_suite/main/binary-arm64/Packages.xz" |
+    grep -Fxq 'Architecture: arm64' ||
+    die "arm64 package index is missing its native package"
+  grep -Fxq 'Architectures: amd64 arm64' \
+    "$repo_dir/dists/$test_suite/Release" ||
+    die "Release metadata does not advertise both architectures"
 
-  build_self_test_deb "$second_artifacts" "1.0~daily2"
+  build_self_test_deb "$second_artifacts" "1.0~daily2" amd64
+  build_self_test_deb "$second_artifacts" "1.0~daily2" arm64
   cmd_generate_repo "$second_artifacts" "$repo_dir" "$test_suite" main amd64
+  cmd_generate_repo "$second_artifacts" "$repo_dir" "$test_suite" main arm64
   cmd_verify_repo "file://$repo_dir" "$test_suite" main amd64 \
     "1.0~daily1" "$fingerprint"
   cmd_verify_repo "file://$repo_dir" "$test_suite" main amd64 \
+    "1.0~daily2" "$fingerprint"
+  cmd_verify_repo "file://$repo_dir" "$test_suite" main arm64 \
+    "1.0~daily1" "$fingerprint"
+  cmd_verify_repo "file://$repo_dir" "$test_suite" main arm64 \
     "1.0~daily2" "$fingerprint"
 
   rm -rf "$tmp_dir"

--- a/devtools/release/rpm-daily-stable.sh
+++ b/devtools/release/rpm-daily-stable.sh
@@ -8,7 +8,7 @@ Usage: rpm-daily-stable.sh <command> [args...]
 Commands:
   version
   prepare-sources <baseline-dir> <dist-tarball> <output-dir> <policy-file> <feature-contract> <version> <release>
-  build-package <prepared-dir> <mock-config> <artifact-dir> <build-log> <expected-evr>
+  build-package <prepared-dir> <mock-config> <artifact-dir> <build-log> <expected-evr> <arch>
   sign-rpms <artifact-dir> <fingerprint>
   generate-repo <artifact-dir> <repo-dir> <arch> <fingerprint> <passphrase-file>
   verify-repo <repo-url> <arch> <expected-evr> <expected-fingerprint>
@@ -211,6 +211,7 @@ cmd_build_package() {
   local artifact_dir="$3"
   local build_log="$4"
   local expected_evr="$5"
+  local arch="$6"
   local srpm rpm_file actual_evr rc
 
   rm -rf "$artifact_dir"
@@ -236,7 +237,7 @@ cmd_build_package() {
   [ "$rc" -eq 0 ] || return "$rc"
 
   rpm_file="$(find "$artifact_dir/rpms" -maxdepth 1 -type f \
-    -name 'rsyslog-[0-9]*.x86_64.rpm' ! -name '*-debuginfo-*' -print -quit)"
+    -name "rsyslog-[0-9]*.${arch}.rpm" ! -name '*-debuginfo-*' -print -quit)"
   [ -n "$rpm_file" ] || die "mock did not produce the base rsyslog RPM"
   actual_evr="$(rpm -qp --qf '%{VERSION}-%{RELEASE}\n' "$rpm_file")"
   [ "$actual_evr" = "$expected_evr" ] ||


### PR DESCRIPTION
## Summary

- build native arm64/aarch64 packages alongside amd64/x86_64 for every current daily-stable distro workflow
- publish both architectures in one serialized repository update with architecture-specific immutable snapshots
- verify each public package by installing and smoke-testing it on a matching native GitHub ARM runner
- make APT and RPM helpers architecture-aware and extend the signed APT repository self-test to both architectures

## Covered distributions

- Debian 13
- Ubuntu 26.04
- EL10 (CentOS Stream, Rocky, AlmaLinux, and Oracle Linux verification)
- Amazon Linux 2023
- Fedora 44
- openSUSE Leap 16.0
- Alpine 3.24

## Local validation

- Ubuntu 26.04 PR-ready container suite: 1,506 passed, 29 skipped, 0 failed/errors
- Ubuntu 26.04 clang static analyzer: passed, no findings
- `actionlint` on all seven workflows: passed
- pinned zizmor 1.25.2 on `.github/workflows`: passed, no findings
- `shellcheck -S warning` on changed release helpers: passed
- flake-evidence workflow coverage: passed
- signed dual-architecture APT archive self-test: passed
- direct host dist-tarball generation used by ARM RPM/Alpine jobs: passed
- `git diff --check`: passed

Local Cubic was intentionally not run per the repository local override.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

