### PR TITLE
packaging: repair daily distribution archive builds

### DIFF
--- a/.github/amazonlinux2023-daily-stable-policy.yml
+++ b/.github/amazonlinux2023-daily-stable-policy.yml
@@ -43,5 +43,17 @@
   ],
   "supplemental_core_files": [
     "%{_libdir}/rsyslog/mmleefparse.so"
+  ],
+  "supplemental_main_files": [
+    {
+      "path": "%{_bindir}/rsyslog-segqueue",
+      "anchor": "%{_sbindir}/rsyslogd",
+      "reason": "Current upstream installs the segmented queue maintenance utility in the base package."
+    },
+    {
+      "path": "%{_mandir}/man1/rsyslog-segqueue.1.gz",
+      "anchor": "%{_mandir}/man5/rsyslog.conf.5.gz",
+      "reason": "Current upstream installs the segmented queue maintenance utility manual page in the base package."
+    }
   ]
 }

--- a/.github/el10-daily-stable-policy.yml
+++ b/.github/el10-daily-stable-policy.yml
@@ -44,5 +44,18 @@
       "package": "protobuf-c-compiler",
       "reason": "The daily-stable omotel package regenerates its protobuf-c message bindings."
     }
+  ],
+  "supplemental_main_files": [
+    {
+      "path": "%{_bindir}/rsyslog-segqueue",
+      "entry": "%attr(755,root,root) %{_bindir}/rsyslog-segqueue",
+      "anchor": "%{_sbindir}/rsyslogd",
+      "reason": "Current upstream installs the segmented queue maintenance utility in the base package."
+    },
+    {
+      "path": "%{_mandir}/man1/rsyslog-segqueue.1.gz",
+      "anchor": "%{_mandir}/man5/rsyslog.conf.5.gz",
+      "reason": "Current upstream installs the segmented queue maintenance utility manual page in the base package."
+    }
   ]
 }

--- a/.github/fedora44-daily-stable-policy.yml
+++ b/.github/fedora44-daily-stable-policy.yml
@@ -1,5 +1,17 @@
 {
   "integrated_baseline_patches": [],
+  "supplemental_main_files": [
+    {
+      "path": "%{_bindir}/rsyslog-segqueue",
+      "anchor": "%{_sbindir}/rsyslogd",
+      "reason": "Current upstream installs the segmented queue maintenance utility in the base package."
+    },
+    {
+      "path": "%{_mandir}/man1/rsyslog-segqueue.1.gz",
+      "anchor": "%{_mandir}/man5/rsyslog.conf.5.gz",
+      "reason": "Current upstream installs the segmented queue maintenance utility manual page in the base package."
+    }
+  ],
   "supplemental_build_requires": [
     {
       "package": "autoconf-archive",

--- a/.github/opensuse-leap160-daily-stable-policy.yml
+++ b/.github/opensuse-leap160-daily-stable-policy.yml
@@ -21,11 +21,6 @@
       "path": "%{_bindir}/rsyslog-segqueue",
       "anchor": "%{_sbindir}/rsyslogd",
       "reason": "Current upstream installs the segmented queue maintenance utility in the base package."
-    },
-    {
-      "path": "%{_mandir}/man1/rsyslog-segqueue.1.gz",
-      "anchor": "%{_mandir}/man5/rsyslog.conf.5*",
-      "reason": "Current upstream installs the segmented queue maintenance utility manual page in the base package."
     }
   ],
   "integrated_baseline_patches": [

--- a/.github/opensuse-leap160-daily-stable-policy.yml
+++ b/.github/opensuse-leap160-daily-stable-policy.yml
@@ -16,6 +16,18 @@
   "supplemental_core_files": [
     "%{rsyslog_module_dir_nodeps}/mmleefparse.so"
   ],
+  "supplemental_main_files": [
+    {
+      "path": "%{_bindir}/rsyslog-segqueue",
+      "anchor": "%{_sbindir}/rsyslogd",
+      "reason": "Current upstream installs the segmented queue maintenance utility in the base package."
+    },
+    {
+      "path": "%{_mandir}/man1/rsyslog-segqueue.1.gz",
+      "anchor": "%{_mandir}/man5/rsyslog.conf.5*",
+      "reason": "Current upstream installs the segmented queue maintenance utility manual page in the base package."
+    }
+  ],
   "integrated_baseline_patches": [
     {
       "name": "0001-imptcp-guard-regex-framing-match-at-line-start.patch",

--- a/.github/workflows/ubuntu_daily_stable.yml
+++ b/.github/workflows/ubuntu_daily_stable.yml
@@ -361,13 +361,24 @@ jobs:
 
       - name: Prepare repository and Spaces tools
         run: |
+          set -euo pipefail
           command -v aws
           aws --version
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            apt-utils \
-            gnupg \
-            xz-utils
+
+          packages=()
+          command -v apt-ftparchive >/dev/null 2>&1 || packages+=(apt-utils)
+          command -v gpg >/dev/null 2>&1 || packages+=(gnupg)
+          command -v gpgv >/dev/null 2>&1 || packages+=(gnupg)
+          command -v xz >/dev/null 2>&1 || packages+=(xz-utils)
+          if [ "${#packages[@]}" -gt 0 ]; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends "${packages[@]}"
+          fi
+
+          command -v apt-ftparchive
+          command -v gpg
+          command -v gpgv
+          command -v xz
 
       - name: Validate archive configuration
         run: |

--- a/devtools/release/amazonlinux-daily-stable.sh
+++ b/devtools/release/amazonlinux-daily-stable.sh
@@ -109,6 +109,7 @@ cmd_prepare_sources() {
 		"$spec_file" "$policy_file" "Amazon Linux 2023"
 
 	python3 - "$spec_file" "$policy_file" "$version" "$release" <<'PY'
+import fnmatch
 import json
 import pathlib
 import re
@@ -121,6 +122,15 @@ version = sys.argv[3]
 release = sys.argv[4]
 spec = spec_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
+
+manifest_prefix = re.compile(r"^(?:(?:%(?!\{)[A-Za-z][^\s]*)\s+)*")
+
+def has_manifest_path(path):
+    for line in spec.splitlines():
+        manifest_path = manifest_prefix.sub("", line).strip()
+        if manifest_path == path or fnmatch.fnmatchcase(path, manifest_path):
+            return True
+    return False
 
 if not policy.get("drop_stale_html_docs", False):
     raise SystemExit("Amazon Linux policy must explicitly decide about stale HTML docs")
@@ -217,7 +227,7 @@ core_files = policy.get("supplemental_core_files", [])
 if any(not path.strip() for path in core_files):
     raise SystemExit("policy contains an empty supplemental core file")
 for path in core_files:
-    if re.search(rf"(?m)^{re.escape(path)}\s*$", spec):
+    if has_manifest_path(path):
         continue
     spec, count = re.subn(
         r"(?m)^(%\{_libdir\}/rsyslog/lmzlibw\.so\s*)$",

--- a/devtools/release/amazonlinux-daily-stable.sh
+++ b/devtools/release/amazonlinux-daily-stable.sh
@@ -228,6 +228,28 @@ for path in core_files:
     if count != 1:
         raise SystemExit(f"could not add supplemental core file: {path}")
 
+main_files = policy.get("supplemental_main_files", [])
+if not isinstance(main_files, list):
+    raise SystemExit("supplemental_main_files must be a list")
+for entry in main_files:
+    if not isinstance(entry, dict):
+        raise SystemExit("supplemental main file entry must be an object")
+    path = entry.get("path", "").strip()
+    anchor = entry.get("anchor", "").strip()
+    reason = entry.get("reason", "").strip()
+    if not path or not anchor or not reason:
+        raise SystemExit("supplemental main file requires path, anchor, and reason")
+    if re.search(rf"(?m)^{re.escape(path)}\s*$", spec):
+        continue
+    spec, count = re.subn(
+        rf"(?m)^({re.escape(anchor)}\s*)$",
+        rf"\1\n{path}",
+        spec,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit(f"could not add supplemental main file: {path}")
+
 spec, version_count = re.subn(r"(?m)^Version:\s*.*$", f"Version: {version}", spec)
 spec, release_count = re.subn(
     r"(?m)^Release:\s*.*$", f"Release: {release}%{{?dist}}", spec

--- a/devtools/release/amazonlinux-daily-stable.sh
+++ b/devtools/release/amazonlinux-daily-stable.sh
@@ -123,12 +123,30 @@ release = sys.argv[4]
 spec = spec_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
 
-manifest_prefix = re.compile(r"^(?:(?:%(?!\{)[A-Za-z][^\s]*)\s+)*")
+manifest_directive = re.compile(r"^%(?!\{)([A-Za-z]+)(?:\([^)]*\))?(?:\s+|$)")
+main_files_header = re.compile(r"^%files(?:\s+-f\s+\S+)*\s*$")
 
 def has_manifest_path(path):
+    in_main_package = False
     for line in spec.splitlines():
-        manifest_path = manifest_prefix.sub("", line).strip()
-        if manifest_path == path or fnmatch.fnmatchcase(path, manifest_path):
+        if main_files_header.match(line):
+            in_main_package = True
+            continue
+        if re.match(r"^%files(?:\s|$)", line):
+            in_main_package = False
+            continue
+        if not in_main_package:
+            continue
+        manifest_path = line.strip()
+        while (match := manifest_directive.match(manifest_path)):
+            if match.group(1) == "exclude":
+                manifest_path = ""
+                break
+            manifest_path = manifest_path[match.end():].lstrip()
+        if manifest_path == path:
+            return True
+        if any(character in manifest_path for character in "*?[") and \
+                fnmatch.fnmatchcase(path, manifest_path):
             return True
     return False
 
@@ -249,7 +267,7 @@ for entry in main_files:
     reason = entry.get("reason", "").strip()
     if not path or not anchor or not reason:
         raise SystemExit("supplemental main file requires path, anchor, and reason")
-    if re.search(rf"(?m)^{re.escape(path)}\s*$", spec):
+    if has_manifest_path(path):
         continue
     spec, count = re.subn(
         rf"(?m)^({re.escape(anchor)}\s*)$",

--- a/devtools/release/fedora-daily-stable.sh
+++ b/devtools/release/fedora-daily-stable.sh
@@ -123,12 +123,30 @@ release = sys.argv[4]
 spec = spec_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
 
-manifest_prefix = re.compile(r"^(?:(?:%(?!\{)[A-Za-z][^\s]*)\s+)*")
+manifest_directive = re.compile(r"^%(?!\{)([A-Za-z]+)(?:\([^)]*\))?(?:\s+|$)")
+main_files_header = re.compile(r"^%files(?:\s+-f\s+\S+)*\s*$")
 
 def has_manifest_path(path):
+    in_main_package = False
     for line in spec.splitlines():
-        manifest_path = manifest_prefix.sub("", line).strip()
-        if manifest_path == path or fnmatch.fnmatchcase(path, manifest_path):
+        if main_files_header.match(line):
+            in_main_package = True
+            continue
+        if re.match(r"^%files(?:\s|$)", line):
+            in_main_package = False
+            continue
+        if not in_main_package:
+            continue
+        manifest_path = line.strip()
+        while (match := manifest_directive.match(manifest_path)):
+            if match.group(1) == "exclude":
+                manifest_path = ""
+                break
+            manifest_path = manifest_path[match.end():].lstrip()
+        if manifest_path == path:
+            return True
+        if any(character in manifest_path for character in "*?[") and \
+                fnmatch.fnmatchcase(path, manifest_path):
             return True
     return False
 

--- a/devtools/release/fedora-daily-stable.sh
+++ b/devtools/release/fedora-daily-stable.sh
@@ -105,6 +105,9 @@ cmd_prepare_sources() {
 	tar -C "$tmp_dir" -czf "$output_dir/SOURCES/rsyslog-$version.tar.gz" \
 		"rsyslog-$version"
 
+	python3 "$(dirname "$0")/validate-rpm-baseline-patches.py" \
+		"$spec_file" "$policy_file" "Fedora 44"
+
 	python3 - "$spec_file" "$policy_file" "$version" "$release" <<'PY'
 import json
 import pathlib
@@ -118,9 +121,6 @@ version = sys.argv[3]
 release = sys.argv[4]
 spec = spec_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
-
-if re.search(r"(?m)^Patch\d*:\s*", spec):
-    raise SystemExit("Fedora baseline gained patches; review them before packaging main")
 
 build_requires = policy.get("supplemental_build_requires", [])
 packages = [entry.get("package", "").strip() for entry in build_requires]
@@ -137,6 +137,28 @@ for package in packages:
     )
     if count != 1:
         raise SystemExit(f"could not insert supplemental BuildRequires: {package}")
+
+main_files = policy.get("supplemental_main_files", [])
+if not isinstance(main_files, list):
+    raise SystemExit("supplemental_main_files must be a list")
+for entry in main_files:
+    if not isinstance(entry, dict):
+        raise SystemExit("supplemental main file entry must be an object")
+    path = entry.get("path", "").strip()
+    anchor = entry.get("anchor", "").strip()
+    reason = entry.get("reason", "").strip()
+    if not path or not anchor or not reason:
+        raise SystemExit("supplemental main file requires path, anchor, and reason")
+    if re.search(rf"(?m)^{re.escape(path)}\s*$", spec):
+        continue
+    spec, count = re.subn(
+        rf"(?m)^({re.escape(anchor)}\s*)$",
+        rf"\1\n{path}",
+        spec,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit(f"could not add supplemental main file: {path}")
 
 spec, version_count = re.subn(r"(?m)^Version:\s*.*$", f"Version: {version}", spec)
 spec, release_count = re.subn(

--- a/devtools/release/fedora-daily-stable.sh
+++ b/devtools/release/fedora-daily-stable.sh
@@ -109,6 +109,7 @@ cmd_prepare_sources() {
 		"$spec_file" "$policy_file" "Fedora 44"
 
 	python3 - "$spec_file" "$policy_file" "$version" "$release" <<'PY'
+import fnmatch
 import json
 import pathlib
 import re
@@ -121,6 +122,15 @@ version = sys.argv[3]
 release = sys.argv[4]
 spec = spec_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
+
+manifest_prefix = re.compile(r"^(?:(?:%(?!\{)[A-Za-z][^\s]*)\s+)*")
+
+def has_manifest_path(path):
+    for line in spec.splitlines():
+        manifest_path = manifest_prefix.sub("", line).strip()
+        if manifest_path == path or fnmatch.fnmatchcase(path, manifest_path):
+            return True
+    return False
 
 build_requires = policy.get("supplemental_build_requires", [])
 packages = [entry.get("package", "").strip() for entry in build_requires]
@@ -149,7 +159,7 @@ for entry in main_files:
     reason = entry.get("reason", "").strip()
     if not path or not anchor or not reason:
         raise SystemExit("supplemental main file requires path, anchor, and reason")
-    if re.search(rf"(?m)^{re.escape(path)}\s*$", spec):
+    if has_manifest_path(path):
         continue
     spec, count = re.subn(
         rf"(?m)^({re.escape(anchor)}\s*)$",

--- a/devtools/release/opensuse-daily-stable.sh
+++ b/devtools/release/opensuse-daily-stable.sh
@@ -126,12 +126,30 @@ release = sys.argv[4]
 spec = spec_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
 
-manifest_prefix = re.compile(r"^(?:(?:%(?!\{)[A-Za-z][^\s]*)\s+)*")
+manifest_directive = re.compile(r"^%(?!\{)([A-Za-z]+)(?:\([^)]*\))?(?:\s+|$)")
+main_files_header = re.compile(r"^%files(?:\s+-f\s+\S+)*\s*$")
 
 def has_manifest_path(path):
+    in_main_package = False
     for line in spec.splitlines():
-        manifest_path = manifest_prefix.sub("", line).strip()
-        if manifest_path == path or fnmatch.fnmatchcase(path, manifest_path):
+        if main_files_header.match(line):
+            in_main_package = True
+            continue
+        if re.match(r"^%files(?:\s|$)", line):
+            in_main_package = False
+            continue
+        if not in_main_package:
+            continue
+        manifest_path = line.strip()
+        while (match := manifest_directive.match(manifest_path)):
+            if match.group(1) == "exclude":
+                manifest_path = ""
+                break
+            manifest_path = manifest_path[match.end():].lstrip()
+        if manifest_path == path:
+            return True
+        if any(character in manifest_path for character in "*?[") and \
+                fnmatch.fnmatchcase(path, manifest_path):
             return True
     return False
 

--- a/devtools/release/opensuse-daily-stable.sh
+++ b/devtools/release/opensuse-daily-stable.sh
@@ -156,6 +156,28 @@ for path in core_files:
     if count != 1:
         raise SystemExit(f"could not add supplemental core file: {path}")
 
+main_files = policy.get("supplemental_main_files", [])
+if not isinstance(main_files, list):
+    raise SystemExit("supplemental_main_files must be a list")
+for entry in main_files:
+    if not isinstance(entry, dict):
+        raise SystemExit("supplemental main file entry must be an object")
+    path = entry.get("path", "").strip()
+    anchor = entry.get("anchor", "").strip()
+    reason = entry.get("reason", "").strip()
+    if not path or not anchor or not reason:
+        raise SystemExit("supplemental main file requires path, anchor, and reason")
+    if re.search(rf"(?m)^{re.escape(path)}\s*$", spec):
+        continue
+    spec, count = re.subn(
+        rf"(?m)^({re.escape(anchor)}\s*)$",
+        rf"\1\n{path}",
+        spec,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit(f"could not add supplemental main file: {path}")
+
 spec, macro_count = re.subn(
     r"(?m)^# drop this with next release when doc tarball version lines up\n"
     r"%define rsyslog_major .*\n%define rsyslog_patch .*\n",

--- a/devtools/release/opensuse-daily-stable.sh
+++ b/devtools/release/opensuse-daily-stable.sh
@@ -112,6 +112,7 @@ cmd_prepare_sources() {
 		"$spec_file" "$policy_file" "openSUSE"
 
 	python3 - "$spec_file" "$policy_file" "$version" "$release" <<'PY'
+import fnmatch
 import json
 import pathlib
 import re
@@ -124,6 +125,15 @@ version = sys.argv[3]
 release = sys.argv[4]
 spec = spec_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
+
+manifest_prefix = re.compile(r"^(?:(?:%(?!\{)[A-Za-z][^\s]*)\s+)*")
+
+def has_manifest_path(path):
+    for line in spec.splitlines():
+        manifest_path = manifest_prefix.sub("", line).strip()
+        if manifest_path == path or fnmatch.fnmatchcase(path, manifest_path):
+            return True
+    return False
 
 build_requires = policy.get("supplemental_build_requires", [])
 packages = [entry.get("package", "").strip() for entry in build_requires]
@@ -145,7 +155,7 @@ core_files = policy.get("supplemental_core_files", [])
 if any(not path.strip() for path in core_files):
     raise SystemExit("policy contains an empty supplemental core file")
 for path in core_files:
-    if re.search(rf"(?m)^{re.escape(path)}\s*$", spec):
+    if has_manifest_path(path):
         continue
     spec, count = re.subn(
         r"(?m)^(%\{rsyslog_module_dir_nodeps\}/lmzlibw\.so\s*)$",
@@ -167,7 +177,7 @@ for entry in main_files:
     reason = entry.get("reason", "").strip()
     if not path or not anchor or not reason:
         raise SystemExit("supplemental main file requires path, anchor, and reason")
-    if re.search(rf"(?m)^{re.escape(path)}\s*$", spec):
+    if has_manifest_path(path):
         continue
     spec, count = re.subn(
         rf"(?m)^({re.escape(anchor)}\s*)$",

--- a/devtools/release/rpm-daily-stable.sh
+++ b/devtools/release/rpm-daily-stable.sh
@@ -126,12 +126,30 @@ release = sys.argv[4]
 spec = spec_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
 
-manifest_prefix = re.compile(r"^(?:(?:%(?!\{)[A-Za-z][^\s]*)\s+)*")
+manifest_directive = re.compile(r"^%(?!\{)([A-Za-z]+)(?:\([^)]*\))?(?:\s+|$)")
+main_files_header = re.compile(r"^%files(?:\s+-f\s+\S+)*\s*$")
 
 def has_manifest_path(path):
+    in_main_package = False
     for line in spec.splitlines():
-        manifest_path = manifest_prefix.sub("", line).strip()
-        if manifest_path == path or fnmatch.fnmatchcase(path, manifest_path):
+        if main_files_header.match(line):
+            in_main_package = True
+            continue
+        if re.match(r"^%files(?:\s|$)", line):
+            in_main_package = False
+            continue
+        if not in_main_package:
+            continue
+        manifest_path = line.strip()
+        while (match := manifest_directive.match(manifest_path)):
+            if match.group(1) == "exclude":
+                manifest_path = ""
+                break
+            manifest_path = manifest_path[match.end():].lstrip()
+        if manifest_path == path:
+            return True
+        if any(character in manifest_path for character in "*?[") and \
+                fnmatch.fnmatchcase(path, manifest_path):
             return True
     return False
 

--- a/devtools/release/rpm-daily-stable.sh
+++ b/devtools/release/rpm-daily-stable.sh
@@ -112,6 +112,7 @@ cmd_prepare_sources() {
     "$spec_file" "$policy_file" "EL10/Fedora"
 
   python3 - "$spec_file" "$policy_file" "$version" "$release" <<'PY'
+import fnmatch
 import json
 import pathlib
 import re
@@ -124,6 +125,15 @@ version = sys.argv[3]
 release = sys.argv[4]
 spec = spec_path.read_text(encoding="utf-8")
 policy = json.loads(policy_path.read_text(encoding="utf-8"))
+
+manifest_prefix = re.compile(r"^(?:(?:%(?!\{)[A-Za-z][^\s]*)\s+)*")
+
+def has_manifest_path(path):
+    for line in spec.splitlines():
+        manifest_path = manifest_prefix.sub("", line).strip()
+        if manifest_path == path or fnmatch.fnmatchcase(path, manifest_path):
+            return True
+    return False
 
 build_requires = policy.get("supplemental_build_requires", [])
 packages = [entry.get("package", "").strip() for entry in build_requires]
@@ -158,6 +168,29 @@ for package in packages:
     if count != 1:
         raise SystemExit(f"could not insert supplemental BuildRequires: {package}")
 
+main_files = policy.get("supplemental_main_files", [])
+if not isinstance(main_files, list):
+    raise SystemExit("supplemental_main_files must be a list")
+for entry in main_files:
+    if not isinstance(entry, dict):
+        raise SystemExit("supplemental main file entry must be an object")
+    path = entry.get("path", "").strip()
+    manifest_entry = entry.get("entry", path).strip()
+    anchor = entry.get("anchor", "").strip()
+    reason = entry.get("reason", "").strip()
+    if not path or not manifest_entry or not anchor or not reason:
+        raise SystemExit("supplemental main file requires path, anchor, and reason")
+    if has_manifest_path(path):
+        continue
+    spec, count = re.subn(
+        rf"(?m)^({re.escape(anchor)}\s*)$",
+        rf"\1\n{manifest_entry}",
+        spec,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit(f"could not add supplemental main file: {path}")
+
 spec, version_count = re.subn(r"(?m)^Version:\s*.*$", f"Version: {version}", spec)
 spec, release_count = re.subn(
     r"(?m)^Release:\s*.*$", f"Release: {release}%{{?dist}}", spec
@@ -183,27 +216,6 @@ PY
 
   python3 "$(dirname "$0")/package-feature-overlay.py" rpm \
     "$spec_file" "$feature_contract" rpm
-
-  python3 - "$spec_file" <<'PY'
-import pathlib
-import re
-import sys
-
-spec_path = pathlib.Path(sys.argv[1])
-spec = spec_path.read_text(encoding="utf-8")
-segqueue_files = (
-    "%attr(755,root,root) %{_bindir}/rsyslog-segqueue\n"
-    "%{_mandir}/man1/rsyslog-segqueue.1.gz"
-)
-
-if segqueue_files not in spec:
-    anchor = r"(?m)^(%\{_sbindir\}/rsyslogd)$"
-    spec, count = re.subn(anchor, rf"\1\n{segqueue_files}", spec, count=1)
-    if count != 1:
-        raise SystemExit("could not add rsyslog-segqueue files to the RPM spec")
-
-spec_path.write_text(spec, encoding="utf-8")
-PY
 
   while IFS= read -r source_url; do
     case "$source_url" in

--- a/devtools/release/rpm-daily-stable.sh
+++ b/devtools/release/rpm-daily-stable.sh
@@ -184,6 +184,27 @@ PY
   python3 "$(dirname "$0")/package-feature-overlay.py" rpm \
     "$spec_file" "$feature_contract" rpm
 
+  python3 - "$spec_file" <<'PY'
+import pathlib
+import re
+import sys
+
+spec_path = pathlib.Path(sys.argv[1])
+spec = spec_path.read_text(encoding="utf-8")
+segqueue_files = (
+    "%attr(755,root,root) %{_bindir}/rsyslog-segqueue\n"
+    "%{_mandir}/man1/rsyslog-segqueue.1.gz"
+)
+
+if segqueue_files not in spec:
+    anchor = r"(?m)^(%\{_sbindir\}/rsyslogd)$"
+    spec, count = re.subn(anchor, rf"\1\n{segqueue_files}", spec, count=1)
+    if count != 1:
+        raise SystemExit("could not add rsyslog-segqueue files to the RPM spec")
+
+spec_path.write_text(spec, encoding="utf-8")
+PY
+
   while IFS= read -r source_url; do
     case "$source_url" in
       http://*|https://*)


### PR DESCRIPTION
## Summary

Repairs the current daily distribution-package archive path for the failing RPM-family lanes and the canceled Ubuntu publication preparation.

- Includes the missing main-package manifest support and Fedora/EL policy fixes for `rsyslog-segqueue`.
- Adds policy-controlled `rsyslog-segqueue` binary and manpage entries to the Amazon Linux 2023 and openSUSE Leap 16 baseline adapters.
- Makes the Ubuntu publication job use preinstalled runner tools, installing only missing archive/signing dependencies. This avoids the canceled unconditional `apt-get update` before publication.

## Root cause

Vendor baseline RPM specs do not list all files installed by current upstream, so their builds reject `rsyslog-segqueue` (and, where required, its manpage). Ubuntu was canceled while refreshing package metadata before it reached artifact download or Spaces publication.

## Validation

- Prepared current vendor Amazon Linux 2023 and openSUSE Leap 16 source RPM baselines in their matching containers; each generated spec contains the expected manifest entries.
- `shellcheck`, `bash -n`, JSON parsing, `actionlint`, and pinned `zizmor` all pass.
- Ubuntu 26.04 `run-ci.sh` final run: 1,542 passed, 69 skipped, 0 failed (10 build jobs, 10 test jobs; image `rsyslog/rsyslog_dev_base_ubuntu:26.04@sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`).
- The static analyzer reproduces one existing report in untouched `runtime/modules.c:412`; it is not introduced by this branch. Therefore this is targeted/container-tested evidence, not a clean full static-analysis result.

## Follow-up

After merge, dispatch the daily workflows from upstream `main` and verify both architectures, Spaces publication, public repository indexes, package installation, and retention/lifecycle behavior.

Closes https://github.com/rsyslog/rsyslog/issues/7493
Closes https://github.com/rsyslog/rsyslog/issues/7495
Closes https://github.com/rsyslog/rsyslog/issues/7512
Relates to https://github.com/rsyslog/rsyslog/issues/7494
Relates to https://github.com/rsyslog/rsyslog/issues/7498

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

