### PR TITLE
runtime: make error-message flag atomic

### DIFF
--- a/runtime/errmsg.c
+++ b/runtime/errmsg.c
@@ -44,6 +44,7 @@
 #include "msg.h"
 #include "errmsg.h"
 #include "operatingstate.h"
+#include "atomic.h"
 #include "srUtils.h"
 #include "stringbuf.h"
 #include "rsconf.h"
@@ -56,6 +57,12 @@
 static int bHadErrMsgs; /* indicates if we had error messages since reset of this flag
                          * This is used to abort a run if the config is unclean.
                          */
+#ifndef HAVE_ATOMIC_BUILTINS
+static DEF_ATOMIC_HELPER_MUT(mutHadErrMsgs) = PTHREAD_MUTEX_INITIALIZER;
+    #define MUT_HAD_ERR_MSGS &mutHadErrMsgs
+#else
+    #define MUT_HAD_ERR_MSGS NULL
+#endif
 
 static int fdOversizeMsgLog = -1;
 static pthread_mutex_t oversizeMsgLogMut = PTHREAD_MUTEX_INITIALIZER;
@@ -167,11 +174,11 @@ finalize_it:
  * files.
  */
 void resetErrMsgsFlag(void) {
-    bHadErrMsgs = 0;
+    ATOMIC_STORE_32BIT(&bHadErrMsgs, MUT_HAD_ERR_MSGS, 0);
 }
 
 int hadErrMsgs(void) {
-    return bHadErrMsgs;
+    return ATOMIC_LOAD_32BIT(&bHadErrMsgs, MUT_HAD_ERR_MSGS);
 }
 
 /** @internal
@@ -221,7 +228,7 @@ static void doLogMsg(const int iErrno, const int iErrCode, const int severity, c
 
     glblErrLogger(severity, iErrCode, (uchar *)buf);
 
-    if (severity == LOG_ERR) bHadErrMsgs = 1;
+    if (severity == LOG_ERR) ATOMIC_STORE_32BIT(&bHadErrMsgs, MUT_HAD_ERR_MSGS, 1);
 }
 
 /* We now receive three parameters: one is the internal error code


### PR DESCRIPTION
## Summary

- make the process-wide `bHadErrMsgs` flag use rsyslog's atomic load/store macros
- provide the standard mutex-backed fallback when atomic builtins are disabled

## Root cause

Concurrent error reporting could write `bHadErrMsgs` while configuration/status code read or reset it. The plain accesses constituted a data race and produced ThreadSanitizer noise during concurrent TLS error handling.

## Impact

The flag now has synchronized access in both atomic and non-atomic builds without changing its behavior.

## Validation

- normal atomic build
- build configured with `--disable-atomic-operations`
- TLS error-storm test under ThreadSanitizer, repeated twice; no `bHadErrMsgs`/`errmsg.c` race reported


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

