### PR TITLE
omsendertrack: recover invalid state files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
 --------------------------------------------------------------------------------------
 Scheduled Release 8.2610.0 (aka 2026.10) 2026-10-??
 
+- 2026-08-23: omsendertrack: recover safely from invalid state files
+  Sender tracking now treats missing and empty state files as a normal first
+  start and can preserve corrupt JSON before starting with empty statistics. A
+  strict per-action setting remains available for deployments that must fail
+  closed.
+
 --------------------------------------------------------------------------------------
 Scheduled Release 8.2608.0 (aka 2026.08) 2026-08-18
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1214,6 +1214,7 @@ EXTRA_DIST = \
     source/reference/parameters/omrelp-windowsize.rst \
     source/reference/parameters/omsendertrack-cmdfile.rst \
     source/reference/parameters/omsendertrack-interval.rst \
+    source/reference/parameters/omsendertrack-ignoreinvalidstatefile.rst \
     source/reference/parameters/omsendertrack-senderid.rst \
     source/reference/parameters/omsendertrack-statefile.rst \
     source/reference/parameters/omsnmp-community.rst \

--- a/doc/source/configuration/modules/omsendertrack.rst
+++ b/doc/source/configuration/modules/omsendertrack.rst
@@ -2,8 +2,19 @@
 
 .. _omsendertrack:
 
+.. meta::
+   :description: Track message senders with crash-resilient JSON state recovery.
+   :keywords: rsyslog, omsendertrack, sender statistics, state file, recovery
+
 omsendertrack: Sender Tracking Output Module
 =============================================
+
+.. summary-start
+
+``omsendertrack`` tracks message senders and persists their statistics in a
+JSON state file that can recover safely from corruption by default.
+
+.. summary-end
 
 .. rst-class:: AdisconInfo
 
@@ -54,6 +65,13 @@ This ensures that message statistics are restored and tracking continues
 seamlessly across daemon restarts. A background task is then spawned to handle
 periodic state persistence.
 
+A missing state file is treated as a normal first start. An empty state file is
+also accepted by default and starts with empty statistics. For nonempty invalid
+files, the default :ref:`IgnoreInvalidStatefile
+<param-omsendertrack-ignoreinvalidstatefile>` behavior preserves the original
+as a ``.corrupt.<timestamp>.<attempt>`` file before starting with empty state.
+Set that parameter to ``off`` when tracking must fail closed instead.
+
 OnAction Call (Message Processing)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -73,23 +91,19 @@ When a message is routed to an ``omsendertrack`` action:
 HUP Signal Handling
 ^^^^^^^^^^^^^^^^^^^
 
-When rsyslog receives a HUP signal (typically used for configuration reloads),
-the ``omsendertrack`` module is designed to check for the existence of a
-:ref:`cmdfile <param-omsendertrack-cmdfile>`. If a `cmdfile` is specified and found,
-it would be read and its commands processed. After processing, the `cmdfile`
-would be deleted to prevent re-execution on subsequent HUP signals.
-
-**Note:** Command file support is currently **not implemented** in this
-proof-of-concept version of the module.
+The optional :ref:`cmdfile <param-omsendertrack-cmdfile>` parameter is accepted
+for compatibility but has no current runtime behavior. ``omsendertrack`` does
+not read, create, or remove that file, including on HUP.
 
 Background Task
 ^^^^^^^^^^^^^^^
 
 A dedicated background task is responsible for persisting the module's current
 state to the configured :ref:`statefile <param-omsendertrack-statefile>`. This task
-wakes up at the `interval` specified in the configuration. It performs atomic
-writes to the `statefile` to prevent data corruption, even if rsyslog
-unexpectedly terminates during a write operation.
+wakes up at the `interval` specified in the configuration. It writes a unique
+temporary file in the target directory, synchronizes it, renames it into place,
+and synchronizes the directory. This protects the last successfully persisted
+state against interrupted writes on filesystems that support these operations.
 
 Shutdown
 ^^^^^^^^
@@ -129,6 +143,10 @@ Action Parameters
      - .. include:: ../../reference/parameters/omsendertrack-statefile.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-omsendertrack-ignoreinvalidstatefile`
+     - .. include:: ../../reference/parameters/omsendertrack-ignoreinvalidstatefile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-omsendertrack-cmdfile`
      - .. include:: ../../reference/parameters/omsendertrack-cmdfile.rst
         :start-after: .. summary-start
@@ -140,6 +158,7 @@ Action Parameters
    ../../reference/parameters/omsendertrack-senderid
    ../../reference/parameters/omsendertrack-interval
    ../../reference/parameters/omsendertrack-statefile
+   ../../reference/parameters/omsendertrack-ignoreinvalidstatefile
    ../../reference/parameters/omsendertrack-cmdfile
 
 Statistic Counter
@@ -158,28 +177,24 @@ state file.
 **Note:** There are currently **no statistics counters available** in this
 proof-of-concept version of the module.
 
-The JSON structure for each sender entry is envisioned to look like this:
+The persisted JSON array contains entries with this structure:
 
 .. code-block:: json
 
    {
-     "senderid": "value_from_template",
-     "last-event-time": "YYYY-MM-DDTHH:MM:SS.sssZ",
-     "message-count": "N_VALUE",
-     "avg-message-count": "M_POINT_M_VALUE"
+     "sender": "value_from_template",
+     "messages": 42,
+     "firstseen": 1710000000,
+     "lastseen": 1710000060
    }
 
 Where:
 
-* ``senderid``: The unique identifier for the sender, as determined by the
+* ``sender``: The unique identifier for the sender, as determined by the
     :ref:`senderid <param-omsendertrack-senderid>` template.
-* ``last-event-time``: A UTC timestamp (ISO 8601 format) indicating when the
-    last message from this sender was received.
-* ``message-count``: The total number of messages received from this sender
-    since tracking began (or since the last reset).
-* ``avg-message-count``: (Optional) The average message rate from this sender
-    since tracking began, calculated over the total elapsed time. This field's
-    presence depends on future module configuration and implementation details.
+* ``messages``: The total number of messages received from this sender.
+* ``firstseen`` and ``lastseen``: UTC Unix timestamps for the first and latest
+    message observed for the sender.
 
 Usage within Rsyslog Configuration
 ----------------------------------
@@ -229,6 +244,12 @@ adhere to the following best practices:
     proper write permissions to the directory specified in the :ref:`statefile
     <param-omsendertrack-statefile>` parameter. Without this, statistics cannot be
     persisted.
+* **Use a Persistent Directory:** Put the state file in a persistent directory
+  such as ``/var/lib/rsyslog``. When using a separate mount, ensure systemd has
+  mounted it and created the directory before rsyslog starts.
+* **Choose Recovery Deliberately:** Keep the default recovery behavior for
+  observability use cases. Set ``IgnoreInvalidStatefile="off"`` only when a
+  missing continuation of sender statistics must stop the service.
 * **Dedicated Ruleset for Unified Stats:** Use a dedicated ruleset that is
     called from multiple input-bound rulesets (Example 2) **only when** you
     need to collect statistics from those diverse inputs into a **single,
@@ -289,7 +310,7 @@ processing flows for other actions.
            senderId="id-template"
            interval="60"
            stateFile="/var/lib/rsyslog/senderstats.json"
-           cmdFile="/var/lib/rsyslog/sendercommands.txt"
+           ignoreInvalidStatefile="on"
        )
    }
 

--- a/doc/source/reference/parameters/omsendertrack-cmdfile.rst
+++ b/doc/source/reference/parameters/omsendertrack-cmdfile.rst
@@ -1,5 +1,9 @@
 .. _param-omsendertrack-cmdfile:
-.. _omsendertrack.parameter.input.cmdfile:
+.. _omsendertrack.parameter.action.cmdfile:
+
+.. meta::
+   :description: Compatibility command-file parameter for omsendertrack.
+   :keywords: rsyslog, omsendertrack, cmdFile, compatibility
 
 cmdfile
 =======
@@ -10,34 +14,29 @@ cmdfile
 
 .. summary-start
 
-Defines the absolute path to the command file that omsendertrack reads when
-rsyslog receives a HUP signal.
+Compatibility parameter reserved for a future omsendertrack command file.
 
 .. summary-end
 
 This parameter applies to :doc:`../../configuration/modules/omsendertrack`.
 
 :Name: cmdfile
-:Scope: input
+:Scope: action
 :Type: string
-:Default: input=none
+:Default: action=none
 :Required?: no
 :Introduced: 8.2506.0 (Proof-of-Concept)
 
 Description
 -----------
-This optional parameter allows you to specify the **absolute path to a command
-file**. This file *is designed to be processed when rsyslog receives a HUP
-signal* (for example via ``systemctl reload rsyslog``).
+This optional compatibility parameter currently has no effect. Command-file
+processing is not implemented: ``omsendertrack`` does not read, create, or
+delete the configured file, and a missing file cannot prevent startup. Do not
+create a command file solely for the current module version.
 
-**Note:** Command file support is currently **not implemented** in this
-proof-of-concept version of the module. When implemented, this feature is
-intended to allow dynamic control over the module's behavior, such as resetting
-statistics for specific senders, without requiring an rsyslog restart.
-
-Input usage
------------
-.. _omsendertrack.parameter.input.cmdfile-usage:
+Action usage
+------------
+.. _omsendertrack.parameter.action.cmdfile-usage:
 
 .. code-block:: rsyslog
 
@@ -50,4 +49,3 @@ Input usage
 See also
 --------
 See also :doc:`../../configuration/modules/omsendertrack`.
-

--- a/doc/source/reference/parameters/omsendertrack-ignoreinvalidstatefile.rst
+++ b/doc/source/reference/parameters/omsendertrack-ignoreinvalidstatefile.rst
@@ -1,0 +1,67 @@
+.. _param-omsendertrack-ignoreinvalidstatefile:
+.. _omsendertrack.parameter.action.ignoreinvalidstatefile:
+
+.. meta::
+   :description: Control omsendertrack recovery from invalid JSON state files.
+   :keywords: rsyslog, omsendertrack, IgnoreInvalidStatefile, state file, recovery
+
+IgnoreInvalidStatefile
+======================
+
+.. index::
+   single: omsendertrack; IgnoreInvalidStatefile
+   single: IgnoreInvalidStatefile
+
+.. summary-start
+
+Controls whether omsendertrack recovers from empty or invalid persisted state.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omsendertrack`.
+
+:Name: IgnoreInvalidStatefile
+:Scope: action
+:Type: boolean
+:Default: action=on
+:Required?: no
+:Introduced: 8.2610.0
+
+Description
+-----------
+
+When ``on``, an empty state file starts with empty statistics. A nonempty file
+that is not a complete valid sender-statistics JSON array is moved aside under a
+unique ``.corrupt.*`` name and rsyslog starts with empty statistics. If that
+backup cannot be made, rsyslog continues but disables later state-file writes
+for that action so the evidence is not overwritten.
+
+When ``off``, an empty or invalid existing state file causes rsyslog startup to
+fail and is left unchanged. A missing state file is always accepted as a normal
+first start.
+
+Action usage
+------------
+.. _param-omsendertrack-action-ignoreinvalidstatefile:
+.. _omsendertrack.parameter.action.ignoreinvalidstatefile-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omsendertrack"
+          stateFile="/var/lib/rsyslog/senderstats.json"
+          ignoreInvalidStatefile="off")
+
+YAML usage
+----------
+
+.. code-block:: yaml
+
+   actions:
+     - type: omsendertrack
+       stateFile: /var/lib/rsyslog/senderstats.json
+       ignoreInvalidStatefile: off
+
+See also
+--------
+
+See also :doc:`omsendertrack-statefile`.

--- a/doc/source/reference/parameters/omsendertrack-statefile.rst
+++ b/doc/source/reference/parameters/omsendertrack-statefile.rst
@@ -1,5 +1,9 @@
 .. _param-omsendertrack-statefile:
-.. _omsendertrack.parameter.input.statefile:
+.. _omsendertrack.parameter.action.statefile:
+
+.. meta::
+   :description: Configure the JSON sender-statistics state file for omsendertrack.
+   :keywords: rsyslog, omsendertrack, stateFile, JSON, recovery
 
 statefile
 =========
@@ -18,9 +22,9 @@ sender statistics.
 This parameter applies to :doc:`../../configuration/modules/omsendertrack`.
 
 :Name: statefile
-:Scope: input
+:Scope: action
 :Type: string
-:Default: input=none
+:Default: action=none
 :Required?: yes
 :Introduced: 8.2506.0 (Proof-of-Concept)
 
@@ -31,13 +35,32 @@ sender information is stored. The module updates this file periodically based
 on the configured :ref:`interval <param-omsendertrack-interval>` and also upon
 rsyslog shutdown to preserve the latest statistics.
 
-**Important:** Ensure that the rsyslog user has appropriate write permissions to
-the directory where this ``statefile`` is located. Failure to do so will
-prevent the module from saving its state.
+A missing file is a normal first start. An empty file is accepted as an empty
+state by default. Invalid nonempty files are preserved under a unique
+``.corrupt.*`` name and replaced by later normal persistence when
+:ref:`IgnoreInvalidStatefile <param-omsendertrack-ignoreinvalidstatefile>` is
+enabled. If preserving the invalid file fails, rsyslog starts with empty
+statistics but disables later writes for that action, leaving the original
+file untouched. Disable recovery when an invalid state file must stop rsyslog
+instead.
 
-Input usage
------------
-.. _omsendertrack.parameter.input.statefile-usage:
+Atomic updates retain the permission mode of an existing state file. Therefore,
+ensure that an existing state file has restrictive permissions, such as
+owner-read/write only (``0600``), before configuring it. A new state file is
+created with owner-only permissions.
+
+**Important:** Ensure that the rsyslog user has appropriate write permissions to
+the directory where this ``statefile`` is located, and that the directory is
+not writable by untrusted users. Failure to do so will prevent the module from
+saving its state or allow another user to replace the state file.
+
+The parent directory must already exist. Place state files on persistent local
+storage; if the directory is on a separate mount, ensure it is available before
+the rsyslog service starts.
+
+Action usage
+------------
+.. _omsendertrack.parameter.action.statefile-usage:
 
 .. code-block:: rsyslog
 
@@ -49,4 +72,3 @@ Input usage
 See also
 --------
 See also :doc:`../../configuration/modules/omsendertrack`.
-

--- a/plugins/omsendertrack/omsendertrack.c
+++ b/plugins/omsendertrack/omsendertrack.c
@@ -43,6 +43,8 @@
 #include <signal.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <limits.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "conf.h"
 #include "syslogd-types.h"
@@ -80,6 +82,13 @@ typedef struct {
     pthread_mutex_t mut;
 } sender_stats_t;
 
+static void destroySenderStats(void *const value) {
+    sender_stats_t *const stat = (sender_stats_t *)value;
+
+    pthread_mutex_destroy(&stat->mut);
+    free(stat);
+}
+
 
 /* config variables */
 
@@ -89,10 +98,11 @@ typedef struct {
 typedef struct _instanceData {
     int interval; /**< write interval in seconds */
     uchar *statefile; /**< path to the JSON state file */
-    uchar *statefile_tmp; /**< cached path to temp state file (statefile + ".tmp") */
-    uchar *cmdfile; /**< path to command file (unused) */
+    int bIgnoreInvalidStatefile; /**< recover from malformed persisted state */
+    int bDisableStatefileWrites; /**< preserve a corrupt file when its backup failed */
     uchar *senderidTemplate; /**< template that defines sender ID */
     pthread_rwlock_t mutSenders; /**< protects the sender hash table */
+    int mutSendersInitialized; /**< indicates sender hash table lock is initialized */
     struct hashtable *stats_senders; /**< hash table of sender_stats_t */
     int bShutdownBackgroundWriter; /**< tells bgwriter to terminate */
     DEF_ATOMIC_HELPER_MUT(mutShutdownBackgroundWriter);
@@ -122,9 +132,10 @@ static struct cnfparamdescr actpdescr[] = {
     {"interval", eCmdHdlrPositiveInt, 0},
     /** @param statefile State file for the statistics object. */
     {"statefile", eCmdHdlrString, 1}, /* required */
+    /** @param ignoreinvalidstatefile Continue with empty state after corrupt state file. */
+    {"ignoreinvalidstatefile", eCmdHdlrBinary, 0},
     /**
-     * @param cmdfile Specifies the full path to the command file that omsendertrack will periodically poll for
-     * new commands. Supported commands are "delete" and "GET". Not implemented in the current PoC.
+     * @param cmdfile Compatibility parameter for unimplemented command-file processing.
      */
     {"cmdfile", eCmdHdlrString, 0},
     /** @param template Template to use for the output format. */
@@ -141,34 +152,6 @@ static modConfData_t *runModConf = NULL; /* modConf ptr to use for the current e
 /* forward references */
 static rsRetVal initHashtable(instanceData *const pData);
 static void *bgWriter(void *arg);
-static rsRetVal buildTmpStatefile(instanceData *const pData);
-
-/**
- * @brief Build and cache the temporary state file path.
- *
- * This constructs "<statefile>.tmp" and stores it in pData->statefile_tmp.
- * Keeping the temp file in the same directory as the final file ensures that
- * the subsequent rename() is atomic on POSIX filesystems.
- */
-static rsRetVal buildTmpStatefile(instanceData *const pData) {
-    DEFiRet;
-    if (pData == NULL || pData->statefile == NULL) {
-        ABORT_FINALIZE(RS_RET_ERR);
-    }
-    const size_t statefile_len = strlen((const char *)pData->statefile);
-    const size_t tmp_len = statefile_len + 4 + 1; /* ".tmp" + NUL */
-    uchar *tmp = (uchar *)malloc(tmp_len);
-    if (tmp == NULL) {
-        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-    }
-    snprintf((char *)tmp, tmp_len, "%s.tmp", (const char *)pData->statefile);
-    if (pData->statefile_tmp != NULL) {
-        free(pData->statefile_tmp);
-    }
-    pData->statefile_tmp = tmp;
-finalize_it:
-    RETiRet;
-}
 
 
 /**
@@ -193,7 +176,7 @@ static rsRetVal addSender(instanceData *const pData,
               nMsgs, (intmax_t)firstSeen, (intmax_t)lastSeen);
 
     CHKmalloc(stat = calloc(1, sizeof(sender_stats_t)));
-    stat->sender = (const uchar *)strdup((const char *)sender);
+    CHKmalloc(stat->sender = (const uchar *)strdup((const char *)sender));
     stat->nMsgs = nMsgs;
     stat->firstSeen = firstSeen;
     stat->lastSeen = lastSeen;
@@ -203,74 +186,321 @@ static rsRetVal addSender(instanceData *const pData,
                  "omsendertrack error inserting sender '%s' into sender "
                  "hash table - entry lost",
                  sender);
+        pthread_mutex_destroy(&stat->mut);
+        free((void *)stat->sender);
         free(stat);
+        stat = NULL;
         ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
     }
 
 finalize_it:
+    if (iRet != RS_RET_OK && stat != NULL) {
+        free((void *)stat->sender);
+        free(stat);
+    }
     RETiRet;
 }
 
 
-#define CHUNK_SIZE 16 * 1024  // Read file in 16KiB chunks
+typedef enum { STATEFILE_VALID, STATEFILE_MISSING, STATEFILE_EMPTY, STATEFILE_INVALID } statefileReadResult_t;
+
+static int isJsonWhitespace(const char ch) {
+    return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n';
+}
+
+static int int64FitsTimeT(const int64_t value) {
+    const time_t converted = (time_t)value;
+
+    if ((time_t)-1 > (time_t)0 && value < 0) {
+        return 0;
+    }
+    return (int64_t)converted == value;
+}
+
+static rsRetVal ATTR_NONNULL() checkStatefileParentDir(const char *const statefile) {
+    int fd = -1;
+    char *dir = NULL;
+    const char *slash;
+    DEFiRet;
+
+    slash = strrchr(statefile, '/');
+    if (slash == NULL) {
+        CHKmalloc(dir = strdup("."));
+    } else if (slash == statefile) {
+        CHKmalloc(dir = strdup("/"));
+    } else {
+        const size_t len = (size_t)(slash - statefile);
+        CHKmalloc(dir = strndup(statefile, len));
+    }
+
+    fd = open(dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (fd == -1) {
+        LogError(errno, RS_RET_FILE_OPEN_ERROR, "omsendertrack: cannot access state file directory '%s'", dir);
+        ABORT_FINALIZE(RS_RET_FILE_OPEN_ERROR);
+    }
+
+finalize_it:
+    if (fd != -1) {
+        close(fd);
+    }
+    free(dir);
+    RETiRet;
+}
+
+static rsRetVal ATTR_NONNULL() fsyncStatefileParentDir(const char *const statefile) {
+    int fd = -1;
+    char *dir = NULL;
+    const char *slash;
+    DEFiRet;
+
+    slash = strrchr(statefile, '/');
+    if (slash == NULL) {
+        CHKmalloc(dir = strdup("."));
+    } else if (slash == statefile) {
+        CHKmalloc(dir = strdup("/"));
+    } else {
+        const size_t len = (size_t)(slash - statefile);
+        CHKmalloc(dir = strndup(statefile, len));
+    }
+
+    fd = open(dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (fd == -1) {
+        LogError(errno, RS_RET_IO_ERROR, "omsendertrack: cannot open state file directory '%s' for fsync", dir);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    if (fsync(fd) == -1) {
+        LogError(errno, RS_RET_IO_ERROR, "omsendertrack: cannot fsync state file directory '%s'", dir);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+
+finalize_it:
+    if (fd != -1) {
+        close(fd);
+    }
+    free(dir);
+    RETiRet;
+}
+
+static int ATTR_NONNULL() senderStateEntryIsValid(json_object *const entry) {
+    json_object *jSender, *jMessages, *jFirstseen, *jLastseen;
+    int64_t value;
+    const char *sender;
+    int senderLen;
+
+    if (!json_object_is_type(entry, json_type_object) || !json_object_object_get_ex(entry, "sender", &jSender) ||
+        !json_object_object_get_ex(entry, "messages", &jMessages) ||
+        !json_object_object_get_ex(entry, "firstseen", &jFirstseen) ||
+        !json_object_object_get_ex(entry, "lastseen", &jLastseen) || !json_object_is_type(jSender, json_type_string) ||
+        !json_object_is_type(jMessages, json_type_int) || !json_object_is_type(jFirstseen, json_type_int) ||
+        !json_object_is_type(jLastseen, json_type_int)) {
+        return 0;
+    }
+
+    sender = json_object_get_string(jSender);
+    senderLen = json_object_get_string_len(jSender);
+    if (sender == NULL || senderLen < 0 || memchr(sender, '\0', (size_t)senderLen) != NULL) {
+        return 0;
+    }
+
+    value = json_object_get_int64(jMessages);
+    if (value < 0) {
+        return 0;
+    }
+    value = json_object_get_int64(jFirstseen);
+    if (!int64FitsTimeT(value)) {
+        return 0;
+    }
+    value = json_object_get_int64(jLastseen);
+    if (!int64FitsTimeT(value)) {
+        return 0;
+    }
+
+    return 1;
+}
+
+static int ATTR_NONNULL() senderStateIsValid(json_object *const jsonTree) {
+    struct hashtable *seenSenders = NULL;
+    int valid = 0;
+
+    if (!json_object_is_type(jsonTree, json_type_array)) {
+        return 0;
+    }
+
+    seenSenders = create_hashtable(100, hash_from_string, key_equals_string, NULL);
+    if (seenSenders == NULL) {
+        return 0;
+    }
+
+    const size_t arrayLen = json_object_array_length(jsonTree);
+    for (size_t i = 0; i < arrayLen; ++i) {
+        json_object *const entry = json_object_array_get_idx(jsonTree, i);
+        json_object *jSender;
+        const char *sender;
+        char *senderCopy;
+
+        if (!senderStateEntryIsValid(entry)) {
+            goto finalize_it;
+        }
+        json_object_object_get_ex(entry, "sender", &jSender);
+        sender = json_object_get_string(jSender);
+        if (hashtable_search(seenSenders, (void *)sender) != NULL) {
+            goto finalize_it;
+        }
+        senderCopy = strdup(sender);
+        if (senderCopy == NULL) {
+            goto finalize_it;
+        }
+        if (hashtable_insert(seenSenders, senderCopy, (void *)1) == 0) {
+            free(senderCopy);
+            goto finalize_it;
+        }
+    }
+
+    valid = 1;
+finalize_it:
+    hashtable_destroy(seenSenders, 0);
+    return valid;
+}
+
 /**
  * Read sender statistics from the configured state file.
  *
  * @param pData     module instance data
  * @param[out] jsontree  parsed JSON tree or NULL on failure
+ * @param[out] result classification of an otherwise readable state file
  * @retval RS_RET_OK on success
  */
-static rsRetVal ATTR_NONNULL() readSenderStats(instanceData *const pData, json_object **jsontree) {
+static rsRetVal ATTR_NONNULL()
+    readSenderStats(instanceData *const pData, json_object **const jsontree, statefileReadResult_t *const result) {
+    int fd = -1;
+    struct stat sb;
+    char *contents = NULL;
+    size_t offset = 0;
+    json_tokener *tok = NULL;
+    json_object *parsedJson = NULL;
     DEFiRet;
 
     *jsontree = NULL;
-    FILE *fp = fopen((const char *)pData->statefile, "r");
-    // TODO: in case of read errors, shall we set the sender info file to a different, configurable, name?
-    // TODO: handle this type of "input file error, starting w/o state" in a generic function
-    // TODO: check error codes returned!
-    if (!fp) {
-        LogMsg(errno, RS_RET_WARN_NO_SENDER_STATS, LOG_ERR,
-               "error opening sender info file '%s' - "
-               "starting without any previous data",
-               pData->statefile);
-        ABORT_FINALIZE(RS_RET_ERR);
-    }
-
-    json_tokener *tok = json_tokener_new();
-    if (!tok) {
-        LogMsg(errno, RS_RET_WARN_NO_SENDER_STATS, LOG_ERR,
-               "error creating json_tokener - "
-               "starting without any previous data");
-        fclose(fp);
-        ABORT_FINALIZE(RS_RET_ERR);
-    }
-
-    char buffer[CHUNK_SIZE];
-    json_object *parsed_json = NULL;
-    enum json_tokener_error jerr;
-
-    while (fgets(buffer, sizeof(buffer), fp)) {
-        parsed_json = json_tokener_parse_ex(tok, buffer, strlen(buffer));
-        jerr = fjson_tokener_get_error(tok);
-
-        if (jerr == json_tokener_continue) {
-            continue;  // Need more data, keep reading
-        } else if (jerr != fjson_tokener_success) {
-            LogMsg(errno, RS_RET_WARN_NO_SENDER_STATS, LOG_ERR,
-                   "error processing input json - "
-                   "starting without any previous data, error: %s",
-                   json_tokener_error_desc(jerr));
-            json_object_put(parsed_json);
-            parsed_json = NULL;
-            break;
+    *result = STATEFILE_VALID;
+    fd = open((const char *)pData->statefile, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+    if (fd == -1) {
+        if (errno == ENOENT) {
+            CHKiRet(checkStatefileParentDir((const char *)pData->statefile));
+            *result = STATEFILE_MISSING;
+            CHKmalloc(*jsontree = json_object_new_array());
+            FINALIZE;
         }
+        LogError(errno, RS_RET_FILE_OPEN_ERROR, "omsendertrack: cannot open state file '%s'", pData->statefile);
+        ABORT_FINALIZE(RS_RET_FILE_OPEN_ERROR);
+    }
+    if (fstat(fd, &sb) == -1) {
+        LogError(errno, RS_RET_IO_ERROR, "omsendertrack: cannot stat state file '%s'", pData->statefile);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    if (!S_ISREG(sb.st_mode)) {
+        LogError(0, RS_RET_IO_ERROR, "omsendertrack: state file '%s' is not a regular file", pData->statefile);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    if (sb.st_size == 0) {
+        *result = STATEFILE_EMPTY;
+        CHKmalloc(*jsontree = json_object_new_array());
+        FINALIZE;
+    }
+    if (sb.st_size < 0 || sb.st_size > INT_MAX) {
+        *result = STATEFILE_INVALID;
+        FINALIZE;
     }
 
-    json_tokener_free(tok);
-    fclose(fp);
+    CHKmalloc(contents = malloc((size_t)sb.st_size));
+    while (offset < (size_t)sb.st_size) {
+        const ssize_t nread = read(fd, contents + offset, (size_t)sb.st_size - offset);
+        if (nread < 0 && errno == EINTR) {
+            continue;
+        }
+        if (nread <= 0) {
+            LogError(errno, RS_RET_READ_ERR, "omsendertrack: cannot read complete state file '%s'", pData->statefile);
+            ABORT_FINALIZE(RS_RET_READ_ERR);
+        }
+        offset += (size_t)nread;
+    }
 
-    *jsontree = parsed_json;
+    CHKmalloc(tok = json_tokener_new());
+    fjson_tokener_set_flags(tok, FJSON_TOKENER_STRICT);
+    parsedJson = json_tokener_parse_ex(tok, contents, (int)sb.st_size);
+    if (fjson_tokener_get_error(tok) != fjson_tokener_success || parsedJson == NULL) {
+        *result = STATEFILE_INVALID;
+        FINALIZE;
+    }
+    offset = (size_t)tok->char_offset;
+    while (offset < (size_t)sb.st_size && isJsonWhitespace(contents[offset])) {
+        ++offset;
+    }
+    if (offset != (size_t)sb.st_size || !senderStateIsValid(parsedJson)) {
+        *result = STATEFILE_INVALID;
+        FINALIZE;
+    }
+
+    *jsontree = parsedJson;
+    parsedJson = NULL;
 finalize_it:
+    if (fd != -1) {
+        close(fd);
+    }
+    if (tok != NULL) {
+        json_tokener_free(tok);
+    }
+    if (parsedJson != NULL) {
+        json_object_put(parsedJson);
+    }
+    free(contents);
+    RETiRet;
+}
+
+static rsRetVal ATTR_NONNULL() quarantineStatefile(const char *const statefile) {
+    char *quarantine = NULL;
+    struct timespec ts;
+    int attempt;
+    DEFiRet;
+
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
+        ts.tv_sec = time(NULL);
+        ts.tv_nsec = 0;
+    }
+    for (attempt = 0; attempt < 100; ++attempt) {
+        if (asprintf(&quarantine, "%s.corrupt.%ld.%ld.%d", statefile, (long)ts.tv_sec, (long)ts.tv_nsec, attempt) ==
+            -1) {
+            quarantine = NULL;
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+        /* link() reserves the destination without replacing an older backup. */
+        if (link(statefile, quarantine) == 0) {
+            if (unlink(statefile) != 0) {
+                const int unlinkErrno = errno;
+                unlink(quarantine);
+                LogError(unlinkErrno, RS_RET_IO_ERROR,
+                         "omsendertrack: cannot finalize preservation of invalid state file '%s'", statefile);
+                ABORT_FINALIZE(RS_RET_IO_ERROR);
+            }
+            CHKiRet(fsyncStatefileParentDir(statefile));
+            LogError(0, NO_ERRCODE, "omsendertrack: moved invalid state file '%s' to '%s' and started with empty state",
+                     statefile, quarantine);
+            FINALIZE;
+        }
+        if (errno != EEXIST) {
+            LogError(errno, RS_RET_IO_ERROR, "omsendertrack: cannot preserve invalid state file '%s' as '%s'",
+                     statefile, quarantine);
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+        free(quarantine);
+        quarantine = NULL;
+    }
+
+    LogError(0, RS_RET_IO_ERROR, "omsendertrack: cannot find a unique backup name for invalid state file '%s'",
+             statefile);
+    ABORT_FINALIZE(RS_RET_IO_ERROR);
+
+finalize_it:
+    free(quarantine);
     RETiRet;
 }
 
@@ -286,31 +516,18 @@ jsonToHashtable(instanceData *const pData, json_object *const jsonTree)
 {
     DEFiRet;
 
-    if (!json_object_is_type(jsonTree, json_type_array)) {
-        LogError(0, RS_RET_ERR,
-                 "current sender file does not contain proper JSON "
-                 "object, array as first-level element excpected. Starting without "
-                 "any previous data");
-        ABORT_FINALIZE(RS_RET_ERR);
-    }
-
     size_t array_len = json_object_array_length(jsonTree);
     for (size_t i = 0; i < array_len; i++) {
         json_object *entry = json_object_array_get_idx(jsonTree, i);
 
-        // Extract fields from each object
+        /* The tree was fully validated before this conversion. */
         json_object *j_sender, *j_messages, *j_firstseen, *j_lastseen;
-        if (json_object_object_get_ex(entry, "sender", &j_sender) &&
-            json_object_object_get_ex(entry, "messages", &j_messages) &&
-            json_object_object_get_ex(entry, "firstseen", &j_firstseen) &&
-            json_object_object_get_ex(entry, "lastseen", &j_lastseen)) {
-            // Convert to C types
-            const char *sender = json_object_get_string(j_sender);
-            int messages = json_object_get_int(j_messages);
-            long firstseen = json_object_get_int64(j_firstseen);
-            long lastseen = json_object_get_int64(j_lastseen);
-            CHKiRet(addSender(pData, sender, messages, firstseen, lastseen));
-        }
+        json_object_object_get_ex(entry, "sender", &j_sender);
+        json_object_object_get_ex(entry, "messages", &j_messages);
+        json_object_object_get_ex(entry, "firstseen", &j_firstseen);
+        json_object_object_get_ex(entry, "lastseen", &j_lastseen);
+        CHKiRet(addSender(pData, json_object_get_string(j_sender), (uint64_t)json_object_get_int64(j_messages),
+                          (time_t)json_object_get_int64(j_firstseen), (time_t)json_object_get_int64(j_lastseen)));
     }
 
 finalize_it:
@@ -327,9 +544,11 @@ static rsRetVal
 initHashtable(instanceData *const pData)
 {
     DEFiRet;
-    rsRetVal localRet;
+    statefileReadResult_t readResult;
+    json_object *jsonTree = NULL;
 
-    if ((pData->stats_senders = create_hashtable(100, hash_from_string, key_equals_string, NULL)) == NULL) {
+    if ((pData->stats_senders = create_hashtable(100, hash_from_string, key_equals_string, destroySenderStats)) ==
+        NULL) {
         LogError(0, RS_RET_INTERNAL_ERROR,
                  "error trying to initialize hash-table "
                  "for sender table. Sender statistics and warnings are disabled.");
@@ -337,19 +556,38 @@ initHashtable(instanceData *const pData)
     }
 
     /* read existing data */
-    json_object *jsonTree;
-    localRet = readSenderStats(pData, &jsonTree);
-    if (localRet != RS_RET_OK && localRet != RS_RET_WARN_NO_SENDER_STATS) {
-        ABORT_FINALIZE(localRet);
+    CHKiRet(readSenderStats(pData, &jsonTree, &readResult));
+    if (readResult == STATEFILE_EMPTY || readResult == STATEFILE_INVALID) {
+        if (!pData->bIgnoreInvalidStatefile) {
+            LogError(0, RS_RET_ERR,
+                     "omsendertrack: state file '%s' is empty or invalid and IgnoreInvalidStatefile is off",
+                     pData->statefile);
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
+        if (readResult == STATEFILE_INVALID && quarantineStatefile((const char *)pData->statefile) != RS_RET_OK) {
+            pData->bDisableStatefileWrites = 1;
+            LogError(0, NO_ERRCODE,
+                     "omsendertrack: continuing with empty state, but state file writes are disabled to preserve '%s'",
+                     pData->statefile);
+        } else if (readResult == STATEFILE_EMPTY) {
+            LogError(0, NO_ERRCODE, "omsendertrack: state file '%s' is empty; starting with empty state",
+                     pData->statefile);
+        }
+        if (jsonTree == NULL) {
+            CHKmalloc(jsonTree = json_object_new_array());
+        }
     }
     CHKiRet(jsonToHashtable(pData, jsonTree));
-    if (jsonTree != NULL) {
-        json_object_put(jsonTree);
-    }
+    json_object_put(jsonTree);
+    jsonTree = NULL;
 
     /* start background writer */
     pData->bgw_initialized = 0;
-    pthread_rwlock_init(&pData->mutSenders, NULL);
+    if (pthread_rwlock_init(&pData->mutSenders, NULL) != 0) {
+        LogError(0, RS_RET_ERR, "omsendertrack: cannot initialize sender-state lock");
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    pData->mutSendersInitialized = 1;
     if (pthread_create(&pData->bgw_tid, NULL, bgWriter, pData) != 0) {
         LogError(0, RS_RET_ERR,
                  "omsendertrack: cannot create background writing thread. "
@@ -359,6 +597,9 @@ initHashtable(instanceData *const pData)
     pData->bgw_initialized = 1;
 
 finalize_it:
+    if (jsonTree != NULL) {
+        json_object_put(jsonTree);
+    }
     RETiRet;
 }
 
@@ -420,13 +661,18 @@ finalize_it:
 static rsRetVal writeSenderStats(instanceData *const pData, FILE *const fp) {
     struct hashtable_itr *itr = NULL;
     sender_stats_t *stat;
+    json_object *jSender = NULL;
     int bNeedEOL = 0;
+    int lockHeld = 0;
     DEFiRet;
 
     dbgprintf("writeSenderStats() called, hashtable_count %d\n", hashtable_count(pData->stats_senders));
-    fprintf(fp, "[\n"); /* begin JSON array */
+    if (fprintf(fp, "[\n") < 0) { /* begin JSON array */
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
 
     pthread_rwlock_rdlock(&pData->mutSenders);
+    lockHeld = 1;
 
     /* Iterator constructor only returns a valid iterator if
      * the hashtable is not empty
@@ -434,36 +680,59 @@ static rsRetVal writeSenderStats(instanceData *const pData, FILE *const fp) {
     if (hashtable_count(pData->stats_senders) > 0) {
         itr = hashtable_iterator(pData->stats_senders);
         do {
+            uint64_t nMsgs;
+            time_t firstSeen;
+            time_t lastSeen;
+
             stat = (sender_stats_t *)hashtable_iterator_value(itr);
-            fprintf(fp,
-                    "%s{"
-                    "\"sender\":\"%s\""
-                    ",\"messages\":%" PRIu64 ",\"firstseen\":%" PRIdMAX ",\"lastseen\":%" PRIdMAX "}",
-                    (bNeedEOL ? ",\n" : ""), stat->sender, stat->nMsgs, (intmax_t)stat->firstSeen,
-                    (intmax_t)stat->lastSeen);
+            pthread_mutex_lock(&stat->mut);
+            jSender = json_object_new_string((const char *)stat->sender);
+            nMsgs = stat->nMsgs;
+            firstSeen = stat->firstSeen;
+            lastSeen = stat->lastSeen;
+            pthread_mutex_unlock(&stat->mut);
+            if (jSender == NULL) {
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+            if (nMsgs > INT64_MAX) {
+                LogError(0, RS_RET_IO_ERROR, "omsendertrack: sender message count exceeds the JSON state-file range");
+                ABORT_FINALIZE(RS_RET_IO_ERROR);
+            }
+            if (fprintf(fp,
+                        "%s{"
+                        "\"sender\":%s"
+                        ",\"messages\":%" PRIu64 ",\"firstseen\":%" PRIdMAX ",\"lastseen\":%" PRIdMAX "}",
+                        (bNeedEOL ? ",\n" : ""), json_object_to_json_string_ext(jSender, JSON_C_TO_STRING_PLAIN), nMsgs,
+                        (intmax_t)firstSeen, (intmax_t)lastSeen) < 0) {
+                ABORT_FINALIZE(RS_RET_IO_ERROR);
+            }
+            json_object_put(jSender);
+            jSender = NULL;
             bNeedEOL = 1;
         } while (hashtable_iterator_advance(itr));
     }
 
-    free(itr);
-    pthread_rwlock_unlock(&pData->mutSenders);
+    if (fprintf(fp, "%s]\n", bNeedEOL ? "\n" : "") < 0) { /* end JSON array */
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
 
-    fprintf(fp, "%s]\n", bNeedEOL ? "\n" : ""); /* end JSON array */
+finalize_it:
+    if (jSender != NULL) {
+        json_object_put(jSender);
+    }
+    free(itr);
+    if (lockHeld) {
+        pthread_rwlock_unlock(&pData->mutSenders);
+    }
     RETiRet;
 }
 
 /**
  * Persist sender statistics to disk.
  *
- * Process overview for new contributors:
- *  1) Use cached temp path (statefile_tmp) created at config-time.
- *  2) Write JSON to the temp file.
- *  3) Atomically replace the final file via rename(temp, statefile).
- *
- * Why cached temp path? It avoids repeated allocations and guarantees the
- * temp file lives in the same directory as the target so that rename()
- * is atomic. If the cache is unexpectedly missing (e.g., future reload
- * flow), we fall back to computing it once here.
+ * A fully synchronized temporary file is renamed into place only after all
+ * data has reached the filesystem. The parent directory is synchronized after
+ * the rename so the name change itself survives a power loss.
  *
  * @param pData module instance data
  * @retval RS_RET_OK on success
@@ -471,51 +740,84 @@ static rsRetVal writeSenderStats(instanceData *const pData, FILE *const fp) {
 static ATTR_NONNULL() rsRetVal writeSenderInfo(instanceData *const pData) {
     DEFiRet;
     FILE *fp = NULL;
-    const char *tmpname = (const char *)pData->statefile_tmp;
-    int tmp_alloc = 0;
+    char *tmpname = NULL;
+    int renamed = 0;
+    struct stat existingStateStat;
+    int haveExistingState = 0;
 
     dbgprintf("writeSenderInfo, file %s\n", pData->statefile);
     if (pData->statefile == NULL) {
         LogError(0, RS_RET_INTERNAL_ERROR, "omsendertrack: statefile is not configured");
         ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
     }
-    if (tmpname == NULL) {
-        /* safety fallback if not yet built */
-        const size_t statefile_len = strlen((const char *)pData->statefile);
-        const size_t tmp_len = statefile_len + 4 + 1;
-        char *tn = (char *)malloc(tmp_len);
-        if (tn == NULL) {
-            LogError(0, RS_RET_OUT_OF_MEMORY, "omsendertrack: out of memory building temp sender file name");
-            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-        }
-        snprintf(tn, tmp_len, "%s.tmp", (const char *)pData->statefile);
-        tmpname = tn;
-        tmp_alloc = 1;
+    if (pData->bDisableStatefileWrites) {
+        FINALIZE;
     }
+    if (fstatat(AT_FDCWD, (const char *)pData->statefile, &existingStateStat, AT_SYMLINK_NOFOLLOW) == 0) {
+        if (!S_ISREG(existingStateStat.st_mode)) {
+            LogError(0, RS_RET_IO_ERROR, "omsendertrack: state file '%s' is not a regular file", pData->statefile);
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+        haveExistingState = 1;
+    } else if (errno != ENOENT) {
+        LogError(errno, RS_RET_IO_ERROR, "omsendertrack: cannot inspect existing state file '%s'", pData->statefile);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    const size_t statefileLen = strlen((const char *)pData->statefile);
+    CHKmalloc(tmpname = malloc(statefileLen + sizeof(".tmp.XXXXXX")));
+    memcpy(tmpname, pData->statefile, statefileLen);
+    memcpy(tmpname + statefileLen, ".tmp.XXXXXX", sizeof(".tmp.XXXXXX"));
 
-    if ((fp = fopen(tmpname, "w")) == NULL) {
-        LogError(errno, RS_RET_IO_ERROR, "omsendertrack could not create new temp sender file");
+    const int fd = mkstemp(tmpname);
+    if (fd == -1) {
+        LogError(errno, RS_RET_IO_ERROR, "omsendertrack: cannot create temporary state file '%s'", tmpname);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    if (haveExistingState && fchmod(fd, existingStateStat.st_mode & 0777) != 0) {
+        LogError(errno, RS_RET_IO_ERROR, "omsendertrack: cannot preserve permissions of state file '%s'",
+                 pData->statefile);
+        close(fd);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    if (fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
+        LogError(errno, RS_RET_IO_ERROR, "omsendertrack: cannot set close-on-exec on '%s'", tmpname);
+        close(fd);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    if ((fp = fdopen(fd, "w")) == NULL) {
+        LogError(errno, RS_RET_IO_ERROR, "omsendertrack: cannot open temporary state file '%s'", tmpname);
+        close(fd);
         ABORT_FINALIZE(RS_RET_IO_ERROR);
     }
 
     CHKiRet(writeSenderStats(pData, fp));
-
-    /* Atomically replace the old file with the new one */
-    if (rename(tmpname, (const char *)pData->statefile) != 0) {
-        LogError(errno, RS_RET_IO_ERROR,
-                 "omsendertrack rename '%s' to configured file name '%s' failed - "
-                 "left temp file intact",
-                 tmpname, pData->statefile);
+    if (fflush(fp) == EOF || fsync(fileno(fp)) == -1) {
+        LogError(errno, RS_RET_IO_ERROR, "omsendertrack: cannot flush temporary state file '%s'", tmpname);
         ABORT_FINALIZE(RS_RET_IO_ERROR);
     }
+    if (fclose(fp) == EOF) {
+        fp = NULL;
+        LogError(errno, RS_RET_IO_ERROR, "omsendertrack: cannot close temporary state file '%s'", tmpname);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    fp = NULL;
+
+    if (rename(tmpname, (const char *)pData->statefile) != 0) {
+        LogError(errno, RS_RET_IO_ERROR, "omsendertrack: cannot rename '%s' to configured state file '%s'", tmpname,
+                 pData->statefile);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    renamed = 1;
+    CHKiRet(fsyncStatefileParentDir((const char *)pData->statefile));
 
 finalize_it:
     if (fp != NULL) {
         fclose(fp);
     }
-    if (tmp_alloc && tmpname != NULL) {
-        free((void *)tmpname);
+    if (iRet != RS_RET_OK && !renamed && tmpname != NULL) {
+        unlink(tmpname);
     }
+    free(tmpname);
     RETiRet;
 }
 
@@ -677,16 +979,21 @@ BEGINfreeInstance
     }
 
     assert(pData->statefile != NULL); /* parameter is mandatory, as such must be set */
-    /* do final write */
-    writeSenderInfo(pData);
+    /* Do a final write only after successful sender-state initialization. */
+    if (pData->mutSendersInitialized) {
+        writeSenderInfo(pData);
+    }
 
     /* destroy data structs */
     free((void *)pData->senderidTemplate);
     free((void *)pData->statefile);
-    if (pData->statefile_tmp) free((void *)pData->statefile_tmp);
-    pthread_rwlock_destroy(&pData->mutSenders);
+    if (pData->mutSendersInitialized) {
+        pthread_rwlock_destroy(&pData->mutSenders);
+    }
     DESTROY_ATOMIC_HELPER_MUT(pData->mutShutdownBackgroundWriter);
-    hashtable_destroy(pData->stats_senders, 1); /* 1 => free all values automatically */
+    if (pData->stats_senders != NULL) {
+        hashtable_destroy(pData->stats_senders, 1); /* 1 => free all values automatically */
+    }
 ENDfreeInstance
 
 
@@ -722,6 +1029,8 @@ ENDcommitTransaction
 static rsRetVal setInstParamDefaults(instanceData *pData) {
     DEFiRet;
     pData->interval = DEFAULT_INTERVAL;
+    pData->bIgnoreInvalidStatefile = 1;
+    pData->bDisableStatefileWrites = 0;
     CHKmalloc(pData->senderidTemplate = (uchar *)strdup(" StdOmSenderTrack-senderid"));
 finalize_it:
     RETiRet;
@@ -760,12 +1069,15 @@ BEGINnewActInst
             continue;
         } else if (!strcmp(actpblk.descr[i].name, "interval")) {
             pData->interval = (int)pvals[i].val.d.n;
-            // TODO: add cmdfile
         } else if (!strcmp(actpblk.descr[i].name, "statefile")) {
             CHKmalloc(pData->statefile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(actpblk.descr[i].name, "ignoreinvalidstatefile")) {
+            pData->bIgnoreInvalidStatefile = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "senderid")) {
             free((void *)pData->senderidTemplate);  // free default template
             CHKmalloc(pData->senderidTemplate = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(actpblk.descr[i].name, "cmdfile")) {
+            /* Accepted for compatibility. Command-file processing is not implemented. */
         } else {
             DBGPRINTF(
                 "omsendertrack: program error, non-handled "
@@ -780,15 +1092,12 @@ BEGINnewActInst
         ABORT_FINALIZE(RS_RET_CONF_RQRD_PARAM_MISSING);
     }
 
-    /* build cached temp filename once */
-    CHKiRet(buildTmpStatefile(pData));
-
     CODE_STD_STRING_REQUESTnewActInst(1);
     tplToUse = (uchar *)strdup((pData->senderidTemplate == NULL) ? " StdOmSenderTrack-senderid"
                                                                  : (char *)pData->senderidTemplate);
     CHKiRet(OMSRsetEntry(*ppOMSR, 0, tplToUse, OMSR_NO_RQD_TPL_OPTS));
 
-    initHashtable(pData);
+    CHKiRet(initHashtable(pData));
     CODE_STD_FINALIZERnewActInst;
     if (bDestructPValsOnExit) cnfparamvalsDestruct(pvals, &actpblk);
 ENDnewActInst

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -665,11 +665,16 @@ TESTS_MMSNAREPARSE_VALGRIND = \
 
 TESTS_OMSENDERTRACK = \
         omsendertrack-basic.sh \
-	omsendertrack-statefile.sh
+	omsendertrack-statefile.sh \
+	omsendertrack-statefile-recovery.sh
 
 TESTS_OMSENDERTRACK_VALGRIND = \
 	omsendertrack-basic-vg.sh \
-	omsendertrack-statefile-vg.sh
+	omsendertrack-statefile-vg.sh \
+	omsendertrack-statefile-recovery-vg.sh
+
+TESTS_OMSENDERTRACK_LIBYAML = \
+	yaml-omsendertrack-statefile-recovery.sh
 
 TESTS_LIBZSTD = \
         zstd.sh
@@ -2407,6 +2412,7 @@ EXTRA_DIST += $(TESTS_MMSNAREPARSE_MINIMAL)
 EXTRA_DIST += $(TESTS_MMSNAREPARSE_VALGRIND)
 EXTRA_DIST += $(TESTS_OMSENDERTRACK)
 EXTRA_DIST += $(TESTS_OMSENDERTRACK_VALGRIND)
+EXTRA_DIST += $(TESTS_OMSENDERTRACK_LIBYAML)
 EXTRA_DIST += $(TESTS_LIBZSTD)
 EXTRA_DIST += $(TESTS_LIBZSTD_VALGRIND)
 EXTRA_DIST += $(TESTS_LIBGCRYPT)
@@ -2934,6 +2940,9 @@ TESTS += $(TESTS_OMSENDERTRACK)
 if HAVE_VALGRIND
 TESTS += $(TESTS_OMSENDERTRACK_VALGRIND)
 endif # if HAVE_VALGRIND
+if HAVE_LIBYAML
+TESTS += $(TESTS_OMSENDERTRACK_LIBYAML)
+endif
 endif
 
 if ENABLE_LIBZSTD

--- a/tests/omsendertrack-statefile-recovery-vg.sh
+++ b/tests/omsendertrack-statefile-recovery-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/omsendertrack-statefile-recovery.sh

--- a/tests/omsendertrack-statefile-recovery.sh
+++ b/tests/omsendertrack-statefile-recovery.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Verify that omsendertrack recovers from missing, empty, and syntactically or
+# semantically corrupt state files without blocking logging. The oracle is a
+# clean daemon shutdown, a valid replacement state file, byte-for-byte
+# preserved corrupt input, and no command-file placeholder creation.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+
+write_config() {
+	local statefile="$1"
+	local ignore="$2"
+	generate_conf
+	add_conf '
+module(load="../plugins/omsendertrack/.libs/omsendertrack")
+template(name="hostname" type="string" string="%hostname%")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+action(type="omsendertrack" senderid="hostname" statefile="'"$statefile"'"
+       ignoreInvalidStatefile="'"$ignore"'" cmdfile="'"$statefile"'.commands")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt" file="'"$RSYSLOG_OUT_LOG"'")
+'
+}
+
+run_recovery_case() {
+	local name="$1"
+	local contents="$2"
+	local statefile="${RSYSLOG_DYNNAME}.${name}.state"
+	local original="${statefile}.original"
+
+	if [ "$name" != "missing" ]; then
+		printf '%s' "$contents" > "$statefile"
+		if [ "$name" != "empty" ]; then
+			cp "$statefile" "$original"
+		fi
+	fi
+	rm -f "$RSYSLOG_OUT_LOG"
+	write_config "$statefile" on
+	startup
+	injectmsg_literal '<167>Mar  1 01:00:00 sender1.example.net tag msgnum:00000000:'
+	shutdown_when_empty
+	wait_shutdown
+	content_check '"sender":"sender1.example.net"' "$statefile"
+	content_check '"messages":1' "$statefile"
+	if [ -e "${statefile}.commands" ]; then
+		echo "FAIL: omsendertrack created the unimplemented cmdFile for ${name}"
+		error_exit 1
+	fi
+	if [ "$name" != "missing" ] && [ "$name" != "empty" ]; then
+		set -- "${statefile}".corrupt.*
+		if [ ! -e "$1" ]; then
+			echo "FAIL: corrupt state file was not quarantined for ${name}"
+			error_exit 1
+		fi
+		cmp_exact_file "$original" "$1" || error_exit 1 "corrupt state file changed during quarantine"
+	fi
+}
+
+run_recovery_case missing ''
+run_recovery_case empty ''
+run_recovery_case truncated '['
+run_recovery_case wrong-root '{}'
+run_recovery_case trailing '[] trailing'
+run_recovery_case bad-entry '[{"sender":"sender1.example.net","messages":"1","firstseen":1,"lastseen":1}]'
+run_recovery_case duplicate '[{"sender":"sender1.example.net","messages":1,"firstseen":1,"lastseen":1},{"sender":"sender1.example.net","messages":2,"firstseen":1,"lastseen":2}]'
+
+strict_state="${RSYSLOG_DYNNAME}.strict.state"
+printf '[' > "$strict_state"
+cp "$strict_state" "${strict_state}.original"
+write_config "$strict_state" off
+if ../tools/rsyslogd -N1 \
+	-M"../plugins/omsendertrack/.libs:../plugins/imdiag/.libs:../runtime/.libs:../tools/.libs:../tools" \
+	-f"${TESTCONF_NM}.conf" >"${RSYSLOG_DYNNAME}.strict.log" 2>&1; then
+	echo "FAIL: IgnoreInvalidStatefile=off accepted an invalid state file"
+	cat "${RSYSLOG_DYNNAME}.strict.log"
+	error_exit 1
+fi
+cmp_exact_file "${strict_state}.original" "$strict_state" || error_exit 1 "strict mode modified invalid state"
+content_check 'IgnoreInvalidStatefile is off' "${RSYSLOG_DYNNAME}.strict.log"
+
+exit_test

--- a/tests/yaml-omsendertrack-statefile-recovery.sh
+++ b/tests/yaml-omsendertrack-statefile-recovery.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Verify YAML parity for omsendertrack IgnoreInvalidStatefile. A zero-byte
+# state file is accepted by the default but rejected when the action opts into
+# strict recovery; a clean startup and the strict -N1 diagnostic are the oracle.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+
+write_config() {
+	local config="$1"
+	local statefile="$2"
+	local ignore="$3"
+	generate_conf
+	add_conf '
+include(file="'"$config"'")
+'
+	cat > "$config" <<YAMLEOF
+version: 2
+modules:
+  - load: "../plugins/omsendertrack/.libs/omsendertrack"
+rulesets:
+  - name: main
+    actions:
+      - type: omsendertrack
+        stateFile: "${statefile}"
+        ignoreInvalidStatefile: ${ignore}
+YAMLEOF
+}
+
+empty_state="${RSYSLOG_DYNNAME}.empty.state"
+: > "$empty_state"
+write_config "${RSYSLOG_DYNNAME}.recover.yaml" "$empty_state" on
+startup
+shutdown_immediate
+wait_shutdown
+
+strict_state="${RSYSLOG_DYNNAME}.strict.state"
+: > "$strict_state"
+write_config "${RSYSLOG_DYNNAME}.strict.yaml" "$strict_state" off
+if ../tools/rsyslogd -N1 \
+	-M"../plugins/omsendertrack/.libs:../plugins/imdiag/.libs:../runtime/.libs:../tools/.libs:../tools" \
+	-f"${TESTCONF_NM}.conf" >"${RSYSLOG_DYNNAME}.strict.log" 2>&1; then
+	echo "FAIL: YAML strict recovery accepted an empty state file"
+	cat "${RSYSLOG_DYNNAME}.strict.log"
+	error_exit 1
+fi
+content_check 'IgnoreInvalidStatefile is off' "${RSYSLOG_DYNNAME}.strict.log"
+if [ -s "$strict_state" ]; then
+	echo "FAIL: YAML strict recovery modified the empty state file"
+	error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
## Summary

- recover from missing, empty, or invalid sender-tracking state by default
- add strict `IgnoreNonValidStatefile="off"` behavior and corrupt-file quarantine
- make state persistence atomic and durable; document `cmdFile` as a no-op

## Validation

- focused RainerScript, YAML, and Valgrind tests
- Sphinx build and `make distcheck TEST_RUN_TYPE=MOCK-OK`
- Ubuntu 26.04 container, SAN, and TSAN lanes

Static analysis completed with no omsendertrack finding; it reports one
pre-existing warning in `runtime/modules.c`.

No issue.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

