### PR TITLE
msg: ignore null values in msgSetPropViaJSON() instead of crashing

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -4749,6 +4749,13 @@ static rsRetVal msgSetPropViaJSON(smsg_t *__restrict__ const pMsg,
      *       string. So we MUST NOT free it!
      */
     dbgprintf("DDDD: msgSetPropViaJSON key: '%s'\n", name);
+    if (json == NULL) {
+        /* Ignore a JSON null value: a core property can be neither null nor
+         * unset, and the setters below would otherwise crash on
+         * strlen(jsonToString(NULL)). */
+        DBGPRINTF("msgSetPropViaJSON: null value for property '%s' ignored\n", name);
+        return RS_RET_OK;
+    }
     if (!strcmp(name, "rawmsg")) {
         psz = jsonToString(json);
         MsgSetRawMsg(pMsg, psz, strlen(psz));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -244,6 +244,8 @@ TESTS_DEFAULT = \
 	glbl_setenv_err_too_long.sh \
 	glbl_setenv.sh \
 	mmexternal-SegFault.sh \
+	mmexternal-set-msg-null-crash.sh \
+	mmexternal-set-syslogtag-null-crash.sh \
 	mmexternal-interface-output-none.sh \
 	mmexternal-single-instance.sh \
 	mmexternal-response-too-long.sh \
@@ -3793,6 +3795,7 @@ EXTRA_DIST += \
 	testsuites/mmexternal-hang-no-reply.sh \
 	testsuites/mmexternal-no-output.sh \
 	testsuites/mmexternal-single-instance-bin.sh \
+	testsuites/mmexternal-null-prop-bin.sh \
 	testsuites/mmexternal-too-long-reply-bin.sh \
 	testsuites/mmexternal-trickle-no-lf.sh \
 	testsuites/mmsnareparse/sample-custom-pattern.data \

--- a/tests/mmexternal-set-msg-null-crash.sh
+++ b/tests/mmexternal-set-msg-null-crash.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# added 2026-08-07 by Julien Thomas, released under ASL 2.0
+# Regression test: an mmexternal program that returns a core property set to a
+# JSON null ({"msg": null}) must NOT crash rsyslogd. jsonToString() returns NULL
+# for a JSON null and the string setters in msgSetPropViaJSON() (msg, rawmsg,
+# syslogtag, hostname, ...) used to strlen(NULL) -> SIGSEGV. The dispatch is
+# shared, so mmlua and pmnormalize hit the same path. A null core property is
+# now ignored (it can be neither null nor unset), leaving the value unchanged.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/mmexternal/.libs/mmexternal")
+template(name="outfmt" type="string" string="msg=%msg%\n")
+action(type="mmexternal" binary="'$srcdir'/testsuites/mmexternal-null-prop-bin.sh msg")
+action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+injectmsg literal "<13>Mar 10 01:00:00 host tag:test-message"
+shutdown_when_empty
+wait_shutdown
+
+# no crash, and the null value left "msg" untouched
+content_check "msg=test-message"
+exit_test

--- a/tests/mmexternal-set-syslogtag-null-crash.sh
+++ b/tests/mmexternal-set-syslogtag-null-crash.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# added 2026-08-07 by Julien Thomas, released under ASL 2.0
+# Same null-value regression as mmexternal-set-msg-null-crash.sh, but on
+# "syslogtag" ({"syslogtag": null}) -- shows the crash was not specific to
+# "msg": every string setter in msgSetPropViaJSON() that does
+# strlen(jsonToString(json)) was affected. A null core property is ignored,
+# leaving the value unchanged.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/mmexternal/.libs/mmexternal")
+template(name="outfmt" type="string" string="tag=%syslogtag%\n")
+action(type="mmexternal" binary="'$srcdir'/testsuites/mmexternal-null-prop-bin.sh syslogtag")
+action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+injectmsg literal "<13>Mar 10 01:00:00 host tag:test-message"
+shutdown_when_empty
+wait_shutdown
+
+# no crash, and the null value left "syslogtag" untouched
+content_check "tag=tag:"
+exit_test

--- a/tests/testsuites/mmexternal-null-prop-bin.sh
+++ b/tests/testsuites/mmexternal-null-prop-bin.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# added 2026-08-07 by Julien Thomas, released under ASL 2.0
+# mmexternal helper that replies, for every input message, with a single core
+# property set to a bare JSON null. The property name comes from $1 (default
+# "msg"). This exercises the NULL-value path of msgSetPropViaJSON(): a JSON
+# null is stringified by jsonToString() to NULL, and the string setters
+# (msg/rawmsg/syslogtag/hostname/...) then call strlen(NULL).
+prop=${1:-msg}
+while IFS= read -r line; do
+	printf '{"%s": null}\n' "$prop"
+done


### PR DESCRIPTION
Why: setting a core message property to a JSON null crashed rsyslogd. jsonToString() returns NULL for a JSON null and the string setters (msg, rawmsg, syslogtag, hostname/source, fromhost, fromhost-ip) then called strlen(NULL). Reachable from mmexternal (a program returning {"msg": null}), from mmlua and from pmnormalize.

Impact: no crash; a null core property is ignored -- it can be neither null nor unset -- leaving the current value unchanged.

Technical Overview: the value is null exactly when the json argument is NULL, so a single guard at the top of msgSetPropViaJSON() covers every property (string and numeric). It skips the property with a DBGPRINTF, mirroring the existing "unknown property ignored" policy. Two mmexternal regression tests cover the msg and syslogtag setters.

With the help of Claude AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

