### PR TITLE
imptcp: add regression test for regex-framing negative iMsg crash

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1510,6 +1510,7 @@ TESTS_IMPTCP = \
 	imptcp-epoll-add-failure.sh \
 	imptcp_framing_regex.sh \
 	imptcp_framing_regex-oversize.sh \
+	imptcp-framing-regex-neg-imsg-crash.sh \
 	imptcp_large.sh \
 	imptcp-connection-msg-disabled.sh \
 	imptcp-connection-msg-received.sh \

--- a/tests/imptcp-framing-regex-neg-imsg-crash.sh
+++ b/tests/imptcp-framing-regex-neg-imsg-crash.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Regression test for imptcp regex-framing negative iMsg crash.
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+. "${srcdir:=.}"/diag.sh init
+
+MAXMSG=256
+
+generate_conf
+add_conf '
+global(maxMessageSize="'$MAXMSG'")
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+    framing.delimiter.regex="^X")
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+assign_tcpflood_port "$RSYSLOG_DYNNAME".tcpflood_port
+
+# Phase 1: 2*MAXMSG-1 bytes of 'A' + '\n' triggers the oversize handler on the
+# 512th byte, resetting iMsg=0/iCurrLine=1; the '\n' branch then sets iCurrLine=0.
+# Phase 2: 'X' matches "^X" at iCurrLine=0, computing iMsg = 0 - 1 = -1 (crash).
+# Phase 3: follow-up messages verify rsyslog keeps delivering after the attack.
+{ head -c $((MAXMSG * 2 - 1)) /dev/zero | tr '\0' 'A'
+  printf '\nX\nXtest message 1\nXtest message 2\n'
+} > "$RSYSLOG_DYNNAME".crash_payload
+
+tcpflood -B -I "$RSYSLOG_DYNNAME".crash_payload
+
+./msleep 500
+
+PID=$(cat "$RSYSLOG_PIDBASE".pid 2>/dev/null)
+if [ -z "$PID" ]; then
+    printf 'FAIL: could not read rsyslog PID\n'
+    error_exit 1
+fi
+
+if ! kill -0 "$PID" 2>/dev/null; then
+    printf 'FAIL: rsyslogd crashed after receiving the crafted payload\n'
+    error_exit 1
+fi
+
+shutdown_when_empty
+wait_shutdown
+content_check "Xtest message 1"
+exit_test


### PR DESCRIPTION
Adds a dedicated crash-reproduction regression test for the negative `iMsg`
DoS vulnerability in `processDataRcvd_regexFraming()` (fixed upstream in
commit 07b3c40a5a78c79ed9109251f842ca7e955dd586, security advisory
GHSA-cj5r-wh2m-7w29).

**Root cause recap**

When the 2×`iMaxLine`-th byte is `\n`, the oversize handler resets
`iMsg=0`/`iCurrLine=1`, then the `\n` branch sets `iCurrLine=iMsg=0`.
On the very next byte that matches the start regex the code computes
`iMsg = iCurrLine - 1 = -1`, which is passed as `size_t` to
`MsgSetRawMsg`, yielding `SIZE_MAX` and crashing rsyslogd (SIGABRT on
assert, SIGSEGV on `memcpy` without it).

**Attack sequence** (`maxMessageSize=256` to keep the payload small)

1. Send 511 bytes of `A` + `\n` (total 512 == 2×`iMaxLine`) — triggers
   the oversize handler on the `\n`, leaving `iMsg=0`/`iCurrLine=0`
   after the `\n` branch.
2. Send one byte matching the regex (`X` matching `^X`) — triggers
   `isMatch=1` at `iCurrLine=0`, computing `iMsg = 0 − 1 = −1`.

The test also sends follow-up messages after the attack bytes to verify
rsyslog keeps delivering normally after recovery.

**Test verified**

- Without the `iCurrLine > 0` guard: rsyslogd aborts with
  `SanitizeMsg: Assertion 'pMsg->iLenRawMsg > 0' failed` (exit 1).
- With the guard: rsyslogd survives and delivers both follow-up messages
  (exit 0).

Related downstream tracker: https://issues.redhat.com/browse/RHEL-212698