### PR TITLE
tests: cover tcpsrv shutdown with pending accepts

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -811,6 +811,7 @@ TESTS_IMTCP = \
 	imtcp-multiline.sh \
 	imtcp-spacelf-escape.sh \
 	imtcp-basic-hup.sh \
+	imtcp-shutdown-pending-accepts.sh \
 	imtcp-impstats-single-thread.sh \
 	imtcp-starvation-0.sh \
 	imtcp-starvation-1.sh \

--- a/tests/imtcp-shutdown-pending-accepts.sh
+++ b/tests/imtcp-shutdown-pending-accepts.sh
@@ -80,7 +80,12 @@ for thread in threads:
 if not ready.is_set():
     sys.exit(1)
 
+# The shell normally creates the release file after shutdown. Do not leave this
+# background helper holding sessions if the test harness terminates the shell.
+release_deadline = time.monotonic() + 30
 while not os.path.exists(release_file):
+    if time.monotonic() >= release_deadline:
+        raise SystemExit("timed out waiting for the test shutdown to complete")
     time.sleep(0.05)
 
 for sock in sockets:

--- a/tests/imtcp-shutdown-pending-accepts.sh
+++ b/tests/imtcp-shutdown-pending-accepts.sh
@@ -52,7 +52,7 @@ failed = threading.Event()
 
 def connect_many():
     for _ in range(256):
-        if failed.is_set():
+        if failed.is_set() or ready.is_set():
             return
         try:
             sock = socket.create_connection(("127.0.0.1", port), timeout=2)
@@ -65,7 +65,7 @@ def connect_many():
             return
         with lock:
             sockets.append(sock)
-            if len(sockets) >= 128 and not ready.is_set():
+            if len(sockets) >= 128 and not ready.is_set() and not failed.is_set():
                 with open(ready_file, "w", encoding="ascii") as stream:
                     stream.write("ready\n")
                 ready.set()

--- a/tests/imtcp-shutdown-pending-accepts.sh
+++ b/tests/imtcp-shutdown-pending-accepts.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Regression test for listener-descriptor teardown racing imtcp workers.
+. ${srcdir:=.}/diag.sh init
+
+skip_platform "FreeBSD" "the tcpsrv worker-pool race is specific to epoll"
+skip_platform "SunOS" "the tcpsrv worker-pool race is specific to epoll"
+skip_platform "Darwin" "the tcpsrv worker-pool race is specific to epoll"
+check_command_available python3
+
+generate_conf
+add_conf '
+$MaxOpenFiles 4096
+module(load="../plugins/imtcp/.libs/imtcp" maxSessions="2048")
+input(type="imtcp"
+      address="127.0.0.1"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+      socketBacklog="2048"
+      workerThreads="8")
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+
+startup
+rm -f "$RSYSLOG_DYNNAME.client-ready"
+
+# Fill the listen backlog while a tcpsrv worker drains it. Reaching the marker
+# proves that enough connects are pending to keep doAccept() active when the
+# input thread starts shutdown. ASan turns the historical teardown race into a
+# reliable UAF report; non-sanitizer jobs still check clean termination.
+python3 - "$TCPFLOOD_PORT" "$RSYSLOG_DYNNAME.client-ready" <<'PY' &
+import socket
+import sys
+import threading
+import time
+
+port = int(sys.argv[1])
+ready_file = sys.argv[2]
+sockets = []
+lock = threading.Lock()
+ready = threading.Event()
+
+
+def connect_many():
+    for _ in range(256):
+        try:
+            sock = socket.create_connection(("127.0.0.1", port), timeout=2)
+        except OSError:
+            return
+        with lock:
+            sockets.append(sock)
+            if len(sockets) >= 128 and not ready.is_set():
+                with open(ready_file, "w", encoding="ascii") as stream:
+                    stream.write("ready\n")
+                ready.set()
+
+
+threads = [threading.Thread(target=connect_many) for _ in range(8)]
+for thread in threads:
+    thread.start()
+for thread in threads:
+    thread.join()
+
+time.sleep(1)
+for sock in sockets:
+    try:
+        sock.close()
+    except OSError:
+        pass
+PY
+client_pid=$!
+
+wait_file_exists "$RSYSLOG_DYNNAME.client-ready"
+shutdown_immediate
+wait_shutdown "" 15
+if [ -e "$RSYSLOG_PIDBASE.pid" ]; then
+	error_exit 1 "rsyslogd left its pid file behind after shutdown"
+fi
+wait "$client_pid" || error_exit 1
+
+exit_test

--- a/tests/imtcp-shutdown-pending-accepts.sh
+++ b/tests/imtcp-shutdown-pending-accepts.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
-# Regression test for listener-descriptor teardown racing imtcp workers.
+# Regression test for imtcp listener-descriptor teardown after concurrent TCP
+# connection acceptance on Linux's epoll worker path. The client marks ready
+# only after 128 sessions are established and holds those sessions open until
+# shutdown completes. Passing requires the normal shutdown marker and no
+# leftover pid file; sanitizer builds also turn a teardown UAF into a failure.
 . ${srcdir:=.}/diag.sh init
 
-skip_platform "FreeBSD" "the tcpsrv worker-pool race is specific to epoll"
-skip_platform "SunOS" "the tcpsrv worker-pool race is specific to epoll"
-skip_platform "Darwin" "the tcpsrv worker-pool race is specific to epoll"
+if [ "$(uname)" != "Linux" ]; then
+	echo "the tcpsrv worker-pool regression is specific to Linux epoll"
+	exit 77
+fi
 check_command_available python3
 
 generate_conf
@@ -23,12 +28,14 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 
 startup
 rm -f "$RSYSLOG_DYNNAME.client-ready"
+release_file="$RSYSLOG_DYNNAME.client-release"
+rm -f "$release_file"
 
-# Fill the listen backlog while a tcpsrv worker drains it. Reaching the marker
-# proves that enough connects are pending to keep doAccept() active when the
-# input thread starts shutdown. ASan turns the historical teardown race into a
-# reliable UAF report; non-sanitizer jobs still check clean termination.
-python3 - "$TCPFLOOD_PORT" "$RSYSLOG_DYNNAME.client-ready" <<'PY' &
+# Concurrent connects establish the workload before the shell requests
+# shutdown. The release file is an explicit completion signal, replacing a
+# host-speed-dependent delay while keeping established client sessions alive.
+python3 - "$TCPFLOOD_PORT" "$RSYSLOG_DYNNAME.client-ready" "$release_file" <<'PY' &
+import os
 import socket
 import sys
 import threading
@@ -36,16 +43,25 @@ import time
 
 port = int(sys.argv[1])
 ready_file = sys.argv[2]
+release_file = sys.argv[3]
 sockets = []
 lock = threading.Lock()
 ready = threading.Event()
+failed = threading.Event()
 
 
 def connect_many():
     for _ in range(256):
+        if failed.is_set():
+            return
         try:
             sock = socket.create_connection(("127.0.0.1", port), timeout=2)
-        except OSError:
+        except OSError as error:
+            with lock:
+                if not ready.is_set() and not failed.is_set():
+                    with open(ready_file, "w", encoding="ascii") as stream:
+                        stream.write(f"error: {error}\n")
+                    failed.set()
             return
         with lock:
             sockets.append(sock)
@@ -61,7 +77,12 @@ for thread in threads:
 for thread in threads:
     thread.join()
 
-time.sleep(1)
+if not ready.is_set():
+    sys.exit(1)
+
+while not os.path.exists(release_file):
+    time.sleep(0.05)
+
 for sock in sockets:
     try:
         sock.close()
@@ -69,13 +90,20 @@ for sock in sockets:
         pass
 PY
 client_pid=$!
+trap 'touch "$release_file"; wait "$client_pid" 2>/dev/null || true' EXIT
 
 wait_file_exists "$RSYSLOG_DYNNAME.client-ready"
+if ! grep -qx "ready" "$RSYSLOG_DYNNAME.client-ready"; then
+	cat "$RSYSLOG_DYNNAME.client-ready"
+	error_exit 1 "connection setup failed before the shutdown workload was ready"
+fi
 shutdown_immediate
 wait_shutdown "" 15
 if [ -e "$RSYSLOG_PIDBASE.pid" ]; then
 	error_exit 1 "rsyslogd left its pid file behind after shutdown"
 fi
+touch "$release_file"
 wait "$client_pid" || error_exit 1
+trap - EXIT
 
 exit_test


### PR DESCRIPTION
## Summary

- add a focused imtcp regression test that fills the accept backlog while tcpsrv workers are active
- initiate immediate shutdown while pending accepts keep `doAccept()` busy
- require clean process teardown and PID-file removal

## Why

Before `ab11e9c0f79accb48b6a7bdf24fea4e814e07b12`, `RunEpoll()` could free listener descriptors before the tcpsrv worker pool had stopped. A worker could then continue through `doAccept()` or rearm the listener using freed descriptor storage. The ordering fix landed as a side effect of broader atomic-helper work and had no focused regression test.

## Impact

The test preserves the shutdown-ordering invariant for shared TCP input code. It takes about 1 to 1.5 seconds locally, so it is suitable for the regular imtcp suite and existing sanitizer lanes without adding the multi-minute customer-like stress campaign to blocking CI.

## Validation

- current `main`, normal build: pass
- current `main`, ASan/UBSan build: 10/10 repetitions passed
- rsyslog v8.2606 ASan build: reliably reproduces the shutdown crash and leaves the PID file behind
- `bash -n tests/imtcp-shutdown-pending-accepts.sh`
- `shellcheck -S warning tests/imtcp-shutdown-pending-accepts.sh`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

