### PR TITLE
mmnormalize: preserve turbo $! snapshot across MsgDup

### DIFF
--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -56,6 +56,8 @@ runtime_msg:
   requires_serialization: true
   notes:
     - MsgGetRcvFromProp returns fromhost, fromhost-ip, or fromhost-port with the stored prop length; it resolves DNS only when NEEDS_DNSRESOL is still set.
+    - MsgDup locks the source message while coherently copying JSON state and the lazy turbo snapshot callbacks.
+    - Turbo parse snapshots are immutable and may be shared by MsgDup copies through an atomic reference count; each owner must release only through MsgReleaseTurboResult while holding the message lock or exclusive access.
 
 mmnormalize:
   paths: ["plugins/mmnormalize/"]

--- a/plugins/mmnormalize/mmnormalize.c
+++ b/plugins/mmnormalize/mmnormalize.c
@@ -699,9 +699,7 @@ BEGINdoAction_NoStrings
                      * overwriting — rsyslog action chains can stack
                      * parsers, and each snapshot owns ~6KB of string
                      * data that would otherwise leak. */
-                    if (pMsg->turbo_result != NULL && pMsg->turbo_result_free != NULL) {
-                        pMsg->turbo_result_free(pMsg->turbo_result);
-                    }
+                    MsgReleaseTurboResult(pMsg);
                     pMsg->turbo_result = (void *)snap;
                     pMsg->turbo_result_free = turbo_result_snapshot_free;
                     pMsg->turbo_result_to_json = turbo_result_to_json_cb;

--- a/plugins/mmnormalize/mmnormalize.c
+++ b/plugins/mmnormalize/mmnormalize.c
@@ -699,12 +699,14 @@ BEGINdoAction_NoStrings
                      * overwriting — rsyslog action chains can stack
                      * parsers, and each snapshot owns ~6KB of string
                      * data that would otherwise leak. */
+                    MsgLock(pMsg);
                     MsgReleaseTurboResult(pMsg);
                     pMsg->turbo_result = (void *)snap;
                     pMsg->turbo_result_free = turbo_result_snapshot_free;
                     pMsg->turbo_result_to_json = turbo_result_to_json_cb;
                     pMsg->turbo_result_get_str = turbo_result_get_str_cb;
                     MsgSetParseSuccess(pMsg, 1);
+                    MsgUnlock(pMsg);
                     goto turbo_done;
                 }
             }

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -722,6 +722,7 @@ static rsRetVal msgBaseConstruct(smsg_t **ppThis) {
     pM->turbo_result_free = NULL;
     pM->turbo_result_to_json = NULL;
     pM->turbo_result_get_str = NULL;
+    pM->turbo_result_refs = NULL;
 #endif
     pM->dfltTZ[0] = '\0';
     memset(&pM->tRcvdAt, 0, sizeof(pM->tRcvdAt));
@@ -815,6 +816,28 @@ static inline void freeHOSTNAME(smsg_t *pThis) {
 }
 
 
+#ifdef HAVE_LOGNORM_TURBO
+/* Release one reference on the turbo parse snapshot and clear this message's
+ * slot.  refs == NULL means sole ownership (the message was never duplicated):
+ * free directly, no atomics.  Otherwise the counter is shared across MsgDup()
+ * copies and the last owner out frees both the snapshot and the counter. */
+void MsgReleaseTurboResult(smsg_t *const pMsg) {
+    if (pMsg->turbo_result != NULL && pMsg->turbo_result_free != NULL) {
+        if (pMsg->turbo_result_refs == NULL) {
+            pMsg->turbo_result_free(pMsg->turbo_result);
+        } else if (__atomic_sub_fetch(pMsg->turbo_result_refs, 1, __ATOMIC_ACQ_REL) == 0) {
+            pMsg->turbo_result_free(pMsg->turbo_result);
+            free(pMsg->turbo_result_refs);
+        }
+    }
+    pMsg->turbo_result = NULL;
+    pMsg->turbo_result_free = NULL;
+    pMsg->turbo_result_to_json = NULL;
+    pMsg->turbo_result_get_str = NULL;
+    pMsg->turbo_result_refs = NULL;
+}
+#endif
+
 rsRetVal msgDestruct(smsg_t **ppThis) {
     DEFiRet;
     smsg_t *pThis;
@@ -864,8 +887,7 @@ rsRetVal msgDestruct(smsg_t **ppThis) {
         if (pThis->json != NULL) json_object_put(pThis->json);
         if (pThis->localvars != NULL) json_object_put(pThis->localvars);
 #ifdef HAVE_LOGNORM_TURBO
-        if (pThis->turbo_result != NULL && pThis->turbo_result_free != NULL)
-            pThis->turbo_result_free(pThis->turbo_result);
+        MsgReleaseTurboResult(pThis);
 #endif
         if (pThis->pszUUID != NULL) free(pThis->pszUUID);
 #ifndef HAVE_ATOMIC_BUILTINS
@@ -1021,16 +1043,37 @@ ENDobjDestruct
     tmpCOPYCSTR(PROCID);
     tmpCOPYCSTR(MSGID);
 
-#ifdef HAVE_LOGNORM_TURBO
-    /* Turbo snapshots are opaque and cannot be duplicated generically.  Turn
-     * one into the normal owned JSON representation before copying so callers
-     * of MsgDup() retain CEE properties just like the standard path does. */
-    MsgLock(pOld);
-    msgMaterializeTurboJSON(pOld);
-    MsgUnlock(pOld);
-#endif
     if (pOld->json != NULL) pNew->json = jsonDeepCopy(pOld->json);
     if (pOld->localvars != NULL) pNew->localvars = jsonDeepCopy(pOld->localvars);
+
+#ifdef HAVE_LOGNORM_TURBO
+    /* Share the turbo parse snapshot with the duplicate.  The snapshot is
+     * immutable after parsing, so copies may read it concurrently; ownership
+     * is tracked by a lazily-allocated shared counter (see msg.h).  Only the
+     * processing worker duplicates a message, so mutating pOld's bookkeeping
+     * pointer here is single-threaded by the same contract that makes the
+     * rest of this function lock-free.  On counter allocation failure the
+     * duplicate simply proceeds without the snapshot (consumers fall back to
+     * the deep-copied $! tree). */
+    if (pOld->turbo_result != NULL) {
+        if (pOld->turbo_result_refs == NULL) {
+            unsigned *refs = malloc(sizeof(*refs));
+            if (refs != NULL) {
+                *refs = 2; /* pOld + pNew */
+                pOld->turbo_result_refs = refs;
+            }
+        } else {
+            __atomic_add_fetch(pOld->turbo_result_refs, 1, __ATOMIC_RELAXED);
+        }
+        if (pOld->turbo_result_refs != NULL) {
+            pNew->turbo_result = pOld->turbo_result;
+            pNew->turbo_result_free = pOld->turbo_result_free;
+            pNew->turbo_result_to_json = pOld->turbo_result_to_json;
+            pNew->turbo_result_get_str = pOld->turbo_result_get_str;
+            pNew->turbo_result_refs = pOld->turbo_result_refs;
+        }
+    }
+#endif
 
     /* we do not copy all other cache properties, as we do not even know
      * if they are needed once again. So we let them re-create if needed.

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -27,6 +27,19 @@
  * A copy of the GPL can be found in the file "COPYING" in this distribution.
  * A copy of the LGPL can be found in the file "COPYING.LESSER" in this distribution.
  */
+
+/* Concurrency & Locking
+ *
+ * A message's mut mutex protects its mutable JSON trees and turbo snapshot
+ * slots.  MsgDup() holds the source mutex while it takes a coherent copy of
+ * JSON state and establishes shared snapshot ownership.  Lazy snapshot
+ * materialization also runs under that mutex.
+ *
+ * Turbo snapshots are immutable after publication.  Separate MsgDup() copies
+ * may therefore read one snapshot concurrently; turbo_result_refs tracks
+ * their shared ownership with atomic increments and decrements.  Each message
+ * releases its reference exactly once through MsgReleaseTurboResult().
+ */
 #include "config.h"
 #include <stdio.h>
 #include <stdarg.h>
@@ -80,7 +93,7 @@ static pthread_mutex_t glblVars_lock;
 struct json_object *global_var_root = NULL;
 
 #ifdef HAVE_LOGNORM_TURBO
-static void msgMaterializeTurboJSON(smsg_t *pMsg);
+static int msgMaterializeTurboJSON(smsg_t *pMsg);
 #endif
 
 /* static data */
@@ -949,12 +962,9 @@ ENDobjDestruct
     }
 
     /* Constructs a message object by duplicating another one.
-     * Returns NULL if duplication failed. We do not need to lock the
-     * message object here, because a fully-created msg object is never
-     * allowed to be manipulated. For this, MsgDup() must be used, so MsgDup()
-     * can never run into a situation where the message object is being
-     * modified while its content is copied - it's forbidden by definition.
-     * rgerhards, 2007-07-10
+     * Returns NULL if duplication failed. Most message fields are immutable
+     * after construction. The JSON and turbo snapshot fields are mutable, so
+     * they are copied coherently under the source message lock below.
      */
     smsg_t *MsgDup(smsg_t *pOld) {
     smsg_t *pNew;
@@ -1043,24 +1053,28 @@ ENDobjDestruct
     tmpCOPYCSTR(PROCID);
     tmpCOPYCSTR(MSGID);
 
-    if (pOld->json != NULL) pNew->json = jsonDeepCopy(pOld->json);
-    if (pOld->localvars != NULL) pNew->localvars = jsonDeepCopy(pOld->localvars);
+    MsgLock(pOld);
 
 #ifdef HAVE_LOGNORM_TURBO
     /* Share the turbo parse snapshot with the duplicate.  The snapshot is
      * immutable after parsing, so copies may read it concurrently; ownership
-     * is tracked by a lazily-allocated shared counter (see msg.h).  Only the
-     * processing worker duplicates a message, so mutating pOld's bookkeeping
-     * pointer here is single-threaded by the same contract that makes the
-     * rest of this function lock-free.  On counter allocation failure the
-     * duplicate simply proceeds without the snapshot (consumers fall back to
-     * the deep-copied $! tree). */
+     * is tracked by a lazily-allocated shared counter (see msg.h).  The source
+     * message lock serializes first-counter publication and makes the JSON and
+     * lazy-callback snapshot coherent.  On counter allocation failure,
+     * materialize the source while locked so the duplicate still receives the
+     * normalized fields through its deep-copied $! tree. */
     if (pOld->turbo_result != NULL) {
         if (pOld->turbo_result_refs == NULL) {
             unsigned *refs = malloc(sizeof(*refs));
             if (refs != NULL) {
                 *refs = 2; /* pOld + pNew */
                 pOld->turbo_result_refs = refs;
+            } else if (!msgMaterializeTurboJSON(pOld)) {
+                /* A second allocation failure means neither shared snapshot
+                 * ownership nor a complete JSON copy can be established. */
+                MsgUnlock(pOld);
+                msgDestruct(&pNew);
+                return NULL;
             }
         } else {
             __atomic_add_fetch(pOld->turbo_result_refs, 1, __ATOMIC_RELAXED);
@@ -1074,6 +1088,10 @@ ENDobjDestruct
         }
     }
 #endif
+
+    if (pOld->json != NULL) pNew->json = jsonDeepCopy(pOld->json);
+    if (pOld->localvars != NULL) pNew->localvars = jsonDeepCopy(pOld->localvars);
+    MsgUnlock(pOld);
 
     /* we do not copy all other cache properties, as we do not even know
      * if they are needed once again. So we let them re-create if needed.
@@ -1133,8 +1151,9 @@ static rsRetVal MsgSerialize(smsg_t *pThis, strm_t *pStrm) {
 #ifdef HAVE_LOGNORM_TURBO
     /* Disk queues persist JSON, not the opaque module-owned snapshot. */
     MsgLock(pThis);
-    msgMaterializeTurboJSON(pThis);
+    const int materialized = msgMaterializeTurboJSON(pThis);
     MsgUnlock(pThis);
+    if (!materialized) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 #endif
 
     /* then serialize elements */
@@ -3027,22 +3046,25 @@ static uchar *getNOW(eNOWType eNow, struct syslogTime *t, const int inUTC) {
 /* Lazy materialization of turbo result into json_object* tree.
  * Called when template/property access needs pMsg->json but mmnormalize
  * stored a turbo snapshot instead.  One-shot: turbo_result_to_json is
- * NULLed after firing so we never double-materialize, while turbo_result
- * stays valid for the get_str fast-path.
+ * NULLed after successful materialization so we never double-materialize,
+ * while turbo_result stays valid for the get_str fast-path.
  * When pMsg->json is already non-NULL (imfile metadata, enrichment, ...),
  * snapshot fields are merged in using msgAddJSON() semantics: later
  * normalization fields replace colliding top-level keys.
  * Must be called with pMsg->mut held.
  */
-static void msgMaterializeTurboJSON(smsg_t *pMsg) {
+static int msgMaterializeTurboJSON(smsg_t *pMsg) {
     struct json_object *snap_json = NULL;
 
-    if (pMsg->turbo_result == NULL || pMsg->turbo_result_to_json == NULL) return;
+    if (pMsg->turbo_result == NULL || pMsg->turbo_result_to_json == NULL) return 1;
 
     pMsg->turbo_result_to_json(pMsg->turbo_result, &snap_json);
-    pMsg->turbo_result_to_json = NULL; /* one-shot */
 
-    if (snap_json == NULL) return;
+    /* Keep the callback live after allocation failure so a later access may
+     * retry instead of permanently losing the normalized fields. */
+    if (snap_json == NULL) return 0;
+
+    pMsg->turbo_result_to_json = NULL; /* materialized successfully */
 
     if (pMsg->json == NULL) {
         pMsg->json = snap_json;
@@ -3058,6 +3080,7 @@ static void msgMaterializeTurboJSON(smsg_t *pMsg) {
         }
         json_object_put(snap_json);
     }
+    return 1;
 }
 #endif
 

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -122,6 +122,11 @@ struct msg {
         void (*turbo_result_free)(void *);
         void (*turbo_result_to_json)(void *, struct json_object **);
         int (*turbo_result_get_str)(void *, const uchar *, int, const uchar **, rs_size_t *);
+        /* Shared-ownership refcount for turbo_result across MsgDup() copies.
+         * NULL while a single message owns the snapshot (the common case:
+         * no allocation, no atomics); lazily allocated on the first dup.
+         * The last owner (counter reaches 0) frees the snapshot. */
+        unsigned *turbo_result_refs;
     #endif
         /* some fixed-size buffers to save malloc()/free() for frequently used fields (from the default templates) */
         uchar szRawMsg[CONF_RAWMSG_BUFSIZE];
@@ -188,6 +193,12 @@ rsRetVal msgConstructForDeserializer(smsg_t **ppThis);
 rsRetVal msgConstructFinalizer(smsg_t *pThis);
 rsRetVal msgDestruct(smsg_t **ppM);
 smsg_t *MsgDup(smsg_t *pOld);
+    #ifdef HAVE_LOGNORM_TURBO
+/* Release this message's reference on its turbo parse snapshot (shared across
+ * MsgDup() copies) and clear the slot.  The last owner frees the snapshot.
+ * Use this instead of calling turbo_result_free() directly. */
+void MsgReleaseTurboResult(smsg_t *pMsg);
+    #endif
 smsg_t *MsgAddRef(smsg_t *pM);
 void setProtocolVersion(smsg_t *pM, int iNewVersion);
 /** Set a message's input-name property.

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -194,9 +194,17 @@ rsRetVal msgConstructFinalizer(smsg_t *pThis);
 rsRetVal msgDestruct(smsg_t **ppM);
 smsg_t *MsgDup(smsg_t *pOld);
     #ifdef HAVE_LOGNORM_TURBO
-/* Release this message's reference on its turbo parse snapshot (shared across
- * MsgDup() copies) and clear the slot.  The last owner frees the snapshot.
- * Use this instead of calling turbo_result_free() directly. */
+/**
+ * @brief Release a message's reference to its turbo parse snapshot.
+ *
+ * The snapshot can be shared across MsgDup() copies. This function decrements
+ * the shared ownership count, frees the snapshot for the last owner, and
+ * clears the message's snapshot pointer and all associated callbacks. Callers
+ * must hold @p pMsg's mutex or otherwise have exclusive access to the message.
+ * Never invoke turbo_result_free directly.
+ *
+ * @param pMsg Message whose turbo snapshot reference is released.
+ */
 void MsgReleaseTurboResult(smsg_t *pMsg);
     #endif
 smsg_t *MsgAddRef(smsg_t *pM);


### PR DESCRIPTION
## Problem

mmnormalize turbo `$!` output (added in #6667, v8.2608) stores parsed fields in a
deep-copy snapshot on `pMsg->turbo_result` and materializes JSON lazily, one-shot,
on the first `$!` access. `MsgDup()` copies `json` only when it is non-NULL and
never propagates `turbo_result`, so a message duplicated **before** its first
`$!` access ends up with both `json == NULL` and `turbo_result == NULL` — every
normalized field is silently lost on the duplicate. A shallow pointer copy would
instead double-free the ~6 KB snapshot on destruct.

This is reachable from stock configuration: a `call` into a ruleset that has a
queue (`execCall` → `MsgDup`), omruleset, repeated-message reduction, and
oversized-message segmentation all duplicate the message.

## Fix

Reference-count the immutable snapshot through a lazily-allocated, atomic
`turbo_result_refs` owner, and centralize release in `MsgReleaseTurboResult()`
(used by both `msgDestruct()` and the mmnormalize snapshot-overwrite site). The
last owner frees the snapshot exactly once. The common case — a message that is
never duplicated — pays nothing: `turbo_result_refs` stays NULL, with no
allocation and no atomics.

## Validation

- Reproduced with a call-to-queued-ruleset config: the duplicate emitted empty
  `$!` fields before this change and the correct fields after.
- ASan over 40k duplicated messages: no leak, no double-free.
- clang-format-18 clean; builds clean against liblognorm turbo.

## Notes

Orthogonal to the now-merged HUP reload fix (#7422): per-worker ctx lifetime vs.
per-message snapshot lifetime. Proposed for **v8.2608** so the turbo `$!` feature
ships without this silent-data-loss path in the same release it lands in.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

