### PR TITLE
Codex/local validation process

### DIFF
--- a/.agent/skills/rsyslog_commit/SKILL.md
+++ b/.agent/skills/rsyslog_commit/SKILL.md
@@ -45,12 +45,11 @@ This skill standardizes the final step of the development workflow: committing a
     plumbing changes, follow the local container-testing skill's late
     prompt-audit stage. Read and apply the project's canned prompts directly;
     do not launch another AI CLI from repository scripts.
-  - **Local Cubic**: Run local Cubic review for code changes when `cubic` is
-    installed and reachable. Skip Cubic for documentation-only changes. For
-    tests, workflows, build tooling, and mixed changes, use Cubic when the
-    change is non-trivial, behavior-affecting, security-sensitive, or large.
-    Hosted Cubic/Gemini PR comments are additional review feedback, not a
-    substitute for local Cubic where local Cubic applies.
+  - **Optional AI Review**: Local Cubic review may provide useful additional
+    feedback when `cubic` is installed and reachable, especially for
+    non-trivial code, test, workflow, build, or tooling changes. It is not a
+    required validation gate. Hosted Cubic/Gemini PR comments likewise provide
+    supplemental review feedback and must be considered when present.
   - **Container Gate**: For implementation changes, run the
     `rsyslog_local_container_testing` skill's PR-ready change-gated local
     container sequence when container tooling is available. Focused

--- a/.agent/skills/rsyslog_local_container_testing/SKILL.md
+++ b/.agent/skills/rsyslog_local_container_testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rsyslog_local_container_testing
-description: Mirror rsyslog run_checks.yml container validation locally, including the change-gated Ubuntu 26.04 run-ci.sh check run, the clang static analyzer job, late prompt-based audit passes, Cubic review where applicable, service-skip validation, clean-tree rules, and container path caveats.
+description: Mirror rsyslog run_checks.yml container validation locally, including the change-gated Ubuntu 26.04 run-ci.sh check run, the clang static analyzer job, late prompt-based audit passes, service-skip validation, clean-tree rules, and container path caveats.
 ---
 
 # rsyslog_local_container_testing
@@ -57,8 +57,8 @@ container validation failure.
 By default the helper compares committed branch changes against the worktree's
 creation baseline: `RSYSLOG_LOCAL_VALIDATION_BASE` when set, otherwise
 `rsyslog.localValidationBase` from git config when present, otherwise the
-oldest `HEAD` reflog entry for the worktree. This keeps local Cubic and local
-diff classification tied to the commit that was `HEAD` when the dedicated
+oldest `HEAD` reflog entry for the worktree. This keeps local diff
+classification tied to the commit that was `HEAD` when the dedicated
 worktree was created, even after `origin/main` moves. Use `--base REF` for an
 intentional one-off override.
 
@@ -116,8 +116,8 @@ is too noisy for routine rsyslog PR validation.
   docs build unless they also change rendered Sphinx inputs.
 - **Tier 1: default PR-ready gate for code or testbench changes**. Run a
   change-gated Ubuntu 26.04 `devtools/run-ci.sh` check first, then the existing
-  static-analyzer pass, then late prompt-based audit passes and local Cubic
-  review when applicable. This is the normal local confidence gate for C,
+  static-analyzer pass and late prompt-based audit passes. This is the normal
+  local confidence gate for C,
   parser, module, runtime, `tests/*.sh`, `diag.sh`, `Makefile.am`,
   `configure.ac`, and `run_checks.yml` changes.
 - **Tier 2: compile portability gate for non-trivial C/header changes**. Add
@@ -200,27 +200,26 @@ that the audit was clean. Skip prompt audits for documentation-only and
 instruction-only changes unless the edited instructions themselves change audit
 or validation behavior.
 
-## Cubic Review
+## Optional Cubic Review
 
-Run the local `cubic` CLI as an AI review gate when it applies. Cubic is a small
+The local `cubic` CLI can provide additional AI review when it applies. Cubic is a small
 local shim that forwards the review request to the configured cloud AI service,
 so it should run late on the stabilized candidate. It is a broad review pass,
 not a fast compile detector.
 
-- **Docs-only changes**: do not run Cubic.
-- **Code changes (`*.c`, `*.h`, grammar/parser/runtime/module logic)**: always
-  run Cubic when the command is installed and reachable.
-- **Test-only changes**: run Cubic for non-trivial test logic, timing/sync
+- **Docs-only changes**: Cubic is usually not useful.
+- **Code changes (`*.c`, `*.h`, grammar/parser/runtime/module logic)**: consider
+  Cubic when the command is installed and reachable.
+- **Test-only changes**: consider Cubic for non-trivial test logic, timing/sync
   changes, helper changes, or broad testbench behavior.
-- **Workflow, build, and tooling changes**: run Cubic when the change is
+- **Workflow, build, and tooling changes**: consider Cubic when the change is
   non-trivial, behavior-affecting, security-sensitive, or large. Use
   `actionlint`, pinned `zizmor`, and the relevant local linters as the primary
   deterministic checks for workflow syntax/security.
-- **Mixed or large changes**: run Cubic.
+- **Mixed or large changes**: consider Cubic.
 
-Hosted Cubic or Gemini PR comments are useful additional feedback, but they do
-not replace local Cubic for code changes and do not replace local analyzer,
-build, or container checks.
+Hosted Cubic or Gemini PR comments are useful additional feedback. Neither
+local nor hosted AI review replaces local analyzer, build, or container checks.
 
 ## Extended Lane Triggers
 
@@ -261,14 +260,13 @@ change-gated Ubuntu 26.04 check would not expose. Do not add lanes by habit.
 
 ## Preferred Order
 
-For the PR-ready final gate, run Cubic where applicable and two container
-validations for broad local confidence. Mirror these
+For the PR-ready final gate, run two container validations for broad local
+confidence. Mirror these
 `.github/workflows/run_checks.yml` paths:
 
-1. Local Cubic review and the `clang static analyzer` job's container command.
-   These can run in parallel when the agent harness supports parallel commands.
+1. The `clang static analyzer` job's container command.
 2. The change-gated Ubuntu 26.04 `devtools/run-ci.sh` check run, only after the
-   analyzer and Cubic results are clean or their findings are understood.
+   analyzer results are clean or their findings are understood.
 
 This sequence is what "PR-ready local container validation" means in agent
 status reports. It is intentionally not an unconditional full-suite run; it
@@ -502,12 +500,10 @@ environment:
 - Provide the exact local container lanes or hosted CI lanes that a container
   capable agent should run next.
 - Missing local tools such as `shellcheck`, `checkbashisms`, `actionlint`,
-  `zizmor`, `hadolint`, `trivy`, `jscpd`, `pycodestyle`, Cubic, Docker, or
+  `zizmor`, `hadolint`, `trivy`, `jscpd`, `pycodestyle`, Docker, or
   Podman are not fatal by themselves. Report the missing checks and continue
   with all deterministic checks that are available and relevant.
-- For code changes, still run or request Cubic according to the Cubic rules
-  when the local CLI is available. If Cubic is unavailable, report that as a
-  separate AI-review limitation.
+- Local Cubic review is optional and does not affect validation completeness.
 
 ## Service Relevance
 

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -15,6 +15,8 @@ This repository ships a repo-local Codex hook configuration for trusted projects
 - If formatting fails, the `git commit` tool call is blocked and Codex is told to fix formatting first
 - If formatting updates `.c` or `.h` files, the hook stages those tracked formatter updates automatically and then allows the commit
 - If partially staged `.c` or `.h` files are present, the hook blocks because auto-restaging would not be safe
+- Blocks pushes when source, build, or test changes are newer than the local container-validation marker
+- Allows an explicit one-command override with `SKIP_CONTAINER_VALIDATION=1 git push ...`; the hook reads the assignment from the command payload because hook processes do not inherit inline command assignments
 
 ## Repo-local skills
 

--- a/.codex/pre_push_container_gate.sh
+++ b/.codex/pre_push_container_gate.sh
@@ -132,9 +132,10 @@ def inline_validation_skip(words: list[str]) -> bool:
         break
     return override == "1"
 
-def classify_git_push(words: list[str]) -> str | None:
+def classify_git_push(words: list[str], inherited_skip: bool = False) -> str | None:
+    effective_skip = inherited_skip or inline_validation_skip(words)
     if is_git_push(words):
-        return "skip" if inline_validation_skip(words) else "gate"
+        return "skip" if effective_skip else "gate"
 
     nested_command = unwrap_shell_command(words)
     if not nested_command:
@@ -149,7 +150,7 @@ def classify_git_push(words: list[str]) -> str | None:
     except ValueError:
         return None
 
-    decisions = [classify_git_push(simple_command) for simple_command in commands]
+    decisions = [classify_git_push(simple_command, effective_skip) for simple_command in commands]
     if "gate" in decisions:
         return "gate"
     if "skip" in decisions:

--- a/.codex/pre_push_container_gate.sh
+++ b/.codex/pre_push_container_gate.sh
@@ -122,6 +122,17 @@ def inline_validation_override(words):
             continue
         if token == "env":
             i += 1
+            while i < len(words):
+                token = words[i]
+                if token == "-u" and i + 1 < len(words):
+                    if words[i + 1] == "SKIP_CONTAINER_VALIDATION":
+                        override = "0"
+                    i += 2
+                    continue
+                if token.startswith("-"):
+                    i += 1
+                    continue
+                break
             continue
         match = assignment_re.fullmatch(token)
         if match:
@@ -133,6 +144,20 @@ def inline_validation_override(words):
     if override is None:
         return None
     return override == "1"
+
+def shell_validation_override(words):
+    """Return a persistent override set by a shell builtin, if any."""
+    words = strip_prefixes(words)
+    if not words:
+        return None
+    if words[0] == "unset" and "SKIP_CONTAINER_VALIDATION" in words[1:]:
+        return False
+    if words[0] != "export":
+        return None
+    for token in words[1:]:
+        if token.startswith("SKIP_CONTAINER_VALIDATION="):
+            return token.split("=", 1)[1] == "1"
+    return None
 
 def classify_git_push(words, inherited_skip=False):
     override = inline_validation_override(words)
@@ -153,7 +178,14 @@ def classify_git_push(words, inherited_skip=False):
     except ValueError:
         return None
 
-    decisions = [classify_git_push(simple_command, effective_skip) for simple_command in commands]
+    nested_skip = effective_skip
+    decisions = []
+    for simple_command in commands:
+        shell_override = shell_validation_override(simple_command)
+        if shell_override is not None:
+            nested_skip = shell_override
+            continue
+        decisions.append(classify_git_push(simple_command, nested_skip))
     if "gate" in decisions:
         return "gate"
     if "skip" in decisions:
@@ -182,7 +214,14 @@ try:
 except ValueError:
     sys.exit(0)
 
-decisions = [classify_git_push(simple_command) for simple_command in commands]
+skip = False
+decisions = []
+for simple_command in commands:
+    shell_override = shell_validation_override(simple_command)
+    if shell_override is not None:
+        skip = shell_override
+        continue
+    decisions.append(classify_git_push(simple_command, skip))
 if "gate" in decisions:
     print("yes")
 elif "skip" in decisions:

--- a/.codex/pre_push_container_gate.sh
+++ b/.codex/pre_push_container_gate.sh
@@ -48,8 +48,15 @@ def strip_prefixes(words):
             continue
         if token == "env":
             i += 1
-            while i < len(words) and assignment_re.fullmatch(words[i]):
-                i += 1
+            while i < len(words):
+                token = words[i]
+                if token == "-u" and i + 1 < len(words):
+                    i += 2
+                    continue
+                if token.startswith("-") or assignment_re.fullmatch(token):
+                    i += 1
+                    continue
+                break
             continue
         if assignment_re.fullmatch(token):
             i += 1
@@ -145,19 +152,12 @@ def inline_validation_override(words):
         return None
     return override == "1"
 
-def shell_validation_override(words):
-    """Return a persistent override set by a shell builtin, if any."""
+def shell_validation_reset(words):
+    """Return whether a shell builtin clears the push override."""
     words = strip_prefixes(words)
     if not words:
-        return None
-    if words[0] == "unset" and "SKIP_CONTAINER_VALIDATION" in words[1:]:
         return False
-    if words[0] != "export":
-        return None
-    for token in words[1:]:
-        if token.startswith("SKIP_CONTAINER_VALIDATION="):
-            return token.split("=", 1)[1] == "1"
-    return None
+    return words[0] == "unset" and "SKIP_CONTAINER_VALIDATION" in words[1:]
 
 def classify_git_push(words, inherited_skip=False):
     override = inline_validation_override(words)
@@ -178,14 +178,11 @@ def classify_git_push(words, inherited_skip=False):
     except ValueError:
         return None
 
-    nested_skip = effective_skip
     decisions = []
     for simple_command in commands:
-        shell_override = shell_validation_override(simple_command)
-        if shell_override is not None:
-            nested_skip = shell_override
-            continue
-        decisions.append(classify_git_push(simple_command, nested_skip))
+        if effective_skip and shell_validation_reset(simple_command):
+            return "gate"
+        decisions.append(classify_git_push(simple_command, effective_skip))
     if "gate" in decisions:
         return "gate"
     if "skip" in decisions:
@@ -214,14 +211,9 @@ try:
 except ValueError:
     sys.exit(0)
 
-skip = False
 decisions = []
 for simple_command in commands:
-    shell_override = shell_validation_override(simple_command)
-    if shell_override is not None:
-        skip = shell_override
-        continue
-    decisions.append(classify_git_push(simple_command, skip))
+    decisions.append(classify_git_push(simple_command))
 if "gate" in decisions:
     print("yes")
 elif "skip" in decisions:

--- a/.codex/pre_push_container_gate.sh
+++ b/.codex/pre_push_container_gate.sh
@@ -18,7 +18,7 @@ import re
 import shlex
 import sys
 
-def split_simple_commands(command: str) -> list[list[str]]:
+def split_simple_commands(command):
     lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
     lexer.whitespace_split = True
     lexer.commenters = ""
@@ -35,7 +35,7 @@ def split_simple_commands(command: str) -> list[list[str]]:
         commands.append(current)
     return commands
 
-def strip_prefixes(words: list[str]) -> list[str]:
+def strip_prefixes(words):
     i = 0
     assignment_re = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=.*")
     while i < len(words):
@@ -57,7 +57,7 @@ def strip_prefixes(words: list[str]) -> list[str]:
         break
     return words[i:]
 
-def is_git_push(words: list[str]) -> bool:
+def is_git_push(words):
     words = strip_prefixes(words)
     if not words or words[0] != "git":
         return False
@@ -77,7 +77,7 @@ def is_git_push(words: list[str]) -> bool:
         return False
     return False
 
-def unwrap_shell_command(words: list[str]) -> list[str] | None:
+def unwrap_shell_command(words):
     words = strip_prefixes(words)
     if not words:
         return None
@@ -107,7 +107,7 @@ def unwrap_shell_command(words: list[str]) -> list[str] | None:
 
     return None
 
-def inline_validation_skip(words: list[str]) -> bool:
+def inline_validation_skip(words):
     """Return whether the simple command sets the documented push override."""
     assignment_re = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)=(.*)")
     i = 0
@@ -132,7 +132,7 @@ def inline_validation_skip(words: list[str]) -> bool:
         break
     return override == "1"
 
-def classify_git_push(words: list[str], inherited_skip: bool = False) -> str | None:
+def classify_git_push(words, inherited_skip=False):
     effective_skip = inherited_skip or inline_validation_skip(words)
     if is_git_push(words):
         return "skip" if effective_skip else "gate"

--- a/.codex/pre_push_container_gate.sh
+++ b/.codex/pre_push_container_gate.sh
@@ -107,8 +107,8 @@ def unwrap_shell_command(words):
 
     return None
 
-def inline_validation_skip(words):
-    """Return whether the simple command sets the documented push override."""
+def inline_validation_override(words):
+    """Return the documented push override, or None when the command omits it."""
     assignment_re = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)=(.*)")
     i = 0
     override = None
@@ -130,10 +130,13 @@ def inline_validation_skip(words):
             i += 1
             continue
         break
+    if override is None:
+        return None
     return override == "1"
 
 def classify_git_push(words, inherited_skip=False):
-    effective_skip = inherited_skip or inline_validation_skip(words)
+    override = inline_validation_override(words)
+    effective_skip = inherited_skip if override is None else override
     if is_git_push(words):
         return "skip" if effective_skip else "gate"
 

--- a/.codex/pre_push_container_gate.sh
+++ b/.codex/pre_push_container_gate.sh
@@ -107,24 +107,54 @@ def unwrap_shell_command(words: list[str]) -> list[str] | None:
 
     return None
 
-def contains_git_push(words: list[str]) -> bool:
+def inline_validation_skip(words: list[str]) -> bool:
+    """Return whether the simple command sets the documented push override."""
+    assignment_re = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)=(.*)")
+    i = 0
+    override = None
+    while i < len(words):
+        token = words[i]
+        if token == "sudo":
+            i += 1
+            continue
+        if token in {"command", "builtin", "noglob", "time"}:
+            i += 1
+            continue
+        if token == "env":
+            i += 1
+            continue
+        match = assignment_re.fullmatch(token)
+        if match:
+            if match.group(1) == "SKIP_CONTAINER_VALIDATION":
+                override = match.group(2)
+            i += 1
+            continue
+        break
+    return override == "1"
+
+def classify_git_push(words: list[str]) -> str | None:
     if is_git_push(words):
-        return True
+        return "skip" if inline_validation_skip(words) else "gate"
 
     nested_command = unwrap_shell_command(words)
     if not nested_command:
-        return False
+        return None
 
     command = nested_command[0]
     if not isinstance(command, str) or not command.strip():
-        return False
+        return None
 
     try:
         commands = split_simple_commands(command)
     except ValueError:
-        return False
+        return None
 
-    return any(contains_git_push(simple_command) for simple_command in commands)
+    decisions = [classify_git_push(simple_command) for simple_command in commands]
+    if "gate" in decisions:
+        return "gate"
+    if "skip" in decisions:
+        return "skip"
+    return None
 
 payload_raw = os.environ.get("PAYLOAD")
 if payload_raw is None:
@@ -148,12 +178,17 @@ try:
 except ValueError:
     sys.exit(0)
 
-for simple_command in commands:
-    if contains_git_push(simple_command):
-        print("yes")
-        break
+decisions = [classify_git_push(simple_command) for simple_command in commands]
+if "gate" in decisions:
+    print("yes")
+elif "skip" in decisions:
+    print("skip")
 PY
 )"
+
+if [[ "${should_gate}" == "skip" ]]; then
+  exit 0
+fi
 
 if [[ "${should_gate}" != "yes" ]]; then
   exit 0

--- a/.codex/pre_push_container_gate.sh
+++ b/.codex/pre_push_container_gate.sh
@@ -53,6 +53,9 @@ def strip_prefixes(words):
                 if token == "-u" and i + 1 < len(words):
                     i += 2
                     continue
+                if token == "--unset" and i + 1 < len(words):
+                    i += 2
+                    continue
                 if token.startswith("-") or assignment_re.fullmatch(token):
                     i += 1
                     continue
@@ -135,6 +138,15 @@ def inline_validation_override(words):
                     if words[i + 1] == "SKIP_CONTAINER_VALIDATION":
                         override = "0"
                     i += 2
+                    continue
+                if token == "--unset" and i + 1 < len(words):
+                    if words[i + 1] == "SKIP_CONTAINER_VALIDATION":
+                        override = "0"
+                    i += 2
+                    continue
+                if token in {"-uSKIP_CONTAINER_VALIDATION", "--unset=SKIP_CONTAINER_VALIDATION"}:
+                    override = "0"
+                    i += 1
                     continue
                 if token.startswith("-"):
                     i += 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,6 @@ Follow these steps for a typical development task:
 2.  **Validate**: Use the `rsyslog_test` skill to run relevant shell tests.
 3.  **Container Validation**: Use the `rsyslog_local_container_testing` skill
     when Docker or Podman container tooling is available.
-4.  **Local AI Review**: Run local Cubic review when `cubic` is available.
 5.  **Commit**: Use the `rsyslog_commit` skill to format code and draft your message.
 
 Tip: You do NOT need to re-run your build, test, or container validation cycle
@@ -107,19 +106,12 @@ validation as the final validation gate when container tooling is available.
 - PR-ready local container validation means the skill's ordered
   change-gated sequence: the Ubuntu 26.04 `run-ci.sh` check run using the same
   relevance gates as regular PR CI, the Ubuntu 26.04 static analyzer where
-  applicable, late prompt-based audit passes where applicable, and local Cubic
-  where applicable. Focused container tests are useful targeted evidence, but
+  applicable, and late prompt-based audit passes where applicable. Focused container tests are useful targeted evidence, but
   they are not the final gate unless the skill explicitly allows the reduced
   lane for the touched area.
 - Use the skill's configured CI-equivalent dev image, including Docker Hub dev
   images when appropriate. Use a locally built image only when validating that
   local image or the runtime container produced by the task.
-- Run local Cubic validation for code changes when `cubic` is installed and
-  reachable. Do not run Cubic for documentation-only changes. For tests,
-  workflow, build, and other non-code changes, use Cubic when the change is
-  non-trivial, behavior-affecting, security-sensitive, or large. Hosted Cubic
-  or Gemini PR comments are additional review feedback, not substitutes for
-  local Cubic or local container validation.
 - Agents should honor local machine capacity knobs when running broad local
   checks: `RSYSLOG_LOCAL_CHECK_JOBS` for `make check` concurrency and
   `RSYSLOG_LOCAL_BUILD_JOBS` for build concurrency, both defaulting to `10`
@@ -138,7 +130,7 @@ validation as the final validation gate when container tooling is available.
   the reduced validation scope after the blocker was reported.
 - Session ledgers and final summaries for PR work must distinguish fully
   PR-ready container-validated work from targeted container-tested-only work.
-  Include the local Cubic status, hosted AI review status, image tag and ID,
+  Include hosted AI review status, image tag and ID,
   exact commands, local concurrency values, lane relaxations, and pass/fail
   results.
 
@@ -278,7 +270,7 @@ test classifications, a no-container agent should report the recommended lanes
 instead of trying to replace them with weaker local evidence.
 
 Missing optional tools such as `shellcheck`, `checkbashisms`, `actionlint`,
-`zizmor`, `hadolint`, `trivy`, `jscpd`, `pycodestyle`, Cubic, Docker, or
+`zizmor`, `hadolint`, `trivy`, `jscpd`, `pycodestyle`, Docker, or
 Podman are not fatal by themselves. Record which checks could not run, run the
 available applicable subset, and name the missing checks or container lanes
 that still need coverage.

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,7 @@ EXTRA_DIST = \
 	COPYING \
 	COPYING.LESSER \
 	COPYING.ASL20 \
+	.codex/pre_push_container_gate.sh \
 	contrib/gnutls/ca.pem \
 	contrib/gnutls/cert.pem \
 	contrib/gnutls/key.pem \

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,6 @@ EXTRA_DIST = \
 	COPYING \
 	COPYING.LESSER \
 	COPYING.ASL20 \
-	.codex/pre_push_container_gate.sh \
 	contrib/gnutls/ca.pem \
 	contrib/gnutls/cert.pem \
 	contrib/gnutls/key.pem \

--- a/devtools/local-validation-plan.sh
+++ b/devtools/local-validation-plan.sh
@@ -13,7 +13,7 @@
 #
 # Keep this script portable POSIX sh. It is meant to run on lean developer and
 # container images, including Alpine-style environments where Bash may be
-# absent. Optional diff-scoped tools such as shellcheck, checkbashisms, Cubic,
+# absent. Optional diff-scoped tools such as shellcheck and checkbashisms,
 # and pycodestyle-backed formatters must not make this helper fail merely
 # because they are unavailable; print a warning and continue. A validation tool
 # that exists but reports a real finding still fails normally. Do not run
@@ -288,7 +288,6 @@ print_plan() {
 		echo "  - Change-gated Ubuntu 26.04 run-ci.sh check."
 		echo "  - Ubuntu 26.04 static analyzer for C/testbench/code changes."
 		echo "  - Late prompt-based audit passes for applicable C/H, concurrency, test, or build changes."
-		echo "  - Cubic where applicable."
 		;;
 	esac
 	if [ "$has_dist_risk" -eq 1 ]; then
@@ -510,19 +509,6 @@ have_devcontainer_script() {
 	return 1
 }
 
-run_cubic_if_available() {
-	case "$classification" in
-	agent-doc-only | internal-doc-only | rendered-docs)
-		return 0
-		;;
-	esac
-	if command -v cubic >/dev/null 2>&1; then
-		cubic review --print-logs --base "$base_ref"
-	else
-		echo "warning: cubic not installed; skipping local Cubic review" >&2
-	fi
-}
-
 run_mock_distcheck_if_needed() {
 	if [ "$has_dist_risk" -ne 1 ]; then
 		return 0
@@ -653,6 +639,5 @@ testbench-plumbing | code-or-ci | general)
 	run_change_gated_ubuntu26
 	run_static_analyzer
 	run_prompt_audit_reminder
-	run_cubic_if_available
 	;;
 esac

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -194,6 +194,7 @@ TESTS_ELASTICSEARCH_VALGRIND = \
 	es-basic-ha-vg.sh
 
 TESTS_DEFAULT = \
+	codex-pre-push-container-gate.sh \
 	backtick-cat-procfs.sh \
 	preservefqdn-localhostname-internal.sh \
 	net-enabledns-off-localhostname.sh \

--- a/tests/codex-pre-push-container-gate.sh
+++ b/tests/codex-pre-push-container-gate.sh
@@ -74,4 +74,5 @@ assert_blocked "bash -lc 'git push origin topic'"
 assert_blocked 'SKIP_CONTAINER_VALIDATION=0 git push origin topic'
 assert_blocked "SKIP_CONTAINER_VALIDATION=0 bash -lc 'git push origin topic'"
 assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'SKIP_CONTAINER_VALIDATION=0 git push origin topic'"
+assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'unset SKIP_CONTAINER_VALIDATION; git push origin topic'"
 assert_blocked 'SKIP_CONTAINER_VALIDATION=1 git push origin topic; git push origin other'

--- a/tests/codex-pre-push-container-gate.sh
+++ b/tests/codex-pre-push-container-gate.sh
@@ -1,22 +1,43 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Regression test for the Codex pre-push gate's explicit validation bypass.
 # It proves that direct, env-prefixed, and shell-wrapped inline overrides are
 # accepted, while ordinary pushes, false overrides, and mixed command lists
 # still produce the hook's deny decision. Empty output is the allow oracle;
 # the JSON permissionDecision=deny response is the block oracle.
+# This is intentionally standalone rather than a diag.sh scenario: it exercises
+# only hook command parsing and needs neither rsyslogd nor testbench helpers.
+# The hook is intentionally absent from release tarballs, so this test skips
+# there; source and CI checkouts retain the hook and run the assertions below.
 set -eu
 
 tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/rsyslog-codex-push-gate.XXXXXX")"
 trap 'rm -rf "$tmpdir"' EXIT HUP INT TERM
 
+test_srcdir="${srcdir:-$(dirname "$0")}"
+gate_source="$test_srcdir/../.codex/pre_push_container_gate.sh"
+[ -f "$gate_source" ] || exit 77
+command -v python3 >/dev/null 2>&1 || exit 77
+
 mkdir -p "$tmpdir/.codex"
-cp "${srcdir:-.}/../.codex/pre_push_container_gate.sh" "$tmpdir/.codex/"
+cp "$gate_source" "$tmpdir/.codex/"
 gate="$tmpdir/.codex/pre_push_container_gate.sh"
 
 run_gate() {
 	command_text="$1"
-	printf '%s\n' \
-		'{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"'"$command_text"'"}}' |
+	python3 -c '
+import json
+import sys
+
+print(json.dumps({
+    "hook_event_name": "PreToolUse",
+    "tool_name": "Bash",
+    "tool_input": {"command": sys.argv[1]},
+}))
+' "$command_text" |
 		"$gate"
 }
 
@@ -44,7 +65,10 @@ assert_blocked() {
 assert_allowed 'SKIP_CONTAINER_VALIDATION=1 git push origin topic'
 assert_allowed 'env SKIP_CONTAINER_VALIDATION=1 git push origin topic'
 assert_allowed "bash -lc 'SKIP_CONTAINER_VALIDATION=1 git push origin topic'"
+assert_allowed "SKIP_CONTAINER_VALIDATION=1 bash -lc 'git push origin topic'"
+assert_allowed "env SKIP_CONTAINER_VALIDATION=1 sh -c 'git push origin topic'"
 
 assert_blocked 'git push origin topic'
 assert_blocked 'SKIP_CONTAINER_VALIDATION=0 git push origin topic'
+assert_blocked "SKIP_CONTAINER_VALIDATION=0 bash -lc 'git push origin topic'"
 assert_blocked 'SKIP_CONTAINER_VALIDATION=1 git push origin topic; git push origin other'

--- a/tests/codex-pre-push-container-gate.sh
+++ b/tests/codex-pre-push-container-gate.sh
@@ -5,9 +5,10 @@
 #
 # Regression test for the Codex pre-push gate's explicit validation bypass.
 # It proves that direct, env-prefixed, and shell-wrapped inline overrides are
-# accepted, while ordinary pushes, false overrides, and mixed command lists
-# still produce the hook's deny decision. Empty output is the allow oracle;
-# the JSON permissionDecision=deny response is the block oracle.
+# accepted, while ordinary and shell-wrapped pushes, false overrides, and
+# mixed command lists still produce the hook's deny decision. Empty output is
+# the allow oracle; the JSON permissionDecision=deny response is the block
+# oracle. The shell-wrapped blocked case proves wrapper push recognition.
 # This is intentionally standalone rather than a diag.sh scenario: it exercises
 # only hook command parsing and needs neither rsyslogd nor testbench helpers.
 # The hook is intentionally absent from release tarballs, so this test skips
@@ -69,6 +70,8 @@ assert_allowed "SKIP_CONTAINER_VALIDATION=1 bash -lc 'git push origin topic'"
 assert_allowed "env SKIP_CONTAINER_VALIDATION=1 sh -c 'git push origin topic'"
 
 assert_blocked 'git push origin topic'
+assert_blocked "bash -lc 'git push origin topic'"
 assert_blocked 'SKIP_CONTAINER_VALIDATION=0 git push origin topic'
 assert_blocked "SKIP_CONTAINER_VALIDATION=0 bash -lc 'git push origin topic'"
+assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'SKIP_CONTAINER_VALIDATION=0 git push origin topic'"
 assert_blocked 'SKIP_CONTAINER_VALIDATION=1 git push origin topic; git push origin other'

--- a/tests/codex-pre-push-container-gate.sh
+++ b/tests/codex-pre-push-container-gate.sh
@@ -74,5 +74,6 @@ assert_blocked "bash -lc 'git push origin topic'"
 assert_blocked 'SKIP_CONTAINER_VALIDATION=0 git push origin topic'
 assert_blocked "SKIP_CONTAINER_VALIDATION=0 bash -lc 'git push origin topic'"
 assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'SKIP_CONTAINER_VALIDATION=0 git push origin topic'"
+assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'env -u SKIP_CONTAINER_VALIDATION git push origin topic'"
 assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'unset SKIP_CONTAINER_VALIDATION; git push origin topic'"
 assert_blocked 'SKIP_CONTAINER_VALIDATION=1 git push origin topic; git push origin other'

--- a/tests/codex-pre-push-container-gate.sh
+++ b/tests/codex-pre-push-container-gate.sh
@@ -75,5 +75,8 @@ assert_blocked 'SKIP_CONTAINER_VALIDATION=0 git push origin topic'
 assert_blocked "SKIP_CONTAINER_VALIDATION=0 bash -lc 'git push origin topic'"
 assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'SKIP_CONTAINER_VALIDATION=0 git push origin topic'"
 assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'env -u SKIP_CONTAINER_VALIDATION git push origin topic'"
+assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'env --unset SKIP_CONTAINER_VALIDATION git push origin topic'"
+assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'env --unset=SKIP_CONTAINER_VALIDATION git push origin topic'"
+assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'env -uSKIP_CONTAINER_VALIDATION git push origin topic'"
 assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'unset SKIP_CONTAINER_VALIDATION; git push origin topic'"
 assert_blocked 'SKIP_CONTAINER_VALIDATION=1 git push origin topic; git push origin other'

--- a/tests/codex-pre-push-container-gate.sh
+++ b/tests/codex-pre-push-container-gate.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Regression test for the Codex pre-push gate's explicit validation bypass.
+# It proves that direct, env-prefixed, and shell-wrapped inline overrides are
+# accepted, while ordinary pushes, false overrides, and mixed command lists
+# still produce the hook's deny decision. Empty output is the allow oracle;
+# the JSON permissionDecision=deny response is the block oracle.
+set -eu
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/rsyslog-codex-push-gate.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT HUP INT TERM
+
+mkdir -p "$tmpdir/.codex"
+cp "${srcdir:-.}/../.codex/pre_push_container_gate.sh" "$tmpdir/.codex/"
+gate="$tmpdir/.codex/pre_push_container_gate.sh"
+
+run_gate() {
+	command_text="$1"
+	printf '%s\n' \
+		'{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"'"$command_text"'"}}' |
+		"$gate"
+}
+
+assert_allowed() {
+	command_text="$1"
+	output="$(run_gate "$command_text")"
+	if [ -n "$output" ]; then
+		printf 'expected push command to be allowed: %s\n%s\n' "$command_text" "$output" >&2
+		exit 1
+	fi
+}
+
+assert_blocked() {
+	command_text="$1"
+	output="$(run_gate "$command_text")"
+	case "$output" in
+		*'"permissionDecision": "deny"'*) ;;
+		*)
+			printf 'expected push command to be blocked: %s\n%s\n' "$command_text" "$output" >&2
+			exit 1
+			;;
+	esac
+}
+
+assert_allowed 'SKIP_CONTAINER_VALIDATION=1 git push origin topic'
+assert_allowed 'env SKIP_CONTAINER_VALIDATION=1 git push origin topic'
+assert_allowed "bash -lc 'SKIP_CONTAINER_VALIDATION=1 git push origin topic'"
+
+assert_blocked 'git push origin topic'
+assert_blocked 'SKIP_CONTAINER_VALIDATION=0 git push origin topic'
+assert_blocked 'SKIP_CONTAINER_VALIDATION=1 git push origin topic; git push origin other'


### PR DESCRIPTION
remove hard cubic requirement - codex is a bit too motivated to match it all the time, even in user cases where this is not possible. we may change method later, but now we need a fix that works.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

