### PR TITLE
ci: retain EL10 Mock failure evidence

### DIFF
--- a/.github/workflows/el10_daily_stable.yml
+++ b/.github/workflows/el10_daily_stable.yml
@@ -190,6 +190,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/el10-build"
+          evidence_log=".ci/flake-evidence/logs/el10-package-build.log"
+          mkdir -p "$(dirname "$evidence_log")"
           devtools/ci-flake-phase.sh begin el10-package-build custom
           set +e
           docker run --rm --privileged \
@@ -220,8 +222,13 @@ jobs:
                 /runner-temp/el10-build.log \
                 "$EXPECTED_EVR" \
                 "$RPM_ARCH"
-            '
-          build_status=$?
+            ' 2>&1 | tee "$evidence_log"
+          pipeline_status=("${PIPESTATUS[@]}")
+          build_status="${pipeline_status[0]}"
+          tee_status="${pipeline_status[1]}"
+          if [ "$build_status" -eq 0 ] && [ "$tee_status" -ne 0 ]; then
+            build_status="$tee_status"
+          fi
           set -e
           devtools/ci-flake-phase.sh end \
             el10-package-build custom "$build_status" || true
@@ -232,10 +239,18 @@ jobs:
           else
             {
               echo 'EL10 Mock build log:'
-              cat "$RUNNER_TEMP/el10-build.log"
-              find "$RUNNER_TEMP/el10-artifacts" -type f -name '*.log' \
-                -exec sh -c 'echo; echo "Mock result log: $1"; cat "$1"' sh {} \;
-            } > failed-tests.log
+              if [ -f "$RUNNER_TEMP/el10-build.log" ]; then
+                cat "$RUNNER_TEMP/el10-build.log"
+              else
+                echo 'EL10 helper build log is unavailable.'
+              fi
+              if [ -d "$RUNNER_TEMP/el10-artifacts" ]; then
+                find "$RUNNER_TEMP/el10-artifacts" -type f -name '*.log' \
+                  -exec sh -c 'echo; echo "Mock result log: $1"; cat "$1"' sh {} \;
+              else
+                echo 'EL10 Mock result directory is unavailable.'
+              fi
+            } >> "$evidence_log"
           fi
           exit "$build_status"
 


### PR DESCRIPTION
## Summary

Preserves EL10 daily-stable Mock failure logs in phase-specific flake evidence.

The 12 August scheduled run failed in both architectures, but the generic collector overwrote `failed-tests.log`, so the artifact did not contain Mock's inner `rpmbuild` diagnostic. The exact same source succeeded the previous day and reproduces successfully with the current EL10 baseline; this PR makes the next failure diagnosable without changing package contents.

Related: https://github.com/rsyslog/rsyslog/issues/7485

## Validation

- `actionlint .github/workflows/el10_daily_stable.yml`
- pinned `zizmor --strict-collection .github/workflows/el10_daily_stable.yml`
- shell syntax check of the workflow run block
- failure-path smoke test: preserved outer, helper and Mock result logs after `gather-check-logs.sh`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

