### PR TITLE
rainerscript: prevent replace() buffer underallocation

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -1827,8 +1827,8 @@ static es_str_t *doFuncReplace(struct svar *__restrict__ const operandVal,
         if (src_buff[i] == find[j]) {
             j++;
         } else if (j > 0) {
-            i -= (j - 1);
-            lDst -= (j - 1);
+            i -= j;
+            lDst -= j;
             j = 0;
         }
     }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -37,6 +37,9 @@ EXTRA_DIST += $(TESTS_TEMPLATE_REGEX_BOUNDS) $(TESTS_TEMPLATE_REGEX_BOUNDS_LIBYA
 TESTS_RSCRIPT_OBJECT_STRINGS = rscript-object-string-escapes.sh
 EXTRA_DIST += $(TESTS_RSCRIPT_OBJECT_STRINGS)
 
+TESTS_RSCRIPT_REPLACE_OVERLAP = rscript_replace-overlap.sh
+EXTRA_DIST += $(TESTS_RSCRIPT_REPLACE_OVERLAP)
+
 TESTS_TEMPLATE_PARAMETER_ERRORS = template-parameter-errors.sh
 EXTRA_DIST += $(TESTS_TEMPLATE_PARAMETER_ERRORS)
 
@@ -529,6 +532,7 @@ TESTS_DEFAULT = \
 	rscript_set_modify.sh \
 	rscript_unaffected_reset.sh \
 	rscript_replace_complex.sh \
+	$(TESTS_RSCRIPT_REPLACE_OVERLAP) \
 	rscript_wrap2.sh \
 	rscript_wrap3.sh \
 	rscript_re_extract_i.sh \

--- a/tests/rscript_replace-overlap.sh
+++ b/tests/rscript_replace-overlap.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Regression test for replace() sizing after a failed partial match overlaps a
+# later match. The exact output values prove both replacement semantics and
+# that the shared three-argument wrap() path writes the complete result.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string"
+         string="long=%$.long%;short=%$.short%;equal=%$.equal%;tail=%$.tail%;empty=%$.empty%;wrap=%$.wrapped%\n")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" address="127.0.0.1" port="0" ruleset="replace_regression"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+ruleset(name="replace_regression") {
+set $.long = replace($msg, "ab", "0123456789");
+set $.short = replace("aab", "ab", "X");
+set $.equal = replace("ababa", "ab", "XY");
+set $.tail = replace("aab", "abc", "Z");
+set $.empty = replace("ab", "", "Z");
+set $.wrapped = wrap("aab", "ab", "0123456789");
+
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+tcpflood -m1 -M '"<13>Aug 20 00:00:00 host tag: aab"'
+shutdown_when_empty
+wait_shutdown
+content_check 'long= a0123456789;short=aX;equal=XYXYa;tail=aab;empty=Z;wrap=aba0123456789ab'
+exit_test


### PR DESCRIPTION
## Summary

- align the `replace()` sizing-pass rewind with the output pass
- prevent output-buffer underallocation after overlapping partial matches
- add focused regression coverage for `replace()` and three-argument `wrap()`

## Security impact

A ruleset that explicitly applies `replace()` or three-argument `wrap()` to attacker-controlled data could underallocate the output buffer and write past it. The affected functions are not applied by default. We reproduced heap corruption and daemon termination; confidentiality loss, integrity loss, and code execution were not demonstrated.

## Validation

- independently reproduced the pre-fix heap-buffer overflow with ASan
- confirmed the same trigger no longer reproduces after the fix
- focused regression test passed
- Ubuntu 26.04 CI-equivalent suite passed before the final rebase
- Ubuntu 26.04 ASan/UBSan suite passed before the final rebase
- mock distribution check passed after the final rebase
- formatting, ShellCheck, and test-antipattern checks passed

Per maintainer direction, the branch was pushed without waiting for an additional full post-rebase container run. Hosted CI provides the final PR-head validation.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

