### PR TITLE
tests: cover mmkubernetes token reload in YAML

### DIFF
--- a/doc/source/reference/parameters/mmkubernetes-tokenreloadinterval.rst
+++ b/doc/source/reference/parameters/mmkubernetes-tokenreloadinterval.rst
@@ -1,6 +1,10 @@
 .. _param-mmkubernetes-tokenreloadinterval:
 .. _mmkubernetes.parameter.action.tokenreloadinterval:
 
+.. meta::
+   :description: Configure proactive Kubernetes ServiceAccount token reloads in mmkubernetes.
+   :keywords: rsyslog, mmkubernetes, ServiceAccount, token, token reload, Kubernetes
+
 tokenreloadinterval
 ===================
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2293,6 +2293,7 @@ TESTS_MMKUBERNETES = \
 	mmkubernetes-url-failover.sh \
 	mmkubernetes-namespace-metadata-off.sh \
 	yaml-mmkubernetes-namespace-metadata-off.sh \
+	yaml-mmkubernetes-token-reload.sh \
 	mmkubernetes-token-reload.sh
 
 TESTS_MMKUBERNETES_VALGRIND = \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2292,9 +2292,11 @@ TESTS_MMKUBERNETES = \
 	mmkubernetes-cache-expire.sh \
 	mmkubernetes-url-failover.sh \
 	mmkubernetes-namespace-metadata-off.sh \
-	yaml-mmkubernetes-namespace-metadata-off.sh \
-	yaml-mmkubernetes-token-reload.sh \
 	mmkubernetes-token-reload.sh
+
+TESTS_MMKUBERNETES_LIBYAML = \
+	yaml-mmkubernetes-namespace-metadata-off.sh \
+	yaml-mmkubernetes-token-reload.sh
 
 TESTS_MMKUBERNETES_VALGRIND = \
 	mmkubernetes-basic-vg.sh \
@@ -2529,6 +2531,7 @@ EXTRA_DIST += $(TESTS_IMBATCHREPORT_VALGRIND)
 EXTRA_DIST += $(TESTS_OMTCL)
 EXTRA_DIST += $(TESTS_MMTAGHOSTNAME)
 EXTRA_DIST += $(TESTS_MMKUBERNETES)
+EXTRA_DIST += $(TESTS_MMKUBERNETES_LIBYAML)
 EXTRA_DIST += $(TESTS_MMKUBERNETES_VALGRIND)
 EXTRA_DIST += $(TESTS_IMKUBERNETES)
 EXTRA_DIST += $(TESTS_IMTUXEDOULOG)
@@ -3756,6 +3759,9 @@ if ENABLE_MMJSONPARSE
 if ENABLE_IMFILE
 if ENABLE_IMPSTATS
 TESTS += $(TESTS_MMKUBERNETES)
+if HAVE_LIBYAML
+TESTS += $(TESTS_MMKUBERNETES_LIBYAML)
+endif # HAVE_LIBYAML
 if HAVE_VALGRIND
 TESTS += $(TESTS_MMKUBERNETES_VALGRIND)
 endif

--- a/tests/yaml-mmkubernetes-token-reload.sh
+++ b/tests/yaml-mmkubernetes-token-reload.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Verify YAML delivers tokenreloadinterval=0 to mmkubernetes while exercising
+# the reactive ServiceAccount token reload. The first record starts the worker
+# with token v1; after the token file rotates, the second cache miss must reload
+# v2 on HTTP 401 and be enriched. The second record's API-derived pod ID is the
+# oracle: the server accepts it only after mmkubernetes re-reads token v2. The
+# two-minute server timeout is hang protection; PID/port files provide readiness
+# and cleanup without sleeps.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+check_command_available timeout
+require_yaml_support
+require_plugin mmkubernetes ../contrib/mmkubernetes
+
+pwd=$(pwd)
+k8s_srv_port_file="${RSYSLOG_DYNNAME}mmk8s-test-server.port"
+token_file=$RSYSLOG_DYNNAME.spool/sa-token
+testsrv=mmk8s-test-server
+
+generate_conf --yaml-only
+printf 'token-v1' > "$token_file"
+
+# The server compares each bearer token with token_file and returns 401 for the
+# stale v1 value, making the reload-and-retry path observable.
+MMK8S_EXPECTED_TOKEN_FILE=$pwd/$token_file \
+	timeout 2m "$PYTHON" -u "$srcdir/mmkubernetes_test_server.py" 0 \
+	"${RSYSLOG_DYNNAME}${testsrv}.pid" \
+	"${RSYSLOG_DYNNAME}${testsrv}.started" \
+	"${k8s_srv_port_file}" > "${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log" 2>&1 &
+BGPROCESS=$!
+wait_file_exists "$k8s_srv_port_file"
+k8s_srv_port="$(cat "$k8s_srv_port_file")"
+wait_process_startup "${RSYSLOG_DYNNAME}${testsrv}" "${RSYSLOG_DYNNAME}${testsrv}.started"
+
+add_yaml_conf 'modules:'
+add_yaml_conf '  - load: "../plugins/imfile/.libs/imfile"'
+add_yaml_conf '  - load: "../plugins/mmjsonparse/.libs/mmjsonparse"'
+add_yaml_conf '  - load: "../contrib/mmkubernetes/.libs/mmkubernetes"'
+add_yaml_conf 'inputs:'
+add_yaml_conf '  - type: imfile'
+add_yaml_conf '    file: "'$RSYSLOG_DYNNAME.spool'/pod-*.log"'
+add_yaml_conf '    tag: kubernetes'
+add_yaml_conf '    addmetadata: on'
+add_yaml_conf '    ruleset: main'
+add_yaml_conf 'templates:'
+add_yaml_conf '  - name: outfmt'
+add_yaml_conf '    type: string'
+add_yaml_conf '    string: "%$!all-json-plain%\\n"'
+add_yaml_conf 'rulesets:'
+add_yaml_conf '  - name: main'
+add_yaml_conf '    statements:'
+add_yaml_conf '      - type: mmjsonparse'
+add_yaml_conf '        cookie: ""'
+add_yaml_conf '      - type: mmkubernetes'
+add_yaml_conf '        busyretryinterval: 1'
+add_yaml_conf '        tokenfile: "'$pwd/$token_file'"'
+add_yaml_conf '        tokenreloadinterval: 0'
+add_yaml_conf '        kubernetesurl: "http://localhost:'$k8s_srv_port'"'
+add_yaml_conf '        filenamerules:'
+add_yaml_conf '          - "rule=:'$pwd/$RSYSLOG_DYNNAME.spool'/%pod_name:char-to:.%.%container_hash:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log"'
+add_yaml_conf '          - "rule=:'$pwd/$RSYSLOG_DYNNAME.spool'/%pod_name:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log"'
+add_yaml_conf '      - type: omfile'
+add_yaml_conf '        file: "'$RSYSLOG_OUT_LOG'"'
+add_yaml_conf '        template: outfmt'
+
+startup
+
+# Record 1 populates the worker's Authorization header with token v1.
+cat > "${RSYSLOG_DYNNAME}.spool/pod-name1_namespace-name1_container-name1-id1.log" <<EOF
+{"log":"{\"message\":\"HEAD1 / 200 1ms - 9.0B\"}\\n","stream":"stdout","time":"2018-04-06T17:26:34.492083106Z","testid":1}
+EOF
+wait_queueempty
+
+# Rotate the projected token. With tokenreloadinterval=0, the following cache
+# miss must use the reactive 401 path rather than a periodic reload.
+printf 'token-v2' > "$token_file"
+cat > "${RSYSLOG_DYNNAME}.spool/pod-name2_namespace-name2_container-name2-id2.log" <<EOF
+{"log":"{\"message\":\"HEAD2 / 200 1ms - 9.0B\"}\\n","stream":"stdout","time":"2018-04-06T17:26:34.492083106Z","testid":2}
+EOF
+wait_queueempty
+
+shutdown_when_empty
+wait_shutdown
+kill "$BGPROCESS"
+wait_pid_termination "${RSYSLOG_DYNNAME}${testsrv}.pid"
+
+# The second ID can only come from the API after it accepts reloaded token v2.
+content_check 'pod-name1-id'
+content_check 'pod-name2-id'
+
+exit_test

--- a/tests/yaml-mmkubernetes-token-reload.sh
+++ b/tests/yaml-mmkubernetes-token-reload.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
-# Verify YAML delivers tokenreloadinterval=0 to mmkubernetes while exercising
-# the reactive ServiceAccount token reload. The first record starts the worker
-# with token v1; after the token file rotates, the second cache miss must reload
-# v2 on HTTP 401 and be enriched. The second record's API-derived pod ID is the
-# oracle: the server accepts it only after mmkubernetes re-reads token v2. The
-# two-minute server timeout is hang protection; PID/port files provide readiness
-# and cleanup without sleeps.
-# This file is part of the rsyslog project, released under ASL 2.0.
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
+# Verify the YAML action's tokenreloadinterval=0 overrides the module's one
+# second interval while exercising reactive ServiceAccount token reload. The
+# first record starts the worker with token v1; after the token file rotates, a
+# 1.2-second wait makes a non-overridden proactive reload inevitable. The
+# second cache miss must instead receive 401, reload v2 reactively, and enrich
+# the record. The server's stale-token rejection and the API-derived second pod
+# ID are the oracle. The two-minute server timeout is hang protection; PID/port
+# files provide readiness and cleanup without sleeps.
 . ${srcdir:=.}/diag.sh init
 check_command_available timeout
 require_yaml_support
@@ -36,6 +39,7 @@ add_yaml_conf 'modules:'
 add_yaml_conf '  - load: "../plugins/imfile/.libs/imfile"'
 add_yaml_conf '  - load: "../plugins/mmjsonparse/.libs/mmjsonparse"'
 add_yaml_conf '  - load: "../contrib/mmkubernetes/.libs/mmkubernetes"'
+add_yaml_conf '    tokenreloadinterval: 1'
 add_yaml_conf 'inputs:'
 add_yaml_conf '  - type: imfile'
 add_yaml_conf '    file: "'$RSYSLOG_DYNNAME.spool'/pod-*.log"'
@@ -45,7 +49,7 @@ add_yaml_conf '    ruleset: main'
 add_yaml_conf 'templates:'
 add_yaml_conf '  - name: outfmt'
 add_yaml_conf '    type: string'
-add_yaml_conf '    string: "%$!all-json-plain%\\n"'
+add_yaml_conf '    string: "%$!all-json-plain%\n"'
 add_yaml_conf 'rulesets:'
 add_yaml_conf '  - name: main'
 add_yaml_conf '    statements:'
@@ -71,9 +75,11 @@ cat > "${RSYSLOG_DYNNAME}.spool/pod-name1_namespace-name1_container-name1-id1.lo
 EOF
 wait_queueempty
 
-# Rotate the projected token. With tokenreloadinterval=0, the following cache
-# miss must use the reactive 401 path rather than a periodic reload.
+# Rotate the projected token. Waiting 1.2 seconds exceeds the module-level
+# one-second interval: without the action-level zero override, mmkubernetes
+# would proactively load v2 and the mock server would not record a 401.
 printf 'token-v2' > "$token_file"
+./msleep 1200
 cat > "${RSYSLOG_DYNNAME}.spool/pod-name2_namespace-name2_container-name2-id2.log" <<EOF
 {"log":"{\"message\":\"HEAD2 / 200 1ms - 9.0B\"}\\n","stream":"stdout","time":"2018-04-06T17:26:34.492083106Z","testid":2}
 EOF
@@ -87,5 +93,8 @@ wait_pid_termination "${RSYSLOG_DYNNAME}${testsrv}.pid"
 # The second ID can only come from the API after it accepts reloaded token v2.
 content_check 'pod-name1-id'
 content_check 'pod-name2-id'
+# The server records the stale v1 rejection; the API-derived second ID above
+# then proves token v2 recovered the lookup.
+content_check 'invalid bearer token' "${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log"
 
 exit_test


### PR DESCRIPTION
## What

- add a YAML configuration regression test for `mmkubernetes` token rotation and `tokenreloadinterval`
- register the test with the existing mmkubernetes suite
- add required metadata to the new parameter reference page

## Why

PR #7403 added `tokenreloadinterval`, but its regression coverage only used RainerScript. This PR verifies that YAML reaches the same action configuration backend.

## Validation

- `bash -n tests/yaml-mmkubernetes-token-reload.sh`
- `shellcheck -S warning tests/yaml-mmkubernetes-token-reload.sh`
- `devtools/check-test-antipatterns.sh tests/yaml-mmkubernetes-token-reload.sh`
- focused Ubuntu 26.04 container run: `./tests/yaml-mmkubernetes-token-reload.sh` (pass)
- Ubuntu 26.04 static analyzer (0 reports)
- documentation HTML build (pass)
- mock `make distcheck TEST_RUN_TYPE=MOCK-OK -j10` (pass)

The change-gated Ubuntu 26.04 check executed the new YAML test successfully, but the broad suite ended with an unrelated intermittent failure in `segmented-da-idle-cleanup-failure.sh`; its isolated rerun passed. The PR remains draft pending hosted CI.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

