### PR TITLE
packaging: verify daily RPM baseline patches

### DIFF
--- a/.github/amazonlinux2023-daily-stable-policy.yml
+++ b/.github/amazonlinux2023-daily-stable-policy.yml
@@ -1,11 +1,13 @@
 {
-  "allowed_patch_skips": [
+  "integrated_baseline_patches": [
     {
-      "patch": "openssl3-compatibility.patch",
+      "name": "openssl3-compatibility.patch",
+      "sha256": "df627935d9ffbee0dfae8053fb12c15481e51d27b0465c90a18df718186b08f4",
       "reason": "Current upstream already contains the OpenSSL 3 compatibility changes carried by the Amazon Linux 2023 source package."
     },
     {
-      "patch": "rsyslog-8.2204.0-rhbz2082302-CVE-heap-based-buffer-overflow.patch",
+      "name": "rsyslog-8.2204.0-rhbz2082302-CVE-heap-based-buffer-overflow.patch",
+      "sha256": "3ab3c768b0dd8d500f0541ca290ca7858046908175117f0e8ffd62a4e05631e2",
       "reason": "Current upstream contains the CVE-2022-24903 fix and later parser development."
     }
   ],

--- a/.github/el10-daily-stable-policy.yml
+++ b/.github/el10-daily-stable-policy.yml
@@ -1,20 +1,30 @@
 {
-  "allowed_patch_skips": [
+  "integrated_baseline_patches": [
     {
-      "patch": "imfile-inotify-fd-release-on-delete.patch",
+      "name": "imfile-inotify-fd-release-on-delete.patch",
+      "sha256": "9001a56b1f4d660056d4328c35850b8d8f6db10b805d7bb4c29a4f0343a73d13",
       "reason": "The EL10 deferred-delete fix is already represented by newer imfile lifecycle handling in current upstream."
     },
     {
-      "patch": "imjournal-warn-on-missing-MESSAGE-field.patch",
+      "name": "imjournal-warn-on-missing-MESSAGE-field.patch",
+      "sha256": "ac3397b44fbeef92904454e899585022c8661582fa84d261119ffe17036cf8cc",
       "reason": "The EL10 missing MESSAGE warning patch is already present in current upstream."
     },
     {
-      "patch": "omelasticsearch-pqc-tls.patch",
+      "name": "omelasticsearch-pqc-tls.patch",
+      "sha256": "b485f0c0440c658b230f95e6d26bcbce71e323d4d245cd3cc0df07b45fdc0a89",
       "reason": "The EL10 Elasticsearch TLS controls are already present in current upstream with later development."
     },
     {
-      "patch": "omelasticsearch-apply-tls-opts-during-detection.patch",
+      "name": "omelasticsearch-apply-tls-opts-during-detection.patch",
+      "sha256": "dda4f2faf62f1832e017705910892bbb397c83cce0c0c2b4d8559cea52ca9d4d",
       "reason": "The EL10 Elasticsearch detection TLS fix is already present in current upstream with later development."
+    },
+    {
+      "name": "imptcp-guard-regex-framing-at-line-start.patch",
+      "sha256": "b59b0ab26da84c6c6baf408e697f71b8a320fa74e360c5a5a88ff0629ce8e1e5",
+      "upstream_commit": "07b3c40a5a78c79ed9109251f842ca7e955dd586",
+      "reason": "The EL10 imptcp regex framing fix is already present in the daily-stable source."
     }
   ],
   "supplemental_build_requires": [

--- a/.github/fedora44-daily-stable-policy.yml
+++ b/.github/fedora44-daily-stable-policy.yml
@@ -1,4 +1,5 @@
 {
+  "integrated_baseline_patches": [],
   "supplemental_build_requires": [
     {
       "package": "autoconf-archive",

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,8 @@ EXTRA_DIST = \
 	contrib/gnutls/ca.pem \
 	contrib/gnutls/cert.pem \
 	contrib/gnutls/key.pem \
-	scripts/generate_distro_component_map.py
+	scripts/generate_distro_component_map.py \
+	devtools/release/validate-rpm-baseline-patches.py
 
 SUBDIRS = doc compat grammar runtime . plugins/immark plugins/imuxsock plugins/imtcp plugins/imudp plugins/omtesting
 # external plugin driver is always enabled (core component)

--- a/devtools/release/amazonlinux-daily-stable.sh
+++ b/devtools/release/amazonlinux-daily-stable.sh
@@ -105,6 +105,9 @@ cmd_prepare_sources() {
 	tar -C "$tmp_dir" -czf "$output_dir/SOURCES/rsyslog-$version.tar.gz" \
 		"rsyslog-$version"
 
+	python3 "$(dirname "$0")/validate-rpm-baseline-patches.py" \
+		"$spec_file" "$policy_file" "Amazon Linux 2023"
+
 	python3 - "$spec_file" "$policy_file" "$version" "$release" <<'PY'
 import json
 import pathlib
@@ -118,33 +121,6 @@ version = sys.argv[3]
 release = sys.argv[4]
 spec = spec_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
-
-patches = {
-    match.group(2): match.group(1)
-    for match in re.finditer(r"(?m)^Patch(\d+):\s*(\S+)\s*$", spec)
-}
-allowed = policy.get("allowed_patch_skips", [])
-allowed_names = [entry.get("patch", "").strip() for entry in allowed]
-if any(not name for name in allowed_names):
-    raise SystemExit("policy contains an empty allowed patch name")
-missing = sorted(set(allowed_names) - set(patches))
-if missing:
-    raise SystemExit(f"allowed patch is absent from Amazon Linux baseline: {missing}")
-
-for name in allowed_names:
-    number = patches[name]
-    spec, declaration_count = re.subn(
-        rf"(?m)^Patch{re.escape(number)}:\s*{re.escape(name)}\s*\n", "", spec
-    )
-    application_pattern = (
-        rf"(?m)^%patch(?:\s+-P\s*{re.escape(number)}|"
-        rf"\s+-P{re.escape(number)}|{re.escape(number)})(?:\s+[^\n]*)?\s*\n"
-    )
-    spec, application_count = re.subn(application_pattern, "", spec)
-    if declaration_count != 1 or application_count != 1:
-        raise SystemExit(
-            f"could not remove exactly one declaration/application for {name}"
-        )
 
 if not policy.get("drop_stale_html_docs", False):
     raise SystemExit("Amazon Linux policy must explicitly decide about stale HTML docs")

--- a/devtools/release/opensuse-daily-stable.sh
+++ b/devtools/release/opensuse-daily-stable.sh
@@ -108,8 +108,10 @@ cmd_prepare_sources() {
 		"rsyslog-$version"
 	cp "$doc_tarball" "$output_dir/SOURCES/rsyslog-doc-$version.tar.gz"
 
+	python3 "$(dirname "$0")/validate-rpm-baseline-patches.py" \
+		"$spec_file" "$policy_file" "openSUSE"
+
 	python3 - "$spec_file" "$policy_file" "$version" "$release" <<'PY'
-import hashlib
 import json
 import pathlib
 import re
@@ -122,64 +124,6 @@ version = sys.argv[3]
 release = sys.argv[4]
 spec = spec_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
-
-reviewed_patches = policy.get("integrated_baseline_patches", [])
-if not isinstance(reviewed_patches, list):
-    raise SystemExit("integrated_baseline_patches must be a list")
-reviewed_patch_hashes = {}
-for entry in reviewed_patches:
-    if not isinstance(entry, dict):
-        raise SystemExit("integrated baseline patch entry must be an object")
-    name = entry.get("name", "").strip()
-    digest = entry.get("sha256", "").lower()
-    if not name or not re.fullmatch(r"[A-Za-z0-9._+-]+", name):
-        raise SystemExit("integrated baseline patch has an invalid name")
-    if not re.fullmatch(r"[0-9a-f]{64}", digest):
-        raise SystemExit(f"integrated baseline patch {name} has an invalid SHA-256")
-    if name in reviewed_patch_hashes:
-        raise SystemExit(f"integrated baseline patch {name} is listed more than once")
-    reviewed_patch_hashes[name] = digest
-
-patch_declarations = re.findall(r"(?m)^Patch(\d*):\s*(\S+)\s*$", spec)
-patch_numbers = [number for number, _ in patch_declarations]
-patches = [name for _, name in patch_declarations]
-duplicate_patch_numbers = sorted(
-    number for number in set(patch_numbers) if patch_numbers.count(number) > 1
-)
-duplicate_patches = sorted(name for name in set(patches) if patches.count(name) > 1)
-if duplicate_patch_numbers or duplicate_patches:
-    details = []
-    if duplicate_patch_numbers:
-        details.append("numbers: " + ", ".join(duplicate_patch_numbers))
-    if duplicate_patches:
-        details.append("names: " + ", ".join(duplicate_patches))
-    raise SystemExit("duplicate openSUSE baseline patch declaration (" + "; ".join(details) + ")")
-
-baseline_patches = set(patches)
-unreviewed_patches = sorted(baseline_patches - set(reviewed_patch_hashes))
-if unreviewed_patches:
-    raise SystemExit(
-        "openSUSE baseline gained unreviewed patches; review them before packaging main: "
-        + ", ".join(unreviewed_patches)
-    )
-missing_patches = sorted(set(reviewed_patch_hashes) - baseline_patches)
-if missing_patches:
-    raise SystemExit(
-        "reviewed baseline patches are absent from openSUSE baseline: "
-        + ", ".join(missing_patches)
-    )
-for name in patches:
-    patch_path = spec_path.parent.parent / "SOURCES" / name
-    if not patch_path.is_file():
-        raise SystemExit(f"reviewed baseline patch is missing: {name}")
-    digest = hashlib.sha256(patch_path.read_bytes()).hexdigest()
-    if digest != reviewed_patch_hashes[name]:
-        raise SystemExit(f"reviewed baseline patch changed: {name}")
-    patch_path.unlink()
-
-spec, removed_patch_count = re.subn(r"(?m)^Patch\d*:\s*\S+\s*\n", "", spec)
-if removed_patch_count != len(patches):
-    raise SystemExit("openSUSE baseline patch declarations did not match exactly")
 
 build_requires = policy.get("supplemental_build_requires", [])
 packages = [entry.get("package", "").strip() for entry in build_requires]

--- a/devtools/release/rpm-daily-stable.sh
+++ b/devtools/release/rpm-daily-stable.sh
@@ -108,6 +108,9 @@ cmd_prepare_sources() {
   tar -C "$tmp_dir" -czf "$sources_dir/rsyslog-$version.tar.gz" \
     "rsyslog-$version"
 
+  python3 "$(dirname "$0")/validate-rpm-baseline-patches.py" \
+    "$spec_file" "$policy_file" "EL10/Fedora"
+
   python3 - "$spec_file" "$policy_file" "$version" "$release" <<'PY'
 import json
 import pathlib
@@ -121,31 +124,6 @@ version = sys.argv[3]
 release = sys.argv[4]
 spec = spec_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
-
-patches = {}
-for match in re.finditer(r"(?m)^Patch(\d+):\s*(\S+)\s*$", spec):
-    patches[match.group(2)] = match.group(1)
-
-allowed = policy.get("allowed_patch_skips", [])
-allowed_names = [entry.get("patch", "").strip() for entry in allowed]
-if any(not name for name in allowed_names):
-    raise SystemExit("policy contains an empty allowed patch name")
-missing = sorted(set(allowed_names) - set(patches))
-if missing:
-    raise SystemExit(f"allowed patch is absent from EL10 baseline: {missing}")
-
-for name in allowed_names:
-    number = patches[name]
-    spec, declaration_count = re.subn(
-        rf"(?m)^Patch{re.escape(number)}:\s*{re.escape(name)}\s*\n", "", spec
-    )
-    spec, application_count = re.subn(
-        rf"(?m)^%patch\s+-P{re.escape(number)}(?:\s+[^\n]*)?\s*\n", "", spec
-    )
-    if declaration_count != 1 or application_count != 1:
-        raise SystemExit(
-            f"could not remove exactly one declaration/application for {name}"
-        )
 
 build_requires = policy.get("supplemental_build_requires", [])
 packages = [entry.get("package", "").strip() for entry in build_requires]

--- a/devtools/release/validate-rpm-baseline-patches.py
+++ b/devtools/release/validate-rpm-baseline-patches.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Rainer Gerhards and Others
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Verify and remove reviewed downstream RPM baseline patches.
 
 Daily-stable packages replace a distribution's source archive with current
@@ -53,7 +67,12 @@ def main():
     declarations = re.findall(r"(?m)^Patch(\d*):\s*(\S+)\s*$", spec)
     numbers = [number for number, _ in declarations]
     names = [name for _, name in declarations]
-    duplicate_numbers = sorted(number for number in set(numbers) if numbers.count(number) > 1)
+    normalized_numbers = [int(number or "0") for number in numbers]
+    duplicate_numbers = sorted(
+        str(number)
+        for number in set(normalized_numbers)
+        if normalized_numbers.count(number) > 1
+    )
     duplicate_names = sorted(name for name in set(names) if names.count(name) > 1)
     if duplicate_numbers or duplicate_names:
         details = []
@@ -78,6 +97,7 @@ def main():
         )
 
     sources_dir = spec_path.parent.parent / "SOURCES"
+    patch_paths = []
     for number, name in declarations:
         patch_path = sources_dir / name
         if not patch_path.is_file():
@@ -85,16 +105,22 @@ def main():
         digest = hashlib.sha256(patch_path.read_bytes()).hexdigest()
         if digest != reviewed_hashes[name]:
             fail(f"reviewed baseline patch changed: {name}")
-        patch_path.unlink()
+        patch_paths.append(patch_path)
 
         spec, declaration_count = re.subn(
             rf"(?m)^Patch{re.escape(number)}:\s*{re.escape(name)}\s*\n", "", spec
         )
-        application_pattern = (
-            rf"(?m)^%patch(?:{re.escape(number)}(?=\s|$)|"
-            rf"\s+-P\s*{re.escape(number)}|\s+-P{re.escape(number)}|"
-            rf"\s+{re.escape(number)})(?:\s+[^\n]*)?\s*\n"
-        )
+        if number:
+            application_pattern = (
+                rf"(?m)^%patch(?:{re.escape(number)}(?=\s|$)|"
+                rf"\s+-P\s*{re.escape(number)}|\s+-P{re.escape(number)}|"
+                rf"\s+{re.escape(number)})(?:\s+[^\n]*)?\s*\n"
+            )
+        else:
+            application_pattern = (
+                r"(?m)^%patch(?!\s+(?:-P\s*\d+|-P\d+|\d+)(?:\s|$))"
+                r"(?:\s+[^\n]*)?\s*\n"
+            )
         spec, application_count = re.subn(application_pattern, "", spec)
         if declaration_count != 1:
             fail(f"could not remove exactly one declaration for {name}")
@@ -104,6 +130,8 @@ def main():
             fail(f"could not remove exactly one application for {name}")
 
     spec_path.write_text(spec, encoding="utf-8")
+    for patch_path in patch_paths:
+        patch_path.unlink()
 
 
 if __name__ == "__main__":

--- a/devtools/release/validate-rpm-baseline-patches.py
+++ b/devtools/release/validate-rpm-baseline-patches.py
@@ -118,7 +118,9 @@ def main():
             )
         else:
             application_pattern = (
-                r"(?m)^%patch(?!\s+(?:-P\s*\d+|-P\d+|\d+)(?:\s|$))"
+                r"(?m)^%patch(?:0(?=\s|$)|\s+-P\s*0(?=\s|$)|"
+                r"\s+-P0(?=\s|$)|\s+0(?=\s|$)|"
+                r"(?!\s+(?:-P\s*[1-9]\d*|-P[1-9]\d*|[1-9]\d*)(?:\s|$)))"
                 r"(?:\s+[^\n]*)?\s*\n"
             )
         spec, application_count = re.subn(application_pattern, "", spec)

--- a/devtools/release/validate-rpm-baseline-patches.py
+++ b/devtools/release/validate-rpm-baseline-patches.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Verify and remove reviewed downstream RPM baseline patches.
+
+Daily-stable packages replace a distribution's source archive with current
+upstream.  Every downstream patch must therefore be explicitly reviewed,
+content-pinned, and removed before the RPM spec is reused.
+"""
+
+import hashlib
+import json
+import pathlib
+import re
+import sys
+
+
+def fail(message):
+    raise SystemExit(message)
+
+
+def main():
+    if len(sys.argv) != 4:
+        fail("usage: validate-rpm-baseline-patches.py <spec> <policy> <distro>")
+
+    spec_path = pathlib.Path(sys.argv[1])
+    policy_path = pathlib.Path(sys.argv[2])
+    distro = sys.argv[3]
+    spec = spec_path.read_text(encoding="utf-8")
+    policy = json.loads(policy_path.read_text(encoding="utf-8"))
+
+    if "allowed_patch_skips" in policy:
+        fail(f"{distro} policy must use integrated_baseline_patches")
+    reviewed = policy.get("integrated_baseline_patches", [])
+    if not isinstance(reviewed, list):
+        fail("integrated_baseline_patches must be a list")
+
+    reviewed_hashes = {}
+    for entry in reviewed:
+        if not isinstance(entry, dict):
+            fail("integrated baseline patch entry must be an object")
+        name = entry.get("name", "").strip()
+        digest = entry.get("sha256", "").lower()
+        reason = entry.get("reason", "").strip()
+        if not name or not re.fullmatch(r"[A-Za-z0-9._+-]+", name):
+            fail("integrated baseline patch has an invalid name")
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            fail(f"integrated baseline patch {name} has an invalid SHA-256")
+        if not reason:
+            fail(f"integrated baseline patch {name} has no reason")
+        if name in reviewed_hashes:
+            fail(f"integrated baseline patch {name} is listed more than once")
+        reviewed_hashes[name] = digest
+
+    declarations = re.findall(r"(?m)^Patch(\d*):\s*(\S+)\s*$", spec)
+    numbers = [number for number, _ in declarations]
+    names = [name for _, name in declarations]
+    duplicate_numbers = sorted(number for number in set(numbers) if numbers.count(number) > 1)
+    duplicate_names = sorted(name for name in set(names) if names.count(name) > 1)
+    if duplicate_numbers or duplicate_names:
+        details = []
+        if duplicate_numbers:
+            details.append("numbers: " + ", ".join(duplicate_numbers))
+        if duplicate_names:
+            details.append("names: " + ", ".join(duplicate_names))
+        fail(f"duplicate {distro} baseline patch declaration (" + "; ".join(details) + ")")
+
+    baseline_names = set(names)
+    unreviewed = sorted(baseline_names - set(reviewed_hashes))
+    missing = sorted(set(reviewed_hashes) - baseline_names)
+    if unreviewed:
+        fail(
+            f"{distro} baseline gained unreviewed patches; review them before packaging main: "
+            + ", ".join(unreviewed)
+        )
+    if missing:
+        fail(
+            f"reviewed baseline patches are absent from {distro} baseline: "
+            + ", ".join(missing)
+        )
+
+    sources_dir = spec_path.parent.parent / "SOURCES"
+    for number, name in declarations:
+        patch_path = sources_dir / name
+        if not patch_path.is_file():
+            fail(f"reviewed baseline patch is missing: {name}")
+        digest = hashlib.sha256(patch_path.read_bytes()).hexdigest()
+        if digest != reviewed_hashes[name]:
+            fail(f"reviewed baseline patch changed: {name}")
+        patch_path.unlink()
+
+        spec, declaration_count = re.subn(
+            rf"(?m)^Patch{re.escape(number)}:\s*{re.escape(name)}\s*\n", "", spec
+        )
+        application_pattern = (
+            rf"(?m)^%patch(?:{re.escape(number)}(?=\s|$)|"
+            rf"\s+-P\s*{re.escape(number)}|\s+-P{re.escape(number)}|"
+            rf"\s+{re.escape(number)})(?:\s+[^\n]*)?\s*\n"
+        )
+        spec, application_count = re.subn(application_pattern, "", spec)
+        if declaration_count != 1:
+            fail(f"could not remove exactly one declaration for {name}")
+        if application_count == 0 and not re.search(r"(?m)^%autosetup(?:\s|$)", spec):
+            fail(f"could not find an application for {name}")
+        if application_count > 1:
+            fail(f"could not remove exactly one application for {name}")
+
+    spec_path.write_text(spec, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,6 +15,7 @@ EXTRA_DIST = \
 	unit/README.md
 
 TESTS_FUZZING = fuzz-syslog-message-smoke.sh
+TESTS_RELEASE_PACKAGING = rpm-baseline-patch-policy.sh
 FUZZING_CORPUS = \
 	fuzz/README.md \
 	fuzz/corpus/syslog-message/rfc3164-basic \
@@ -24,7 +25,7 @@ FUZZING_CORPUS = \
 	fuzz/corpus/syslog-message/rfc5424-basic \
 	fuzz/corpus/syslog-message/rfc5424-escaped-sd \
 	fuzz/corpus/syslog-message/rfc5424-nil
-EXTRA_DIST += $(TESTS_FUZZING) $(FUZZING_CORPUS)
+EXTRA_DIST += $(TESTS_FUZZING) $(TESTS_RELEASE_PACKAGING) $(FUZZING_CORPUS)
 
 TESTS_JSON_OMITIFZERO = json-omitifzero.sh json-omitifzero-subtree.sh json-whitespace.sh
 EXTRA_DIST += $(TESTS_JSON_OMITIFZERO)
@@ -3783,6 +3784,8 @@ endif # ENABLE_OMAMQP1
 if HAVE_SRV_DISCOVERY
 TESTS += $(TESTS_SRV_DISCOVERY)
 endif # HAVE_SRV_DISCOVERY
+
+TESTS += $(TESTS_RELEASE_PACKAGING)
 
 if ENABLE_GNUTLS
 check_PROGRAMS += gnutls_sni_server

--- a/tests/rpm-baseline-patch-policy.sh
+++ b/tests/rpm-baseline-patch-policy.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Verify RPM daily-stable patch policies are exact and content-pinned.  A
+# reviewed patch must be removed from both its source and explicit %patch
+# application, while an unreviewed baseline patch must reject packaging before
+# a build can apply a stale downstream change to current upstream sources.
+set -eu
+
+test_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
+helper="$test_dir/../devtools/release/validate-rpm-baseline-patches.py"
+work_dir="./rpm-baseline-patch-policy-work.$$"
+
+cleanup() {
+	rm -rf -- "$work_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$work_dir/SPECS" "$work_dir/SOURCES"
+cat >"$work_dir/SPECS/rsyslog.spec" <<'EOF'
+Name: rsyslog
+Patch4: integrated.patch
+Patch5: legacy-integrated.patch
+%prep
+%patch -P4 -p1
+%patch5 -p1
+EOF
+printf '%s\n' 'reviewed patch content' >"$work_dir/SOURCES/integrated.patch"
+printf '%s\n' 'reviewed legacy patch content' >"$work_dir/SOURCES/legacy-integrated.patch"
+digest=$(sha256sum "$work_dir/SOURCES/integrated.patch" | awk '{print $1}')
+legacy_digest=$(sha256sum "$work_dir/SOURCES/legacy-integrated.patch" | awk '{print $1}')
+cat >"$work_dir/policy.json" <<EOF
+{
+  "integrated_baseline_patches": [
+    {
+      "name": "integrated.patch",
+      "sha256": "$digest",
+      "reason": "The test fixture models an upstream-integrated patch."
+    },
+    {
+      "name": "legacy-integrated.patch",
+      "sha256": "$legacy_digest",
+      "reason": "The test fixture models the compact RPM patch macro form."
+    }
+  ]
+}
+EOF
+
+python3 "$helper" "$work_dir/SPECS/rsyslog.spec" "$work_dir/policy.json" test
+test ! -e "$work_dir/SOURCES/integrated.patch"
+test "$(grep -c '^Patch' "$work_dir/SPECS/rsyslog.spec" || true)" -eq 0
+test "$(grep -c '^%patch' "$work_dir/SPECS/rsyslog.spec" || true)" -eq 0
+
+mkdir -p "$work_dir/reject/SPECS" "$work_dir/reject/SOURCES"
+printf '%s\n' 'Patch5: unreviewed.patch' >"$work_dir/reject/SPECS/rsyslog.spec"
+printf '%s\n' 'unreviewed patch content' >"$work_dir/reject/SOURCES/unreviewed.patch"
+printf '%s\n' '{"integrated_baseline_patches": []}' >"$work_dir/reject/policy.json"
+if result=$(python3 "$helper" "$work_dir/reject/SPECS/rsyslog.spec" "$work_dir/reject/policy.json" test 2>&1); then
+	echo "unreviewed baseline patch was accepted" >&2
+	exit 1
+fi
+printf '%s\n' "$result" | grep -F 'baseline gained unreviewed patches' >/dev/null

--- a/tests/rpm-baseline-patch-policy.sh
+++ b/tests/rpm-baseline-patch-policy.sh
@@ -100,6 +100,30 @@ test ! -e "$work_dir/unnumbered/SOURCES/unnumbered.patch"
 test ! -e "$work_dir/unnumbered/SOURCES/numbered.patch"
 test "$(grep -c '^%patch' "$work_dir/unnumbered/SPECS/rsyslog.spec" || true)" -eq 0
 
+variant=0
+for unnumbered_application in '%patch0 -p1' '%patch 0 -p1' '%patch -P0 -p1'; do
+	variant=$((variant + 1))
+	fixture="$work_dir/unnumbered-zero-$variant"
+	mkdir -p "$fixture/SPECS" "$fixture/SOURCES"
+	{
+		printf '%s\n' 'Patch: unnumbered.patch'
+		printf '%%prep\n'
+		printf '%s\n' "$unnumbered_application"
+	} >"$fixture/SPECS/rsyslog.spec"
+	printf '%s\n' 'unnumbered zero-form content' >"$fixture/SOURCES/unnumbered.patch"
+	zero_digest=$(digest "$fixture/SOURCES/unnumbered.patch")
+	cat >"$fixture/policy.json" <<EOF
+{
+  "integrated_baseline_patches": [
+    {"name": "unnumbered.patch", "sha256": "$zero_digest", "reason": "fixture"}
+  ]
+}
+EOF
+	python3 "$helper" "$fixture/SPECS/rsyslog.spec" "$fixture/policy.json" test
+	test ! -e "$fixture/SOURCES/unnumbered.patch"
+	test "$(grep -c '^%patch' "$fixture/SPECS/rsyslog.spec" || true)" -eq 0
+done
+
 mkdir -p "$work_dir/atomic/SPECS" "$work_dir/atomic/SOURCES"
 cat >"$work_dir/atomic/SPECS/rsyslog.spec" <<'EOF'
 Patch0: first.patch

--- a/tests/rpm-baseline-patch-policy.sh
+++ b/tests/rpm-baseline-patch-policy.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Rainer Gerhards and Others
+#
+# This file is part of the rsyslog project, released under ASL 2.0.
 # Verify RPM daily-stable patch policies are exact and content-pinned.  A
 # reviewed patch must be removed from both its source and explicit %patch
 # application, while an unreviewed baseline patch must reject packaging before
@@ -9,10 +13,22 @@ test_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
 helper="$test_dir/../devtools/release/validate-rpm-baseline-patches.py"
 work_dir="./rpm-baseline-patch-policy-work.$$"
 
+command -v python3 >/dev/null 2>&1 || exit 77
+
 cleanup() {
 	rm -rf -- "$work_dir"
 }
 trap cleanup EXIT HUP INT TERM
+
+digest() {
+	python3 - "$1" <<'PY'
+import hashlib
+import pathlib
+import sys
+
+print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+}
 
 mkdir -p "$work_dir/SPECS" "$work_dir/SOURCES"
 cat >"$work_dir/SPECS/rsyslog.spec" <<'EOF'
@@ -25,14 +41,14 @@ Patch5: legacy-integrated.patch
 EOF
 printf '%s\n' 'reviewed patch content' >"$work_dir/SOURCES/integrated.patch"
 printf '%s\n' 'reviewed legacy patch content' >"$work_dir/SOURCES/legacy-integrated.patch"
-digest=$(sha256sum "$work_dir/SOURCES/integrated.patch" | awk '{print $1}')
-legacy_digest=$(sha256sum "$work_dir/SOURCES/legacy-integrated.patch" | awk '{print $1}')
+integrated_digest=$(digest "$work_dir/SOURCES/integrated.patch")
+legacy_digest=$(digest "$work_dir/SOURCES/legacy-integrated.patch")
 cat >"$work_dir/policy.json" <<EOF
 {
   "integrated_baseline_patches": [
     {
       "name": "integrated.patch",
-      "sha256": "$digest",
+      "sha256": "$integrated_digest",
       "reason": "The test fixture models an upstream-integrated patch."
     },
     {
@@ -58,3 +74,78 @@ if result=$(python3 "$helper" "$work_dir/reject/SPECS/rsyslog.spec" "$work_dir/r
 	exit 1
 fi
 printf '%s\n' "$result" | grep -F 'baseline gained unreviewed patches' >/dev/null
+
+mkdir -p "$work_dir/unnumbered/SPECS" "$work_dir/unnumbered/SOURCES"
+cat >"$work_dir/unnumbered/SPECS/rsyslog.spec" <<'EOF'
+Patch: unnumbered.patch
+Patch4: numbered.patch
+%prep
+%patch -p1
+%patch -P4 -p1
+EOF
+printf '%s\n' 'unnumbered content' >"$work_dir/unnumbered/SOURCES/unnumbered.patch"
+printf '%s\n' 'numbered content' >"$work_dir/unnumbered/SOURCES/numbered.patch"
+unnumbered_digest=$(digest "$work_dir/unnumbered/SOURCES/unnumbered.patch")
+numbered_digest=$(digest "$work_dir/unnumbered/SOURCES/numbered.patch")
+cat >"$work_dir/unnumbered/policy.json" <<EOF
+{
+  "integrated_baseline_patches": [
+    {"name": "unnumbered.patch", "sha256": "$unnumbered_digest", "reason": "fixture"},
+    {"name": "numbered.patch", "sha256": "$numbered_digest", "reason": "fixture"}
+  ]
+}
+EOF
+python3 "$helper" "$work_dir/unnumbered/SPECS/rsyslog.spec" "$work_dir/unnumbered/policy.json" test
+test ! -e "$work_dir/unnumbered/SOURCES/unnumbered.patch"
+test ! -e "$work_dir/unnumbered/SOURCES/numbered.patch"
+test "$(grep -c '^%patch' "$work_dir/unnumbered/SPECS/rsyslog.spec" || true)" -eq 0
+
+mkdir -p "$work_dir/atomic/SPECS" "$work_dir/atomic/SOURCES"
+cat >"$work_dir/atomic/SPECS/rsyslog.spec" <<'EOF'
+Patch0: first.patch
+Patch1: changed.patch
+%prep
+%patch -P0 -p1
+%patch -P1 -p1
+EOF
+printf '%s\n' 'first content' >"$work_dir/atomic/SOURCES/first.patch"
+printf '%s\n' 'changed content' >"$work_dir/atomic/SOURCES/changed.patch"
+first_digest=$(digest "$work_dir/atomic/SOURCES/first.patch")
+cat >"$work_dir/atomic/policy.json" <<EOF
+{
+  "integrated_baseline_patches": [
+    {"name": "first.patch", "sha256": "$first_digest", "reason": "fixture"},
+    {"name": "changed.patch", "sha256": "0000000000000000000000000000000000000000000000000000000000000000", "reason": "fixture"}
+  ]
+}
+EOF
+cp "$work_dir/atomic/SPECS/rsyslog.spec" "$work_dir/atomic/original.spec"
+if python3 "$helper" "$work_dir/atomic/SPECS/rsyslog.spec" "$work_dir/atomic/policy.json" test; then
+	echo "changed baseline patch was accepted" >&2
+	exit 1
+fi
+cmp "$work_dir/atomic/original.spec" "$work_dir/atomic/SPECS/rsyslog.spec"
+test -f "$work_dir/atomic/SOURCES/first.patch"
+
+mkdir -p "$work_dir/duplicate/SPECS" "$work_dir/duplicate/SOURCES"
+cat >"$work_dir/duplicate/SPECS/rsyslog.spec" <<'EOF'
+Patch4: first.patch
+Patch04: duplicate.patch
+EOF
+printf '%s\n' 'first content' >"$work_dir/duplicate/SOURCES/first.patch"
+printf '%s\n' 'duplicate content' >"$work_dir/duplicate/SOURCES/duplicate.patch"
+first_digest=$(digest "$work_dir/duplicate/SOURCES/first.patch")
+duplicate_digest=$(digest "$work_dir/duplicate/SOURCES/duplicate.patch")
+cat >"$work_dir/duplicate/policy.json" <<EOF
+{
+  "integrated_baseline_patches": [
+    {"name": "first.patch", "sha256": "$first_digest", "reason": "fixture"},
+    {"name": "duplicate.patch", "sha256": "$duplicate_digest", "reason": "fixture"}
+  ]
+}
+EOF
+if result=$(python3 "$helper" "$work_dir/duplicate/SPECS/rsyslog.spec" "$work_dir/duplicate/policy.json" test 2>&1); then
+	echo "equivalent patch numbers were accepted" >&2
+	exit 1
+fi
+printf '%s\n' "$result" | grep -F 'duplicate test baseline patch declaration' >/dev/null


### PR DESCRIPTION
Closes https://github.com/rsyslog/rsyslog/issues/7490

This makes the RPM daily-stable patch contract content-pinned and fail-closed across EL10/Fedora, Amazon Linux, and openSUSE.

Validation:
- EL10, Amazon Linux, and openSUSE baseline policy smoke checks
- rpm-baseline-patch-policy.sh
- make distcheck TEST_RUN_TYPE=MOCK-OK -j10
- Ubuntu 26.04 static analyzer (no findings)
- Ubuntu 26.04 change-gated check: 1518 pass, 29 skip, 0 fail

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

