### PR TITLE
codex: fix pre-push parsing on Python 3.6

### DIFF
--- a/.codex/pre_push_container_gate.sh
+++ b/.codex/pre_push_container_gate.sh
@@ -20,7 +20,8 @@ import sys
 
 def split_simple_commands(command):
     lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
-    lexer.whitespace_split = True
+    # Keep the default lexer mode: Python 3.6 ignores punctuation characters
+    # adjacent to a word when whitespace_split is enabled.
     lexer.commenters = ""
     commands = []
     current = []


### PR DESCRIPTION
Fixes the CentOS 8 daily failure in `codex-pre-push-container-gate.sh`.

Python 3.6 does not split a semicolon adjacent to a word when `shlex` uses both `punctuation_chars` and `whitespace_split`. Keeping the default lexer mode preserves the delimiter, so a nested `unset SKIP_CONTAINER_VALIDATION; git push` correctly re-enables the gate.

Validation:
- focused regression script on host Python 3.12
- focused regression script in `rsyslog/rsyslog_dev_base_centos:8` (Python 3.6.8)
- ShellCheck
- change-gated Ubuntu 26.04 container run: 1,454 total, 1,381 pass, 73 expected skips, 0 failures

The Ubuntu static-analyzer lane reports one unrelated existing warning in unchanged `runtime/modules.c:412`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

