### PR TITLE
packaging: fix daily ARM verification

### DIFF
--- a/.github/workflows/alpine324_daily_stable.yml
+++ b/.github/workflows/alpine324_daily_stable.yml
@@ -503,9 +503,6 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
-    container:
-      image: alpine:3.24
-      options: --user root
     environment: debian-daily-stable
     permissions:
       contents: read
@@ -521,9 +518,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install verification tools
-        run: apk add --no-cache bash ca-certificates curl python3
-
       - name: Verify CDN reachability and exact origin installation
         id: published_install
         shell: bash
@@ -532,57 +526,18 @@ jobs:
           mkdir -p .ci/flake-evidence/logs
           devtools/ci-flake-phase.sh begin alpine324-published-install custom
           set +e
-          (
-            set -euo pipefail
-            [ -n "$REPO_URL" ]
-            [ -n "$ORIGIN_REPO_URL" ]
-            curl -fsSL "$REPO_URL/rsyslog-alpine-archive.rsa.pub" \
-              -o /tmp/rsyslog-alpine-cdn-key.pub
-            [ "$(sha256sum /tmp/rsyslog-alpine-cdn-key.pub | awk '{print $1}')" = \
-              "$EXPECTED_PUBLIC_KEY_SHA256" ]
-            curl -fsSL "$REPO_URL/$ALPINE_ARCH/APKINDEX.tar.gz" \
-              -o /tmp/rsyslog-alpine-cdn-index.tar.gz
-            tar -tzf /tmp/rsyslog-alpine-cdn-index.tar.gz | grep -Fx APKINDEX
-            verification_rc=1
-            for attempt in $(seq 1 20); do
-              rm -f /tmp/rsyslog-alpine-archive.rsa.pub
-              if curl -fsSL \
-                  "$ORIGIN_REPO_URL/rsyslog-alpine-archive.rsa.pub" \
-                  -o /tmp/rsyslog-alpine-archive.rsa.pub &&
-                [ "$(sha256sum /tmp/rsyslog-alpine-archive.rsa.pub | awk '{print $1}')" = \
-                  "$EXPECTED_PUBLIC_KEY_SHA256" ]; then
-                cp /tmp/rsyslog-alpine-archive.rsa.pub /etc/apk/keys/
-                if ! grep -Fxq "$ORIGIN_REPO_URL" /etc/apk/repositories; then
-                  echo "$ORIGIN_REPO_URL" >> /etc/apk/repositories
-                fi
-                if apk update --no-cache &&
-                  apk add --no-cache \
-                    "rsyslog=$EXPECTED_VERSION" \
-                    "rsyslog-omazuredce=$EXPECTED_VERSION"; then
-                  verification_rc=0
-                  break
-                fi
-              fi
-              echo "Origin repository not ready yet, retrying ($attempt/20)..."
-              [ "$attempt" -eq 20 ] || sleep 30
-            done
-            [ "$verification_rc" -eq 0 ]
-            installed_version="$(
-              apk query --from installed --fields version --format json rsyslog |
-                sed -n 's/.*"version": "\([^"]*\)".*/\1/p'
-            )"
-            [ "$installed_version" = "$EXPECTED_VERSION" ]
-            module_version="$(
-              apk query --from installed --fields version --format json \
-                rsyslog-omazuredce |
-                sed -n 's/.*"version": "\([^"]*\)".*/\1/p'
-            )"
-            [ "$module_version" = "$EXPECTED_VERSION" ]
-            apk info -L rsyslog-omazuredce | \
-              grep -Eq '/rsyslog/omazuredce\.so$'
-            rsyslogd -v
-            devtools/release/package-feature-smoke.sh
-          ) 2>&1 | tee .ci/flake-evidence/logs/alpine324-published-install.log
+          docker run --rm \
+            -e ALPINE_ARCH -e ALPINE_DAILY_STABLE_HELPER \
+            -e EXPECTED_PUBLIC_KEY_SHA256 \
+            -e EXPECTED_VERSION -e ORIGIN_REPO_URL -e REPO_URL \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -w /workspace \
+            alpine:3.24 sh -lc '
+            apk add --no-cache bash ca-certificates curl python3
+            "$ALPINE_DAILY_STABLE_HELPER" verify-published \
+              "$REPO_URL" "$ORIGIN_REPO_URL" "$ALPINE_ARCH" \
+              "$EXPECTED_VERSION" "$EXPECTED_PUBLIC_KEY_SHA256"
+          ' 2>&1 | tee .ci/flake-evidence/logs/alpine324-published-install.log
           install_status=${PIPESTATUS[0]}
           set -e
           devtools/ci-flake-phase.sh end \

--- a/.github/workflows/el10_daily_stable.yml
+++ b/.github/workflows/el10_daily_stable.yml
@@ -501,7 +501,7 @@ jobs:
           done
 
   verify:
-    name: verify ${{ matrix.name }} EL10 ${{ matrix.target.arch }} repository
+    name: verify ${{ matrix.distro.name }} EL10 ${{ matrix.target.arch }} repository
     needs: [preflight, build, publish]
     if: needs.preflight.outputs.should_publish == 'true'
     runs-on: ${{ matrix.target.runner }}
@@ -514,7 +514,7 @@ jobs:
             runner: ubuntu-24.04
           - arch: aarch64
             runner: ubuntu-24.04-arm
-        include:
+        distro:
           - name: CentOS Stream
             image: quay.io/centos/centos:stream10
           - name: Rocky Linux
@@ -524,7 +524,7 @@ jobs:
           - name: Oracle Linux
             image: container-registry.oracle.com/os/oraclelinux:10
     container:
-      image: ${{ matrix.image }}
+      image: ${{ matrix.distro.image }}
       options: --user root
     environment: debian-daily-stable
     permissions:
@@ -606,7 +606,7 @@ jobs:
           }}
         uses: ./.github/actions/upload-flake-evidence
         with:
-          job-name: ${{ matrix.name }} EL10 daily stable verification
+          job-name: ${{ matrix.distro.name }} EL10 daily stable verification
 
   report_failure:
     name: report failure

--- a/devtools/release/alpine-daily-stable.sh
+++ b/devtools/release/alpine-daily-stable.sh
@@ -9,6 +9,7 @@ Commands:
   version
   prepare-sources <baseline-dir> <dist-tarball> <output-dir> <policy-file> <feature-contract> <pkgver>
   verify-artifacts <artifact-dir> <expected-version> <arch>
+  verify-published <repo-url> <origin-url> <arch> <expected-version> <public-key-sha256>
   generate-index <artifact-dir> <previous-index> <repo-dir> <arch> <private-key> <public-key>
   manifest <artifact-dir> <expected-version> <arch> <channel> <distro> <distro-version>
 EOF
@@ -159,6 +160,64 @@ cmd_verify_artifacts() {
 		die "builder architecture $(apk --print-arch) does not match $arch"
 }
 
+cmd_verify_published() {
+	local repo_url="$1"
+	local origin_url="$2"
+	local arch="$3"
+	local expected_version="$4"
+	local expected_public_key_sha256="$5"
+	local attempt installed_version module_version verification_rc=1
+
+	[ -n "$repo_url" ] || die "missing public Alpine repository URL"
+	[ -n "$origin_url" ] || die "missing Alpine repository origin URL"
+	curl -fsSL "$repo_url/rsyslog-alpine-archive.rsa.pub" \
+		-o /tmp/rsyslog-alpine-cdn-key.pub
+	[ "$(sha256sum /tmp/rsyslog-alpine-cdn-key.pub | awk '{print $1}')" = \
+		"$expected_public_key_sha256" ] || die "CDN public key digest mismatch"
+	curl -fsSL "$repo_url/$arch/APKINDEX.tar.gz" \
+		-o /tmp/rsyslog-alpine-cdn-index.tar.gz
+	tar -tzf /tmp/rsyslog-alpine-cdn-index.tar.gz | grep -Fxq APKINDEX ||
+		die "CDN repository index is invalid"
+
+	for attempt in $(seq 1 20); do
+		rm -f /tmp/rsyslog-alpine-archive.rsa.pub
+		if curl -fsSL "$origin_url/rsyslog-alpine-archive.rsa.pub" \
+			-o /tmp/rsyslog-alpine-archive.rsa.pub &&
+			[ "$(sha256sum /tmp/rsyslog-alpine-archive.rsa.pub | awk '{print $1}')" = \
+				"$expected_public_key_sha256" ]; then
+			cp /tmp/rsyslog-alpine-archive.rsa.pub /etc/apk/keys/
+			if ! grep -Fxq "$origin_url" /etc/apk/repositories; then
+				echo "$origin_url" >> /etc/apk/repositories
+			fi
+			if apk update --no-cache &&
+				apk add --no-cache \
+					"rsyslog=$expected_version" \
+					"rsyslog-omazuredce=$expected_version"; then
+				verification_rc=0
+				break
+			fi
+		fi
+		echo "Origin repository not ready yet, retrying ($attempt/20)..."
+		[ "$attempt" -eq 20 ] || sleep 30
+	done
+	[ "$verification_rc" -eq 0 ] || die "could not install the expected published packages"
+	installed_version="$(
+		apk query --from installed --fields version --format json rsyslog |
+			sed -n 's/.*"version": "\([^"]*\)".*/\1/p'
+	)"
+	[ "$installed_version" = "$expected_version" ] || die "installed rsyslog version mismatch"
+	module_version="$(
+		apk query --from installed --fields version --format json \
+			rsyslog-omazuredce |
+			sed -n 's/.*"version": "\([^"]*\)".*/\1/p'
+	)"
+	[ "$module_version" = "$expected_version" ] || die "installed omazuredce version mismatch"
+	apk info -L rsyslog-omazuredce | grep -Eq '/rsyslog/omazuredce\.so$' ||
+		die "omazuredce module file is absent"
+	rsyslogd -v
+	"$(dirname "$0")/package-feature-smoke.sh"
+}
+
 cmd_generate_index() {
 	local artifact_dir="$1"
 	local previous_index="$2"
@@ -239,6 +298,7 @@ case "$command" in
 	version) shift; cmd_version "$@" ;;
 	prepare-sources) shift; cmd_prepare_sources "$@" ;;
 	verify-artifacts) shift; cmd_verify_artifacts "$@" ;;
+	verify-published) shift; cmd_verify_published "$@" ;;
 	generate-index) shift; cmd_generate_index "$@" ;;
 	manifest) shift; cmd_manifest "$@" ;;
 	*) usage; exit 2 ;;

--- a/devtools/release/package-feature-overlay.py
+++ b/devtools/release/package-feature-overlay.py
@@ -168,7 +168,7 @@ def apply_rpm(spec_path, contract_path, flavor):
     if configure_flag not in text:
         text = replace_once(
             text,
-            r"(?m)^(\s*--enable-omhttp(?:fs)?\s*\\)$",
+            r"(?m)^(\s*--enable-omhttp\s*\\)$",
             rf"\t{configure_flag} \\" + "\n" + r"\g<1>",
             "RPM configure option anchor",
         )


### PR DESCRIPTION
## Summary

Fix three defects found by the first public native ARM archive run:

- run Alpine verification from the native Ubuntu host and launch Alpine in Docker, avoiding the GitHub JavaScript-action limitation inside musl ARM job containers
- use the unique `--enable-omhttp` openSUSE spec anchor instead of matching both `omhttp` and `omhttpfs`
- cross the EL10 distro and architecture matrix axes so CentOS Stream, Rocky, AlmaLinux, and Oracle Linux are all verified on x86_64 and aarch64

## End-to-end evidence

Initial public run results:

- Debian 13: passed both architectures, publication, and public installation
- Ubuntu 26.04: passed both architectures, publication, and public installation
- EL10: passed both builds, publication, and the two Oracle checks that the matrix accidentally generated
- Amazon Linux 2023: passed both architectures, publication, and public installation
- Fedora 44: passed both architectures, publication, and public installation
- Alpine 3.24: both builds and publication passed; x86_64 installation passed; aarch64 stopped before testing because checkout cannot run in an Alpine ARM job container
- openSUSE Leap 16.0: both builds reached the same ambiguous overlay anchor and stopped before publication

## Local validation

- Ubuntu 26.04 PR-ready container suite: 1,506 passed, 29 skipped, zero failures/errors
- Ubuntu 26.04 static analyzer: passed, no findings
- public Alpine x86_64 archive install and YAML/omazuredce smoke test through the new helper: passed
- openSUSE duplicate-anchor overlay fixture: passed
- actionlint, pinned zizmor 1.25.2, shellcheck, Python syntax, flake-evidence coverage, and `git diff --check`: passed

Local Cubic is not a validation gate per the repository-local override.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

