### PR TITLE
packaging: add daily-stable package profile POC

### DIFF
--- a/.github/DAILY_STABLE_PACKAGE_FEATURES.md
+++ b/.github/DAILY_STABLE_PACKAGE_FEATURES.md
@@ -8,23 +8,28 @@ layout.
 The prototype contract requires:
 
 - libyaml-backed YAML configuration support in the base `rsyslog` package;
-- a separately installable `omazuredce` module package; and
-- published-package smoke tests that parse YAML and load `omazuredce`.
+- separately installable OpenSSL, GnuTLS, `omotel`, and `omazuredce` module
+  packages;
+- an `rsyslog-standard` profile that pulls in the TLS drivers and `omotel`;
+- an `rsyslog-full` profile that extends `standard` with `omazuredce`; and
+- published-package smoke tests that parse YAML and load every profile module.
 
 The overlay fails when a native baseline disables YAML, omits the distribution's
 YAML development dependency, or no longer contains a unique structural anchor.
 This makes native packaging drift a review event instead of silently generating
 a different package.
 
-Package names follow native conventions:
+The module package names follow native conventions:
 
-| Packaging family | Package |
-| --- | --- |
-| Debian, Ubuntu | `rsyslog-omazuredce` |
-| Fedora, EL, Amazon Linux | `rsyslog-omazuredce` |
-| openSUSE | `rsyslog-module-omazuredce` |
-| Alpine | `rsyslog-omazuredce` |
+| Packaging family | OpenSSL | GnuTLS | omotel | omazuredce |
+| --- | --- | --- | --- | --- |
+| Debian, Ubuntu | `rsyslog-openssl` | `rsyslog-gnutls` | `rsyslog-omotel` | `rsyslog-omazuredce` |
+| Fedora, EL, Amazon Linux | `rsyslog-openssl` | `rsyslog-gnutls` | `rsyslog-omotel` | `rsyslog-omazuredce` |
+| openSUSE | `rsyslog-module-ossl` | `rsyslog-module-gtls` | `rsyslog-module-omotel` | `rsyslog-module-omazuredce` |
+| Alpine | `rsyslog-openssl` | `rsyslog-gnutls` | `rsyslog-omotel` | `rsyslog-omazuredce` |
 
-The feature smoke test runs only after installing the exact published versions
-of both the base and module packages. Scheduled workflow failures continue to
-create or update the distribution-specific daily-stable failure issue.
+Both profiles depend on the exact build version of the base and their selected
+modules. Published verification installs `standard` before `full`, then checks
+the installed version, module ownership, YAML parsing, and module loading.
+Scheduled workflow failures continue to create or update the
+distribution-specific daily-stable failure issue.

--- a/.github/daily-stable-package-features.yml
+++ b/.github/daily-stable-package-features.yml
@@ -9,15 +9,79 @@
   },
   "module_packages": [
     {
+      "module": "openssl",
+      "configure_flag": "--enable-openssl",
+      "module_file": "lmnsd_ossl.so",
+      "summary": "OpenSSL TLS support for rsyslog",
+      "description": "This package provides the OpenSSL network stream driver for encrypted TLS transport.",
+      "package_names": {
+        "deb": "rsyslog-openssl",
+        "rpm": "rsyslog-openssl",
+        "opensuse": "rsyslog-module-ossl",
+        "apk": "rsyslog-openssl"
+      }
+    },
+    {
+      "module": "gnutls",
+      "configure_flag": "--enable-gnutls",
+      "module_file": "lmnsd_gtls.so",
+      "summary": "GnuTLS TLS support for rsyslog",
+      "description": "This package provides the GnuTLS network stream driver for encrypted TLS transport.",
+      "package_names": {
+        "deb": "rsyslog-gnutls",
+        "rpm": "rsyslog-gnutls",
+        "opensuse": "rsyslog-module-gtls",
+        "apk": "rsyslog-gnutls"
+      }
+    },
+    {
+      "module": "omotel",
+      "configure_flag": "--enable-omotel",
+      "module_file": "omotel.so",
+      "summary": "OpenTelemetry output module for rsyslog",
+      "description": "This package provides the omotel output module for sending logs with OpenTelemetry OTLP/HTTP.",
+      "package_names": {
+        "deb": "rsyslog-omotel",
+        "rpm": "rsyslog-omotel",
+        "opensuse": "rsyslog-module-omotel",
+        "apk": "rsyslog-omotel"
+      }
+    },
+    {
       "module": "omazuredce",
       "configure_flag": "--enable-omazuredce",
       "module_file": "omazuredce.so",
       "summary": "Microsoft Azure Monitor Data Collection Endpoint output module for rsyslog",
+      "description": "This package provides the omazuredce output module for sending logs to Microsoft Azure Monitor through a Data Collection Endpoint.",
       "package_names": {
         "deb": "rsyslog-omazuredce",
         "rpm": "rsyslog-omazuredce",
         "opensuse": "rsyslog-module-omazuredce",
         "apk": "rsyslog-omazuredce"
+      }
+    }
+  ],
+  "profiles": [
+    {
+      "profile": "standard",
+      "summary": "Rsyslog standard functionality profile",
+      "modules": ["openssl", "gnutls", "omotel"],
+      "package_names": {
+        "deb": "rsyslog-standard",
+        "rpm": "rsyslog-standard",
+        "opensuse": "rsyslog-standard",
+        "apk": "rsyslog-standard"
+      }
+    },
+    {
+      "profile": "full",
+      "summary": "Rsyslog extended functionality profile",
+      "modules": ["openssl", "gnutls", "omotel", "omazuredce"],
+      "package_names": {
+        "deb": "rsyslog-full",
+        "rpm": "rsyslog-full",
+        "opensuse": "rsyslog-full",
+        "apk": "rsyslog-full"
       }
     }
   ]

--- a/.github/el10-daily-stable-policy.yml
+++ b/.github/el10-daily-stable-policy.yml
@@ -25,6 +25,14 @@
     {
       "package": "libyaml-devel",
       "reason": "Current upstream enables YAML configuration support by default while the EL10 8.2604 source package predates that build dependency."
+    },
+    {
+      "package": "protobuf-c-devel",
+      "reason": "The daily-stable omotel package uses protobuf-c generated message bindings."
+    },
+    {
+      "package": "protobuf-c-compiler",
+      "reason": "The daily-stable omotel package regenerates its protobuf-c message bindings."
     }
   ]
 }

--- a/.github/workflows/amazonlinux2023_daily_stable.yml
+++ b/.github/workflows/amazonlinux2023_daily_stable.yml
@@ -623,6 +623,11 @@ jobs:
               [ "$installed_evr" = "$EXPECTED_EVR" ]
             done
             dnf -q -y install "rsyslog-full-$EXPECTED_EVR"
+            full_requirements="$(rpm -q --requires rsyslog-full)"
+            for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
+              rsyslog-omazuredce; do
+              printf '%s\n' "$full_requirements" | grep -Fqx "$package = $EXPECTED_EVR"
+            done
             for package in rsyslog rsyslog-logrotate rsyslog-openssl \
               rsyslog-gnutls rsyslog-omotel rsyslog-omazuredce \
               rsyslog-standard rsyslog-full; do

--- a/.github/workflows/amazonlinux2023_daily_stable.yml
+++ b/.github/workflows/amazonlinux2023_daily_stable.yml
@@ -624,10 +624,18 @@ jobs:
             done
             dnf -q -y install "rsyslog-full-$EXPECTED_EVR"
             full_requirements="$(rpm -q --requires rsyslog-full)"
-            for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
-              rsyslog-omazuredce; do
-              printf '%s\n' "$full_requirements" | grep -Fqx "$package = $EXPECTED_EVR"
-            done
+            expected_full_requirements="$(
+              printf '%s\n' \
+                "rsyslog = $EXPECTED_EVR" \
+                "rsyslog-openssl = $EXPECTED_EVR" \
+                "rsyslog-gnutls = $EXPECTED_EVR" \
+                "rsyslog-omotel = $EXPECTED_EVR" \
+                "rsyslog-omazuredce = $EXPECTED_EVR" | sort
+            )"
+            actual_full_requirements="$(
+              printf '%s\n' "$full_requirements" | grep '^rsyslog' | sort
+            )"
+            [ "$actual_full_requirements" = "$expected_full_requirements" ]
             for package in rsyslog rsyslog-logrotate rsyslog-openssl \
               rsyslog-gnutls rsyslog-omotel rsyslog-omazuredce \
               rsyslog-standard rsyslog-full; do

--- a/.github/workflows/amazonlinux2023_daily_stable.yml
+++ b/.github/workflows/amazonlinux2023_daily_stable.yml
@@ -614,16 +614,25 @@ jobs:
             dnf -q -y install \
               "rsyslog-$EXPECTED_EVR" \
               "rsyslog-logrotate-$EXPECTED_EVR" \
-              "rsyslog-omazuredce-$EXPECTED_EVR" \
-              "rsyslog-openssl-$EXPECTED_EVR"
-            for package in rsyslog rsyslog-logrotate rsyslog-omazuredce \
-              rsyslog-openssl; do
+              "rsyslog-standard-$EXPECTED_EVR" \
+              "rsyslog-full-$EXPECTED_EVR"
+            for package in rsyslog rsyslog-logrotate rsyslog-openssl \
+              rsyslog-gnutls rsyslog-omotel rsyslog-omazuredce \
+              rsyslog-standard rsyslog-full; do
               installed_evr="$(
                 rpm -q --qf '%{VERSION}-%{RELEASE}\n' "$package"
               )"
               [ "$installed_evr" = "$EXPECTED_EVR" ]
             done
-            rpm -ql rsyslog-omazuredce | grep -Eq '/rsyslog/omazuredce\.so$'
+            for package_file in \
+              rsyslog-openssl:lmnsd_ossl.so \
+              rsyslog-gnutls:lmnsd_gtls.so \
+              rsyslog-omotel:omotel.so \
+              rsyslog-omazuredce:omazuredce.so; do
+              package="${package_file%%:*}"
+              module_file="${package_file#*:}"
+              rpm -ql "$package" | grep -Eq "/rsyslog/$module_file$"
+            done
             rsyslogd -v
             devtools/release/package-feature-smoke.sh
           ) 2>&1 | tee \

--- a/.github/workflows/amazonlinux2023_daily_stable.yml
+++ b/.github/workflows/amazonlinux2023_daily_stable.yml
@@ -614,8 +614,15 @@ jobs:
             dnf -q -y install \
               "rsyslog-$EXPECTED_EVR" \
               "rsyslog-logrotate-$EXPECTED_EVR" \
-              "rsyslog-standard-$EXPECTED_EVR" \
-              "rsyslog-full-$EXPECTED_EVR"
+              "rsyslog-standard-$EXPECTED_EVR"
+            for package in rsyslog rsyslog-logrotate rsyslog-openssl rsyslog-gnutls \
+              rsyslog-omotel rsyslog-standard; do
+              installed_evr="$(
+                rpm -q --qf '%{VERSION}-%{RELEASE}\n' "$package"
+              )"
+              [ "$installed_evr" = "$EXPECTED_EVR" ]
+            done
+            dnf -q -y install "rsyslog-full-$EXPECTED_EVR"
             for package in rsyslog rsyslog-logrotate rsyslog-openssl \
               rsyslog-gnutls rsyslog-omotel rsyslog-omazuredce \
               rsyslog-standard rsyslog-full; do
@@ -631,6 +638,7 @@ jobs:
               rsyslog-omazuredce:omazuredce.so; do
               package="${package_file%%:*}"
               module_file="${package_file#*:}"
+              module_file="${module_file//./\\.}"
               rpm -ql "$package" | grep -Eq "/rsyslog/$module_file$"
             done
             rsyslogd -v

--- a/.github/workflows/debian_daily_stable.yml
+++ b/.github/workflows/debian_daily_stable.yml
@@ -676,10 +676,19 @@ jobs:
             done
             apt-get install -y "rsyslog-full=$VERSION"
             full_dependencies="$(dpkg-query -W -f='${Depends}\n' rsyslog-full)"
-            for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
-              rsyslog-omazuredce; do
-              printf '%s\n' "$full_dependencies" | grep -Fq "$package (= $VERSION)"
-            done
+            expected_full_dependencies="$(
+              printf '%s\n' \
+                "rsyslog (= $VERSION)" \
+                "rsyslog-openssl (= $VERSION)" \
+                "rsyslog-gnutls (= $VERSION)" \
+                "rsyslog-omotel (= $VERSION)" \
+                "rsyslog-omazuredce (= $VERSION)" | sort
+            )"
+            actual_full_dependencies="$(
+              printf '%s\n' "$full_dependencies" | tr ',' '\n' |
+                sed 's/^ *//; s/ *$//' | grep '^rsyslog' | sort
+            )"
+            [ "$actual_full_dependencies" = "$expected_full_dependencies" ]
             installed_version="$(dpkg-query -W -f='${Version}\n' rsyslog)"
             [ "$installed_version" = "$VERSION" ] || {
               echo "installed rsyslog version $installed_version does not match $VERSION" >&2

--- a/.github/workflows/debian_daily_stable.yml
+++ b/.github/workflows/debian_daily_stable.yml
@@ -669,15 +669,26 @@ jobs:
             apt-get update
             apt-get install -y \
               "rsyslog=$VERSION" \
-              "rsyslog-omazuredce=$VERSION"
+              "rsyslog-standard=$VERSION" \
+              "rsyslog-full=$VERSION"
             installed_version="$(dpkg-query -W -f='${Version}\n' rsyslog)"
             [ "$installed_version" = "$VERSION" ] || {
               echo "installed rsyslog version $installed_version does not match $VERSION" >&2
               exit 1
             }
-            [ "$(dpkg-query -W -f='${Version}\n' rsyslog-omazuredce)" = "$VERSION" ]
-            dpkg-query -L rsyslog-omazuredce | \
-              grep -Eq '/rsyslog/omazuredce\.so$'
+            for package in rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
+              rsyslog-omazuredce rsyslog-standard rsyslog-full; do
+              [ "$(dpkg-query -W -f='${Version}\n' "$package")" = "$VERSION" ]
+            done
+            for package_file in \
+              rsyslog-openssl:lmnsd_ossl.so \
+              rsyslog-gnutls:lmnsd_gtls.so \
+              rsyslog-omotel:omotel.so \
+              rsyslog-omazuredce:omazuredce.so; do
+              package="${package_file%%:*}"
+              module_file="${package_file#*:}"
+              dpkg-query -L "$package" | grep -Eq "/rsyslog/$module_file$"
+            done
             rsyslogd -v
             devtools/release/package-feature-smoke.sh
           ) 2>&1 | tee .ci/flake-evidence/logs/debian-published-install.log

--- a/.github/workflows/debian_daily_stable.yml
+++ b/.github/workflows/debian_daily_stable.yml
@@ -669,8 +669,12 @@ jobs:
             apt-get update
             apt-get install -y \
               "rsyslog=$VERSION" \
-              "rsyslog-standard=$VERSION" \
-              "rsyslog-full=$VERSION"
+              "rsyslog-standard=$VERSION"
+            for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
+              rsyslog-standard; do
+              [ "$(dpkg-query -W -f='${Version}\n' "$package")" = "$VERSION" ]
+            done
+            apt-get install -y "rsyslog-full=$VERSION"
             installed_version="$(dpkg-query -W -f='${Version}\n' rsyslog)"
             [ "$installed_version" = "$VERSION" ] || {
               echo "installed rsyslog version $installed_version does not match $VERSION" >&2
@@ -687,6 +691,7 @@ jobs:
               rsyslog-omazuredce:omazuredce.so; do
               package="${package_file%%:*}"
               module_file="${package_file#*:}"
+              module_file="${module_file//./\\.}"
               dpkg-query -L "$package" | grep -Eq "/rsyslog/$module_file$"
             done
             rsyslogd -v

--- a/.github/workflows/debian_daily_stable.yml
+++ b/.github/workflows/debian_daily_stable.yml
@@ -675,6 +675,11 @@ jobs:
               [ "$(dpkg-query -W -f='${Version}\n' "$package")" = "$VERSION" ]
             done
             apt-get install -y "rsyslog-full=$VERSION"
+            full_dependencies="$(dpkg-query -W -f='${Depends}\n' rsyslog-full)"
+            for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
+              rsyslog-omazuredce; do
+              printf '%s\n' "$full_dependencies" | grep -Fq "$package (= $VERSION)"
+            done
             installed_version="$(dpkg-query -W -f='${Version}\n' rsyslog)"
             [ "$installed_version" = "$VERSION" ] || {
               echo "installed rsyslog version $installed_version does not match $VERSION" >&2

--- a/.github/workflows/el10_daily_stable.yml
+++ b/.github/workflows/el10_daily_stable.yml
@@ -590,10 +590,18 @@ jobs:
             done
             dnf -y install "rsyslog-full-$EXPECTED_EVR"
             full_requirements="$(rpm -q --requires rsyslog-full)"
-            for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
-              rsyslog-omazuredce; do
-              printf '%s\n' "$full_requirements" | grep -Fqx "$package = $EXPECTED_EVR"
-            done
+            expected_full_requirements="$(
+              printf '%s\n' \
+                "rsyslog = $EXPECTED_EVR" \
+                "rsyslog-openssl = $EXPECTED_EVR" \
+                "rsyslog-gnutls = $EXPECTED_EVR" \
+                "rsyslog-omotel = $EXPECTED_EVR" \
+                "rsyslog-omazuredce = $EXPECTED_EVR" | sort
+            )"
+            actual_full_requirements="$(
+              printf '%s\n' "$full_requirements" | grep '^rsyslog' | sort
+            )"
+            [ "$actual_full_requirements" = "$expected_full_requirements" ]
             for package in rsyslog rsyslog-openssl rsyslog-gnutls \
               rsyslog-omotel rsyslog-omazuredce rsyslog-standard rsyslog-full; do
               installed_evr="$(rpm -q --qf '%{VERSION}-%{RELEASE}\n' "$package")"

--- a/.github/workflows/el10_daily_stable.yml
+++ b/.github/workflows/el10_daily_stable.yml
@@ -582,12 +582,22 @@ jobs:
             dnf -y makecache --refresh
             dnf -y install \
               "rsyslog-$EXPECTED_EVR" \
-              "rsyslog-omazuredce-$EXPECTED_EVR"
-            installed_evr="$(rpm -q --qf '%{VERSION}-%{RELEASE}\n' rsyslog)"
-            [ "$installed_evr" = "$EXPECTED_EVR" ]
-            [ "$(rpm -q --qf '%{VERSION}-%{RELEASE}\n' rsyslog-omazuredce)" = \
-              "$EXPECTED_EVR" ]
-            rpm -ql rsyslog-omazuredce | grep -Eq '/rsyslog/omazuredce\.so$'
+              "rsyslog-standard-$EXPECTED_EVR" \
+              "rsyslog-full-$EXPECTED_EVR"
+            for package in rsyslog rsyslog-openssl rsyslog-gnutls \
+              rsyslog-omotel rsyslog-omazuredce rsyslog-standard rsyslog-full; do
+              installed_evr="$(rpm -q --qf '%{VERSION}-%{RELEASE}\n' "$package")"
+              [ "$installed_evr" = "$EXPECTED_EVR" ]
+            done
+            for package_file in \
+              rsyslog-openssl:lmnsd_ossl.so \
+              rsyslog-gnutls:lmnsd_gtls.so \
+              rsyslog-omotel:omotel.so \
+              rsyslog-omazuredce:omazuredce.so; do
+              package="${package_file%%:*}"
+              module_file="${package_file#*:}"
+              rpm -ql "$package" | grep -Eq "/rsyslog/$module_file$"
+            done
             rsyslogd -v
             devtools/release/package-feature-smoke.sh
           ) 2>&1 | tee .ci/flake-evidence/logs/el10-published-install.log

--- a/.github/workflows/el10_daily_stable.yml
+++ b/.github/workflows/el10_daily_stable.yml
@@ -589,6 +589,11 @@ jobs:
               [ "$installed_evr" = "$EXPECTED_EVR" ]
             done
             dnf -y install "rsyslog-full-$EXPECTED_EVR"
+            full_requirements="$(rpm -q --requires rsyslog-full)"
+            for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
+              rsyslog-omazuredce; do
+              printf '%s\n' "$full_requirements" | grep -Fqx "$package = $EXPECTED_EVR"
+            done
             for package in rsyslog rsyslog-openssl rsyslog-gnutls \
               rsyslog-omotel rsyslog-omazuredce rsyslog-standard rsyslog-full; do
               installed_evr="$(rpm -q --qf '%{VERSION}-%{RELEASE}\n' "$package")"

--- a/.github/workflows/el10_daily_stable.yml
+++ b/.github/workflows/el10_daily_stable.yml
@@ -582,8 +582,13 @@ jobs:
             dnf -y makecache --refresh
             dnf -y install \
               "rsyslog-$EXPECTED_EVR" \
-              "rsyslog-standard-$EXPECTED_EVR" \
-              "rsyslog-full-$EXPECTED_EVR"
+              "rsyslog-standard-$EXPECTED_EVR"
+            for package in rsyslog rsyslog-openssl rsyslog-gnutls \
+              rsyslog-omotel rsyslog-standard; do
+              installed_evr="$(rpm -q --qf '%{VERSION}-%{RELEASE}\n' "$package")"
+              [ "$installed_evr" = "$EXPECTED_EVR" ]
+            done
+            dnf -y install "rsyslog-full-$EXPECTED_EVR"
             for package in rsyslog rsyslog-openssl rsyslog-gnutls \
               rsyslog-omotel rsyslog-omazuredce rsyslog-standard rsyslog-full; do
               installed_evr="$(rpm -q --qf '%{VERSION}-%{RELEASE}\n' "$package")"
@@ -596,6 +601,7 @@ jobs:
               rsyslog-omazuredce:omazuredce.so; do
               package="${package_file%%:*}"
               module_file="${package_file#*:}"
+              module_file="${module_file//./\\.}"
               rpm -ql "$package" | grep -Eq "/rsyslog/$module_file$"
             done
             rsyslogd -v

--- a/.github/workflows/fedora44_daily_stable.yml
+++ b/.github/workflows/fedora44_daily_stable.yml
@@ -613,8 +613,15 @@ jobs:
             dnf -q -y install \
               "rsyslog-$EXPECTED_EVR" \
               "rsyslog-crypto-$EXPECTED_EVR" \
-              "rsyslog-standard-$EXPECTED_EVR" \
-              "rsyslog-full-$EXPECTED_EVR"
+              "rsyslog-standard-$EXPECTED_EVR"
+            for package in rsyslog rsyslog-crypto rsyslog-openssl rsyslog-gnutls \
+              rsyslog-omotel rsyslog-standard; do
+              installed_evr="$(
+                rpm -q --qf '%{VERSION}-%{RELEASE}\n' "$package"
+              )"
+              [ "$installed_evr" = "$EXPECTED_EVR" ]
+            done
+            dnf -q -y install "rsyslog-full-$EXPECTED_EVR"
             for package in rsyslog rsyslog-crypto rsyslog-openssl \
               rsyslog-gnutls rsyslog-omotel rsyslog-omazuredce \
               rsyslog-standard rsyslog-full; do
@@ -630,6 +637,7 @@ jobs:
               rsyslog-omazuredce:omazuredce.so; do
               package="${package_file%%:*}"
               module_file="${package_file#*:}"
+              module_file="${module_file//./\\.}"
               rpm -ql "$package" | grep -Eq "/rsyslog/$module_file$"
             done
             rsyslogd -v

--- a/.github/workflows/fedora44_daily_stable.yml
+++ b/.github/workflows/fedora44_daily_stable.yml
@@ -613,16 +613,25 @@ jobs:
             dnf -q -y install \
               "rsyslog-$EXPECTED_EVR" \
               "rsyslog-crypto-$EXPECTED_EVR" \
-              "rsyslog-omazuredce-$EXPECTED_EVR" \
-              "rsyslog-openssl-$EXPECTED_EVR"
-            for package in rsyslog rsyslog-crypto rsyslog-omazuredce \
-              rsyslog-openssl; do
+              "rsyslog-standard-$EXPECTED_EVR" \
+              "rsyslog-full-$EXPECTED_EVR"
+            for package in rsyslog rsyslog-crypto rsyslog-openssl \
+              rsyslog-gnutls rsyslog-omotel rsyslog-omazuredce \
+              rsyslog-standard rsyslog-full; do
               installed_evr="$(
                 rpm -q --qf '%{VERSION}-%{RELEASE}\n' "$package"
               )"
               [ "$installed_evr" = "$EXPECTED_EVR" ]
             done
-            rpm -ql rsyslog-omazuredce | grep -Eq '/rsyslog/omazuredce\.so$'
+            for package_file in \
+              rsyslog-openssl:lmnsd_ossl.so \
+              rsyslog-gnutls:lmnsd_gtls.so \
+              rsyslog-omotel:omotel.so \
+              rsyslog-omazuredce:omazuredce.so; do
+              package="${package_file%%:*}"
+              module_file="${package_file#*:}"
+              rpm -ql "$package" | grep -Eq "/rsyslog/$module_file$"
+            done
             rsyslogd -v
             devtools/release/package-feature-smoke.sh
           ) 2>&1 | tee \

--- a/.github/workflows/fedora44_daily_stable.yml
+++ b/.github/workflows/fedora44_daily_stable.yml
@@ -623,10 +623,18 @@ jobs:
             done
             dnf -q -y install "rsyslog-full-$EXPECTED_EVR"
             full_requirements="$(rpm -q --requires rsyslog-full)"
-            for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
-              rsyslog-omazuredce; do
-              printf '%s\n' "$full_requirements" | grep -Fqx "$package = $EXPECTED_EVR"
-            done
+            expected_full_requirements="$(
+              printf '%s\n' \
+                "rsyslog = $EXPECTED_EVR" \
+                "rsyslog-openssl = $EXPECTED_EVR" \
+                "rsyslog-gnutls = $EXPECTED_EVR" \
+                "rsyslog-omotel = $EXPECTED_EVR" \
+                "rsyslog-omazuredce = $EXPECTED_EVR" | sort
+            )"
+            actual_full_requirements="$(
+              printf '%s\n' "$full_requirements" | grep '^rsyslog' | sort
+            )"
+            [ "$actual_full_requirements" = "$expected_full_requirements" ]
             for package in rsyslog rsyslog-crypto rsyslog-openssl \
               rsyslog-gnutls rsyslog-omotel rsyslog-omazuredce \
               rsyslog-standard rsyslog-full; do

--- a/.github/workflows/fedora44_daily_stable.yml
+++ b/.github/workflows/fedora44_daily_stable.yml
@@ -622,6 +622,11 @@ jobs:
               [ "$installed_evr" = "$EXPECTED_EVR" ]
             done
             dnf -q -y install "rsyslog-full-$EXPECTED_EVR"
+            full_requirements="$(rpm -q --requires rsyslog-full)"
+            for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
+              rsyslog-omazuredce; do
+              printf '%s\n' "$full_requirements" | grep -Fqx "$package = $EXPECTED_EVR"
+            done
             for package in rsyslog rsyslog-crypto rsyslog-openssl \
               rsyslog-gnutls rsyslog-omotel rsyslog-omazuredce \
               rsyslog-standard rsyslog-full; do

--- a/.github/workflows/opensuse_leap160_daily_stable.yml
+++ b/.github/workflows/opensuse_leap160_daily_stable.yml
@@ -634,8 +634,15 @@ jobs:
             zypper -n install --oldpackage \
               "rsyslog=$EXPECTED_EVR" \
               "rsyslog-standard=$EXPECTED_EVR" \
-              "rsyslog-full=$EXPECTED_EVR" \
               "rsyslog-doc=$EXPECTED_EVR"
+            for package in rsyslog rsyslog-module-ossl rsyslog-module-gtls \
+              rsyslog-module-omotel rsyslog-standard rsyslog-doc; do
+              installed_evr="$(
+                rpm -q --qf '%{VERSION}-%{RELEASE}\n' "$package"
+              )"
+              [ "$installed_evr" = "$EXPECTED_EVR" ]
+            done
+            zypper -n install --oldpackage "rsyslog-full=$EXPECTED_EVR"
             for package in rsyslog rsyslog-module-ossl rsyslog-module-gtls \
               rsyslog-module-omotel rsyslog-module-omazuredce \
               rsyslog-standard rsyslog-full rsyslog-doc; do
@@ -651,6 +658,7 @@ jobs:
               rsyslog-module-omazuredce:omazuredce.so; do
               package="${package_file%%:*}"
               module_file="${package_file#*:}"
+              module_file="${module_file//./\\.}"
               rpm -ql "$package" | grep -Eq "/rsyslog/$module_file$"
             done
             rsyslogd -v

--- a/.github/workflows/opensuse_leap160_daily_stable.yml
+++ b/.github/workflows/opensuse_leap160_daily_stable.yml
@@ -633,18 +633,26 @@ jobs:
             zypper --gpg-auto-import-keys -n refresh rsyslog-daily-stable
             zypper -n install --oldpackage \
               "rsyslog=$EXPECTED_EVR" \
-              "rsyslog-module-omazuredce=$EXPECTED_EVR" \
-              "rsyslog-module-ossl=$EXPECTED_EVR" \
+              "rsyslog-standard=$EXPECTED_EVR" \
+              "rsyslog-full=$EXPECTED_EVR" \
               "rsyslog-doc=$EXPECTED_EVR"
-            for package in rsyslog rsyslog-module-omazuredce \
-              rsyslog-module-ossl rsyslog-doc; do
+            for package in rsyslog rsyslog-module-ossl rsyslog-module-gtls \
+              rsyslog-module-omotel rsyslog-module-omazuredce \
+              rsyslog-standard rsyslog-full rsyslog-doc; do
               installed_evr="$(
                 rpm -q --qf '%{VERSION}-%{RELEASE}\n' "$package"
               )"
               [ "$installed_evr" = "$EXPECTED_EVR" ]
             done
-            rpm -ql rsyslog-module-omazuredce | \
-              grep -Eq '/rsyslog/omazuredce\.so$'
+            for package_file in \
+              rsyslog-module-ossl:lmnsd_ossl.so \
+              rsyslog-module-gtls:lmnsd_gtls.so \
+              rsyslog-module-omotel:omotel.so \
+              rsyslog-module-omazuredce:omazuredce.so; do
+              package="${package_file%%:*}"
+              module_file="${package_file#*:}"
+              rpm -ql "$package" | grep -Eq "/rsyslog/$module_file$"
+            done
             rsyslogd -v
             devtools/release/package-feature-smoke.sh
           ) 2>&1 | tee \

--- a/.github/workflows/opensuse_leap160_daily_stable.yml
+++ b/.github/workflows/opensuse_leap160_daily_stable.yml
@@ -643,6 +643,11 @@ jobs:
               [ "$installed_evr" = "$EXPECTED_EVR" ]
             done
             zypper -n install --oldpackage "rsyslog-full=$EXPECTED_EVR"
+            full_requirements="$(rpm -q --requires rsyslog-full)"
+            for package in rsyslog rsyslog-module-ossl rsyslog-module-gtls \
+              rsyslog-module-omotel rsyslog-module-omazuredce; do
+              printf '%s\n' "$full_requirements" | grep -Fqx "$package = $EXPECTED_EVR"
+            done
             for package in rsyslog rsyslog-module-ossl rsyslog-module-gtls \
               rsyslog-module-omotel rsyslog-module-omazuredce \
               rsyslog-standard rsyslog-full rsyslog-doc; do

--- a/.github/workflows/opensuse_leap160_daily_stable.yml
+++ b/.github/workflows/opensuse_leap160_daily_stable.yml
@@ -644,10 +644,18 @@ jobs:
             done
             zypper -n install --oldpackage "rsyslog-full=$EXPECTED_EVR"
             full_requirements="$(rpm -q --requires rsyslog-full)"
-            for package in rsyslog rsyslog-module-ossl rsyslog-module-gtls \
-              rsyslog-module-omotel rsyslog-module-omazuredce; do
-              printf '%s\n' "$full_requirements" | grep -Fqx "$package = $EXPECTED_EVR"
-            done
+            expected_full_requirements="$(
+              printf '%s\n' \
+                "rsyslog = $EXPECTED_EVR" \
+                "rsyslog-module-ossl = $EXPECTED_EVR" \
+                "rsyslog-module-gtls = $EXPECTED_EVR" \
+                "rsyslog-module-omotel = $EXPECTED_EVR" \
+                "rsyslog-module-omazuredce = $EXPECTED_EVR" | sort
+            )"
+            actual_full_requirements="$(
+              printf '%s\n' "$full_requirements" | grep '^rsyslog' | sort
+            )"
+            [ "$actual_full_requirements" = "$expected_full_requirements" ]
             for package in rsyslog rsyslog-module-ossl rsyslog-module-gtls \
               rsyslog-module-omotel rsyslog-module-omazuredce \
               rsyslog-standard rsyslog-full rsyslog-doc; do

--- a/.github/workflows/ubuntu_daily_stable.yml
+++ b/.github/workflows/ubuntu_daily_stable.yml
@@ -670,8 +670,12 @@ jobs:
             apt-get update
             apt-get install -y \
               "rsyslog=$VERSION" \
-              "rsyslog-standard=$VERSION" \
-              "rsyslog-full=$VERSION"
+              "rsyslog-standard=$VERSION"
+            for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
+              rsyslog-standard; do
+              [ "$(dpkg-query -W -f='${Version}\n' "$package")" = "$VERSION" ]
+            done
+            apt-get install -y "rsyslog-full=$VERSION"
             installed_version="$(dpkg-query -W -f='${Version}\n' rsyslog)"
             [ "$installed_version" = "$VERSION" ] || {
               echo "installed rsyslog version $installed_version does not match $VERSION" >&2
@@ -688,6 +692,7 @@ jobs:
               rsyslog-omazuredce:omazuredce.so; do
               package="${package_file%%:*}"
               module_file="${package_file#*:}"
+              module_file="${module_file//./\\.}"
               dpkg-query -L "$package" | grep -Eq "/rsyslog/$module_file$"
             done
             rsyslogd -v

--- a/.github/workflows/ubuntu_daily_stable.yml
+++ b/.github/workflows/ubuntu_daily_stable.yml
@@ -670,15 +670,26 @@ jobs:
             apt-get update
             apt-get install -y \
               "rsyslog=$VERSION" \
-              "rsyslog-omazuredce=$VERSION"
+              "rsyslog-standard=$VERSION" \
+              "rsyslog-full=$VERSION"
             installed_version="$(dpkg-query -W -f='${Version}\n' rsyslog)"
             [ "$installed_version" = "$VERSION" ] || {
               echo "installed rsyslog version $installed_version does not match $VERSION" >&2
               exit 1
             }
-            [ "$(dpkg-query -W -f='${Version}\n' rsyslog-omazuredce)" = "$VERSION" ]
-            dpkg-query -L rsyslog-omazuredce | \
-              grep -Eq '/rsyslog/omazuredce\.so$'
+            for package in rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
+              rsyslog-omazuredce rsyslog-standard rsyslog-full; do
+              [ "$(dpkg-query -W -f='${Version}\n' "$package")" = "$VERSION" ]
+            done
+            for package_file in \
+              rsyslog-openssl:lmnsd_ossl.so \
+              rsyslog-gnutls:lmnsd_gtls.so \
+              rsyslog-omotel:omotel.so \
+              rsyslog-omazuredce:omazuredce.so; do
+              package="${package_file%%:*}"
+              module_file="${package_file#*:}"
+              dpkg-query -L "$package" | grep -Eq "/rsyslog/$module_file$"
+            done
             rsyslogd -v
             devtools/release/package-feature-smoke.sh
           ) 2>&1 | tee .ci/flake-evidence/logs/ubuntu-published-install.log

--- a/.github/workflows/ubuntu_daily_stable.yml
+++ b/.github/workflows/ubuntu_daily_stable.yml
@@ -677,10 +677,19 @@ jobs:
             done
             apt-get install -y "rsyslog-full=$VERSION"
             full_dependencies="$(dpkg-query -W -f='${Depends}\n' rsyslog-full)"
-            for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
-              rsyslog-omazuredce; do
-              printf '%s\n' "$full_dependencies" | grep -Fq "$package (= $VERSION)"
-            done
+            expected_full_dependencies="$(
+              printf '%s\n' \
+                "rsyslog (= $VERSION)" \
+                "rsyslog-openssl (= $VERSION)" \
+                "rsyslog-gnutls (= $VERSION)" \
+                "rsyslog-omotel (= $VERSION)" \
+                "rsyslog-omazuredce (= $VERSION)" | sort
+            )"
+            actual_full_dependencies="$(
+              printf '%s\n' "$full_dependencies" | tr ',' '\n' |
+                sed 's/^ *//; s/ *$//' | grep '^rsyslog' | sort
+            )"
+            [ "$actual_full_dependencies" = "$expected_full_dependencies" ]
             installed_version="$(dpkg-query -W -f='${Version}\n' rsyslog)"
             [ "$installed_version" = "$VERSION" ] || {
               echo "installed rsyslog version $installed_version does not match $VERSION" >&2

--- a/.github/workflows/ubuntu_daily_stable.yml
+++ b/.github/workflows/ubuntu_daily_stable.yml
@@ -676,6 +676,11 @@ jobs:
               [ "$(dpkg-query -W -f='${Version}\n' "$package")" = "$VERSION" ]
             done
             apt-get install -y "rsyslog-full=$VERSION"
+            full_dependencies="$(dpkg-query -W -f='${Depends}\n' rsyslog-full)"
+            for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
+              rsyslog-omazuredce; do
+              printf '%s\n' "$full_dependencies" | grep -Fq "$package (= $VERSION)"
+            done
             installed_version="$(dpkg-query -W -f='${Version}\n' rsyslog)"
             [ "$installed_version" = "$VERSION" ] || {
               echo "installed rsyslog version $installed_version does not match $VERSION" >&2

--- a/devtools/release/alpine-daily-stable.sh
+++ b/devtools/release/alpine-daily-stable.sh
@@ -195,8 +195,7 @@ cmd_verify_published() {
 			if apk update --no-cache &&
 				apk add --no-cache \
 					"rsyslog=$expected_version" \
-					"rsyslog-standard=$expected_version" \
-					"rsyslog-full=$expected_version"; then
+					"rsyslog-standard=$expected_version"; then
 				verification_rc=0
 				break
 			fi
@@ -211,7 +210,17 @@ cmd_verify_published() {
 	)"
 	[ "$installed_version" = "$expected_version" ] || die "installed rsyslog version mismatch"
 	local package module_file
-	for package in openssl gnutls omotel omazuredce standard full; do
+	for package in openssl gnutls omotel standard; do
+		module_version="$(
+			apk query --from installed --fields version --format json "rsyslog-$package" |
+				sed -n 's/.*"version": "\([^"]*\)".*/\1/p'
+		)"
+		[ "$module_version" = "$expected_version" ] ||
+			die "installed rsyslog-$package version mismatch"
+	done
+	apk add --no-cache "rsyslog-full=$expected_version" ||
+		die "could not install the expected full profile package"
+	for package in omazuredce full; do
 		module_version="$(
 			apk query --from installed --fields version --format json "rsyslog-$package" |
 				sed -n 's/.*"version": "\([^"]*\)".*/\1/p'
@@ -225,6 +234,7 @@ cmd_verify_published() {
 			gnutls) module_file=lmnsd_gtls.so ;;
 			*) module_file=$package.so ;;
 		esac
+		module_file="${module_file//./\\.}"
 		apk info -L "rsyslog-$package" | grep -Eq "/rsyslog/$module_file$" ||
 			die "$package module file is absent"
 	done

--- a/devtools/release/alpine-daily-stable.sh
+++ b/devtools/release/alpine-daily-stable.sh
@@ -220,6 +220,11 @@ cmd_verify_published() {
 	done
 	apk add --no-cache "rsyslog-full=$expected_version" ||
 		die "could not install the expected full profile package"
+	full_dependencies="$(apk info -R --from installed rsyslog-full)"
+	for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel rsyslog-omazuredce; do
+		printf '%s\n' "$full_dependencies" | grep -Fq "$package=$expected_version" ||
+			die "rsyslog-full is missing its $package dependency"
+	done
 	for package in omazuredce full; do
 		module_version="$(
 			apk query --from installed --fields version --format json "rsyslog-$package" |

--- a/devtools/release/alpine-daily-stable.sh
+++ b/devtools/release/alpine-daily-stable.sh
@@ -149,8 +149,11 @@ cmd_verify_artifacts() {
 		-name "rsyslog-${expected_version}.apk" -print -quit)"
 	[ -n "$base_apk" ] ||
 		die "base rsyslog APK for $expected_version is absent"
-	[ -f "$artifact_dir/rsyslog-omazuredce-$expected_version.apk" ] ||
-		die "omazuredce subpackage APK for $expected_version is absent"
+	local package
+	for package in openssl gnutls omotel omazuredce standard full; do
+		[ -f "$artifact_dir/rsyslog-$package-$expected_version.apk" ] ||
+			die "rsyslog-$package APK for $expected_version is absent"
+	done
 	if ! apk verify "$base_apk"; then
 		die "base rsyslog APK failed signature or integrity verification"
 	fi
@@ -192,7 +195,8 @@ cmd_verify_published() {
 			if apk update --no-cache &&
 				apk add --no-cache \
 					"rsyslog=$expected_version" \
-					"rsyslog-omazuredce=$expected_version"; then
+					"rsyslog-standard=$expected_version" \
+					"rsyslog-full=$expected_version"; then
 				verification_rc=0
 				break
 			fi
@@ -206,14 +210,24 @@ cmd_verify_published() {
 			sed -n 's/.*"version": "\([^"]*\)".*/\1/p'
 	)"
 	[ "$installed_version" = "$expected_version" ] || die "installed rsyslog version mismatch"
-	module_version="$(
-		apk query --from installed --fields version --format json \
-			rsyslog-omazuredce |
-			sed -n 's/.*"version": "\([^"]*\)".*/\1/p'
-	)"
-	[ "$module_version" = "$expected_version" ] || die "installed omazuredce version mismatch"
-	apk info -L rsyslog-omazuredce | grep -Eq '/rsyslog/omazuredce\.so$' ||
-		die "omazuredce module file is absent"
+	local package module_file
+	for package in openssl gnutls omotel omazuredce standard full; do
+		module_version="$(
+			apk query --from installed --fields version --format json "rsyslog-$package" |
+				sed -n 's/.*"version": "\([^"]*\)".*/\1/p'
+		)"
+		[ "$module_version" = "$expected_version" ] ||
+			die "installed rsyslog-$package version mismatch"
+	done
+	for package in openssl gnutls omotel omazuredce; do
+		case "$package" in
+			openssl) module_file=lmnsd_ossl.so ;;
+			gnutls) module_file=lmnsd_gtls.so ;;
+			*) module_file=$package.so ;;
+		esac
+		apk info -L "rsyslog-$package" | grep -Eq "/rsyslog/$module_file$" ||
+			die "$package module file is absent"
+	done
 	rsyslogd -v
 	"$(dirname "$0")/package-feature-smoke.sh"
 }

--- a/devtools/release/alpine-daily-stable.sh
+++ b/devtools/release/alpine-daily-stable.sh
@@ -221,10 +221,19 @@ cmd_verify_published() {
 	apk add --no-cache "rsyslog-full=$expected_version" ||
 		die "could not install the expected full profile package"
 	full_dependencies="$(apk info -R --from installed rsyslog-full)"
-	for package in rsyslog rsyslog-openssl rsyslog-gnutls rsyslog-omotel rsyslog-omazuredce; do
-		printf '%s\n' "$full_dependencies" | grep -Fq "$package=$expected_version" ||
-			die "rsyslog-full is missing its $package dependency"
-	done
+	expected_full_dependencies="$(
+		printf '%s\n' \
+			"rsyslog=$expected_version" \
+			"rsyslog-openssl=$expected_version" \
+			"rsyslog-gnutls=$expected_version" \
+			"rsyslog-omotel=$expected_version" \
+			"rsyslog-omazuredce=$expected_version" | sort
+	)"
+	actual_full_dependencies="$(
+		printf '%s\n' "$full_dependencies" | sed '1d' | grep '^rsyslog' | sort
+	)"
+	[ "$actual_full_dependencies" = "$expected_full_dependencies" ] ||
+		die "rsyslog-full dependency set differs from the package profile"
 	for package in omazuredce full; do
 		module_version="$(
 			apk query --from installed --fields version --format json "rsyslog-$package" |

--- a/devtools/release/amazonlinux-daily-stable.sh
+++ b/devtools/release/amazonlinux-daily-stable.sh
@@ -312,9 +312,12 @@ cmd_build_package() {
 	actual_evr="$(rpm -qp --qf '%{VERSION}-%{RELEASE}\n' "$rpm_file")"
 	[ "$actual_evr" = "$expected_evr" ] ||
 		die "built RPM EVR $actual_evr does not match $expected_evr"
-	find "$artifact_dir/rpms" -maxdepth 1 -type f \
-		-name 'rsyslog*omazuredce-[0-9]*.rpm' -print -quit | grep -q . ||
-		die "omazuredce subpackage RPM was not produced"
+	local package
+	for package in openssl gnutls omotel omazuredce standard full; do
+		find "$artifact_dir/rpms" -maxdepth 1 -type f \
+			-name "rsyslog-${package}-[0-9]*.rpm" -print -quit | grep -q . ||
+			die "rsyslog-$package RPM was not produced"
+	done
 
 	cp "$build_log" "$artifact_dir/build.log"
 	cp "$prepared_dir/SPECS/rsyslog.spec" "$artifact_dir/rsyslog.spec"

--- a/devtools/release/debian-daily-stable.sh
+++ b/devtools/release/debian-daily-stable.sh
@@ -156,9 +156,13 @@ cmd_build_package() {
 
   find "$artifact_dir" -maxdepth 1 -type f -name '*.deb' | grep -q . ||
     die "no .deb artifacts collected"
-  find "$artifact_dir" -maxdepth 1 -type f \
-    -name 'rsyslog-omazuredce_*.deb' -print -quit | grep -q . ||
-    die "omazuredce subpackage DEB was not produced"
+  local package
+  for package in rsyslog-openssl rsyslog-gnutls rsyslog-omotel \
+    rsyslog-omazuredce rsyslog-standard rsyslog-full; do
+    find "$artifact_dir" -maxdepth 1 -type f \
+      -name "${package}_*.deb" -print -quit | grep -q . ||
+      die "$package DEB was not produced"
+  done
   find "$artifact_dir" -maxdepth 1 -type f -name '*.dsc' | grep -q . ||
     die "no .dsc artifact collected"
   find "$artifact_dir" -maxdepth 1 -type f -name '*.changes' | grep -q . ||

--- a/devtools/release/fedora-daily-stable.sh
+++ b/devtools/release/fedora-daily-stable.sh
@@ -214,9 +214,12 @@ cmd_build_package() {
 	actual_evr="$(rpm -qp --qf '%{VERSION}-%{RELEASE}\n' "$rpm_file")"
 	[ "$actual_evr" = "$expected_evr" ] ||
 		die "built RPM EVR $actual_evr does not match $expected_evr"
-	find "$artifact_dir/rpms" -maxdepth 1 -type f \
-		-name 'rsyslog*omazuredce-[0-9]*.rpm' -print -quit | grep -q . ||
-		die "omazuredce subpackage RPM was not produced"
+	local package
+	for package in openssl gnutls omotel omazuredce standard full; do
+		find "$artifact_dir/rpms" -maxdepth 1 -type f \
+			-name "rsyslog-${package}-[0-9]*.rpm" -print -quit | grep -q . ||
+			die "rsyslog-$package RPM was not produced"
+	done
 
 	cp "$build_log" "$artifact_dir/build.log"
 	cp "$prepared_dir/SPECS/rsyslog.spec" "$artifact_dir/rsyslog.spec"

--- a/devtools/release/opensuse-daily-stable.sh
+++ b/devtools/release/opensuse-daily-stable.sh
@@ -239,9 +239,13 @@ cmd_build_package() {
 	actual_evr="$(rpm -qp --qf '%{VERSION}-%{RELEASE}\n' "$rpm_file")"
 	[ "$actual_evr" = "$expected_evr" ] ||
 		die "built RPM EVR $actual_evr does not match $expected_evr"
-	find "$artifact_dir/rpms" -maxdepth 1 -type f \
-		-name 'rsyslog*omazuredce-[0-9]*.rpm' -print -quit | grep -q . ||
-		die "omazuredce subpackage RPM was not produced"
+	local package
+	for package in module-ossl module-gtls module-omotel module-omazuredce \
+		standard full; do
+		find "$artifact_dir/rpms" -maxdepth 1 -type f \
+			-name "rsyslog-${package}-[0-9]*.rpm" -print -quit | grep -q . ||
+			die "rsyslog-$package RPM was not produced"
+	done
 
 	cp "$build_log" "$artifact_dir/build.log"
 	cp "$prepared_dir/SPECS/rsyslog.spec" "$artifact_dir/rsyslog.spec"

--- a/devtools/release/package-feature-overlay.py
+++ b/devtools/release/package-feature-overlay.py
@@ -85,9 +85,10 @@ def alpine_build_dependencies(apkbuild):
 def add_configure_flag(text, configure_flag, pattern, label, indentation=None):
     if configure_flag in text:
         return text
-    match = re.search(pattern, text)
-    if not match:
+    matches = list(re.finditer(pattern, text))
+    if len(matches) != 1:
         fail(f"could not find unique {label}")
+    match = matches[0]
     if indentation is None:
         indentation = match.group(1)
     addition = f"{indentation}{configure_flag} \\\n"

--- a/devtools/release/package-feature-overlay.py
+++ b/devtools/release/package-feature-overlay.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Apply the daily-stable feature contract to native distro packaging."""
+"""Apply the daily-stable feature and package-profile contract."""
 
 import argparse
 import json
@@ -24,10 +24,26 @@ def load_contract(path):
     yaml_feature = contract.get("yaml", {})
     if yaml_feature.get("required_in_base") is not True:
         fail("feature contract must require YAML support in the base package")
+
     modules = contract.get("module_packages", [])
-    if len(modules) != 1 or modules[0].get("module") != "omazuredce":
-        fail("prototype contract must define exactly the omazuredce module package")
-    return contract, yaml_feature, modules[0]
+    module_names = {module.get("module") for module in modules}
+    required_modules = {"openssl", "gnutls", "omotel"}
+    if not required_modules.issubset(module_names):
+        fail("feature contract must define openssl, gnutls, and omotel module packages")
+    if len(module_names) != len(modules):
+        fail("feature contract contains duplicate module names")
+
+    profiles = contract.get("profiles", [])
+    profile_names = {profile.get("profile") for profile in profiles}
+    if profile_names != {"standard", "full"}:
+        fail("feature contract must define standard and full profiles")
+    if len(profile_names) != len(profiles):
+        fail("feature contract contains duplicate profile names")
+    for profile in profiles:
+        unknown = set(profile.get("modules", [])) - module_names
+        if unknown:
+            fail(f"profile {profile['profile']} contains unknown modules: {sorted(unknown)}")
+    return yaml_feature, modules, profiles
 
 
 def require_dependency(declarations, dependency, source_name):
@@ -66,10 +82,52 @@ def alpine_build_dependencies(apkbuild):
     return [match.group("value")]
 
 
+def add_configure_flag(text, configure_flag, pattern, label, indentation=None):
+    if configure_flag in text:
+        return text
+    match = re.search(pattern, text)
+    if not match:
+        fail(f"could not find unique {label}")
+    if indentation is None:
+        indentation = match.group(1)
+    addition = f"{indentation}{configure_flag} \\\n"
+    return text[:match.start()] + addition + text[match.start():]
+
+
+def debian_module_stanza(module):
+    package_name = module["package_names"]["deb"]
+    description = module["description"]
+    return (
+        f"\nPackage: {package_name}\n"
+        "Architecture: any\n"
+        "Depends: ${shlibs:Depends},\n"
+        "         ${misc:Depends},\n"
+        "         rsyslog (= ${binary:Version})\n"
+        f"Description: {module['summary']}\n"
+        f" {description}\n"
+    )
+
+
+def debian_profile_stanza(profile, modules_by_name):
+    dependencies = ["${misc:Depends}", "rsyslog (= ${binary:Version})"]
+    dependencies.extend(
+        f"{modules_by_name[name]['package_names']['deb']} (= ${{binary:Version}})"
+        for name in profile["modules"]
+    )
+    formatted_dependencies = ",\n         ".join(dependencies)
+    return (
+        f"\nPackage: {profile['package_names']['deb']}\n"
+        "Architecture: all\n"
+        f"Depends: {formatted_dependencies}\n"
+        f"Description: {profile['summary']}\n"
+        " This empty package installs a version-locked, cross-distribution rsyslog\n"
+        " functionality profile.\n"
+    )
+
+
 def apply_debian(packaging_dir, contract_path):
     root = pathlib.Path(packaging_dir)
-    contract, yaml_feature, module = load_contract(contract_path)
-    del contract
+    yaml_feature, modules, profiles = load_contract(contract_path)
     control_path = root / "control"
     rules_path = root / "rules"
     if not control_path.is_file() or not rules_path.is_file():
@@ -85,71 +143,83 @@ def apply_debian(packaging_dir, contract_path):
     if "--disable-libyaml" in rules:
         fail("Debian rules explicitly disable required YAML support")
 
-    package_name = module["package_names"]["deb"]
-    if not re.search(rf"(?m)^Package: {re.escape(package_name)}$", control):
-        stanza = (
-            f"\nPackage: {package_name}\n"
-            "Architecture: any\n"
-            "Depends: ${shlibs:Depends},\n"
-            "         ${misc:Depends},\n"
-            "         rsyslog (= ${binary:Version})\n"
-            f"Description: {module['summary']}\n"
-            " This package provides the omazuredce output module for sending logs to\n"
-            " Microsoft Azure Monitor through a Data Collection Endpoint.\n"
-        )
-        control = control.rstrip() + "\n" + stanza
+    for module in modules:
+        package_name = module["package_names"]["deb"]
+        if not re.search(rf"(?m)^Package: {re.escape(package_name)}$", control):
+            control = control.rstrip() + "\n" + debian_module_stanza(module)
 
-    configure_flag = module["configure_flag"]
-    if configure_flag not in rules:
-        rules = replace_once(
+        rules = add_configure_flag(
             rules,
-            r"(?m)^(\s*)(--enable-omprog\s+\\)$",
-            rf"\g<1>{configure_flag} \\" + "\n" + r"\g<1>\g<2>",
+            module["configure_flag"],
+            r"(?m)^(\s*)--enable-omprog\s+\\$",
             "Debian configure option anchor",
         )
 
-    manifest = root / f"{package_name}.install"
-    expected_path = f"usr/lib/${{DEB_HOST_MULTIARCH}}/rsyslog/{module['module_file']}"
-    if manifest.exists():
-        entries = manifest.read_text(encoding="utf-8").splitlines()
-        if expected_path not in entries:
-            fail(f"existing {manifest.name} does not own {expected_path}")
-    else:
-        manifest.write_text(expected_path + "\n", encoding="utf-8")
+        manifest = root / f"{package_name}.install"
+        expected_path = f"usr/lib/${{DEB_HOST_MULTIARCH}}/rsyslog/{module['module_file']}"
+        if manifest.exists():
+            entries = manifest.read_text(encoding="utf-8").splitlines()
+            if expected_path not in entries:
+                fail(f"existing {manifest.name} does not own {expected_path}")
+        else:
+            manifest.write_text(expected_path + "\n", encoding="utf-8")
+
+    modules_by_name = {module["module"]: module for module in modules}
+    for profile in profiles:
+        package_name = profile["package_names"]["deb"]
+        if not re.search(rf"(?m)^Package: {re.escape(package_name)}$", control):
+            control = control.rstrip() + "\n" + debian_profile_stanza(profile, modules_by_name)
 
     control_path.write_text(control, encoding="utf-8")
     rules_path.write_text(rules, encoding="utf-8")
 
 
-def rpm_package_block(module, flavor):
+def rpm_exact_requirement(package_name, flavor):
+    if flavor == "opensuse":
+        return f"{package_name} = %{{version}}-%{{release}}"
+    return f"{package_name} = %version-%release"
+
+
+def rpm_module_block(module, flavor):
     package_name = module["package_names"][flavor]
     suffix = package_name.removeprefix("rsyslog-")
-    if flavor == "opensuse":
-        return (
-            f"%package {suffix}\n"
-            "Requires:       %{name} = %{version}\n"
-            f"Summary:        {module['summary']}\n"
-            "Group:          System/Daemons\n\n"
-            f"%description {suffix}\n"
-            "Rsyslog is an enhanced multi-threaded syslog daemon. See rsyslog\n"
-            "package.\n\n"
-            "This module sends logs to Microsoft Azure Monitor through a Data\n"
-            "Collection Endpoint.\n\n"
-        )
+    group = "Group:          System/Daemons\n" if flavor == "opensuse" else ""
+    base_name = "%{name}" if flavor == "opensuse" else "%name"
     return (
         f"%package {suffix}\n"
-        f"Summary: {module['summary']}\n"
-        "Requires: %name = %version-%release\n\n"
+        f"Requires:       {rpm_exact_requirement(base_name, flavor)}\n"
+        f"Summary:        {module['summary']}\n"
+        f"{group}\n"
         f"%description {suffix}\n"
-        "This module sends logs to Microsoft Azure Monitor through a Data\n"
-        "Collection Endpoint.\n\n"
+        f"{module['description']}\n\n"
+    )
+
+
+def rpm_profile_block(profile, modules_by_name, flavor):
+    package_name = profile["package_names"][flavor]
+    suffix = package_name.removeprefix("rsyslog-")
+    requirements = [rpm_exact_requirement("%{name}" if flavor == "opensuse" else "%name", flavor)]
+    requirements.extend(
+        rpm_exact_requirement(modules_by_name[name]["package_names"][flavor], flavor)
+        for name in profile["modules"]
+    )
+    requirement_lines = "".join(f"Requires:       {requirement}\n" for requirement in requirements)
+    group = "Group:          System/Daemons\n" if flavor == "opensuse" else ""
+    return (
+        f"%package {suffix}\n"
+        "BuildArch:      noarch\n"
+        f"{requirement_lines}"
+        f"Summary:        {profile['summary']}\n"
+        f"{group}\n"
+        f"%description {suffix}\n"
+        "This empty package installs a version-locked, cross-distribution rsyslog\n"
+        "functionality profile.\n\n"
     )
 
 
 def apply_rpm(spec_path, contract_path, flavor):
     path = pathlib.Path(spec_path)
-    contract, yaml_feature, module = load_contract(contract_path)
-    del contract
+    yaml_feature, modules, profiles = load_contract(contract_path)
     text = path.read_text(encoding="utf-8")
     require_dependency(
         rpm_build_dependencies(text),
@@ -159,41 +229,71 @@ def apply_rpm(spec_path, contract_path, flavor):
     if "--disable-libyaml" in text:
         fail("RPM spec explicitly disables required YAML support")
 
-    package_name = module["package_names"][flavor]
-    suffix = package_name.removeprefix("rsyslog-")
-    if not re.search(rf"(?m)^%package\s+{re.escape(suffix)}$", text):
-        text = replace_once(text, r"(?m)^%prep\s*$", rpm_package_block(module, flavor) + "%prep", "RPM %prep")
+    for module in modules:
+        package_name = module["package_names"][flavor]
+        suffix = package_name.removeprefix("rsyslog-")
+        if not re.search(rf"(?m)^%package\s+{re.escape(suffix)}$", text):
+            text = replace_once(text, r"(?m)^%prep\s*$", rpm_module_block(module, flavor) + "%prep", "RPM %prep")
 
-    configure_flag = module["configure_flag"]
-    if configure_flag not in text:
-        text = replace_once(
+        text = add_configure_flag(
             text,
-            r"(?m)^(\s*--enable-omhttp\s*\\)$",
-            rf"\t{configure_flag} \\" + "\n" + r"\g<1>",
+            module["configure_flag"],
+            r"(?m)^(\s*)--enable-omhttp\s*\\$",
             "RPM configure option anchor",
+            "\t",
         )
 
-    if flavor == "opensuse" and module["module_file"] not in text:
-        text = replace_once(
-            text,
-            r"(?m)^(\s*omhttpfs\.so\s*\\)$",
-            rf"\1\n\t\t{module['module_file']} \\",
-            "openSUSE module relocation anchor",
-        )
+        if flavor == "opensuse" and module["module_file"] not in text:
+            text = replace_once(
+                text,
+                r"(?m)^(\s*omhttpfs\.so\s*\\)$",
+                rf"\1\n\t\t{module['module_file']} \\",
+                "openSUSE module relocation anchor",
+            )
 
-    files_header = f"%files {suffix}"
-    module_macro = "%{rsyslog_module_dir_withdeps}" if flavor == "opensuse" else "%{_libdir}/rsyslog"
-    if not re.search(rf"(?m)^{re.escape(files_header)}$", text):
-        files = f"{files_header}\n{module_macro}/{module['module_file']}\n\n"
-        text = replace_once(text, r"(?m)^%changelog\s*$", files + "%changelog", "RPM %changelog")
+        files_header = f"%files {suffix}"
+        module_macro = "%{rsyslog_module_dir_withdeps}" if flavor == "opensuse" else "%{_libdir}/rsyslog"
+        if not re.search(rf"(?m)^{re.escape(files_header)}$", text):
+            files = f"{files_header}\n{module_macro}/{module['module_file']}\n\n"
+            text = replace_once(text, r"(?m)^%changelog\s*$", files + "%changelog", "RPM %changelog")
+
+    modules_by_name = {module["module"]: module for module in modules}
+    for profile in profiles:
+        package_name = profile["package_names"][flavor]
+        suffix = package_name.removeprefix("rsyslog-")
+        if not re.search(rf"(?m)^%package\s+{re.escape(suffix)}$", text):
+            text = replace_once(
+                text,
+                r"(?m)^%prep\s*$",
+                rpm_profile_block(profile, modules_by_name, flavor) + "%prep",
+                "RPM %prep",
+            )
+        files_header = f"%files {suffix}"
+        if not re.search(rf"(?m)^{re.escape(files_header)}$", text):
+            text = replace_once(text, r"(?m)^%changelog\s*$", files_header + "\n\n%changelog", "RPM %changelog")
 
     path.write_text(text, encoding="utf-8")
 
 
+def alpine_profile_function(profile, modules_by_name):
+    dependencies = [f"$pkgname=$pkgver-r$pkgrel"]
+    dependencies.extend(
+        f"{modules_by_name[name]['package_names']['apk']}=$pkgver-r$pkgrel"
+        for name in profile["modules"]
+    )
+    depends = " ".join(dependencies)
+    return (
+        f"\n_profile_{profile['profile']}() {{\n"
+        f"\tpkgdesc=\"{profile['summary']}\"\n"
+        f"\tdepends=\"{depends}\"\n"
+        "\tmkdir -p \"$subpkgdir\"\n"
+        "}\n"
+    )
+
+
 def apply_alpine(apkbuild_path, contract_path):
     path = pathlib.Path(apkbuild_path)
-    contract, yaml_feature, module = load_contract(contract_path)
-    del contract
+    yaml_feature, modules, profiles = load_contract(contract_path)
     text = path.read_text(encoding="utf-8")
     require_dependency(
         alpine_build_dependencies(text),
@@ -203,28 +303,46 @@ def apply_alpine(apkbuild_path, contract_path):
     if "--disable-libyaml" in text:
         fail("APKBUILD explicitly disables required YAML support")
 
-    package_name = module["package_names"]["apk"]
-    plugin_name = package_name.removeprefix("rsyslog-")
     plugins_match = re.search(r'(?ms)^_plugins="\n(?P<body>.*?)\n\s*"$', text)
     if not plugins_match:
         fail("could not find Alpine _plugins block")
-    plugin_entries = [line.strip() for line in plugins_match.group("body").splitlines()]
-    if plugin_name not in plugin_entries:
-        text = replace_once(
+    plugin_entries = [line.strip().split(":", 1)[0] for line in plugins_match.group("body").splitlines()]
+    for module in modules:
+        package_name = module["package_names"]["apk"]
+        plugin_name = package_name.removeprefix("rsyslog-")
+        if plugin_name not in plugin_entries:
+            text = replace_once(
+                text,
+                r"(?m)^(\s*omotel(?:\s*:[^\n]+)?\s*)$",
+                rf"\1\n\t{plugin_name}",
+                "Alpine plugin package anchor",
+            )
+            plugin_entries.append(plugin_name)
+
+        text = add_configure_flag(
             text,
-            r"(?m)^(\s*omotel\s*)$",
-            rf"\1\n\t{plugin_name}",
-            "Alpine plugin package anchor",
+            module["configure_flag"],
+            r"(?m)^(\s*)--enable-omotel\s*\\$",
+            "Alpine configure option anchor",
+            "\t\t",
         )
 
-    configure_flag = module["configure_flag"]
-    if configure_flag not in text:
+    modules_by_name = {module["module"]: module for module in modules}
+    profile_subpackages = " ".join(
+        f"{profile['package_names']['apk']}:_profile_{profile['profile']}" for profile in profiles
+    )
+    if profile_subpackages not in text:
         text = replace_once(
             text,
-            r"(?m)^(\s*--enable-omotel\s*\\)$",
-            rf"\1\n\t\t{configure_flag} \\",
-            "Alpine configure option anchor",
+            r'(?m)^(subpackages="[^"]*)"$',
+            rf'\1 {profile_subpackages}"',
+            "Alpine subpackages assignment",
         )
+    for profile in profiles:
+        function_name = f"_profile_{profile['profile']}()"
+        if function_name not in text:
+            text = text.rstrip() + "\n" + alpine_profile_function(profile, modules_by_name)
+
     path.write_text(text, encoding="utf-8")
 
 

--- a/devtools/release/package-feature-smoke.sh
+++ b/devtools/release/package-feature-smoke.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify the package contract after installing the base and module packages.
+# Verify YAML support and the modules in the package-profile POC.
 set -euo pipefail
 
 rsyslogd_bin="${RSYSLOGD_BIN:-rsyslogd}"
@@ -21,15 +21,17 @@ rulesets:
       action(type="omfile" file="/dev/null")
 EOF
 
-cat > "$tmp_dir/omazuredce.yaml" <<'EOF'
+"$rsyslogd_bin" -N1 -f "$tmp_dir/base.yaml" "${module_args[@]}"
+
+for module in lmnsd_ossl lmnsd_gtls omotel omazuredce; do
+	cat > "$tmp_dir/$module.yaml" <<EOF
 version: 2
 modules:
-  - load: omazuredce
+  - load: $module
 rulesets:
   - name: main
     script: |
       action(type="omfile" file="/dev/null")
 EOF
-
-"$rsyslogd_bin" -N1 -f "$tmp_dir/base.yaml" "${module_args[@]}"
-"$rsyslogd_bin" -N1 -f "$tmp_dir/omazuredce.yaml" "${module_args[@]}"
+	"$rsyslogd_bin" -N1 -f "$tmp_dir/$module.yaml" "${module_args[@]}"
+done

--- a/devtools/release/rpm-daily-stable.sh
+++ b/devtools/release/rpm-daily-stable.sh
@@ -242,9 +242,12 @@ cmd_build_package() {
   actual_evr="$(rpm -qp --qf '%{VERSION}-%{RELEASE}\n' "$rpm_file")"
   [ "$actual_evr" = "$expected_evr" ] ||
     die "built RPM EVR $actual_evr does not match $expected_evr"
-  find "$artifact_dir/rpms" -maxdepth 1 -type f \
-    -name 'rsyslog*omazuredce-[0-9]*.rpm' -print -quit | grep -q . ||
-    die "omazuredce subpackage RPM was not produced"
+  local package
+  for package in openssl gnutls omotel omazuredce standard full; do
+    find "$artifact_dir/rpms" -maxdepth 1 -type f \
+      -name "rsyslog-${package}-[0-9]*.rpm" -print -quit | grep -q . ||
+      die "rsyslog-$package RPM was not produced"
+  done
 
   cp "$build_log" "$artifact_dir/build.log"
   cp "$prepared_dir/SPECS/rsyslog.spec" "$artifact_dir/rsyslog.spec"


### PR DESCRIPTION
## What changed

Adds a common package-feature contract and version-locked `rsyslog-standard` and `rsyslog-full` meta-packages. The initial profiles cover OpenSSL, GnuTLS, omotel, and the existing omazuredce module.

The overlay preserves native Debian, RPM, openSUSE, and Alpine module layouts while adding missing module packages and profiles. Daily helpers and published-archive smoke checks require the profile packages, verify module ownership, and load all selected modules.

## Why

Give daily package users a consistent initial feature baseline without erasing each distribution's native package conventions.

## Validation

- Reapplied the Debian, Fedora, Amazon Linux, EL10, openSUSE, and Alpine overlays twice against captured packaging inputs; output was idempotent.
- Verified every expected module/profile package mapping and Alpine APKBUILD syntax.
- Ran Python compilation/style checks, shell syntax and ShellCheck, actionlint, flake-evidence coverage, and pinned zizmor.

No publishing workflow was dispatched from this branch; the normal daily workflow is the post-merge end-to-end package build and archive verification.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

