### PR TITLE
imrelp: preserve errno across stop signal

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -872,11 +872,13 @@ ENDfreeCnf
  * we terminate, relpEngine is called, and it's select() loop interrupted. But
  * only *after this function is done*. So we do not have a race!
  */
-static void doSIGTTIN(int __attribute__((unused)) sig) {
+static void imrelpDoSIGTTIN(int __attribute__((unused)) sig) {
+    const int saved_errno = errno;
     const int bTerminate = PREFER_LOAD_INT(&bTerminateInputsSigSafe);
     if (bTerminate && (pRelpEngine != NULL)) {
         relpEngineSetStop(pRelpEngine);
     }
+    errno = saved_errno;
 }
 
 
@@ -897,7 +899,7 @@ BEGINrunInput
     pthread_sigmask(SIG_UNBLOCK, &sigSet, NULL);
     memset(&sigAct, 0, sizeof(sigAct));
     sigemptyset(&sigAct.sa_mask);
-    sigAct.sa_handler = doSIGTTIN;
+    sigAct.sa_handler = imrelpDoSIGTTIN;
     sigaction(SIGTTIN, &sigAct, NULL);
 
     iRet = relpEngineRun(pRelpEngine);

--- a/tests/tsan-rt.supp
+++ b/tests/tsan-rt.supp
@@ -6,7 +6,6 @@ race:^bs_arrcmp_glblDbgFiles$
 race:^imptcp_destruct_epd$
 race:doLogMsg
 race:setlocale
-race:doSIGTTIN
 race:libfaketime
 # ommysql uses per-worker MYSQL handles. Ubuntu 26.04/Clang 21 can report the
 # existing stock libmysqlclient false positive through OpenSSL frames


### PR DESCRIPTION
## Summary

- preserve the interrupted thread's `errno` in the `imrelp` SIGTTIN stop handler
- remove the now-obsolete ThreadSanitizer suppressions for `doSIGTTIN`

## Root cause and impact

The stop handler calls into librelp, which may change `errno`. Signal handlers run in the interrupted thread's context, so returning with a different `errno` can corrupt an unrelated operation in that thread. Saving and restoring `errno` follows the required signal-handler pattern and lets ThreadSanitizer monitor this path again.

## Validation

- normal build with `RSYSLOG_LOCAL_BUILD_JOBS=60`
- `make -C tests check TESTS=imrelp-manyconn.sh`
- ThreadSanitizer build and 10 runs of the concurrent imtcp/imrelp TLS error-storm test, with the obsolete `doSIGTTIN` suppression removed
- `./devtools/format-code.sh --git-changed`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

