### PR TITLE
tests: deflake imptcp truncated-message ordering

### DIFF
--- a/tests/imptcp-discard-truncated-msg.sh
+++ b/tests/imptcp-discard-truncated-msg.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-# addd 2016-05-13 by RGerhards, released under ASL 2.0
+# added 2016-05-13 by RGerhards, released under ASL 2.0
+# Verifies that imptcp discards the excess portion of each oversized LF-framed
+# message while continuing to process following messages. Separate TCP client
+# connections may be handled by different workers, so delivery order is not an
+# invariant. The oracle requires exactly two truncated long messages and two
+# intact short messages among exactly four output lines after shutdown.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
@@ -24,9 +29,7 @@ tcpflood -m1 -M "\"<120> 2011-03-01T11:22:12Z host tag: this is a way to long me
 shutdown_when_empty
 wait_shutdown
 
-export EXPECTED='<120> 2011-03-01T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 t
-<120> 2011-03-01T11:22:12Z host tag: this is a way to long message
-<120> 2011-03-01T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 t
-<120> 2011-03-01T11:22:12Z host tag: this is a way to long message'
-cmp_exact
+wait_file_lines "$RSYSLOG_OUT_LOG" 4
+content_count_check '<120> 2011-03-01T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 t' 2
+content_count_check --regex '^<120> 2011-03-01T11:22:12Z host tag: this is a way to long message$' 2
 exit_test


### PR DESCRIPTION
## Summary

Fixes an unrelated TSAN flake observed in [CI job 96811037943](https://github.com/rsyslog/rsyslog/actions/runs/32494765900/job/96811037943?pr=7517).

`imptcp-discard-truncated-msg.sh` sends four messages through separate TCP connections. imptcp workers can process those connections in a different valid order, while the previous oracle required one exact cross-connection ordering.

The test now requires exactly four records containing two truncated long messages and two intact short messages, without treating delivery order as a contract.

## Validation

- `bash -n tests/imptcp-discard-truncated-msg.sh`
- `devtools/check-test-antipatterns.sh tests/imptcp-discard-truncated-msg.sh`
- 20 consecutive focused runs of `./tests/imptcp-discard-truncated-msg.sh`
- Ubuntu 26.04 CI-equivalent change-gated run: 1,381 passed, 73 skipped, 0 failed (including this test)

The static-analyzer lane reports one pre-existing `core.NullDereference` in `runtime/modules.c`; this test-only patch does not touch that code.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

