### PR TITLE
packaging: fix daily archive profile failures

### DIFF
--- a/.github/amazonlinux2023-daily-stable-policy.yml
+++ b/.github/amazonlinux2023-daily-stable-policy.yml
@@ -11,6 +11,12 @@
   ],
   "drop_stale_html_docs": true,
   "drop_stale_html_docs_reason": "Amazon Linux 2023 packages HTML documentation from a separate versioned 8.2204.0 tarball. Daily main builds must not relabel those stale files as current documentation.",
+  "enabled_bconds": [
+    {
+      "feature": "gnutls",
+      "reason": "The daily-stable feature contract requires the GnuTLS network stream driver."
+    }
+  ],
   "supplemental_build_requires": [
     {
       "package": "autoconf-archive",

--- a/.github/workflows/el10_daily_stable.yml
+++ b/.github/workflows/el10_daily_stable.yml
@@ -225,10 +225,17 @@ jobs:
           set -e
           devtools/ci-flake-phase.sh end \
             el10-package-build custom "$build_status"
+          sudo chown -R "$(id -u):$(id -g)" \
+            "$RUNNER_TEMP/el10-artifacts" "$RUNNER_TEMP/el10-build.log" || true
           if [ "$build_status" -eq 0 ]; then
-            sudo chown -R "$(id -u):$(id -g)" \
-              "$RUNNER_TEMP/el10-artifacts" "$RUNNER_TEMP/el10-build.log"
             cp -a "$RUNNER_TEMP/el10-artifacts" el10-daily-stable-artifacts
+          else
+            {
+              echo 'EL10 Mock build log:'
+              cat "$RUNNER_TEMP/el10-build.log"
+              find "$RUNNER_TEMP/el10-artifacts" -type f -name '*.log' \
+                -exec sh -c 'echo; echo "Mock result log: $1"; cat "$1"' sh {} \;
+            } > failed-tests.log
           fi
           exit "$build_status"
 

--- a/.github/workflows/el10_daily_stable.yml
+++ b/.github/workflows/el10_daily_stable.yml
@@ -224,7 +224,7 @@ jobs:
           build_status=$?
           set -e
           devtools/ci-flake-phase.sh end \
-            el10-package-build custom "$build_status"
+            el10-package-build custom "$build_status" || true
           sudo chown -R "$(id -u):$(id -g)" \
             "$RUNNER_TEMP/el10-artifacts" "$RUNNER_TEMP/el10-build.log" || true
           if [ "$build_status" -eq 0 ]; then

--- a/devtools/release/amazonlinux-daily-stable.sh
+++ b/devtools/release/amazonlinux-daily-stable.sh
@@ -205,6 +205,22 @@ for pattern, replacement, expected, label in doc_edits:
     if count != expected:
         raise SystemExit(f"Amazon Linux spec {label} did not match exactly once")
 
+enabled_bconds = policy.get("enabled_bconds", [])
+features = [entry.get("feature", "").strip() for entry in enabled_bconds]
+if any(not feature for feature in features):
+    raise SystemExit("policy contains an empty enabled bcond feature")
+if len(features) != len(set(features)):
+    raise SystemExit("policy contains duplicate enabled bcond features")
+for feature in features:
+    spec, count = re.subn(
+        rf"(?m)^%bcond_with\s+{re.escape(feature)}\s*$",
+        f"%bcond_without {feature}",
+        spec,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit(f"could not enable Amazon Linux bcond: {feature}")
+
 build_requires = policy.get("supplemental_build_requires", [])
 packages = [entry.get("package", "").strip() for entry in build_requires]
 if any(not package for package in packages):

--- a/devtools/release/debian-daily-stable.sh
+++ b/devtools/release/debian-daily-stable.sh
@@ -343,12 +343,29 @@ add_by_hash() {
 copy_pool_artifacts() {
   local artifact_dir="$1"
   local pool_dir="$2"
+  local path target
 
   mkdir -p "$pool_dir"
-  find "$artifact_dir" -maxdepth 1 -type f \
-    \( -name '*.deb' -o -name '*.dsc' -o -name '*.orig.tar.*' \
-       -o -name '*.debian.tar.*' \) \
-    -exec cp -a {} "$pool_dir/" \;
+  while IFS= read -r -d '' path; do
+    target="$pool_dir/$(basename "$path")"
+    if [ -e "$target" ]; then
+      if cmp -s "$path" "$target"; then
+        continue
+      fi
+      if [[ "$path" = *.deb ]] && [ "$(dpkg-deb -f "$path" Architecture)" = all ]; then
+        # Each native build produces the same profile filename.  Keep the first
+        # copy so both architecture indexes and the pool reference one immutable
+        # artifact instead of silently overwriting the indexed file.
+        continue
+      fi
+      die "conflicting package artifact for pool path: $(basename "$path")"
+    fi
+    cp -a "$path" "$target"
+  done < <(
+    find "$artifact_dir" -maxdepth 1 -type f \
+      \( -name '*.deb' -o -name '*.dsc' -o -name '*.orig.tar.*' \
+         -o -name '*.debian.tar.*' \) -print0
+  )
 }
 
 cmd_generate_repo() {
@@ -516,21 +533,24 @@ build_self_test_deb() {
   local root="$1"
   local version="$2"
   local arch="${3:-amd64}"
-  local package_dir="$root/package-$version"
+  local package="${4:-rsyslog}"
+  local marker="${5:-$arch}"
+  local package_dir="$root/package-$package-$version"
 
-  install -m 755 -d "$package_dir/DEBIAN"
+  install -m 755 -d "$package_dir/DEBIAN" "$package_dir/usr/share/$package"
+  printf '%s\n' "$marker" > "$package_dir/usr/share/$package/$marker"
   {
-    echo "Package: rsyslog"
+    echo "Package: $package"
     echo "Version: $version"
     echo "Architecture: $arch"
     echo "Maintainer: rsyslog test <test@example.invalid>"
     echo "Description: synthetic daily archive test package"
   } > "$package_dir/DEBIAN/control"
-  dpkg-deb --build "$package_dir" "$root/rsyslog_${version}_${arch}.deb" >/dev/null
+  dpkg-deb --build "$package_dir" "$root/${package}_${version}_${arch}.deb" >/dev/null
 }
 
 cmd_self_test() (
-  local tmp_dir repo_dir first_artifacts second_artifacts fingerprint
+  local tmp_dir repo_dir first_artifacts second_artifacts first_all_artifacts second_all_artifacts fingerprint
   local test_suite test_version
   local cleanup_command
 
@@ -554,7 +574,10 @@ cmd_self_test() (
   repo_dir="$tmp_dir/repo"
   first_artifacts="$tmp_dir/artifacts-1"
   second_artifacts="$tmp_dir/artifacts-2"
-  mkdir -p "$repo_dir" "$first_artifacts" "$second_artifacts"
+  first_all_artifacts="$tmp_dir/artifacts-all-amd64"
+  second_all_artifacts="$tmp_dir/artifacts-all-arm64"
+  mkdir -p "$repo_dir" "$first_artifacts" "$second_artifacts" \
+    "$first_all_artifacts" "$second_all_artifacts"
   export GNUPGHOME="$tmp_dir/gnupg"
   install -m 700 -d "$GNUPGHOME"
   gpg --batch --pinentry-mode loopback --passphrase '' --quick-generate-key \
@@ -566,6 +589,15 @@ cmd_self_test() (
   build_self_test_deb "$first_artifacts" "1.0~daily1" arm64
   cmd_generate_repo "$first_artifacts" "$repo_dir" "$test_suite" main amd64
   cmd_generate_repo "$first_artifacts" "$repo_dir" "$test_suite" main arm64
+  # Profile packages are Architecture: all but arrive from both native builds.
+  # Their contents differ deliberately, proving the first immutable pool file
+  # stays aligned with the indexes instead of being overwritten by the second.
+  build_self_test_deb "$first_all_artifacts" "1.0~daily1" all \
+    rsyslog-standard from-amd64
+  build_self_test_deb "$second_all_artifacts" "1.0~daily1" all \
+    rsyslog-standard from-arm64
+  cmd_generate_repo "$first_all_artifacts" "$repo_dir" "$test_suite" main amd64
+  cmd_generate_repo "$second_all_artifacts" "$repo_dir" "$test_suite" main arm64
   cmd_verify_repo "file://$repo_dir" "$test_suite" main amd64 \
     "1.0~daily1" "$fingerprint"
   cmd_verify_repo "file://$repo_dir" "$test_suite" main arm64 \
@@ -580,6 +612,18 @@ cmd_self_test() (
   xz -dc "$repo_dir/dists/$test_suite/main/binary-arm64/Packages.xz" |
     grep -Fxq 'Architecture: arm64' ||
     die "arm64 package index is missing its native package"
+  for arch in amd64 arm64; do
+    xz -dc "$repo_dir/dists/$test_suite/main/binary-$arch/Packages.xz" |
+      grep -Fxq 'Package: rsyslog-standard' ||
+      die "$arch package index is missing the all-architecture profile"
+  done
+  dpkg-deb -c "$repo_dir/pool/main/r/rsyslog/rsyslog-standard_1.0~daily1_all.deb" |
+    grep -Fq 'from-amd64' ||
+    die "pool did not retain the first all-architecture profile artifact"
+  if dpkg-deb -c "$repo_dir/pool/main/r/rsyslog/rsyslog-standard_1.0~daily1_all.deb" |
+     grep -Fq 'from-arm64'; then
+    die "pool overwrote the first all-architecture profile artifact"
+  fi
   grep -Fxq 'Architectures: amd64 arm64' \
     "$repo_dir/dists/$test_suite/Release" ||
     die "Release metadata does not advertise both architectures"

--- a/devtools/release/debian-daily-stable.sh
+++ b/devtools/release/debian-daily-stable.sh
@@ -544,7 +544,7 @@ build_self_test_deb() {
   local arch="${3:-amd64}"
   local package="${4:-rsyslog}"
   local marker="${5:-$arch}"
-  local package_dir="$root/package-$package-$version"
+  local package_dir="$root/package-$package-$version-$arch"
 
   install -m 755 -d "$package_dir/DEBIAN" "$package_dir/usr/share/$package"
   printf '%s\n' "$marker" > "$package_dir/usr/share/$package/$marker"

--- a/devtools/release/debian-daily-stable.sh
+++ b/devtools/release/debian-daily-stable.sh
@@ -358,6 +358,15 @@ copy_pool_artifacts() {
         # artifact instead of silently overwriting the indexed file.
         continue
       fi
+      case "$path" in
+        *.dsc|*.orig.tar.*|*.debian.tar.*)
+          # One source package is built beside each native package set.  The
+          # source archive names are stable but their bytes need not be (for
+          # example, tar timestamps may differ).  Keep the complete first set
+          # so its .dsc checksums and pool files remain consistent.
+          continue
+          ;;
+      esac
       die "conflicting package artifact for pool path: $(basename "$path")"
     fi
     cp -a "$path" "$target"
@@ -550,7 +559,8 @@ build_self_test_deb() {
 }
 
 cmd_self_test() (
-  local tmp_dir repo_dir first_artifacts second_artifacts first_all_artifacts second_all_artifacts fingerprint
+  local tmp_dir repo_dir first_artifacts second_artifacts first_all_artifacts second_all_artifacts
+  local first_source_artifacts second_source_artifacts fingerprint
   local test_suite test_version
   local cleanup_command
 
@@ -576,8 +586,11 @@ cmd_self_test() (
   second_artifacts="$tmp_dir/artifacts-2"
   first_all_artifacts="$tmp_dir/artifacts-all-amd64"
   second_all_artifacts="$tmp_dir/artifacts-all-arm64"
+  first_source_artifacts="$tmp_dir/artifacts-source-amd64"
+  second_source_artifacts="$tmp_dir/artifacts-source-arm64"
   mkdir -p "$repo_dir" "$first_artifacts" "$second_artifacts" \
-    "$first_all_artifacts" "$second_all_artifacts"
+    "$first_all_artifacts" "$second_all_artifacts" \
+    "$first_source_artifacts" "$second_source_artifacts"
   export GNUPGHOME="$tmp_dir/gnupg"
   install -m 700 -d "$GNUPGHOME"
   gpg --batch --pinentry-mode loopback --passphrase '' --quick-generate-key \
@@ -623,6 +636,20 @@ cmd_self_test() (
   if dpkg-deb -c "$repo_dir/pool/main/r/rsyslog/rsyslog-standard_1.0~daily1_all.deb" |
      grep -Fq 'from-arm64'; then
     die "pool overwrote the first all-architecture profile artifact"
+  fi
+  # Source artifacts arrive from both native package builds as well.  Their
+  # content differs deliberately, which proves we retain one coherent source
+  # set instead of replacing files named by the same source package version.
+  printf '%s\n' from-amd64 > "$first_source_artifacts/rsyslog_1.0~daily1.orig.tar.gz"
+  printf '%s\n' from-arm64 > "$second_source_artifacts/rsyslog_1.0~daily1.orig.tar.gz"
+  copy_pool_artifacts "$first_source_artifacts" "$repo_dir/pool/main/r/rsyslog"
+  copy_pool_artifacts "$second_source_artifacts" "$repo_dir/pool/main/r/rsyslog"
+  grep -Fxq from-amd64 \
+    "$repo_dir/pool/main/r/rsyslog/rsyslog_1.0~daily1.orig.tar.gz" ||
+    die "pool did not retain the first source artifact"
+  if grep -Fxq from-arm64 \
+     "$repo_dir/pool/main/r/rsyslog/rsyslog_1.0~daily1.orig.tar.gz"; then
+    die "pool overwrote the first source artifact"
   fi
   grep -Fxq 'Architectures: amd64 arm64' \
     "$repo_dir/dists/$test_suite/Release" ||

--- a/devtools/release/package-feature-overlay.py
+++ b/devtools/release/package-feature-overlay.py
@@ -126,6 +126,11 @@ def debian_profile_stanza(profile, modules_by_name):
     )
 
 
+def normalize_debian_install_path(path):
+    """Normalize Debian multiarch spellings used in baseline install manifests."""
+    return path.replace("${DEB_HOST_MULTIARCH}", "*")
+
+
 def apply_debian(packaging_dir, contract_path):
     root = pathlib.Path(packaging_dir)
     yaml_feature, modules, profiles = load_contract(contract_path)
@@ -160,7 +165,10 @@ def apply_debian(packaging_dir, contract_path):
         expected_path = f"usr/lib/${{DEB_HOST_MULTIARCH}}/rsyslog/{module['module_file']}"
         if manifest.exists():
             entries = manifest.read_text(encoding="utf-8").splitlines()
-            if expected_path not in entries:
+            normalized_expected_path = normalize_debian_install_path(expected_path)
+            if normalized_expected_path not in {
+                normalize_debian_install_path(entry) for entry in entries
+            }:
                 fail(f"existing {manifest.name} does not own {expected_path}")
         else:
             manifest.write_text(expected_path + "\n", encoding="utf-8")

--- a/devtools/release/rpm-daily-stable.sh
+++ b/devtools/release/rpm-daily-stable.sh
@@ -151,8 +151,25 @@ build_requires = policy.get("supplemental_build_requires", [])
 packages = [entry.get("package", "").strip() for entry in build_requires]
 if any(not package for package in packages):
     raise SystemExit("policy contains an empty supplemental BuildRequires package")
+
+def has_unconditional_build_requirement(package):
+    conditional_depth = 0
+    requirement = re.compile(
+        rf"^BuildRequires:\s*{re.escape(package)}(?:\s|$)"
+    )
+    for line in spec.splitlines():
+        if re.match(r"^%if(?:arch|narch)?(?:\s|$)", line):
+            conditional_depth += 1
+            continue
+        if re.match(r"^%endif(?:\s|$)", line):
+            conditional_depth = max(0, conditional_depth - 1)
+            continue
+        if conditional_depth == 0 and requirement.match(line):
+            return True
+    return False
+
 for package in packages:
-    if re.search(rf"(?m)^BuildRequires:\s*{re.escape(package)}(?:\s|$)", spec):
+    if has_unconditional_build_requirement(package):
         continue
     spec, count = re.subn(
         r"(?m)^(BuildRequires:\s*autoconf\s*)$",

--- a/devtools/release/rpm-daily-stable.sh
+++ b/devtools/release/rpm-daily-stable.sh
@@ -158,7 +158,7 @@ def has_unconditional_build_requirement(package):
         rf"^BuildRequires:\s*{re.escape(package)}(?:\s|$)"
     )
     for line in spec.splitlines():
-        if re.match(r"^%if(?:arch|narch)?(?:\s|$)", line):
+        if re.match(r"^%if(?:arch|narch|os|nos)?(?:\s|$)", line):
             conditional_depth += 1
             continue
         if re.match(r"^%endif(?:\s|$)", line):

--- a/plugins/omotel/Makefile.am
+++ b/plugins/omotel/Makefile.am
@@ -13,15 +13,16 @@ OTLP_PB_RESOURCE_H = opentelemetry/proto/resource/v1/resource.pb-c.h
 OTLP_PB_LOGS_C = opentelemetry/proto/logs/v1/logs.pb-c.c
 OTLP_PB_LOGS_H = opentelemetry/proto/logs/v1/logs.pb-c.h
 
-nodist_omotel_la_SOURCES = \
-       $(OTLP_PB_COMMON_C) \
-       $(OTLP_PB_RESOURCE_C) \
-       $(OTLP_PB_LOGS_C)
-
 noinst_HEADERS = \
        otlp_json.h \
        omotel_http.h \
        otlp_protobuf.h
+
+if ENABLE_OMOTEL
+nodist_omotel_la_SOURCES = \
+       $(OTLP_PB_COMMON_C) \
+       $(OTLP_PB_RESOURCE_C) \
+       $(OTLP_PB_LOGS_C)
 
 nodist_noinst_HEADERS = \
        $(OTLP_PB_COMMON_H) \
@@ -54,6 +55,7 @@ $(OTLP_PB_RESOURCE_C) $(OTLP_PB_RESOURCE_H): $(srcdir)/proto/opentelemetry/proto
 
 $(OTLP_PB_LOGS_C) $(OTLP_PB_LOGS_H): $(srcdir)/proto/opentelemetry/proto/logs/v1/logs.proto $(OTLP_PB_COMMON_H) $(OTLP_PB_RESOURCE_H)
 	$(PROTOC_C) --proto_path=$(srcdir)/proto --c_out=$(builddir) $<
+endif
 
 CLEANFILES = $(OTLP_PB_COMMON_C) $(OTLP_PB_COMMON_H) \
              $(OTLP_PB_RESOURCE_C) $(OTLP_PB_RESOURCE_H) \


### PR DESCRIPTION
Fixes the three failed daily-stable package runs:

- EL10 source-tarball generation invokes protobuf-c only when omotel is enabled.
- Ubuntu accepts the baseline wildcard spelling for the Debian multiarch library path.
- Debian retains the first Architecture: all artifact in the shared pool, preventing a later native build from invalidating indexed hashes.
- Amazon Linux 2023 explicitly enables its native GnuTLS build condition, producing the package required by the common profile contract.

Validation:
- archive self-test passed
- disabled/enabled omotel build paths passed (`protoc-c` used for enabled build)
- mock `distcheck` passed
- Ubuntu 26.04 CI-equivalent run: 1,347 passed, 33 skipped, 0 failures/errors
- clang static analyzer: no bugs found
- Amazon Linux 2023 native baseline build produced `rsyslog-gnutls` with `lmnsd_gtls.so` and validated standard/full profile requirements
- local Cubic review could not run because the subscription is expired

Fixes https://github.com/rsyslog/rsyslog/issues/7462
Fixes https://github.com/rsyslog/rsyslog/issues/7463
Fixes https://github.com/rsyslog/rsyslog/issues/7464
Fixes https://github.com/rsyslog/rsyslog/issues/7466

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
