### PR TITLE
packaging: codify daily archive program

### DIFF
--- a/.github/ALPINE_DAILY_STABLE.md
+++ b/.github/ALPINE_DAILY_STABLE.md
@@ -8,9 +8,9 @@ subpackage split, OpenRC integration, and default configuration.
 The only current policy addition is `autoconf-archive`, required by AX macros
 used by current upstream but not by Alpine's released 8.2604 source package.
 
-Package construction does not run for pull requests. Manual dispatch remains
-available for bootstrap and recovery. The schedule is inactive until a manual
-publication and clean Alpine installation test pass.
+Package construction does not run for pull requests. Scheduled publishing is
+enabled; manual dispatch remains available for recovery and controlled
+end-to-end verification.
 
 ## Archive layout and retention
 
@@ -80,7 +80,7 @@ Add these variables to the `debian-daily-stable` environment:
 The existing shared Space bucket, endpoint, region, access key, and secret key
 remain unchanged. A DigitalOcean account API token is not required.
 
-## End-to-end activation
+## Provisioning and recovery
 
 1. Generate and store the Alpine RSA key and its public-key SHA-256.
 2. Run the workflow manually with publication disabled and inspect the APK

--- a/.github/AMAZONLINUX_DAILY_STABLE.md
+++ b/.github/AMAZONLINUX_DAILY_STABLE.md
@@ -16,9 +16,9 @@ omitted instead of being relabeled as current documentation; current source
 licenses, README, ChangeLog, and recovery-tool documentation remain in the
 core package.
 
-Package construction does not run for pull requests. Manual dispatch remains
-available for bootstrap and recovery. The schedule is inactive until a manual
-publication and clean Amazon Linux installation test pass.
+Package construction does not run for pull requests. Scheduled publishing is
+enabled; manual dispatch remains available for recovery and controlled
+end-to-end verification.
 
 ## Archive layout and retention
 
@@ -87,7 +87,7 @@ Add these variables to the `debian-daily-stable` environment:
 No new private key, DigitalOcean account API token, or bucket permission is
 required.
 
-## End-to-end activation
+## Provisioning and recovery
 
 1. Set the CDN and public-origin repository variables while leaving the
    schedule flag unset or false.

--- a/.github/DAILY_STABLE_PACKAGE_ARCHIVE.md
+++ b/.github/DAILY_STABLE_PACKAGE_ARCHIVE.md
@@ -1,0 +1,117 @@
+# Daily stable package archive program
+
+## Purpose
+
+The daily stable package archive delivers current rsyslog `main` through each
+target distribution's native packaging system.  It is the integration testbed
+for the package-release process: release packaging must reuse these policies,
+package contracts, publication safeguards, and repository layouts rather than
+creating a parallel packaging path.
+
+Daily stable does **not** rebuild a distribution's historical rsyslog source.
+It starts from the target distribution's current packaging baseline and
+replaces its upstream source with current rsyslog `main`.  Native package
+names, dependencies, service integration, configuration, file ownership, and
+subpackage layout remain authoritative unless a narrowly reviewed policy
+requires a current-upstream delta.
+
+## Current targets
+
+| Distribution | Version | Architectures | Archive prefix | Workflow |
+| --- | --- | --- | --- | --- |
+| Debian | 13 (trixie) | amd64, arm64 | `apt/daily-stable/debian/13` | `debian_daily_stable.yml` |
+| Ubuntu | 26.04 (resolute) | amd64, arm64 | `apt/daily-stable/ubuntu/26.04` | `ubuntu_daily_stable.yml` |
+| Enterprise Linux | 10 | x86_64, aarch64 | `rpm/daily-stable/el/10` | `el10_daily_stable.yml` |
+| Fedora | 44 | x86_64, aarch64 | `rpm/daily-stable/fedora/44` | `fedora44_daily_stable.yml` |
+| Amazon Linux | 2023 | x86_64, aarch64 | `rpm/daily-stable/amazonlinux/2023` | `amazonlinux2023_daily_stable.yml` |
+| openSUSE Leap | 16.0 | x86_64, aarch64 | `rpm/daily-stable/opensuse/leap/16.0` | `opensuse_leap160_daily_stable.yml` |
+| Alpine | 3.24 | x86_64, aarch64 | `apk/daily-stable/alpine/3.24` | `alpine324_daily_stable.yml` |
+
+Extend support to further non-EOL versions and distributions by adding a
+target-specific policy and a conservative workflow overlay.  Do not replace
+the target's packaging layout with a one-size-fits-all package definition.
+
+## Archive architecture
+
+GitHub Actions builds, signs, publishes, and verifies packages.  DigitalOcean
+Spaces is passive S3-compatible storage behind its CDN; it does not build
+packages.  Workflows use the AWS CLI against the configured Spaces endpoint.
+The shared `debian-daily-stable` GitHub Environment holds the archive signing
+material and bucket-scoped Spaces credentials.
+
+The archive uses the `rsyslog-packages` Spaces bucket in the `fra1` region.
+Repository URL and endpoint values are GitHub repository variables so a target
+workflow never hard-codes credentials or an account API token.  A bucket-scoped
+read/write Spaces key is sufficient; do not require a DigitalOcean account API
+token for regular publication.
+
+## Publication invariants
+
+- Build artifacts, package-pool objects, and dated snapshots are immutable.
+  A collision with different content is a publication failure.
+- Repository indexes and signed metadata are the only mutable objects.
+  Upload immutable objects first and `InRelease` or signed RPM/APK metadata
+  last.
+- Metadata receives a short cache lifetime; immutable packages and snapshots
+  receive a long lifetime.  CDN metadata refresh is expected and must not be
+  blocked by an object policy that prevents required updates or deletes.
+- Keep all published package versions and snapshots for at least five years
+  from the first successful publication.  GitHub Actions artifacts are only a
+  short-lived transport between jobs, not the archive of record.
+- A package build alone is not success.  Every published target must verify
+  public signed metadata from a clean matching environment, install the exact
+  published package, and run the target's rsyslog smoke test.
+- Scheduled failures create or update a distribution-specific GitHub issue.
+  Manual recovery runs report through their Actions run and should be reviewed
+  before enabling or changing a schedule.
+
+## Package policy and feature contract
+
+Target-specific policy files live in `.github/*daily-stable-policy.yml`.
+They document every deviation from the native baseline, including additional
+build dependencies, newly produced core files, and baseline-patch decisions.
+
+RPM downstream patches require particular care.  A patch may only be removed
+when it is explicitly reviewed as integrated or superseded in current `main`,
+with its SHA-256 and rationale recorded in policy.  The generic validator is
+`devtools/release/validate-rpm-baseline-patches.py`; do not restore broad patch
+skip lists.
+
+The cross-distribution feature contract is
+`.github/daily-stable-package-features.yml`; its human-facing explanation is
+[DAILY_STABLE_PACKAGE_FEATURES.md](DAILY_STABLE_PACKAGE_FEATURES.md).  Current
+requirements include YAML support in the base package and separately
+installable OpenSSL, GnuTLS, `omotel`, and `omazuredce` packages.  The
+`rsyslog-standard` and `rsyslog-full` profiles express the common rsyslog
+product offering while retaining native package names and layouts.
+
+## CI and release rules
+
+Ordinary pull requests do not run expensive daily package builds.  They retain
+workflow linting and security checks; daily and release workflows are the
+package-build lanes.  Daily stable is the testbed for future scheduled release
+automation: release additions must consume this common policy and verification
+framework.
+
+When modifying a target, validate end to end where publication credentials and
+the target environment are available:
+
+```text
+build -> artifact checksum verification -> signed archive publication
+      -> public metadata verification -> exact-version installation -> smoke test
+```
+
+Do not claim a target is operational from a local or build-only result.  Check
+both configured architectures, investigate current workflow failures from their
+logs, and treat a changed native package baseline as a review event.
+
+## Detailed operational references
+
+- [Debian 13](DEBIAN_DAILY_STABLE.md)
+- [Fedora 44](FEDORA_DAILY_STABLE.md)
+- [Amazon Linux 2023](AMAZONLINUX_DAILY_STABLE.md)
+- [openSUSE Leap 16.0](OPENSUSE_DAILY_STABLE.md)
+- [Alpine 3.24](ALPINE_DAILY_STABLE.md)
+- Ubuntu and Enterprise Linux follow their named workflow and policy files;
+  add comparable operational documents when introducing material new setup or
+  recovery requirements.

--- a/.github/DEBIAN_DAILY_STABLE.md
+++ b/.github/DEBIAN_DAILY_STABLE.md
@@ -3,9 +3,9 @@
 The `debian daily stable` workflow builds current rsyslog `main` for Debian 13
 (`trixie`) on `amd64` and `arm64`. Package construction does not run for pull requests;
 the repository's workflow lint and security checks still validate workflow
-changes without consuming a full Debian package-build runner. Manual dispatch
-remains available for bootstrap and recovery. Scheduled publishing remains
-disabled until the DigitalOcean archive is provisioned.
+changes without consuming a full Debian package-build runner. Scheduled
+publishing is enabled; manual dispatch remains available for recovery and
+controlled verification.
 
 The workflow owns package construction, APT metadata generation, signing,
 upload ordering, and post-publication installation verification. The
@@ -91,9 +91,10 @@ The passphrase may be empty only if the archive key was intentionally created
 without one. Keep stable-release publishing in a separate environment when it
 is added later.
 
-## Activation
+## Provisioning and recovery
 
-Before enabling the schedule:
+For a new archive environment, or after material archive-configuration
+changes:
 
 1. Run the workflow manually with publication disabled and review its package
    artifact.

--- a/.github/FEDORA_DAILY_STABLE.md
+++ b/.github/FEDORA_DAILY_STABLE.md
@@ -15,9 +15,9 @@ selection, package split, configuration, documentation, service unit, and
 file ownership remain unchanged. If Fedora adds a downstream patch, the build
 stops for review instead of silently dropping it.
 
-Package construction does not run for pull requests. Manual dispatch remains
-available for bootstrap and recovery. The schedule is inactive until a manual
-publication and clean Fedora installation test pass.
+Package construction does not run for pull requests. Scheduled publishing is
+enabled; manual dispatch remains available for recovery and controlled
+end-to-end verification.
 
 ## Archive layout and retention
 
@@ -86,7 +86,7 @@ Add these variables to the `debian-daily-stable` environment:
 No new private key, DigitalOcean account API token, or bucket permission is
 required.
 
-## End-to-end activation
+## Provisioning and recovery
 
 1. Set the CDN and public-origin repository variables while leaving the
    schedule flag unset or false.

--- a/.github/OPENSUSE_DAILY_STABLE.md
+++ b/.github/OPENSUSE_DAILY_STABLE.md
@@ -25,9 +25,9 @@ by a clean exact-version install and rsyslog configuration validation. If Leap
 adds a downstream patch, the build stops for review instead of silently
 dropping it.
 
-Package construction does not run for pull requests. Manual dispatch remains
-available for bootstrap and recovery. The schedule is inactive until a manual
-publication and clean openSUSE installation test pass.
+Package construction does not run for pull requests. Scheduled publishing is
+enabled; manual dispatch remains available for recovery and controlled
+end-to-end verification.
 
 ## Archive layout and retention
 
@@ -96,7 +96,7 @@ Add these variables to the `debian-daily-stable` environment:
 No new private key, DigitalOcean account API token, or bucket permission is
 required.
 
-## End-to-end activation
+## Provisioning and recovery
 
 1. Set the CDN and public-origin repository variables while leaving the
    schedule flag unset or false.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,17 @@ after formatting if you already validated the code immediately before.
   issues, hardening, and invalid findings before using security severity or CWE
   language.
 
+## Package Archive Automation
+
+For any daily-stable, scheduled-release packaging, package archive, or
+distribution-extension work, first read the
+[`Daily Stable Package Archive Program`](.github/DAILY_STABLE_PACKAGE_ARCHIVE.md).
+It defines the current-main/native-baseline model, DigitalOcean Spaces archive,
+five-year retention, publication verification, and common feature-contract
+rules.  Treat a package build as incomplete until the public archive has been
+signature-verified and the exact published package has been installed and
+smoke-tested on the matching target.
+
 ## Container Images
 
 - Runtime container definitions live in `packaging/docker/rsyslog`.
@@ -71,7 +82,9 @@ after formatting if you already validated the code immediately before.
 - Manual release flows use two fixed channels:
   `stable` maps `8.yymm.0` to `20yy-mm` via `ppa:adiscon/v8-stable`,
   and `daily-stable` uses `ppa:adiscon/daily-stable` with the fixed tag
-  `daily-stable`.
+  `daily-stable`. These PPA references govern the legacy container-image
+  release flow only; multi-distribution package archive work uses the
+  DigitalOcean Spaces program above.
 - AI agents must not introduce release-looking fallback tags such as
   `2026-03` as the default local container build version.
 


### PR DESCRIPTION
## Summary

- Add one canonical daily-stable package-archive program document.
- Make it mandatory reading for archive, release-packaging, and distro-extension work.
- Clarify that PPA settings apply only to the legacy container release path.
- Update target guides from stale bootstrap wording to enabled scheduled publishing.

The document codifies the current-main/native-baseline model, DigitalOcean
Spaces architecture, immutable-publication and five-year-retention invariants,
public end-to-end verification, package feature contract, and distro-extension
rules. It links to detailed target runbooks rather than duplicating them.

## Validation

- Staged whitespace check passed.
- Search confirmed that stale scheduled-bootstrap wording was removed.
- Internal Markdown target-link check passed.
- codespell passed for all changed Markdown files.
- The automatic local-validation helper compared against an outdated base ref
  containing unrelated upstream changes, so it misclassified the branch as
  testbench plumbing. The actual seven-file internal-documentation diff needs
  no container run.

No code, workflow, package, or rendered Sphinx documentation changed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

