### PR TITLE
fedora: package the segmented queue utility

### DIFF
--- a/.github/FEDORA_DAILY_STABLE.md
+++ b/.github/FEDORA_DAILY_STABLE.md
@@ -8,12 +8,13 @@ subpackage split as the packaging authority. The source RPM's NEVRA and
 SHA-256 are recorded with each build.
 
 The explicit current-source deltas are recorded in
-`fedora44-daily-stable-policy.yml`. The only current delta is an explicit
-`autoconf-archive` build dependency because the generated main-branch tarball
-does not bundle the AX macros used by current `configure.ac`. Fedora's feature
-selection, package split, configuration, documentation, service unit, and
-file ownership remain unchanged. If Fedora adds a downstream patch, the build
-stops for review instead of silently dropping it.
+`fedora44-daily-stable-policy.yml`: an explicit `autoconf-archive` build
+dependency because the generated main-branch tarball does not bundle the AX
+macros used by current `configure.ac`, and the `rsyslog-segqueue` binary and
+manual page in the base-package file manifest because the Fedora baseline does
+not yet list them. Fedora's feature selection, package split, configuration,
+documentation, and service unit remain unchanged. If Fedora adds a downstream
+patch, the build stops for review instead of silently dropping it.
 
 Package construction does not run for pull requests. Manual dispatch remains
 available for bootstrap and recovery. The schedule is inactive until a manual


### PR DESCRIPTION
## Summary

Fix Fedora daily-stable package builds after `rsyslog-segqueue` was added upstream.

The Fedora source spec did not own the installed binary or its manpage, causing RPM builds to reject unpackaged files. The daily-stable policy now declares these files and the helper applies them adjacent to stable anchors. The Fedora helper also uses the shared baseline-patch policy validation.

Fixes https://github.com/rsyslog/rsyslog/issues/7494

## Validation

- Fedora 44 x86_64 RPM rebuild: passed; verified `/usr/bin/rsyslog-segqueue` and `/usr/share/man/man1/rsyslog-segqueue.1.gz` are packaged.
- `tests/rpm-baseline-patch-policy.sh`: passed.
- `shellcheck -S warning devtools/release/fedora-daily-stable.sh`: passed.
- Ubuntu 26.04 local container `run-ci.sh` check: 1,358 passed, 33 skipped, 0 failed.
- Ubuntu 26.04 clang static analyzer: passed.

Local Cubic review was not run because its subscription is unavailable in this environment.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

