### PR TITLE
testbench: ship qradar_json-with-dots in dist

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 --------------------------------------------------------------------------------------
 Scheduled Release 8.2608.0 (aka 2026.08) 2026-08-??
 
+- 2026-07-31: testbench: ship qradar_json-with-dots in dist
+  Include testsuites/qradar_json-with-dots in EXTRA_DIST so
+  data_pipeline-qradar.sh can run from release tarballs.
+  Closes https://github.com/rsyslog/rsyslog/issues/7456
 - 2026-07-15: imjournal: stop invalidation recovery busy-loop
   Reopened journal handles now initialize their change notification state
   before cursor restoration. This prevents journal rotation or invalidation

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3969,6 +3969,7 @@ EXTRA_DIST += \
 	testsuites/pmnormalize_basic.rulebase \
 	validate_json_equality.py \
 	testsuites/qradar_json \
+	testsuites/qradar_json-with-dots \
 	snmptrapreceiver.py \
 	omamqp1-common.sh
 


### PR DESCRIPTION
Why: Release tarball builds failed data_pipeline-qradar.sh because the fixture was missing from EXTRA_DIST.

Impact: Package/dist make check can run the QRadar pipeline test.

Before: make dist omitted testsuites/qradar_json-with-dots.
After: The fixture is packaged next to testsuites/qradar_json.

Technical Overview:
- Add testsuites/qradar_json-with-dots to tests/Makefile.am EXTRA_DIST beside the existing qradar_json fixture.
- data_pipeline-qradar.sh already injects that file; only the dist list was incomplete.
- Document the packaging fix in the 8.2608 ChangeLog block.

Closes: https://github.com/rsyslog/rsyslog/issues/7456
