### PR TITLE
fuzz: accept empty message offset

### DIFF
--- a/tests/fuzz-syslog-message-smoke.sh
+++ b/tests/fuzz-syslog-message-smoke.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 # Smoke-test the opt-in syslog parser fuzzer against its seed corpus. A clean
 # fixed iteration run is the oracle; any crash, sanitizer report, or invariant
-# failure makes libFuzzer return non-zero.
+# failure makes libFuzzer return non-zero. The work corpus recreates the
+# minimized empty-MSG offset regression exactly: its final question marks have
+# no newline.
 set -eu
 
 test_dir=$(CDPATH='' cd -- "$(dirname "$0")" && pwd)
@@ -11,6 +13,7 @@ test -x "$fuzzer" || exit 77
 
 work_corpus="./fuzz-syslog-message-work.$$"
 mkdir "$work_corpus"
+printf '%s' '2021 Oct 1 ::1 Oc???wwwwwwwwwwwwwwwwwww??????' > "$work_corpus/rfc3164-empty-msg-offset"
 cleanup_work_corpus() {
 	rc=$?
 	if test "$rc" -eq 0; then

--- a/tools/fuzz_rsyslog_message.c
+++ b/tools/fuzz_rsyslog_message.c
@@ -42,8 +42,9 @@ static void fuzzOneParser(const uint8_t *data, const size_t size, rsRetVal (*par
 
     ret = parseFn(msg);
     if (ret == RS_RET_OK) {
+        /* MsgSetMSGoffs permits one-past-end for an empty MSG. */
         if (msg->offAfterPRI < 0 || msg->offAfterPRI > msg->iLenRawMsg || msg->offMSG < 0 ||
-            msg->offMSG > msg->iLenRawMsg) {
+            (msg->offMSG > msg->iLenRawMsg && (msg->offMSG - msg->iLenRawMsg != 1 || msg->iLenMSG != 0))) {
             abort();
         }
     }


### PR DESCRIPTION
## Summary

The parser-fuzz harness now accepts the documented one-past-end `offMSG` representation used for an empty message body. It also recreates a newline-free trailing-space case in its temporary smoke corpus.

Five daily fuzz campaigns (2026-08-19 through 2026-08-23) aborted in the harness on this valid state, with no ASan/UBSan finding or per-input timeout. The latest reproducer from run 32613303537 passes with this change.

## Validation

- ASan/UBSan instrumented fuzzer: latest minimized artifact replay passed
- ASan/UBSan fuzzer smoke: 1,000 iterations passed
- `devtools/format-code.sh --git-changed --check --check-if-available` passed
- `devtools/check-test-antipatterns.sh tests/fuzz-syslog-message-smoke.sh` passed
- Ubuntu 26.04 change-gated container lane on commit `5b1d98b8f`: 1,381 passed, 73 skipped, 0 failed
- Static analyzer: one existing, unrelated `runtime/modules.c:412` finding; no finding in this diff

The earlier full U26 run had an unrelated `ratelimit-policy-persource-key-reload.sh` failure; the isolated rerun passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

