### PR TITLE
tests: retire obsolete TSan function suppressions

### DIFF
--- a/contrib/impcap/impcap.c
+++ b/contrib/impcap/impcap.c
@@ -585,18 +585,10 @@ void packet_parse(uchar *arg, const struct pcap_pkthdr *pkthdr, const uchar *pac
 /* This is used to terminate the plugin.
  */
 static void doSIGTTIN(int __attribute__((unused)) sig) {
-    pthread_t tid = pthread_self();
-    const int bTerminate = PREFER_LOAD_INT(&bTerminateInputsSigSafe);
-    DBGPRINTF("impcap: awoken via SIGTTIN; bTerminateInputsSigSafe: %d\n", bTerminate);
-    if (bTerminate) {
-        for (instanceConf_t *inst = runModConf->root; inst != NULL; inst = inst->next) {
-            if (pthread_equal(tid, inst->tid)) {
-                pcap_breakloop(inst->device);
-                DBGPRINTF("impcap: thread %lx, termination requested via SIGTTIN - telling libpcap\n",
-                          (long unsigned int)tid);
-            }
-        }
-    }
+    /* pcap_breakloop() is called by the controller before this signal is sent.
+     * The empty handler only interrupts a blocking capture syscall on platforms
+     * where libpcap cannot wake it from another thread.
+     */
 }
 
 /*
@@ -653,6 +645,7 @@ BEGINrunInput
 
     DBGPRINTF("impcap: received close signal, signaling instance threads...\n");
     for (inst = runModConf->root; inst != NULL; inst = inst->next) {
+        pcap_breakloop(inst->device);
         pthread_kill(inst->tid, SIGTTIN);
     }
 

--- a/plugins/omtesting/omtesting.c
+++ b/plugins/omtesting/omtesting.c
@@ -66,7 +66,7 @@ MODULE_CNFNAME("omtesting")
 DEF_OMOD_STATIC_DATA;
 
 typedef struct _instanceData {
-    enum { MD_SLEEP, MD_FAIL, MD_RANDFAIL, MD_ALWAYS_SUSPEND } mode;
+    enum { MD_SLEEP, MD_FAIL, MD_RANDFAIL, MD_ALWAYS_SUSPEND, MD_BARRIER_ERROR, MD_BARRIER_SUSPEND } mode;
     int bEchoStdout;
     int iWaitSeconds;
     int iWaitUSeconds; /* micro-seconds (one millionth of a second, just to make sure...) */
@@ -77,7 +77,11 @@ typedef struct _instanceData {
     int bFailed; /* indicates if we are already in failed state - this is necessary
                   * to work properly together with multiple worker instances.
                   */
+    int barrierTarget;
+    int barrierCount;
+    int barrierTriggered;
     pthread_mutex_t mut;
+    pthread_cond_t barrierCond;
 } instanceData;
 
 typedef struct wrkrInstanceData {
@@ -99,6 +103,7 @@ BEGINcreateInstance
     pData->iWaitSeconds = 1;
     pData->iWaitUSeconds = 0;
     pthread_mutex_init(&pData->mut, NULL);
+    pthread_cond_init(&pData->barrierCond, NULL);
 ENDcreateInstance
 
 
@@ -182,6 +187,32 @@ static rsRetVal doRandFail(void) {
 }
 
 
+/* Synchronize action workers so TSan tests can exercise concurrent core paths.
+ * Returns one for every worker in the first complete barrier generation and
+ * zero for later calls.
+ */
+static int barrierTrigger(instanceData *const pData) {
+    int triggered = 0;
+
+    pthread_mutex_lock(&pData->mut);
+    if (!pData->barrierTriggered) {
+        ++pData->barrierCount;
+        if (pData->barrierCount == pData->barrierTarget) {
+            pData->barrierTriggered = 1;
+            pthread_cond_broadcast(&pData->barrierCond);
+        } else {
+            while (!pData->barrierTriggered) {
+                pthread_cond_wait(&pData->barrierCond, &pData->mut);
+            }
+        }
+        triggered = 1;
+    }
+    pthread_mutex_unlock(&pData->mut);
+
+    return triggered;
+}
+
+
 BEGINtryResume
     CODESTARTtryResume;
     dbgprintf("omtesting tryResume() called\n");
@@ -197,6 +228,11 @@ BEGINtryResume
             break;
         case MD_ALWAYS_SUSPEND:
             iRet = RS_RET_SUSPENDED;
+            break;
+        case MD_BARRIER_ERROR:
+        case MD_BARRIER_SUSPEND:
+            iRet = RS_RET_OK;
+            break;
         default:
             // No action needed for other cases
             break;
@@ -211,36 +247,49 @@ BEGINdoAction
     CODESTARTdoAction;
     dbgprintf("omtesting received msg '%s'\n", ppString[0]);
     pData = pWrkrData->pData;
-    pthread_mutex_lock(&pData->mut);
-    switch (pData->mode) {
-        case MD_SLEEP:
-            iRet = doSleep(pData);
-            break;
-        case MD_FAIL:
-            iRet = doFail(pData);
-            break;
-        case MD_RANDFAIL:
-            iRet = doRandFail();
-            break;
-        case MD_ALWAYS_SUSPEND:
+    if (pData->mode == MD_BARRIER_ERROR || pData->mode == MD_BARRIER_SUSPEND) {
+        const int triggered = barrierTrigger(pData);
+        if (triggered && pData->mode == MD_BARRIER_ERROR) {
+            LogError(0, RS_RET_ERR, "omtesting synchronized error");
+        } else if (triggered) {
             iRet = RS_RET_SUSPENDED;
-            break;
-        default:
-            // No action needed for other cases
-            break;
-    }
+        }
+    } else {
+        pthread_mutex_lock(&pData->mut);
+        switch (pData->mode) {
+            case MD_SLEEP:
+                iRet = doSleep(pData);
+                break;
+            case MD_FAIL:
+                iRet = doFail(pData);
+                break;
+            case MD_RANDFAIL:
+                iRet = doRandFail();
+                break;
+            case MD_ALWAYS_SUSPEND:
+                iRet = RS_RET_SUSPENDED;
+                break;
+            case MD_BARRIER_ERROR:
+            case MD_BARRIER_SUSPEND:
+                break;
+            default:
+                // No action needed for other cases
+                break;
+        }
 
-    if (iRet == RS_RET_OK && pData->bEchoStdout) {
-        fprintf(stdout, "%s", ppString[0]);
-        fflush(stdout);
+        if (iRet == RS_RET_OK && pData->bEchoStdout) {
+            fprintf(stdout, "%s", ppString[0]);
+            fflush(stdout);
+        }
+        pthread_mutex_unlock(&pData->mut);
     }
-    pthread_mutex_unlock(&pData->mut);
     dbgprintf(":omtesting: end doAction(), iRet %d\n", iRet);
 ENDdoAction
 
 
 BEGINfreeInstance
     CODESTARTfreeInstance;
+    pthread_cond_destroy(&pData->barrierCond);
     pthread_mutex_destroy(&pData->mut);
 ENDfreeInstance
 
@@ -318,6 +367,16 @@ BEGINparseSelectorAct
         pData->mode = MD_RANDFAIL;
     } else if (!strcmp((char *)szBuf, "always_suspend")) {
         pData->mode = MD_ALWAYS_SUSPEND;
+    } else if (!strcmp((char *)szBuf, "barrier_error") || !strcmp((char *)szBuf, "barrier_suspend")) {
+        pData->mode = !strcmp((char *)szBuf, "barrier_error") ? MD_BARRIER_ERROR : MD_BARRIER_SUSPEND;
+        for (i = 0; *p && !isspace(*p) && ((unsigned)i < sizeof(szBuf) - 1); ++i) {
+            szBuf[i] = *p++;
+        }
+        szBuf[i] = '\0';
+        pData->barrierTarget = atoi((char *)szBuf);
+        if (pData->barrierTarget < 2) {
+            pData->barrierTarget = 2;
+        }
     } else {
         dbgprintf("invalid mode '%s', doing 'sleep 1 0' - fix your config\n", szBuf);
     }

--- a/plugins/omtesting/omtesting.c
+++ b/plugins/omtesting/omtesting.c
@@ -77,11 +77,11 @@ typedef struct _instanceData {
     int bFailed; /* indicates if we are already in failed state - this is necessary
                   * to work properly together with multiple worker instances.
                   */
-    int barrierTarget;
-    int barrierCount;
-    int barrierTriggered;
+    int barrier_target;
+    int barrier_count;
+    int barrier_triggered;
     pthread_mutex_t mut;
-    pthread_cond_t barrierCond;
+    pthread_cond_t barrier_cond;
 } instanceData;
 
 typedef struct wrkrInstanceData {
@@ -103,7 +103,7 @@ BEGINcreateInstance
     pData->iWaitSeconds = 1;
     pData->iWaitUSeconds = 0;
     pthread_mutex_init(&pData->mut, NULL);
-    pthread_cond_init(&pData->barrierCond, NULL);
+    pthread_cond_init(&pData->barrier_cond, NULL);
 ENDcreateInstance
 
 
@@ -191,23 +191,24 @@ static rsRetVal doRandFail(void) {
  * Returns one for every worker in the first complete barrier generation and
  * zero for later calls.
  */
-static int barrierTrigger(instanceData *const pData) {
+static int barrier_trigger(instanceData *const pData) {
     int triggered = 0;
 
     pthread_mutex_lock(&pData->mut);
-    if (!pData->barrierTriggered) {
-        ++pData->barrierCount;
-        if (pData->barrierCount == pData->barrierTarget) {
-            pData->barrierTriggered = 1;
-            pthread_cond_broadcast(&pData->barrierCond);
+    pthread_cleanup_push(mutexCancelCleanup, &pData->mut);
+    if (!pData->barrier_triggered) {
+        ++pData->barrier_count;
+        if (pData->barrier_count == pData->barrier_target) {
+            pData->barrier_triggered = 1;
+            pthread_cond_broadcast(&pData->barrier_cond);
         } else {
-            while (!pData->barrierTriggered) {
-                pthread_cond_wait(&pData->barrierCond, &pData->mut);
+            while (!pData->barrier_triggered) {
+                pthread_cond_wait(&pData->barrier_cond, &pData->mut);
             }
         }
         triggered = 1;
     }
-    pthread_mutex_unlock(&pData->mut);
+    pthread_cleanup_pop(1);
 
     return triggered;
 }
@@ -248,7 +249,7 @@ BEGINdoAction
     dbgprintf("omtesting received msg '%s'\n", ppString[0]);
     pData = pWrkrData->pData;
     if (pData->mode == MD_BARRIER_ERROR || pData->mode == MD_BARRIER_SUSPEND) {
-        const int triggered = barrierTrigger(pData);
+        const int triggered = barrier_trigger(pData);
         if (triggered && pData->mode == MD_BARRIER_ERROR) {
             LogError(0, RS_RET_ERR, "omtesting synchronized error");
         } else if (triggered) {
@@ -289,7 +290,7 @@ ENDdoAction
 
 BEGINfreeInstance
     CODESTARTfreeInstance;
-    pthread_cond_destroy(&pData->barrierCond);
+    pthread_cond_destroy(&pData->barrier_cond);
     pthread_mutex_destroy(&pData->mut);
 ENDfreeInstance
 
@@ -373,9 +374,9 @@ BEGINparseSelectorAct
             szBuf[i] = *p++;
         }
         szBuf[i] = '\0';
-        pData->barrierTarget = atoi((char *)szBuf);
-        if (pData->barrierTarget < 2) {
-            pData->barrierTarget = 2;
+        pData->barrier_target = atoi((char *)szBuf);
+        if (pData->barrier_target < 2) {
+            pData->barrier_target = 2;
         }
     } else {
         dbgprintf("invalid mode '%s', doing 'sleep 1 0' - fix your config\n", szBuf);

--- a/plugins/omtesting/omtesting.c
+++ b/plugins/omtesting/omtesting.c
@@ -192,7 +192,7 @@ static rsRetVal doRandFail(void) {
  * zero for later calls.
  */
 static int barrier_trigger(instanceData *const pData) {
-    int triggered = 0;
+    volatile int triggered = 0;
 
     pthread_mutex_lock(&pData->mut);
     pthread_cleanup_push(mutexCancelCleanup, &pData->mut);

--- a/runtime/action.c
+++ b/runtime/action.c
@@ -834,12 +834,9 @@ finalize_it:
 }
 
 
-/* we need to defer setting the action's own bReportSuspension state until
- * after the full config has been processed. So the most simple case to do
- * that is here. It's not a performance problem, as it happens infrequently.
- * it's not a threading race problem, as always the same value will be written.
- * As we need to do this in several places, we have moved the code to its own
- * helper function.
+/* Resolve action-specific suspension reporting defaults after the full config
+ * has been processed. This must happen before action or main-queue workers can
+ * use the action; concurrent same-value writes are still a C data race.
  */
 static void setSuspendMessageConfVars(action_t *__restrict__ const pThis) {
     if (pThis->bReportSuspension == -1) pThis->bReportSuspension = runConf->globals.bActionReportSuspension;
@@ -2344,6 +2341,7 @@ PRAGMA_DIAGNOSTIC_POP
 DEFFUNC_llExecFunc(doActivateActions) {
     rsRetVal localRet;
     action_t *const pThis = (action_t *)pData;
+    setSuspendMessageConfVars(pThis);
     localRet = qqueueStart(runConf, pThis->pQueue);
     if (localRet != RS_RET_OK) {
         if (runConf->globals.bAbortOnFailedQueueStartup) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -460,6 +460,7 @@ TESTS_DEFAULT = \
 	execonlywhenprevsuspended3.sh \
 	execonlywhenprevsuspended4.sh \
 	execonlywhenprevsuspended_multiwrkr.sh \
+	action-reporting-concurrency-tsan.sh \
 	execonlywhenprevsuspended-queue.sh \
 	execonlywhenprevsuspended-nonsusp.sh \
 	execonlywhenprevsuspended-nonsusp-queue.sh \

--- a/tests/action-reporting-concurrency-tsan.sh
+++ b/tests/action-reporting-concurrency-tsan.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Exercise concurrent error reporting and first action suspension under TSan.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+main_queue(queue.workerThreads="2"
+	queue.workerThreadMinimumMessages="1"
+	queue.dequeueBatchSize="1")
+
+module(load="../plugins/omtesting/.libs/omtesting")
+
+$ActionResumeRetryCount 0
+$ActionResumeInterval 1
+:msg, contains, "msgnum:" :omtesting:barrier_error 2
+& :omtesting:barrier_suspend 2
+'
+
+startup
+injectmsg 0 2
+shutdown_when_empty
+wait_shutdown
+exit_test

--- a/tests/action-reporting-concurrency-tsan.sh
+++ b/tests/action-reporting-concurrency-tsan.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # Exercise concurrent error reporting and first action suspension under TSan.
+# The two-message workload and two-worker main queue cause both actions to enter
+# the barrier; it releases only after both are present, exposing concurrent
+# config-default resolution. A ThreadSanitizer report fails the test; a clean,
+# synchronized shutdown proves the actions completed without one.
 . ${srcdir:=.}/diag.sh init
 
 generate_conf

--- a/tests/tsan-rt.supp
+++ b/tests/tsan-rt.supp
@@ -4,8 +4,6 @@ race:^close$
 race:^closeSess$
 race:^bs_arrcmp_glblDbgFiles$
 race:^imptcp_destruct_epd$
-race:doLogMsg
-race:setlocale
 race:libfaketime
 # ommysql uses per-worker MYSQL handles. Ubuntu 26.04/Clang 21 can report the
 # existing stock libmysqlclient false positive through OpenSSL frames

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -6,14 +6,5 @@ src:lookup.c
 src:rainerscript.c
 src:imdiag.c
 
-fun:setlocale
-fun:doSIGTTIN
 # Queue code intentionally is not using atomics
 #fun:
-
-# actual bugs that should be fixed ASAP after TSAN is in place:
-fun:processWorksetItem
-
-fun:doLogMsg
-
-fun:setSuspendMessageConfVars

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -6,5 +6,6 @@ src:lookup.c
 src:rainerscript.c
 src:imdiag.c
 
+fun:doSIGTTIN
 # Queue code intentionally is not using atomics
 #fun:


### PR DESCRIPTION
## Summary

- initialize action suspension-reporting defaults before queue workers start
- make impcap shutdown signaling async-signal-safe
- remove obsolete function-level TSan suppressions and add deterministic concurrency coverage

## Why

The old function-wide suppressions masked more than their original findings. The action reporting race remained real: workers could concurrently resolve the same configuration defaults after startup. The new testbench barrier reproduces that race deterministically, and the fix resolves the values before workers begin.

The impcap signal handler also performed logging and configuration traversal from signal context. The controller now calls `pcap_breakloop()` directly; the empty handler only interrupts capture on platforms where a cross-thread break does not wake the blocking syscall.

`processWorksetItem` and `doLogMsg` are covered by their already-merged synchronization fixes, while rsyslog no longer calls `setlocale`.

## Validation

- focused TSan: `action-reporting-concurrency-tsan.sh`
- focused TSan: `manytcp.sh`
- focused TSan: `impcap_basic_http.sh`
- focused TSan: `impcap_basic_dns.sh`
- full unsuppressed TSan run: 668 tests, 639 passed, 19 skipped, 10 failures from independent existing races in `debug.c`, `queue.c`, and `imdiag.c`; none of the removed function suppressions was a reported race site
- `./devtools/format-code.sh --git-changed --check`
- `git diff --check`
- ShellCheck on the new test using the testbench's established exclusions

The independent full-suite TSan findings are intentionally not hidden or included in this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

