### PR TITLE
tests: deflake imbeats TLS listener rearm

### DIFF
--- a/tests/imbeats-tls-listener-rearm.sh
+++ b/tests/imbeats-tls-listener-rearm.sh
@@ -6,7 +6,10 @@
 # Verify a malformed plaintext connection does not disarm an imbeats TLS
 # listener. The plaintext peer waits for its close to prove the failed accept
 # completed; a subsequent TLS Lumberjack event must receive its ACK and reach
-# the output file. Socket timeouts only bound a listener that remains disarmed.
+# the output file. The listener may reject the malformed handshake before the
+# peer can shut down its write side, so that expected socket error is tolerated
+# before observing the close. Socket timeouts only bound a listener that
+# remains disarmed.
 . ${srcdir:=.}/diag.sh init
 
 generate_conf
@@ -41,6 +44,7 @@ startup
 assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
 
 if ! $PYTHON - "$RS_PORT" <<'PY'
+import errno
 import json
 import socket
 import ssl
@@ -52,7 +56,12 @@ port = int(sys.argv[1])
 with socket.create_connection(("127.0.0.1", port), timeout=5) as plain:
     plain.settimeout(5)
     plain.sendall(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-    plain.shutdown(socket.SHUT_WR)
+    try:
+        plain.shutdown(socket.SHUT_WR)
+    except OSError as e:
+        # The listener may already have closed after rejecting plaintext.
+        if e.errno != errno.ENOTCONN:
+            raise
     try:
         response = plain.recv(1)
     except socket.timeout as e:


### PR DESCRIPTION
## Summary

Fixes a second unrelated TSAN failure from [CI job 96825557839](https://github.com/rsyslog/rsyslog/actions/runs/32494765900/job/96825557839?pr=7517).

After sending malformed plaintext to an imbeats TLS listener, the test called `shutdown(SHUT_WR)`. The listener may validly reject and close the socket before that call, producing `ENOTCONN` and failing the test before its existing close/rearm oracle could run.

The test now tolerates only `ENOTCONN`, then still requires the plaintext connection to be closed and a subsequent TLS Lumberjack event to receive its ACK and reach the output file. Other socket errors remain failures.

## Validation

- `bash -n tests/imbeats-tls-listener-rearm.sh`
- `shellcheck -S warning tests/imbeats-tls-listener-rearm.sh`
- `devtools/check-test-antipatterns.sh tests/imbeats-tls-listener-rearm.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j10`
- Ubuntu 26.04 CI-equivalent change-gated run (image `rsyslog/rsyslog_dev_base_ubuntu:26.04`, ID `sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`): 1,404 passed, 74 skipped, 0 failed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

