### PR TITLE
stream: keep async writer alive across size-limit rotation

### DIFF
--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -57,6 +57,18 @@ runtime_msg:
   notes:
     - MsgGetRcvFromProp returns fromhost, fromhost-ip, or fromhost-port with the stored prop length; it resolves DNS only when NEEDS_DNSRESOL is still set.
 
+runtime_stream:
+  paths: ["runtime/stream.c", "runtime/stream.h"]
+  requires_serialization: true
+  locks:
+    - type: recursive-mutex
+      field: strm_t.mut
+  notes:
+    - strm_t.mut, notFull, notEmpty and isEmpty exist only when bAsyncWrite is set; omfile is the only caller that enables async streams and it serializes writes behind its own pData.mutWrite.
+    - The async writer thread is created once in strmConstructFinalize(); no other code path recreates it, so any caller that stops it must be done with the stream.
+    - strmCloseFile() stops the async writer and, as a documented side effect, leaves pThis->mut unlocked on return; callers must either hold no expectation of the lock or use the non-stopping variant.
+    - Size-limit rotation uses the non-stopping close: the writer thread survives, pending buffers are drained with strmWaitAsyncWriterDone() before the fd is closed, and the caller's mutex stays held across the rotation command.
+
 mmnormalize:
   paths: ["plugins/mmnormalize/"]
   requires_serialization: true

--- a/runtime/AGENTS.md
+++ b/runtime/AGENTS.md
@@ -37,6 +37,10 @@ collection, and process orchestration).
   - Directly invoke the most relevant shell test under `tests/` (e.g. `./tests/queue-persist.sh`).
   - Use `make check TESTS='<script>.sh'` when you need automake’s harness or Valgrind variants (`*-vg.sh`).
   - For configuration validation edits, run `./tests/validation-run.sh`.
+- **Existing smoke coverage:** `tests/omfile-sizelimitcmd-async.sh` covers
+  `stream.c` size-limit rotation with `asyncWriting="on"`, i.e. that the async
+  writer thread survives a rotation. `tests/omfile-sizelimitcmd-many.sh` covers
+  the same rotation path with the default synchronous writer.
 - When changing exported symbols, update `runtime/Makefile.am` and ensure the library version script (if touched) remains consistent with existing SONAME policies.
 
 ## Coding expectations

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -224,11 +224,11 @@ static rsRetVal doSizeLimitProcessing(strm_t *pThis) {
          * need to preserve it.
          */
         CHKmalloc(pszCurrFName = ustrdup(pThis->pszCurrFName));
-        /* The stream keeps being written to after the rotation, so the async
-         * writer thread must survive it. Stopping the writer here would leave
-         * the stream without a consumer for its buffer queue, and the producer
-         * would block on notFull forever. Keeping it alive also preserves the
-         * caller's mutex, which stopWriter() would otherwise release.
+        /* the stream is written to again after the rotation, so the async
+         * writer thread must survive it. stopping it here leaves the buffer
+         * queue without a consumer and the producer blocks on notFull forever.
+         * keeping it also preserves the caller's mutex, which stopWriter()
+         * would release.
          */
         CHKiRet(strmCloseFileInternal(pThis, 0));
         CHKiRet(resolveFileSizeLimit(pThis, pszCurrFName));
@@ -480,15 +480,15 @@ static rsRetVal strmCloseFile(strm_t *pThis) {
 
 
 /**
- * @brief Workhorse for strmCloseFile().
+ * @brief workhorse for strmCloseFile().
  *
- * @param bStopAsyncWriter if set, the async writer thread is terminated, which
- * as a side effect also unlocks pThis->mut (see stopWriter()). This is what
- * every caller that is done with the stream wants. If cleared, the writer
- * thread is kept running and the caller's mutex stays locked; the pending
- * buffers are drained via strmWaitAsyncWriterDone() instead, so the data is on
- * disk before the file descriptor is closed. Callers that continue to use the
- * stream afterwards, like size-limit rotation, must use this mode.
+ * @param bStopAsyncWriter if set, terminates the async writer thread, which
+ * also unlocks pThis->mut as a side effect (see stopWriter()). that is what
+ * callers who are done with the stream want. if cleared, the writer keeps
+ * running and the caller's mutex stays locked; pending buffers drain via
+ * strmWaitAsyncWriterDone() instead, so the data is on disk before the fd is
+ * closed. callers that keep using the stream afterwards, such as size-limit
+ * rotation, must use this mode.
  */
 static rsRetVal strmCloseFileInternal(strm_t *pThis, const int bStopAsyncWriter) {
     off64_t currOffs;

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -84,6 +84,7 @@ DEFobjCurrIf(zlibw) DEFobjCurrIf(zstdw)
 static rsRetVal strmWrite(strm_t *__restrict__ const pThis, const uchar *__restrict__ const pBuf, const size_t lenBuf);
 static rsRetVal strmOpenFile(strm_t *pThis);
 static rsRetVal strmCloseFile(strm_t *pThis);
+static rsRetVal strmCloseFileInternal(strm_t *pThis, const int bStopAsyncWriter);
 static void *asyncWriterThread(void *pPtr);
 static rsRetVal doZipWrite(strm_t *pThis, uchar *pBuf, size_t lenBuf, int bFlush);
 static rsRetVal doZipFinish(strm_t *pThis);
@@ -223,7 +224,13 @@ static rsRetVal doSizeLimitProcessing(strm_t *pThis) {
          * need to preserve it.
          */
         CHKmalloc(pszCurrFName = ustrdup(pThis->pszCurrFName));
-        CHKiRet(strmCloseFile(pThis));
+        /* The stream keeps being written to after the rotation, so the async
+         * writer thread must survive it. Stopping the writer here would leave
+         * the stream without a consumer for its buffer queue, and the producer
+         * would block on notFull forever. Keeping it alive also preserves the
+         * caller's mutex, which stopWriter() would otherwise release.
+         */
+        CHKiRet(strmCloseFileInternal(pThis, 0));
         CHKiRet(resolveFileSizeLimit(pThis, pszCurrFName));
     }
 
@@ -468,6 +475,22 @@ static void stopWriter(strm_t *const pThis) {
  * close it again (this is done via strmFlushInternal and friends).
  */
 static rsRetVal strmCloseFile(strm_t *pThis) {
+    return strmCloseFileInternal(pThis, 1);
+}
+
+
+/**
+ * @brief Workhorse for strmCloseFile().
+ *
+ * @param bStopAsyncWriter if set, the async writer thread is terminated, which
+ * as a side effect also unlocks pThis->mut (see stopWriter()). This is what
+ * every caller that is done with the stream wants. If cleared, the writer
+ * thread is kept running and the caller's mutex stays locked; the pending
+ * buffers are drained via strmWaitAsyncWriterDone() instead, so the data is on
+ * disk before the file descriptor is closed. Callers that continue to use the
+ * stream afterwards, like size-limit rotation, must use this mode.
+ */
+static rsRetVal strmCloseFileInternal(strm_t *pThis, const int bStopAsyncWriter) {
     off64_t currOffs;
     DEFiRet;
 
@@ -484,7 +507,11 @@ static rsRetVal strmCloseFile(strm_t *pThis) {
             doZipFinish(pThis);
         }
         if (pThis->bAsyncWrite) {
-            stopWriter(pThis);
+            if (bStopAsyncWriter) {
+                stopWriter(pThis);
+            } else {
+                strmWaitAsyncWriterDone(pThis);
+            }
         }
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -282,6 +282,7 @@ TESTS_DEFAULT = \
 	omfile-whitespace-filename.sh \
 	omfile-read-only.sh \
 	omfile-outchannel.sh \
+	omfile-sizelimitcmd-async.sh \
 	omfile_both_files_set.sh \
 	omfile_hup.sh \
 	msgvar-concurrency.sh \

--- a/tests/omfile-sizelimitcmd-async.sh
+++ b/tests/omfile-sizelimitcmd-async.sh
@@ -1,24 +1,22 @@
 #!/bin/bash
-# added 2026-08-10 by Owen Rotenberg, released under ASL 2.0
+# added 2026-08-10 by owen-rote, released under ASL 2.0
 #
-# Intent: guard the invariant that an omfile stream stays usable after a
-# rotation.sizeLimit rotation when asyncWriting is enabled.
+# intent: an omfile stream must stay usable after a rotation.sizeLimit rotation
+# with asyncWriting enabled.
 #
-# Regression guard: doSizeLimitProcessing() used to reach stopWriter() via
-# strmCloseFile(), which joined the stream's async writer thread. Nothing ever
-# recreated it, so the stream kept accepting buffers into a queue with no
-# consumer. The first buffer handed over after the rotation was accepted and the
-# next one blocked forever on the notFull condition, wedging the queue worker
-# that drives the action. Output stopped after the first rotation and shutdown
-# hung.
+# regression guard: doSizeLimitProcessing() reached stopWriter() via
+# strmCloseFile(), joining the stream's async writer thread. nothing recreated
+# it, so the stream kept queueing buffers with no consumer. the first buffer
+# after the rotation was accepted, the next blocked on notFull forever and
+# wedged the queue worker driving the action. output stopped after the first
+# rotation and shutdown hung.
 #
-# Oracle: seq_check over the concatenated rotated files. Every injected message
-# must be present exactly once, which can only happen if the stream keeps
-# writing across all rotations. The wedge fails this deterministically: it also
-# stalls the queue, so shutdown_when_empty/wait_shutdown time out first. No
-# sleeps or thresholds are involved; the testbench timeoutGuard remains the hang
-# backstop. This mirrors omfile-sizelimitcmd-many.sh, which covers the same
-# rotation path with the default synchronous writer.
+# oracle: seq_check over the concatenated rotated files. every injected message
+# must appear exactly once, which requires the stream to keep writing across all
+# rotations. the wedge also stalls the queue, so shutdown_when_empty /
+# wait_shutdown time out first. no sleeps, no thresholds; the testbench
+# timeoutGuard is the hang backstop. mirrors omfile-sizelimitcmd-many.sh, which
+# covers the same rotation path with the default synchronous writer.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=50000
 echo "mv -f $RSYSLOG_DYNNAME.channel.log.prev.9 $RSYSLOG_DYNNAME.channel.log.prev.10 2>/dev/null

--- a/tests/omfile-sizelimitcmd-async.sh
+++ b/tests/omfile-sizelimitcmd-async.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# added 2026-08-10 by Owen Rotenberg, released under ASL 2.0
+#
+# Intent: guard the invariant that an omfile stream stays usable after a
+# rotation.sizeLimit rotation when asyncWriting is enabled.
+#
+# Regression guard: doSizeLimitProcessing() used to reach stopWriter() via
+# strmCloseFile(), which joined the stream's async writer thread. Nothing ever
+# recreated it, so the stream kept accepting buffers into a queue with no
+# consumer. The first buffer handed over after the rotation was accepted and the
+# next one blocked forever on the notFull condition, wedging the queue worker
+# that drives the action. Output stopped after the first rotation and shutdown
+# hung.
+#
+# Oracle: seq_check over the concatenated rotated files. Every injected message
+# must be present exactly once, which can only happen if the stream keeps
+# writing across all rotations. The wedge fails this deterministically: it also
+# stalls the queue, so shutdown_when_empty/wait_shutdown time out first. No
+# sleeps or thresholds are involved; the testbench timeoutGuard remains the hang
+# backstop. This mirrors omfile-sizelimitcmd-many.sh, which covers the same
+# rotation path with the default synchronous writer.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=50000
+echo "mv -f $RSYSLOG_DYNNAME.channel.log.prev.9 $RSYSLOG_DYNNAME.channel.log.prev.10 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.8 $RSYSLOG_DYNNAME.channel.log.prev.9 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.7 $RSYSLOG_DYNNAME.channel.log.prev.8 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.6 $RSYSLOG_DYNNAME.channel.log.prev.7 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.5 $RSYSLOG_DYNNAME.channel.log.prev.6 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.4 $RSYSLOG_DYNNAME.channel.log.prev.5 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.3 $RSYSLOG_DYNNAME.channel.log.prev.4 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.2 $RSYSLOG_DYNNAME.channel.log.prev.3 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.1 $RSYSLOG_DYNNAME.channel.log.prev.2 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev   $RSYSLOG_DYNNAME.channel.log.prev.1 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log $RSYSLOG_DYNNAME.channel.log.prev
+"   > $RSYSLOG_DYNNAME.rotate.sh
+chmod +x $RSYSLOG_DYNNAME.rotate.sh
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if $msg contains "msgnum:" then {
+	action(type="omfile" file="'$RSYSLOG_DYNNAME.channel.log'" template="outfmt"
+		asyncWriting="on"
+		rotation.sizeLimit="50k"
+		rotation.sizeLimitCommand="./'$RSYSLOG_DYNNAME.rotate.sh'")
+}
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+ls -l $RSYSLOG_DYNNAME.channel.*
+cat $RSYSLOG_DYNNAME.channel.* > $RSYSLOG_OUT_LOG
+seq_check
+exit_test


### PR DESCRIPTION
fixes https://github.com/rsyslog/rsyslog/issues/7477

## problem

an omfile action with `rotation.sizeLimit`, `rotation.sizeLimitCommand` and
`asyncWriting="on"` rotates once, then stops writing permanently, and shutdown hangs.

`doSizeLimitProcessing()` reaches `stopWriter()` through `strmCloseFile()`
(`runtime/stream.c:226` -> `:487`), which joins the stream's async writer thread. the
writer is created only in `strmConstructFinalize()` (`:1258`), so the stream is left
without a consumer. with `STREAM_ASYNC_NUMBUFS` at 2, the next buffer is accepted and the
one after that waits on `notFull` (`:1499`) forever.

## fix

`strmCloseFile()` becomes a thin wrapper around
`strmCloseFileInternal(pThis, bStopAsyncWriter)` and passes 1, so every existing caller
keeps its current behavior. `doSizeLimitProcessing()` passes 0, which:

* keeps the writer thread alive, so the stream still has a consumer after the rotation
* drains the buffer `strmFlushInternal()` just handed over with a second
  `strmWaitAsyncWriterDone()`, so the data is on disk before the fd is closed and the
  rotation command runs
* keeps the caller's mutex held for the rest of `strmWrite()`, since `stopWriter()` is
  what would otherwise release it

the stream reopens its file descriptor on the next write through the existing
`strmPhysWrite()` -> `strmOpenFile()` path (`:1689`).

scope is limited to omfile: it is the only caller that enables async streams
(`tools/omfile.c:737`) and it uses `STREAMTYPE_FILE_SINGLE`, so `strmNextFile()` and
`rereadTruncated()` cannot reach the async branch.

## test

`tests/omfile-sizelimitcmd-async.sh` mirrors `tests/omfile-sizelimitcmd-many.sh` with
`asyncWriting="on"` added. it fails deterministically on unpatched `main` (timeoutGuard
abort, ~44k messages stranded in the queue) and passes in 2s with the fix, across 8
rotations.

## before/after

standalone reproducer from the issue, 1500 messages plus 50 markers at a 100KiB limit, on
`main` `a3a2a2882`:

| build | delivered | rotations | SIGTERM |
|---|---|---|---|
| `asyncWriting="off"` | 1550/1550 | 3 | clean, 2s |
| `asyncWriting="on"` | 397/1550 | 1 | hung, SIGKILL after 20s |
| `asyncWriting="on"` + this pr | 1550/1550 | 3 | clean, 2s |

## validation

ubuntu 24.04 host with docker.

* clang static analyzer via `devtools/run-static-analyzer.sh` on
  `rsyslog/rsyslog_dev_base_ubuntu:26.04`: no bugs found
* change-gated `devtools/devcontainer.sh --rm devtools/run-ci.sh` on the same image,
  `CC=gcc`, `CFLAGS=-g`, `CI_MAKE_OPT=-j10`, `CI_MAKE_CHECK_OPT=-j10`, default pr service
  suppressions from `devtools/apply-service-relevance.sh`: total 1466, pass 1433, skip 33,
  fail 0, error 0 in 888s
* `make distcheck TEST_RUN_TYPE=MOCK-OK -j16`: pass
* `devtools/format-code.sh --git-changed --check --check-if-available` and
  `shellcheck -S warning` on the new test: clean
* host-side runs of `omfile-outchannel.sh`, `omfile-outchannel-many.sh`, `omfile_hup.sh`,
  `omfile-module-params.sh`, `diskqueue.sh`, `queue-persist.sh`, `gzipwr_*`,
  `imfile-basic.sh`, `imfile-truncate.sh`: pass

local cubic was not run, it is not installed on this machine.

`tests/zstd.sh` fails on this host, but it fails identically on unpatched `main`, verified
by stashing the patch and rebuilding. unrelated to this change.

happy to squash the two commits or adjust anything here.
