### PR TITLE
examples.rst: Missing space in template

### DIFF
--- a/doc/source/configuration/examples.rst
+++ b/doc/source/configuration/examples.rst
@@ -17,6 +17,7 @@ forwarded, or otherwise processed.
        property(name="timegenerated")         # Add message timestamp
        constant(value=" ")                    # Add a space
        property(name="hostname")              # Add the hostname
+       constant(value=" ")                    # Add a space
        property(name="syslogtag")             # Add the syslog tag
        property(name="msg" droplastlf="on")   # Add the message, removing the trailing LF
        constant(value="\n")                   # End with a newline


### PR DESCRIPTION
Add a space between `hostname` and `syslogtag` in a template.

Found out by @jrehmer while investigating how to handle trailing LF (https://github.com/InterNetNews/inn/issues/373).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

