### PR TITLE
tests: support Python 3.6 in segqueue tool test

### DIFF
--- a/tests/rsyslog-segqueue-tool.py
+++ b/tests/rsyslog-segqueue-tool.py
@@ -86,7 +86,7 @@ def run_cli(*arguments):
         check=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
+        universal_newlines=True,
     )
 
 
@@ -230,7 +230,7 @@ def main():
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
+            universal_newlines=True,
         )
         check(tui.returncode == 0 and "Selected slot/generation" in tui.stdout, "guided TUI smoke test failed")
     finally:


### PR DESCRIPTION
Fixes the deterministic CentOS 8 daily failure from run 32616650774, job 97138379028.

CentOS 8 uses Python 3.6, where `subprocess.run(text=True)` is unsupported. `universal_newlines=True` provides the equivalent decoded text I/O behavior and is supported by Python 3.6.

Validation:
- `python3 tests/rsyslog-segqueue-tool.py`
- CentOS 8 dev image (`Python 3.6.8`): `python3 tests/rsyslog-segqueue-tool.py`
- Ubuntu 26.04 CI-equivalent check: 1,454 total / 1,381 pass / 73 skip / 0 fail

The U26 static-analyzer lane reports the reproducible existing `runtime/modules.c:412` warning on both this branch and unmodified upstream; this Python-only change does not affect it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

