### PR TITLE
tests: cover strict dynafile YAML configuration

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -779,6 +779,7 @@ TESTS_LIBYAML = \
 	yaml-basic.sh \
 	yaml-basic-yamlonly.sh \
 	yaml-omfile-dynafilecachesize-invalid.sh \
+	yaml-omfile-dynafile-template-type-invalid.sh \
 	yaml-include.sh \
 	yaml-ruleset-script.sh \
 	yaml-error.sh \

--- a/tests/yaml-omfile-dynafile-template-type-invalid.sh
+++ b/tests/yaml-omfile-dynafile-template-type-invalid.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
+# Ensure a YAML omfile module default rejects an uninspectable dynafile
+# template on a modern YAML action. Configuration validation must fail with the
+# strict-template diagnostic, proving both YAML parameter delivery and action
+# propagation.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" << 'YAMLEOF'
+modules:
+  - load: "builtin:omfile"
+    dynafile.restrictTemplateType: "on"
+
+templates:
+  - name: dynfile
+    type: subtree
+    subtree: "$!dynfile"
+  - name: outfmt
+    type: string
+    string: "%msg:F,58:2%\\n"
+
+rulesets:
+  - name: main
+    actions:
+      - type: omfile
+        dynafile: dynfile
+        template: outfmt
+YAMLEOF
+
+if ../tools/rsyslogd -C -N1 -M"$RSYSLOG_MODDIR" -f"${TESTCONF_NM}.conf" \
+	>"${RSYSLOG_DYNNAME}.log" 2>&1; then
+	echo "FAIL: expected YAML config validation failure for subtree dynafile template"
+	cat "${RSYSLOG_DYNNAME}.log"
+	error_exit 1
+else
+	exit_code=$?
+	if [ "$exit_code" -ne 1 ]; then
+		echo "FAIL: expected exit code 1, got $exit_code"
+		cat "${RSYSLOG_DYNNAME}.log"
+		error_exit 1
+	fi
+fi
+
+grep -F "dynafile template 'dynfile' uses a template type that cannot be safely inspected" \
+	"${RSYSLOG_DYNNAME}.log" >/dev/null || {
+	echo "FAIL: expected dynafile template type validation error"
+	cat "${RSYSLOG_DYNNAME}.log"
+	error_exit 1
+}
+
+exit_test


### PR DESCRIPTION
## What

Add YAML coverage for strict dynafile template validation.

## Why

The hardening added in #7506 needs a regression test that proves a YAML module default reaches a modern YAML `omfile` action.

## Validation

- Ubuntu 26.04 change-gated CI-equivalent test run: new test passed; four unrelated flakes passed on a single rerun.
- Ubuntu 26.04 static analyzer: no findings.
- Ubuntu 26.04 `make distcheck TEST_RUN_TYPE=MOCK-OK -j10`: passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

