### PR TITLE
packaging: accept reviewed Leap baseline patches

### DIFF
--- a/.github/opensuse-leap160-daily-stable-policy.yml
+++ b/.github/opensuse-leap160-daily-stable-policy.yml
@@ -15,5 +15,18 @@
   ],
   "supplemental_core_files": [
     "%{rsyslog_module_dir_nodeps}/mmleefparse.so"
+  ],
+  "integrated_baseline_patches": [
+    {
+      "name": "0001-imptcp-guard-regex-framing-match-at-line-start.patch",
+      "sha256": "bd54507ac5151c3c2b25e19cfa04a215e41fda7a01bb0177d245331955dab22d",
+      "upstream_commit": "07b3c40a5a78c79ed9109251f842ca7e955dd586",
+      "reason": "Already present in the daily-stable source."
+    },
+    {
+      "name": "0001-rsyslogd-fix-rsyslog-mmpstrucdata-stack-overflow.patch",
+      "sha256": "9102ebba992cb7a7c4dd408ed097f28a938b160800c2ec74fcfe8735e2c56fd9",
+      "reason": "Superseded by current main's dynamically allocated structured-data parser value buffer."
+    }
   ]
 }

--- a/devtools/release/opensuse-daily-stable.sh
+++ b/devtools/release/opensuse-daily-stable.sh
@@ -109,6 +109,7 @@ cmd_prepare_sources() {
 	cp "$doc_tarball" "$output_dir/SOURCES/rsyslog-doc-$version.tar.gz"
 
 	python3 - "$spec_file" "$policy_file" "$version" "$release" <<'PY'
+import hashlib
 import json
 import pathlib
 import re
@@ -122,8 +123,63 @@ release = sys.argv[4]
 spec = spec_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
 
-if re.search(r"(?m)^Patch\d*:\s*", spec):
-    raise SystemExit("openSUSE baseline gained patches; review them before packaging main")
+reviewed_patches = policy.get("integrated_baseline_patches", [])
+if not isinstance(reviewed_patches, list):
+    raise SystemExit("integrated_baseline_patches must be a list")
+reviewed_patch_hashes = {}
+for entry in reviewed_patches:
+    if not isinstance(entry, dict):
+        raise SystemExit("integrated baseline patch entry must be an object")
+    name = entry.get("name", "").strip()
+    digest = entry.get("sha256", "").lower()
+    if not name or not re.fullmatch(r"[A-Za-z0-9._+-]+", name):
+        raise SystemExit("integrated baseline patch has an invalid name")
+    if not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise SystemExit(f"integrated baseline patch {name} has an invalid SHA-256")
+    if name in reviewed_patch_hashes:
+        raise SystemExit(f"integrated baseline patch {name} is listed more than once")
+    reviewed_patch_hashes[name] = digest
+
+patch_declarations = re.findall(r"(?m)^Patch(\d*):\s*(\S+)\s*$", spec)
+patch_numbers = [number for number, _ in patch_declarations]
+patches = [name for _, name in patch_declarations]
+duplicate_patch_numbers = sorted(
+    number for number in set(patch_numbers) if patch_numbers.count(number) > 1
+)
+duplicate_patches = sorted(name for name in set(patches) if patches.count(name) > 1)
+if duplicate_patch_numbers or duplicate_patches:
+    details = []
+    if duplicate_patch_numbers:
+        details.append("numbers: " + ", ".join(duplicate_patch_numbers))
+    if duplicate_patches:
+        details.append("names: " + ", ".join(duplicate_patches))
+    raise SystemExit("duplicate openSUSE baseline patch declaration (" + "; ".join(details) + ")")
+
+baseline_patches = set(patches)
+unreviewed_patches = sorted(baseline_patches - set(reviewed_patch_hashes))
+if unreviewed_patches:
+    raise SystemExit(
+        "openSUSE baseline gained unreviewed patches; review them before packaging main: "
+        + ", ".join(unreviewed_patches)
+    )
+missing_patches = sorted(set(reviewed_patch_hashes) - baseline_patches)
+if missing_patches:
+    raise SystemExit(
+        "reviewed baseline patches are absent from openSUSE baseline: "
+        + ", ".join(missing_patches)
+    )
+for name in patches:
+    patch_path = spec_path.parent.parent / "SOURCES" / name
+    if not patch_path.is_file():
+        raise SystemExit(f"reviewed baseline patch is missing: {name}")
+    digest = hashlib.sha256(patch_path.read_bytes()).hexdigest()
+    if digest != reviewed_patch_hashes[name]:
+        raise SystemExit(f"reviewed baseline patch changed: {name}")
+    patch_path.unlink()
+
+spec, removed_patch_count = re.subn(r"(?m)^Patch\d*:\s*\S+\s*\n", "", spec)
+if removed_patch_count != len(patches):
+    raise SystemExit("openSUSE baseline patch declarations did not match exactly")
 
 build_requires = policy.get("supplemental_build_requires", [])
 packages = [entry.get("package", "").strip() for entry in build_requires]


### PR DESCRIPTION
## Summary

Fixes the persistent openSUSE Leap 16.0 daily-stable failure reported in #7471.

Leap's current rsyslog baseline adds two downstream security patches. Both fixes are already present or superseded in the `main` source we package, so the workflow must not apply them a second time. The policy now pins their names and SHA-256 digests, removes only those reviewed patch declarations and files, and rejects every unknown, missing, duplicate, or content-changed patch.

Closes https://github.com/rsyslog/rsyslog/issues/7471

## Validation

- `bash -n devtools/release/opensuse-daily-stable.sh`
- `shellcheck -S warning devtools/release/opensuse-daily-stable.sh`
- JSON policy validation
- current Leap 16.0 baseline `prepare-sources` smoke test
- current Leap 16.0 container `rpmbuild -bs` smoke test
- unknown-patch and changed-reviewed-patch fail-closed smoke tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

