### PR TITLE
security: add local PR threat review workflow

### DIFF
--- a/.agent/skills/rsyslog-security-pr-review/SKILL.md
+++ b/.agent/skills/rsyslog-security-pr-review/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: rsyslog-security-pr-review
+description: Run rsyslog's local, threat-model-aware security delta review for a PR candidate, create a digest-bound local receipt, or resolve one independently confirmed candidate. Use for `$rsyslog-security-pr-review`, `SECURITY REVIEW`, `SECURITY RESOLVE candidate-id`, and FINISH on code PR work.
+---
+
+# rsyslog Security PR Review
+
+Review only the stabilized local PR delta against the reusable project model.
+Keep the normal lane small: deterministic routing, one discovery pass, and no
+further agents when no candidate exists. Never call an external service from a
+repository script, publish artifacts, or edit code during the normal review.
+
+Local artifacts live under ignored `.codex/security-review/`. Never put a PoC,
+credential, embargoed fact, private advisory reference, or unresolved exploit
+instruction in a tracked file or public summary.
+
+## Required context and input
+
+Read, in order:
+
+1. `SECURITY.md`
+2. `doc/ai/security_triage_rubric.md`
+3. `doc/security/project-threat-model.md`
+4. `doc/security/threat-model-components.json`
+
+Then build the complete candidate package:
+
+```sh
+python3 devtools/build-security-review-input.py
+```
+
+The builder is the authority for the base, changed-file inventory, digest,
+component coverage, and route. It includes committed, staged, unstaged, and
+untracked changes. Do not substitute `git diff` by itself. Pass `--base REF`
+only when the PR base is intentionally different from the repository's local
+validation base.
+
+## Review routing
+
+- `not_applicable`: write a minimal receipt and stop. Do not start discovery.
+- `quick`: use one fresh Terra/medium discovery agent. Review every path in
+  `coverage.expected_files` and only directly supporting code needed to trace
+  the mapped boundaries and invariants.
+- `lead_required`: run the same bounded discovery, then give the package and
+  results to a fresh Terra/high security lead. Model changes, unmapped source,
+  high-risk components, and ambiguous trust-boundary changes use this route.
+- `expanded`: split at most once into two non-overlapping discovery shards,
+  with every expected file assigned exactly once. If two bounded shards cannot
+  cover the delta, write `needs_human`; do not truncate or silently exceed the
+  lane.
+
+If a required model or a fresh independent role is unavailable, write
+`needs_human`; do not silently reuse the discovering agent or substitute a
+different role.
+
+Use the installed Codex Security Diff Scan and Finding Discovery phase
+guidance when available. They are phase guidance, not an instruction to run a
+full-repository or deep scan. If unavailable, use this equivalent sequence:
+
+1. Confirm every expected file is assigned exactly once.
+2. Inspect changed lines plus the smallest source/control/sink context.
+3. Test only mapped trust boundaries and invariants, plus obvious newly created
+   boundaries.
+4. Record candidate evidence and counterevidence without severity inflation.
+5. Stop immediately when there are no candidates.
+
+Target less than two minutes and 25,000 aggregate tokens for ordinary
+discovery. Do not run validation, attack-path analysis, or propose fixes for a
+zero-candidate review.
+
+## Candidate validation and lead triage
+
+Always write `.codex/security-review/candidates.json`, including an empty
+`candidates` array for a zero-candidate review. Include `schema_version`, the
+input digest and model revision, discovery coverage, and the array. Each
+candidate needs a stable local ID, introduced-or-worsened status, affected
+files and model IDs, source, control, sink, attacker capability, impact,
+counterevidence, proof gaps, discovery disposition, and timestamps. Candidate
+discovery alone never blocks.
+
+Give candidates to a fresh Terra/medium validator that did not perform
+discovery. Follow the Codex Security Validation phase when available. Require
+direct code proof or a safe reproducer of attacker control, reachability, and
+impact. Classify each result as `confirmed`, `deferred`, `hardening`, or
+`not_actionable`; retain proof gaps and separate pre-existing findings from
+PR-introduced or worsened findings.
+
+The discovery-plus-validation target is less than five minutes and 60,000
+aggregate tokens. Invoke a fresh Terra/high security lead only for confirmed or
+deferred candidates, model changes, unmapped security-relevant code, or an
+ambiguous boundary change. Attack-path analysis is conditional: use it only
+when source-to-sink reachability or severity remains material and unclear.
+
+Blocking policy:
+
+- Confirmed PR-introduced or worsened Critical, High, or Medium findings:
+  `blocked`.
+- Confirmed Low: warn and normally `passed`.
+- Serious unresolved High/Critical hypothesis: `needs_human`.
+- Discovery-only, hardening, not-actionable, and unrelated pre-existing
+  results: do not block; report them separately and precisely.
+
+## Receipt
+
+Write `.codex/security-review/receipt.json` only after coverage and disposition
+are known. Include at least:
+
+- `schema_version`, `input_schema_version`, `diff_digest`, `model_revision`
+- `route`, `coverage.expected_files`, `coverage.reviewed_files`, and whether
+  coverage is complete
+- candidate counts by disposition and introduced-or-worsened status
+- `started_at`, `completed_at`, elapsed time, agent roles used, and approximate
+  aggregate tokens
+- final `status`: `passed`, `blocked`, `needs_human`, or `not_applicable`
+
+A receipt is current only if a freshly rebuilt `input.json` has the same
+`diff_digest` and model revision, `reviewed_files` has no duplicates, and its
+set exactly equals the rebuilt `expected_files` set. Never reuse a stale
+receipt. `FINISH` and agent-led container completion require a current `passed`
+or `not_applicable` receipt for code PR work. This comparison is performed by
+the agent; no shell or CI hook enforces it.
+
+## Resolve one confirmed candidate
+
+Run this section only for `$rsyslog-security-pr-review resolve <candidate-id>`
+or `SECURITY RESOLVE <candidate-id>`. This explicit invocation authorizes one
+fix, not other candidates. Refuse if the candidate is absent, not independently
+confirmed, or its stored digest differs from a freshly built input.
+
+1. Give a fresh Terra/medium agent a read-only boundary and compatibility
+   investigation before editing.
+2. Assign Luna/xhigh as the only writing agent. It implements the smallest
+   complete repository-native fix, a regression test that fails without it,
+   and a legitimate control proving compatible behavior remains.
+3. Run the reproducer, a distinct malicious-input class, the legitimate
+   control, closest tests, and applicable rsyslog build checks. Follow the
+   repository build, test, formatting, and test-comment skills.
+4. Give a fresh Terra/medium verifier only the original finding, repository
+   policy, and candidate diff. Do not give it the patch rationale or earlier
+   conclusions. It must reconstruct the invariant, search for bypasses and
+   regressions, and verify that the original path is closed. Use Codex Security
+   Verify Fix guidance when available.
+5. Rebuild `input.json`, rerun this compact review over the final digest, and
+   replace the receipt only after that digest passes.
+6. Run PR-ready local container validation after the fix loop stabilizes.
+
+Do not auto-fix during `SECURITY REVIEW`. If the specified writer model is not
+available, stop with `needs_human`; do not silently replace the only authorized
+writing role.
+
+## Updating the baseline
+
+Update the model revision and component map together when the PR adds or
+materially changes a trust boundary, security invariant, attacker capability,
+default exposure, privileged operation, executable/module loading path,
+persistent-state authority, or release trust path. Add component-local evidence
+and focused test hints when a new subsystem appears. Routine internal refactors
+that preserve the mapped boundary and invariants do not require model churn.
+
+For a model update, obtain one fresh read-only architecture review, then
+independently verify every material claim and repository-relative citation.
+Keep attacker stories as hypotheses, remove volatile implementation trivia,
+and never turn an unresolved suspicion into a repository claim.

--- a/.agent/skills/rsyslog-security-pr-review/SKILL.md
+++ b/.agent/skills/rsyslog-security-pr-review/SKILL.md
@@ -40,7 +40,8 @@ validation base.
 - `not_applicable`: write a minimal receipt and stop. Do not start discovery.
 - `quick`: use one fresh Terra/medium discovery agent. Review every path in
   `coverage.expected_files` and only directly supporting code needed to trace
-  the mapped boundaries and invariants.
+  the mapped boundaries and invariants. Record expected-file coverage in
+  `reviewed_files`; record supporting paths separately in `context_files`.
 - `lead_required`: run the same bounded discovery, then give the package and
   results to a fresh Terra/high security lead. Model changes, unmapped source,
   high-risk components, and ambiguous trust-boundary changes use this route.
@@ -106,8 +107,8 @@ Write `.codex/security-review/receipt.json` only after coverage and disposition
 are known. Include at least:
 
 - `schema_version`, `input_schema_version`, `diff_digest`, `model_revision`
-- `route`, `coverage.expected_files`, `coverage.reviewed_files`, and whether
-  coverage is complete
+- `route`, `coverage.expected_files`, `coverage.reviewed_files`, optional
+  `coverage.context_files`, and whether expected-file coverage is complete
 - candidate counts by disposition and introduced-or-worsened status
 - `started_at`, `completed_at`, elapsed time, agent roles used, and approximate
   aggregate tokens
@@ -115,7 +116,9 @@ are known. Include at least:
 
 A receipt is current only if a freshly rebuilt `input.json` has the same
 `diff_digest` and model revision, `reviewed_files` has no duplicates, and its
-set exactly equals the rebuilt `expected_files` set. Never reuse a stale
+set exactly equals the rebuilt `expected_files` set. `context_files` may list
+additional supporting paths and does not participate in this equality check.
+Never reuse a stale
 receipt. `FINISH` and agent-led container completion require a current `passed`
 or `not_applicable` receipt for code PR work. This comparison is performed by
 the agent; no shell or CI hook enforces it.

--- a/.agent/skills/rsyslog-security-pr-review/agents/openai.yaml
+++ b/.agent/skills/rsyslog-security-pr-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "rsyslog Security PR Review"
+  short_description: "Review rsyslog PR diffs against security boundaries"
+  default_prompt: "Use $rsyslog-security-pr-review to perform the local security delta review for the current rsyslog PR candidate."

--- a/.agent/skills/rsyslog_local_container_testing/SKILL.md
+++ b/.agent/skills/rsyslog_local_container_testing/SKILL.md
@@ -25,6 +25,15 @@ Focused host-side tests from `rsyslog_test` are still the right first step when
 debugging a specific behavior. After the patch is stable, run this skill before
 pushing if the change is intended for review.
 
+For agent-led PR completion, first apply `rsyslog-security-pr-review` to the
+stabilized candidate. Rebuild its deterministic input immediately before this
+container gate and require a local `receipt.json` with the same diff digest and
+model revision and a `passed` or `not_applicable` disposition. A missing,
+stale, `blocked`, or `needs_human` receipt means the agent may still run useful
+container checks, but must not claim the candidate is PR-ready. This is an
+agent workflow rule, not a shell or CI dependency; repository scripts must not
+invoke an AI client.
+
 ## Pre-PR Testbed Tiers
 
 Use these tiers as a session testbed before opening or updating PRs. The goal is

--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,6 @@ AGENTS.local.md
 
 # Codex container validation marker
 .codex/container_validated.marker
+
+# Local Codex security review packages and receipts
+.codex/security-review/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ To ensure consistency and high-quality contributions, AI agents SHOULD use the f
 |-------|---------|
 | [`rsyslog_build`](.agent/skills/rsyslog_build/SKILL.md) | Environment setup and incremental parallel builds. |
 | [`rsyslog_test`](.agent/skills/rsyslog_test/SKILL.md) | Standardized validation and debugging via `diag.sh`. |
+| [`rsyslog-security-pr-review`](.agent/skills/rsyslog-security-pr-review/SKILL.md) | Local, digest-bound threat-model delta review and explicitly authorized confirmed-finding fix workflow. |
 | [`rsyslog_local_container_testing`](.agent/skills/rsyslog_local_container_testing/SKILL.md) | CI-style local dev-container validation, change-gated Ubuntu 26.04 first, late prompt audits, service-skip checks, and clean-tree rules. |
 | [`rsyslog_pr_babysitting`](.agent/skills/rsyslog_pr_babysitting/SKILL.md) | Post-push PR monitoring, including CI failures, reruns, and unresolved review-thread checks. |
 | [`rsyslog_changelog`](.agent/skills/rsyslog_changelog/SKILL.md) | Selective ChangeLog maintenance that follows release-note style and avoids low-signal churn. |
@@ -35,7 +36,10 @@ Follow these steps for a typical development task:
 
 1.  **Build**: Use the `rsyslog_build` skill to set up and compile.
 2.  **Validate**: Use the `rsyslog_test` skill to run relevant shell tests.
-3.  **Container Validation**: Use the `rsyslog_local_container_testing` skill
+3.  **Security Review**: Use `rsyslog-security-pr-review` on the stabilized
+    local PR candidate. It is a compact, local delta review and writes an
+    ignored digest-bound receipt; it is not a shell or CI gate.
+4.  **Container Validation**: Use the `rsyslog_local_container_testing` skill
     when Docker or Podman container tooling is available.
 5.  **Commit**: Use the `rsyslog_commit` skill to format code and draft your message.
 
@@ -382,7 +386,13 @@ than duplicating them.
 - `TEST`: Triggers the `rsyslog_test` validation workflow.
 - `CHANGELOG`: Triggers the `rsyslog_changelog` release-note maintenance workflow.
 - `SUMMARIZE`: Generates PR and commit summaries using `rsyslog_commit` templates.
-- `FINISH`: Final review of code and style before conclusion.
+- `SECURITY REVIEW`: Runs the local threat-model delta review for the current PR candidate.
+- `SECURITY RESOLVE <candidate-id>`: Starts the separately authorized fix loop for one independently confirmed candidate.
+- `FINISH`: Final review of code and style before conclusion. For agent-led code
+  PR work, this includes a current `.codex/security-review/receipt.json` whose
+  digest and model revision match a freshly built input package. A stale,
+  blocking, or `needs_human` receipt prevents an agent from claiming PR
+  readiness; ordinary human shell use remains unaffected.
 
 ---
 *For human-facing guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md) and [DEVELOPING.md](DEVELOPING.md).*

--- a/devtools/build-security-review-input.py
+++ b/devtools/build-security-review-input.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Rainer Gerhards and Others
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Build the deterministic input package for a local PR security review."""
 
@@ -184,17 +194,30 @@ def collect_changes(repo: Path, merge_base: str, head: str) -> tuple[list[dict[s
 
 
 def collect_numstat(repo: Path, merge_base: str, untracked: list[str]) -> tuple[dict[str, dict[str, object]], int]:
-    result = git(repo, ["diff", "--numstat", "--no-renames", merge_base, "--"])
+    result = git(repo, ["diff", "--numstat", "-z", "--find-renames", merge_base, "--"], text=False)
     by_path: dict[str, dict[str, object]] = {}
     total = 0
-    for line in result.stdout.splitlines():
-        parts = line.split("\t", 2)
+    fields = result.stdout.split(b"\0")
+    index = 0
+    while index < len(fields) and fields[index]:
+        parts = fields[index].split(b"\t", 2)
+        index += 1
         if len(parts) != 3:
-            continue
+            raise ReviewInputError("malformed numstat entry from git")
         added, deleted, path = parts
-        binary = added == "-" or deleted == "-"
+        paths: list[bytes]
+        if path:
+            paths = [path]
+        else:
+            if index + 1 >= len(fields):
+                raise ReviewInputError("truncated rename/copy numstat entry from git")
+            paths = [fields[index], fields[index + 1]]
+            index += 2
+        binary = added == b"-" or deleted == b"-"
         changed = 0 if binary else int(added) + int(deleted)
-        by_path[path] = {"changed_lines": changed, "binary": binary}
+        for changed_path in paths:
+            decoded_path = changed_path.decode("utf-8", "surrogateescape")
+            by_path[decoded_path] = {"changed_lines": changed, "binary": binary}
         total += changed
     for path in untracked:
         file_path = repo / path
@@ -215,7 +238,10 @@ def path_matches(path: str, pattern: str) -> bool:
 def load_model(path: Path) -> tuple[set[str], int]:
     if not path.is_file():
         raise ReviewInputError(f"threat model is missing: {path}")
-    text = path.read_text(encoding="utf-8")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise ReviewInputError(f"invalid threat model UTF-8: {exc}") from exc
     ids = set(MODEL_ID_RE.findall(text))
     if not ids:
         raise ReviewInputError(f"threat model contains no TB-/SI- identifiers: {path}")
@@ -285,8 +311,8 @@ def match_components(path: str, components: list[dict[str, object]]) -> list[dic
     return [component for component in components if any(path_matches(path, pattern) for pattern in component["paths"])]
 
 
-def is_reviewable(path: str, components: list[dict[str, object]]) -> bool:
-    if path in SECURITY_POLICY_PATHS or path.startswith(SECURITY_POLICY_PREFIXES):
+def is_reviewable(path: str, components: list[dict[str, object]], policy_paths: set[str]) -> bool:
+    if path in policy_paths or path.startswith(SECURITY_POLICY_PREFIXES):
         return True
     pure = PurePosixPath(path)
     if pure.name in SOURCE_BASENAMES or pure.suffix.lower() in SOURCE_SUFFIXES:
@@ -343,6 +369,7 @@ def build_package(args: argparse.Namespace) -> dict[str, object]:
     model_ids, model_revision = load_model(model_path)
     routing = load_components(map_path, repo, model_ids, model_revision)
     components = routing["components"]
+    policy_paths = SECURITY_POLICY_PATHS | {model_rel, map_rel}
 
     changes, untracked = collect_changes(repo, merge_base, head_commit)
     numstat, total_changed_lines = collect_numstat(repo, merge_base, untracked)
@@ -364,7 +391,7 @@ def build_package(args: argparse.Namespace) -> dict[str, object]:
                     matched.append(component)
                     seen_components.add(component["id"])
         reviewable = any(
-            is_reviewable(relevant_path, match_components(relevant_path, components))
+            is_reviewable(relevant_path, match_components(relevant_path, components), policy_paths)
             or is_executable(repo, merge_base, relevant_path)
             for relevant_path in relevant_paths
         )

--- a/devtools/build-security-review-input.py
+++ b/devtools/build-security-review-input.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+# Copyright 2026 Rainer Gerhards and Others
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Build the deterministic input package for a local PR security review."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+
+
+DEFAULT_MODEL = "doc/security/project-threat-model.md"
+DEFAULT_COMPONENT_MAP = "doc/security/threat-model-components.json"
+DEFAULT_OUTPUT = ".codex/security-review/input.json"
+MODEL_ID_RE = re.compile(r"^### ((?:TB|SI)-[A-Z0-9-]+)\b", re.MULTILINE)
+MODEL_REVISION_RE = re.compile(r"^Model revision: ([1-9][0-9]*)\s*$", re.MULTILINE)
+SOURCE_SUFFIXES = {
+    ".c", ".cc", ".conf", ".cpp", ".h", ".hh", ".hpp", ".json", ".m4", ".py", ".sh", ".yaml", ".yml",
+}
+SOURCE_BASENAMES = {"configure.ac", "Makefile.am", "Dockerfile", "Containerfile"}
+SOURCE_PREFIXES = (
+    ".github/",
+    "compat/",
+    "contrib/",
+    "devtools/",
+    "grammar/",
+    "m4/",
+    "packaging/",
+    "plugins/",
+    "runtime/",
+    "scripts/",
+    "tests/",
+    "tools/",
+)
+SECURITY_POLICY_PATHS = {
+    "AGENTS.md",
+    "SECURITY.md",
+    "doc/ai/security_triage_rubric.md",
+    DEFAULT_MODEL,
+    DEFAULT_COMPONENT_MAP,
+}
+SECURITY_POLICY_PREFIXES = (".agent/skills/rsyslog-security-pr-review/",)
+EXPANDED_FILE_LIMIT = 50
+EXPANDED_LINE_LIMIT = 2000
+
+
+class ReviewInputError(Exception):
+    """Raised for an invalid repository, model, or routing map."""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".", help="repository root (default: current directory)")
+    parser.add_argument("--base", help="base ref for committed branch changes")
+    parser.add_argument("--head", default="HEAD", help="head commit (default: HEAD)")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="repository-relative threat model path")
+    parser.add_argument("--component-map", default=DEFAULT_COMPONENT_MAP, help="repository-relative routing map path")
+    parser.add_argument(
+        "--output", default=DEFAULT_OUTPUT, help="output JSON path, relative to repo, or '-' for stdout"
+    )
+    return parser.parse_args()
+
+
+def git(repo: Path, args: list[str], *, check: bool = True, text: bool = True):
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=text,
+    )
+    if check and result.returncode != 0:
+        stderr = result.stderr.strip() if text else result.stderr.decode("utf-8", "replace").strip()
+        raise ReviewInputError(f"git {' '.join(args)} failed: {stderr}")
+    return result
+
+
+def verify_repo(path: Path) -> Path:
+    result = git(path, ["rev-parse", "--show-toplevel"])
+    return Path(result.stdout.strip()).resolve()
+
+
+def verify_commit(repo: Path, ref: str) -> str | None:
+    result = git(repo, ["rev-parse", "--verify", f"{ref}^{{commit}}"], check=False)
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def resolve_default_base(repo: Path) -> tuple[str, str]:
+    configured = git(repo, ["config", "--get", "rsyslog.localValidationBase"], check=False)
+    if configured.returncode == 0 and configured.stdout.strip():
+        return configured.stdout.strip(), "git-config"
+
+    reflog = git(repo, ["reflog", "--format=%H", "HEAD"], check=False)
+    reflog_entries = [line for line in reflog.stdout.splitlines() if line]
+    if reflog_entries and verify_commit(repo, reflog_entries[-1]):
+        return reflog_entries[-1], "worktree-reflog"
+
+    return "origin/main", "fallback"
+
+
+def resolve_base(repo: Path, requested: str | None) -> tuple[str, str, str]:
+    if requested:
+        base_ref, source = requested, "command-line"
+    else:
+        base_ref, source = resolve_default_base(repo)
+    base_commit = verify_commit(repo, base_ref)
+    if not base_commit:
+        raise ReviewInputError(f"base ref '{base_ref}' is not available; fetch it or pass --base")
+    return base_ref, base_commit, source
+
+
+def parse_name_status_z(payload: bytes) -> list[dict[str, str]]:
+    fields = payload.split(b"\0")
+    entries: list[dict[str, str]] = []
+    index = 0
+    while index < len(fields) and fields[index]:
+        status = fields[index].decode("ascii", "replace")
+        index += 1
+        if status.startswith(("R", "C")):
+            if index + 1 >= len(fields):
+                raise ReviewInputError("truncated rename/copy entry from git")
+            old_path = fields[index].decode("utf-8", "surrogateescape")
+            path = fields[index + 1].decode("utf-8", "surrogateescape")
+            index += 2
+            entries.append({"status": status[0], "old_path": old_path, "path": path})
+        else:
+            if index >= len(fields):
+                raise ReviewInputError("truncated name-status entry from git")
+            path = fields[index].decode("utf-8", "surrogateescape")
+            index += 1
+            entries.append({"status": status[0], "path": path})
+    return entries
+
+
+def combine_entry(current: dict[str, str] | None, incoming: dict[str, str]) -> dict[str, str]:
+    if current is None:
+        return dict(incoming)
+    result = dict(current)
+    incoming_status = incoming["status"]
+    if incoming_status == "D":
+        result["status"] = "D"
+    elif current["status"] == "A" and incoming_status == "M":
+        result["status"] = "A"
+    elif current["status"] == "R" and incoming_status == "M":
+        result["status"] = "R"
+    else:
+        result.update(incoming)
+    if "old_path" in current and "old_path" not in result:
+        result["old_path"] = current["old_path"]
+    return result
+
+
+def collect_changes(repo: Path, merge_base: str, head: str) -> tuple[list[dict[str, str]], list[str]]:
+    combined: dict[str, dict[str, str]] = {}
+    committed = git(
+        repo,
+        ["diff", "--name-status", "-z", "--find-renames", "--diff-filter=ACMRD", merge_base, head],
+        text=False,
+    )
+    worktree = git(
+        repo,
+        ["diff", "--name-status", "-z", "--find-renames", "--diff-filter=ACMRD", head],
+        text=False,
+    )
+    for entry in parse_name_status_z(committed.stdout) + parse_name_status_z(worktree.stdout):
+        combined[entry["path"]] = combine_entry(combined.get(entry["path"]), entry)
+
+    untracked_result = git(repo, ["ls-files", "--others", "--exclude-standard", "-z"], text=False)
+    untracked = sorted(
+        field.decode("utf-8", "surrogateescape") for field in untracked_result.stdout.split(b"\0") if field
+    )
+    for path in untracked:
+        combined[path] = combine_entry(combined.get(path), {"status": "A", "path": path})
+    return [combined[path] for path in sorted(combined)], untracked
+
+
+def collect_numstat(repo: Path, merge_base: str, untracked: list[str]) -> tuple[dict[str, dict[str, object]], int]:
+    result = git(repo, ["diff", "--numstat", "--no-renames", merge_base, "--"])
+    by_path: dict[str, dict[str, object]] = {}
+    total = 0
+    for line in result.stdout.splitlines():
+        parts = line.split("\t", 2)
+        if len(parts) != 3:
+            continue
+        added, deleted, path = parts
+        binary = added == "-" or deleted == "-"
+        changed = 0 if binary else int(added) + int(deleted)
+        by_path[path] = {"changed_lines": changed, "binary": binary}
+        total += changed
+    for path in untracked:
+        file_path = repo / path
+        data = file_path.read_bytes()
+        binary = b"\0" in data
+        changed = 0 if binary else len(data.splitlines())
+        by_path[path] = {"changed_lines": changed, "binary": binary}
+        total += changed
+    return by_path, total
+
+
+def path_matches(path: str, pattern: str) -> bool:
+    # fnmatch gives repository-root-relative matching here. PurePath.match would
+    # make a root pattern such as AGENTS.md also match doc/ai/AGENTS.md.
+    return fnmatch.fnmatchcase(path, pattern)
+
+
+def load_model(path: Path) -> tuple[set[str], int]:
+    if not path.is_file():
+        raise ReviewInputError(f"threat model is missing: {path}")
+    text = path.read_text(encoding="utf-8")
+    ids = set(MODEL_ID_RE.findall(text))
+    if not ids:
+        raise ReviewInputError(f"threat model contains no TB-/SI- identifiers: {path}")
+    revision_match = MODEL_REVISION_RE.search(text)
+    if not revision_match:
+        raise ReviewInputError(f"threat model contains no valid Model revision: {path}")
+    return ids, int(revision_match.group(1))
+
+
+def validate_relative_path(value: str, field: str) -> None:
+    pure = PurePosixPath(value)
+    if pure.is_absolute() or ".." in pure.parts or not value:
+        raise ReviewInputError(f"invalid repository-relative {field}: {value!r}")
+
+
+def load_components(path: Path, repo: Path, model_ids: set[str], model_revision: int) -> dict[str, object]:
+    if not path.is_file():
+        raise ReviewInputError(f"component map is missing: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ReviewInputError(f"invalid component map JSON: {exc}") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+        raise ReviewInputError("component map schema_version must be 1")
+    if not isinstance(payload.get("model_revision"), int) or payload["model_revision"] < 1:
+        raise ReviewInputError("component map model_revision must be a positive integer")
+    if payload["model_revision"] != model_revision:
+        raise ReviewInputError(
+            f"component map model_revision {payload['model_revision']} does not match threat model {model_revision}"
+        )
+    components = payload.get("components")
+    if not isinstance(components, list) or not components:
+        raise ReviewInputError("component map must contain a non-empty components list")
+
+    seen: set[str] = set()
+    required_arrays = ("paths", "boundaries", "invariants", "evidence", "test_hints")
+    for component in components:
+        if not isinstance(component, dict):
+            raise ReviewInputError("each component must be an object")
+        component_id = component.get("id")
+        if not isinstance(component_id, str) or not component_id:
+            raise ReviewInputError("each component needs a non-empty id")
+        if component_id in seen:
+            raise ReviewInputError(f"duplicate component id: {component_id}")
+        seen.add(component_id)
+        for field in required_arrays:
+            values = component.get(field)
+            if not isinstance(values, list) or any(not isinstance(value, str) for value in values):
+                raise ReviewInputError(f"component {component_id} field {field} must be a string list")
+        if not component["paths"]:
+            raise ReviewInputError(f"component {component_id} has no paths")
+        for pattern in component["paths"]:
+            validate_relative_path(pattern, f"path pattern for {component_id}")
+        for reference in component["boundaries"] + component["invariants"]:
+            if reference not in model_ids:
+                raise ReviewInputError(f"component {component_id} references unknown model id {reference}")
+        for evidence in component["evidence"]:
+            validate_relative_path(evidence, f"evidence path for {component_id}")
+            if not (repo / evidence).exists():
+                raise ReviewInputError(f"component {component_id} evidence path does not exist: {evidence}")
+        if not isinstance(component.get("requires_lead"), bool):
+            raise ReviewInputError(f"component {component_id} requires_lead must be boolean")
+    return payload
+
+
+def match_components(path: str, components: list[dict[str, object]]) -> list[dict[str, object]]:
+    return [component for component in components if any(path_matches(path, pattern) for pattern in component["paths"])]
+
+
+def is_reviewable(path: str, components: list[dict[str, object]]) -> bool:
+    if path in SECURITY_POLICY_PATHS or path.startswith(SECURITY_POLICY_PREFIXES):
+        return True
+    pure = PurePosixPath(path)
+    if pure.name in SOURCE_BASENAMES or pure.suffix.lower() in SOURCE_SUFFIXES:
+        return path.startswith(SOURCE_PREFIXES) or "/" not in path
+    if path.startswith("doc/source/") and pure.suffix.lower() in {".conf", ".json", ".yaml", ".yml"}:
+        return True
+    return any(component["id"] == "security-review-policy" for component in components)
+
+
+def is_executable(repo: Path, merge_base: str, path: str) -> bool:
+    current = repo / path
+    if current.is_file() and current.stat().st_mode & 0o111:
+        return True
+    baseline = git(repo, ["ls-tree", merge_base, "--", path], check=False)
+    return any(line.startswith("100755 ") for line in baseline.stdout.splitlines())
+
+
+def compute_digest(
+    repo: Path, merge_base: str, head_commit: str, untracked: list[str], model: Path, component_map: Path
+) -> str:
+    digest = hashlib.sha256()
+    for label, value in (("merge-base", merge_base), ("head", head_commit)):
+        digest.update(label.encode("ascii") + b"\0" + value.encode("ascii") + b"\0")
+    diff = git(repo, ["diff", "--binary", "--full-index", "--no-ext-diff", merge_base, "--"], text=False)
+    digest.update(b"tracked-diff\0" + diff.stdout)
+    for path in sorted(untracked):
+        encoded = path.encode("utf-8", "surrogateescape")
+        digest.update(b"untracked\0" + encoded + b"\0" + (repo / path).read_bytes())
+    digest.update(b"threat-model\0" + model.read_bytes())
+    digest.update(b"component-map\0" + component_map.read_bytes())
+    return digest.hexdigest()
+
+
+def worktree_state(repo: Path, untracked: list[str]) -> dict[str, object]:
+    staged = git(repo, ["diff", "--cached", "--quiet"], check=False).returncode != 0
+    unstaged = git(repo, ["diff", "--quiet"], check=False).returncode != 0
+    return {"staged": staged, "unstaged": unstaged, "untracked": bool(untracked)}
+
+
+def build_package(args: argparse.Namespace) -> dict[str, object]:
+    repo = verify_repo(Path(args.repo).resolve())
+    head_commit = verify_commit(repo, args.head)
+    if not head_commit:
+        raise ReviewInputError(f"head ref '{args.head}' is not a commit")
+    base_ref, base_commit, base_source = resolve_base(repo, args.base)
+    merge_base = git(repo, ["merge-base", base_commit, head_commit]).stdout.strip()
+
+    model_rel = PurePosixPath(args.model).as_posix()
+    map_rel = PurePosixPath(args.component_map).as_posix()
+    validate_relative_path(model_rel, "threat model path")
+    validate_relative_path(map_rel, "component map path")
+    model_path = repo / model_rel
+    map_path = repo / map_rel
+    model_ids, model_revision = load_model(model_path)
+    routing = load_components(map_path, repo, model_ids, model_revision)
+    components = routing["components"]
+
+    changes, untracked = collect_changes(repo, merge_base, head_commit)
+    numstat, total_changed_lines = collect_numstat(repo, merge_base, untracked)
+    reviewable_files: list[str] = []
+    unmapped: list[str] = []
+    lead_reasons: set[str] = set()
+    enriched: list[dict[str, object]] = []
+
+    for change in changes:
+        path = change["path"]
+        relevant_paths = [path]
+        if "old_path" in change:
+            relevant_paths.append(change["old_path"])
+        matched = []
+        seen_components: set[str] = set()
+        for relevant_path in relevant_paths:
+            for component in match_components(relevant_path, components):
+                if component["id"] not in seen_components:
+                    matched.append(component)
+                    seen_components.add(component["id"])
+        reviewable = any(
+            is_reviewable(relevant_path, match_components(relevant_path, components))
+            or is_executable(repo, merge_base, relevant_path)
+            for relevant_path in relevant_paths
+        )
+        mapped_ids = [component["id"] for component in matched]
+        boundaries = sorted({item for component in matched for item in component["boundaries"]})
+        invariants = sorted({item for component in matched for item in component["invariants"]})
+        if reviewable:
+            reviewable_files.append(path)
+            if not matched:
+                mapped_ids = ["unmapped-code"]
+                unmapped.append(path)
+                lead_reasons.add(f"unmapped security-relevant path: {path}")
+            for component in matched:
+                if component["requires_lead"]:
+                    lead_reasons.add(f"component requires lead review: {component['id']}")
+        stats = numstat.get(path, {"changed_lines": 0, "binary": False})
+        item: dict[str, object] = {
+            **change,
+            "reviewable": reviewable,
+            "changed_lines": stats["changed_lines"],
+            "binary": stats["binary"],
+            "components": mapped_ids,
+            "boundaries": boundaries,
+            "invariants": invariants,
+        }
+        if change["status"] == "D" or "old_path" in change:
+            item["baseline_location"] = f"{merge_base}:{change.get('old_path', path)}"
+        enriched.append(item)
+
+    reviewable_line_count = sum(
+        int(item["changed_lines"]) for item in enriched if item["reviewable"]
+    )
+    if not reviewable_files:
+        route = "not_applicable"
+        reasons = ["no executable, source, build, workflow, sample-configuration, or security-policy changes"]
+    elif len(reviewable_files) > EXPANDED_FILE_LIMIT or reviewable_line_count > EXPANDED_LINE_LIMIT:
+        route = "expanded"
+        reasons = [
+            f"reviewable file/line budget exceeded: {len(reviewable_files)} files, {reviewable_line_count} lines"
+        ]
+        reasons.extend(sorted(lead_reasons))
+    elif lead_reasons:
+        route = "lead_required"
+        reasons = sorted(lead_reasons)
+    else:
+        route = "quick"
+        reasons = ["bounded mapped code delta"]
+
+    package = {
+        "schema_version": 1,
+        "repository": ".",
+        "base": {"ref": base_ref, "commit": base_commit, "source": base_source},
+        "merge_base": merge_base,
+        "head": {"ref": args.head, "commit": head_commit},
+        "worktree": worktree_state(repo, untracked),
+        "diff_digest": compute_digest(repo, merge_base, head_commit, untracked, model_path, map_path),
+        "threat_model": {"path": model_rel, "revision": model_revision},
+        "component_map": {"path": map_rel, "schema_version": routing["schema_version"]},
+        "limits": {"source_files": EXPANDED_FILE_LIMIT, "changed_source_lines": EXPANDED_LINE_LIMIT},
+        "summary": {
+            "changed_files": len(enriched),
+            "reviewable_files": len(reviewable_files),
+            "changed_lines": total_changed_lines,
+            "reviewable_changed_lines": reviewable_line_count,
+        },
+        "route": route,
+        "route_reasons": reasons,
+        "changes": enriched,
+        "coverage": {
+            "expected_files": reviewable_files,
+            "unmapped_files": unmapped,
+            "components": sorted(
+                {component for item in enriched if item["reviewable"] for component in item["components"]}
+            ),
+            "boundaries": sorted(
+                {boundary for item in enriched if item["reviewable"] for boundary in item["boundaries"]}
+            ),
+            "invariants": sorted(
+                {invariant for item in enriched if item["reviewable"] for invariant in item["invariants"]}
+            ),
+            "review_status": "pending",
+        },
+    }
+    return package
+
+
+def write_package(package: dict[str, object], output: str, repo: Path) -> None:
+    rendered = json.dumps(package, indent=2, sort_keys=False) + "\n"
+    if output == "-":
+        sys.stdout.write(rendered)
+        return
+    path = Path(output)
+    if not path.is_absolute():
+        path = repo / path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(rendered, encoding="utf-8")
+    print(path)
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        repo = verify_repo(Path(args.repo).resolve())
+        package = build_package(args)
+        write_package(package, args.output, repo)
+    except (OSError, ReviewInputError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/tests/test_security_review_input.py
+++ b/devtools/tests/test_security_review_input.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+
+"""Regression tests for the local security-review input builder.
+
+The suite creates isolated Git repositories so each test controls the base,
+index, worktree, and untracked state. The oracle is the emitted JSON inventory,
+route, and digest, or a deterministic schema-validation failure.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+BUILDER = Path(__file__).resolve().parents[1] / "build-security-review-input.py"
+BOUNDARIES = ["TB-CI", "TB-PIPELINE"]
+INVARIANTS = ["SI-CI-TRUST-01", "SI-PARSER-SAFETY-01"]
+
+
+class SecurityReviewInputTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tempdir.name)
+        self.git("init", "-q")
+        self.git("config", "user.email", "test@example.invalid")
+        self.git("config", "user.name", "Security Review Test")
+        self.git("config", "commit.gpgsign", "false")
+        self.git("config", "gc.auto", "0")
+        self.git("config", "maintenance.auto", "false")
+        self.write("SECURITY.md", "# Security\n")
+        self.write("doc/README.md", "internal documentation\n")
+        self.write(
+            "doc/security/project-threat-model.md",
+            "# Model\n\nModel revision: 1\n\n### TB-CI — CI\n\n### TB-PIPELINE — Pipeline\n\n"
+            "### SI-CI-TRUST-01 — CI trust\n\n### SI-PARSER-SAFETY-01 — Parser safety\n",
+        )
+        self.write_map(self.default_components())
+        self.write("runtime/existing.c", "int existing(void) { return 0; }\n")
+        self.git("add", ".")
+        self.git("commit", "-qm", "base")
+        self.base = self.git("rev-parse", "HEAD").stdout.strip()
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def git(self, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args], cwd=self.repo, text=True, capture_output=True, check=check
+        )
+
+    def write(self, relative: str, content: str | bytes) -> None:
+        path = self.repo / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            path.write_bytes(content)
+        else:
+            path.write_text(content, encoding="utf-8")
+
+    @staticmethod
+    def default_components() -> list[dict[str, object]]:
+        return [
+            {
+                "id": "runtime",
+                "paths": ["runtime/**"],
+                "boundaries": ["TB-PIPELINE"],
+                "invariants": ["SI-PARSER-SAFETY-01"],
+                "exposure": "shared-runtime",
+                "evidence": ["runtime/existing.c"],
+                "test_hints": ["unit"],
+                "requires_lead": False,
+            },
+            {
+                "id": "security-review-policy",
+                "paths": [
+                    "SECURITY.md",
+                    "doc/security/project-threat-model.md",
+                    "doc/security/threat-model-components.json",
+                ],
+                "boundaries": ["TB-CI"],
+                "invariants": ["SI-CI-TRUST-01"],
+                "exposure": "repository-policy",
+                "evidence": ["SECURITY.md"],
+                "test_hints": [],
+                "requires_lead": True,
+            },
+        ]
+
+    def write_map(self, components: list[dict[str, object]]) -> None:
+        self.write(
+            "doc/security/threat-model-components.json",
+            json.dumps({"schema_version": 1, "model_revision": 1, "components": components}) + "\n",
+        )
+
+    def run_builder(self, *, check: bool = True) -> tuple[subprocess.CompletedProcess[str], dict[str, object] | None]:
+        result = subprocess.run(
+            [
+                "python3",
+                str(BUILDER),
+                "--repo",
+                str(self.repo),
+                "--base",
+                self.base,
+                "--output",
+                "-",
+            ],
+            text=True,
+            capture_output=True,
+            check=check,
+        )
+        return result, json.loads(result.stdout) if result.returncode == 0 else None
+
+    def changes(self, package: dict[str, object]) -> dict[str, dict[str, object]]:
+        return {item["path"]: item for item in package["changes"]}
+
+    def test_accounts_for_committed_staged_unstaged_and_untracked_changes(self) -> None:
+        self.write("runtime/committed.c", "int committed;\n")
+        self.git("add", "runtime/committed.c")
+        self.git("commit", "-qm", "committed change")
+        self.write("runtime/staged.c", "int staged;\n")
+        self.git("add", "runtime/staged.c")
+        self.write("runtime/existing.c", "int existing(void) { return 1; }\n")
+        self.write("runtime/untracked.c", "int untracked;\n")
+
+        _, package = self.run_builder()
+        items = self.changes(package)
+        self.assertEqual(
+            {"runtime/committed.c", "runtime/staged.c", "runtime/existing.c", "runtime/untracked.c"},
+            set(items),
+        )
+        self.assertEqual("M", items["runtime/existing.c"]["status"])
+        self.assertTrue(package["worktree"]["staged"])
+        self.assertTrue(package["worktree"]["unstaged"])
+        self.assertTrue(package["worktree"]["untracked"])
+
+    def test_rename_and_delete_retain_baseline_locations(self) -> None:
+        self.write("runtime/delete.c", "int delete_me;\n")
+        self.write("runtime/rename.c", "int rename_me;\n")
+        self.git("add", ".")
+        self.git("commit", "-qm", "add rename inputs")
+        self.base = self.git("rev-parse", "HEAD").stdout.strip()
+        self.git("mv", "runtime/rename.c", "runtime/renamed.c")
+        self.git("rm", "-q", "runtime/delete.c")
+
+        _, package = self.run_builder()
+        items = self.changes(package)
+        self.assertEqual("R", items["runtime/renamed.c"]["status"])
+        self.assertEqual("runtime/rename.c", items["runtime/renamed.c"]["old_path"])
+        self.assertIn(":runtime/rename.c", items["runtime/renamed.c"]["baseline_location"])
+        self.assertEqual("D", items["runtime/delete.c"]["status"])
+        self.assertIn(":runtime/delete.c", items["runtime/delete.c"]["baseline_location"])
+
+    def test_rename_out_of_source_keeps_old_component_and_review_scope(self) -> None:
+        self.write("runtime/moved.c", "int moved;\n")
+        self.git("add", "runtime/moved.c")
+        self.git("commit", "-qm", "add source to move")
+        self.base = self.git("rev-parse", "HEAD").stdout.strip()
+        self.git("mv", "runtime/moved.c", "doc/moved.md")
+
+        _, package = self.run_builder()
+        item = self.changes(package)["doc/moved.md"]
+        self.assertTrue(item["reviewable"])
+        self.assertEqual(["runtime"], item["components"])
+        self.assertEqual(["doc/moved.md"], package["coverage"]["expected_files"])
+
+    def test_digest_is_stable_and_any_untracked_content_change_invalidates_it(self) -> None:
+        self.write("runtime/new.c", "int value = 1;\n")
+        first = self.run_builder()[1]["diff_digest"]
+        second = self.run_builder()[1]["diff_digest"]
+        self.assertEqual(first, second)
+        self.write("runtime/new.c", "int value = 2;\n")
+        third = self.run_builder()[1]["diff_digest"]
+        self.assertNotEqual(first, third)
+
+    def test_docs_only_is_not_applicable_and_root_pattern_does_not_match_nested_name(self) -> None:
+        self.write("doc/README.md", "changed prose only\n")
+        self.write("doc/AGENTS.md", "nested guide only\n")
+        _, package = self.run_builder()
+        self.assertEqual("not_applicable", package["route"])
+        self.assertEqual([], package["coverage"]["expected_files"])
+
+    def test_known_code_is_quick_and_covered_once(self) -> None:
+        self.write("runtime/new.c", "int value;\n")
+        _, package = self.run_builder()
+        self.assertEqual("quick", package["route"])
+        self.assertEqual(["runtime/new.c"], package["coverage"]["expected_files"])
+        self.assertEqual(["runtime"], self.changes(package)["runtime/new.c"]["components"])
+
+    def test_executable_without_suffix_and_sample_configuration_are_reviewable(self) -> None:
+        self.write("devtools/local-helper", "#!/bin/sh\nexit 0\n")
+        (self.repo / "devtools/local-helper").chmod(0o755)
+        self.write("packaging/example.conf", "module(load=\"imtcp\")\n")
+        self.write("packaging/build-policy.json", "{}\n")
+        _, package = self.run_builder()
+        items = self.changes(package)
+        self.assertTrue(items["devtools/local-helper"]["reviewable"])
+        self.assertTrue(items["packaging/example.conf"]["reviewable"])
+        self.assertTrue(items["packaging/build-policy.json"]["reviewable"])
+
+    def test_model_and_map_changes_require_lead(self) -> None:
+        model = self.repo / "doc/security/project-threat-model.md"
+        model.write_text(model.read_text(encoding="utf-8") + "\nAssumption.\n", encoding="utf-8")
+        _, package = self.run_builder()
+        self.assertEqual("lead_required", package["route"])
+        self.assertIn("security-review-policy", " ".join(package["route_reasons"]))
+
+    def test_unknown_source_path_is_conservatively_unmapped(self) -> None:
+        self.write("plugins/newinput/newinput.c", "int newinput;\n")
+        _, package = self.run_builder()
+        self.assertEqual("lead_required", package["route"])
+        self.assertEqual(["plugins/newinput/newinput.c"], package["coverage"]["unmapped_files"])
+        self.assertEqual(["unmapped-code"], self.changes(package)["plugins/newinput/newinput.c"]["components"])
+
+    def test_component_overlap_keeps_one_file_inventory_entry(self) -> None:
+        components = self.default_components()
+        components.insert(
+            1,
+            {
+                "id": "parser-overlap",
+                "paths": ["runtime/new.c"],
+                "boundaries": ["TB-PIPELINE"],
+                "invariants": ["SI-PARSER-SAFETY-01"],
+                "exposure": "specific-parser",
+                "evidence": ["runtime/existing.c"],
+                "test_hints": [],
+                "requires_lead": False,
+            },
+        )
+        self.write_map(components)
+        self.git("add", "doc/security/threat-model-components.json")
+        self.git("commit", "-qm", "overlap map")
+        self.base = self.git("rev-parse", "HEAD").stdout.strip()
+        self.write("runtime/new.c", "int value;\n")
+        _, package = self.run_builder()
+        self.assertEqual(1, len(package["changes"]))
+        self.assertEqual(["runtime", "parser-overlap"], package["changes"][0]["components"])
+
+    def test_invalid_map_references_and_duplicate_ids_are_rejected(self) -> None:
+        components = self.default_components()
+        components[0]["boundaries"] = ["TB-MISSING"]
+        self.write_map(components)
+        result, _ = self.run_builder(check=False)
+        self.assertEqual(2, result.returncode)
+        self.assertIn("unknown model id TB-MISSING", result.stderr)
+
+        components = self.default_components()
+        components.append(dict(components[0]))
+        self.write_map(components)
+        result, _ = self.run_builder(check=False)
+        self.assertEqual(2, result.returncode)
+        self.assertIn("duplicate component id: runtime", result.stderr)
+
+    def test_model_and_component_map_revisions_must_match(self) -> None:
+        model = self.repo / "doc/security/project-threat-model.md"
+        model.write_text(model.read_text(encoding="utf-8").replace("revision: 1", "revision: 2"), encoding="utf-8")
+        result, _ = self.run_builder(check=False)
+        self.assertEqual(2, result.returncode)
+        self.assertIn("does not match threat model 2", result.stderr)
+
+    def test_invalid_and_missing_evidence_paths_are_rejected(self) -> None:
+        components = self.default_components()
+        components[0]["evidence"] = ["../outside"]
+        self.write_map(components)
+        result, _ = self.run_builder(check=False)
+        self.assertIn("invalid repository-relative evidence path", result.stderr)
+
+        components[0]["evidence"] = ["runtime/missing.c"]
+        self.write_map(components)
+        result, _ = self.run_builder(check=False)
+        self.assertIn("evidence path does not exist", result.stderr)
+
+    def test_binary_file_is_inventory_item_with_zero_changed_lines(self) -> None:
+        self.write("runtime/binary.c", b"source\x00binary\n")
+        _, package = self.run_builder()
+        item = self.changes(package)["runtime/binary.c"]
+        self.assertTrue(item["binary"])
+        self.assertEqual(0, item["changed_lines"])
+
+    def test_expanded_route_for_file_and_line_thresholds(self) -> None:
+        for number in range(51):
+            self.write(f"runtime/generated-{number}.c", "int generated;\n")
+        _, package = self.run_builder()
+        self.assertEqual("expanded", package["route"])
+        self.assertEqual(51, package["summary"]["reviewable_files"])
+
+        self.git("clean", "-fdq")
+        self.write("runtime/large.c", "int line;\n" * 2001)
+        _, package = self.run_builder()
+        self.assertEqual("expanded", package["route"])
+        self.assertEqual(2001, package["summary"]["reviewable_changed_lines"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/devtools/tests/test_security_review_input.py
+++ b/devtools/tests/test_security_review_input.py
@@ -95,7 +95,9 @@ class SecurityReviewInputTest(unittest.TestCase):
             json.dumps({"schema_version": 1, "model_revision": 1, "components": components}) + "\n",
         )
 
-    def run_builder(self, *, check: bool = True) -> tuple[subprocess.CompletedProcess[str], dict[str, object] | None]:
+    def run_builder(
+        self, *, check: bool = True, extra_args: list[str] | None = None
+    ) -> tuple[subprocess.CompletedProcess[str], dict[str, object] | None]:
         result = subprocess.run(
             [
                 "python3",
@@ -104,8 +106,8 @@ class SecurityReviewInputTest(unittest.TestCase):
                 str(self.repo),
                 "--base",
                 self.base,
-                "--output",
-                "-",
+                *(extra_args or []),
+                "--output", "-",
             ],
             text=True,
             capture_output=True,
@@ -166,6 +168,19 @@ class SecurityReviewInputTest(unittest.TestCase):
         self.assertEqual(["runtime"], item["components"])
         self.assertEqual(["doc/moved.md"], package["coverage"]["expected_files"])
 
+    def test_renamed_filename_with_tab_keeps_numstat_accounting(self) -> None:
+        original = "".join(f"int line_{number};\n" for number in range(10))
+        self.write("runtime/rename-me.c", original)
+        self.git("add", "runtime/rename-me.c")
+        self.git("commit", "-qm", "add rename input")
+        self.base = self.git("rev-parse", "HEAD").stdout.strip()
+        self.git("mv", "runtime/rename-me.c", "runtime/renamed\tfile.c")
+        self.write("runtime/renamed\tfile.c", original + "int another;\n")
+        _, package = self.run_builder()
+        item = self.changes(package)["runtime/renamed\tfile.c"]
+        self.assertEqual("R", item["status"])
+        self.assertEqual(1, item["changed_lines"])
+
     def test_digest_is_stable_and_any_untracked_content_change_invalidates_it(self) -> None:
         self.write("runtime/new.c", "int value = 1;\n")
         first = self.run_builder()[1]["diff_digest"]
@@ -206,6 +221,48 @@ class SecurityReviewInputTest(unittest.TestCase):
         _, package = self.run_builder()
         self.assertEqual("lead_required", package["route"])
         self.assertIn("security-review-policy", " ".join(package["route_reasons"]))
+
+    def test_custom_model_path_change_requires_lead(self) -> None:
+        self.write(
+            "doc/security/custom-model.md",
+            (self.repo / "doc/security/project-threat-model.md").read_text(encoding="utf-8"),
+        )
+        self.git("add", "doc/security/custom-model.md")
+        self.git("commit", "-qm", "add custom model")
+        self.write(
+            "doc/security/custom-model.md",
+            (self.repo / "doc/security/custom-model.md").read_text(encoding="utf-8") + "\nAssumption.\n",
+        )
+        _, package = self.run_builder(extra_args=["--model", "doc/security/custom-model.md"])
+        self.assertEqual("lead_required", package["route"])
+
+    def test_custom_component_map_path_change_requires_lead(self) -> None:
+        self.write_map(self.default_components())
+        self.git("mv", "doc/security/threat-model-components.json", "doc/security/custom-components.json")
+        self.git("commit", "-qm", "add custom component map")
+        custom_map = self.repo / "doc/security/custom-components.json"
+        custom_map.write_text(custom_map.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+        _, package = self.run_builder(extra_args=["--component-map", "doc/security/custom-components.json"])
+        self.assertEqual("lead_required", package["route"])
+
+    def test_invalid_model_utf8_is_reported_without_traceback(self) -> None:
+        self.write("doc/security/project-threat-model.md", b"\xff\xfe")
+        result, _ = self.run_builder(check=False)
+        self.assertEqual(2, result.returncode)
+        self.assertIn("invalid threat model UTF-8", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_checked_in_test_hints_exist(self) -> None:
+        repository = Path(__file__).resolve().parents[2]
+        component_map = json.loads(
+            (repository / "doc/security/threat-model-components.json").read_text(encoding="utf-8")
+        )
+        for component in component_map["components"]:
+            for hint in component["test_hints"]:
+                if hint.startswith("tests/"):
+                    self.assertTrue(
+                        any(repository.glob(hint)), f"missing test hint for {component['id']}: {hint}"
+                    )
 
     def test_unknown_source_path_is_conservatively_unmapped(self) -> None:
         self.write("plugins/newinput/newinput.c", "int newinput;\n")

--- a/doc/ai/AGENTS.md
+++ b/doc/ai/AGENTS.md
@@ -8,6 +8,8 @@ This file defines specific guidelines for AI assistants working on the documenta
 - **Structure and Paths:** [`doc/ai/structure_and_paths.md`](./structure_and_paths.md)
 - **Terminology:** [`doc/ai/terminology.md`](./terminology.md)
 - **Security Triage Rubric:** [`doc/ai/security_triage_rubric.md`](./security_triage_rubric.md)
+- **Project Threat Model:** [`doc/security/project-threat-model.md`](../security/project-threat-model.md)
+- **Threat-Model Routing:** [`doc/security/threat-model-components.json`](../security/threat-model-components.json)
 - **Doc Assistant Prompt:** [`ai/rsyslog_doc_assistant/base_prompt.txt`](../../ai/rsyslog_doc_assistant/base_prompt.txt)
 
 ## Critical Requirements for Documentation

--- a/doc/ai/README.md
+++ b/doc/ai/README.md
@@ -13,6 +13,8 @@
 | `mermaid_rules.md` | Diagram syntax rules |
 | `terminology.md` | Canonical rsyslog vocabulary |
 | `security_triage_rubric.md` | Security finding proof, severity, and hardening classification rules |
+| `../security/project-threat-model.md` | Versioned project threat model, trust boundaries, and security invariants |
+| `../security/threat-model-components.json` | Machine-readable path routing for local PR security reviews |
 | `chunking_and_embeddings.md` | RAG extraction schema and chunk structure |
 | `crosslinking_and_nav.md` | Navigation and cross-reference patterns |
 | `drift_monitoring.md` | Detecting doc/code drift |

--- a/doc/security/project-threat-model.md
+++ b/doc/security/project-threat-model.md
@@ -1,0 +1,308 @@
+# rsyslog Project Threat Model
+
+Model revision: 1
+Schema version: 1
+Status: reusable repository baseline
+
+This document is the security context for local pull-request delta reviews. It
+describes stable boundaries and invariants; it is not a list of vulnerabilities.
+Scenarios below are review hypotheses until the evidence standard in
+`doc/ai/security_triage_rubric.md` is met.
+
+## 1. Overview
+
+rsyslog is a modular logging daemon written primarily in C. Input modules turn
+local or remote records into message objects, parsers and rulesets transform and
+route those objects, queues decouple processing, and actions write or forward
+the result. The documented pipeline is input to ruleset to action
+(`doc/source/concepts/log_pipeline/index.rst:20-58`); plugins submit messages to
+the main or ruleset queue through the core (`tools/rsyslogd.c:1238-1295`).
+
+The daemon can start with elevated privileges to acquire resources and then
+drop group and user privileges before input modules run
+(`runtime/rsconf.c:971-985`, `runtime/rsconf.c:1067-1113`). Optional modules,
+configuration, build flags, packaging, and deployment choices determine which
+surfaces are present. Repository security scope includes the core, built-in and
+contrib modules, and build or packaging logic that can affect released
+artifacts (`SECURITY.md:15-31`).
+
+| Component | Purpose | Representative evidence |
+| --- | --- | --- |
+| Inputs and sessions | Receive local files, sockets, journals, or network protocols | `plugins/imtcp/imtcp.c:249-315`, `plugins/imbeats/imbeats.c:242-260` |
+| Message pipeline | Bound, parse, transform, queue, and route messages | `tools/rsyslogd.c:1238-1295`, `runtime/parser.c` |
+| Transport security | Apply TLS authentication modes and peer restrictions | `runtime/nsd_ossl.c:650-725`, `runtime/nsd_gtls.c:1058-1117` |
+| Configuration and modules | Select runtime behavior and dynamically loaded code | `runtime/modules.c:1163-1208`, `runtime/modules.c:1403-1420` |
+| Storage and actions | Persist queues or write/forward messages | `runtime/queue.c:449-505`, `tools/omfile.c:364-399`, `tools/omfile.c:943-1058` |
+| External helpers | Execute operator-selected programs and exchange message data | `plugins/omprog/omprog.c:143-222` |
+| Build and release | Analyze, build, package, and publish artifacts | `.github/workflows/codeql.yml:25-44`, `.github/workflows/draft_release.yml:53-66` |
+
+### Effective resources and authority
+
+| Deployment or workflow | Resource or capability | Configuration and precedence | Readers, writers, or recipients | Enforcing control | Evidence or unknowns |
+| --- | --- | --- | --- | --- | --- |
+| Network collector | Listener socket and session state | Input instance, module defaults, then global stream-driver policy | Remote senders and the selected input module | Framing, session, message-size, rate, and optional peer controls | `plugins/imtcp/imtcp.c:341-351`, `plugins/imtcp/imtcp.c:445-529` |
+| TLS collector or forwarder | Private keys, trust roots, peer identity | Operator-selected driver and authentication mode | rsyslog and configured peers | Driver certificate validation and permitted-peer matching | `runtime/nsd_ossl.c:650-725`, `runtime/nsd_gtls.c:1086-1117` |
+| Privileged startup | Bound sockets, opened files, process identity | Command line and administrator configuration | Startup code, activated modules, then runtime workers | Ordered activation and `setgid`/`setuid` privilege drop | `tools/rsyslogd.c:1932-1953`, `runtime/rsconf.c:893-985` |
+| Disk-backed processing | Queue, spool, state, and output paths | Administrator configuration below the effective work/output directory | Daemon workers and local administrators | Queue limits plus separately configured dynafile containment, final-symlink, and ownership controls | `runtime/queue.c:434-505`, `tools/omfile.c:364-399`, `tools/omfile.c:943-1058`; deployment permissions remain an assumption |
+| Dynamic module loading | Shared-object search path and loaded code | Environment, command line, and configuration under the process authority | rsyslog process | Administrative control of environment, configuration, and module directories | `runtime/modules.c:1183-1208`, `runtime/modules.c:1403-1420` |
+| Release automation | Source revision and release artifacts | Tagged or explicitly dispatched workflow | GitHub Actions and maintainers | Repository checks, pinned actions, and job permissions | `.github/workflows/draft_release.yml:20-65`; hosted repository settings are not visible here |
+
+## 2. Threat Model, Trust Boundaries, and Assumptions
+
+### Protected assets
+
+- Process memory integrity and daemon availability while handling hostile data.
+- Integrity, ordering, provenance, and intended routing of log messages.
+- Confidentiality of message content, TLS keys, credentials, and configuration
+  secrets handled by enabled modules.
+- Peer identity when an operator explicitly configures authentication or sender
+  restrictions.
+- Queue, spool, state, and output-file integrity and durability.
+- Administrative control of configuration, include files, module paths,
+  helper programs, output destinations, and privilege settings.
+- Integrity of source, CI workflows, packages, containers, and release
+  artifacts.
+
+### Actors and attacker capabilities
+
+- **Remote unauthenticated sender:** can choose packet and stream bytes,
+  framing, connection timing, message bodies, structured data, compression, and
+  request volume on an exposed input. It does not start with configuration,
+  host filesystem, or daemon privileges.
+- **Authenticated or permitted peer:** has valid transport or sender
+  credentials but may send malicious message content and resource patterns. Its
+  identity does not make its payload trusted for parsing, paths, queries, or
+  commands.
+- **Local unprivileged producer:** may be able to write to a local log socket,
+  FIFO, journal, or application file. It does not automatically control root-
+  owned configuration, module directories, queues, or output directories.
+- **Remote destination or helper:** receives data selected by the operator and
+  can return malformed responses, withhold acknowledgements, or apply
+  backpressure. The operator, not a log sender, normally selects it.
+- **Pull-request contributor:** controls proposed repository content but does
+  not inherently control protected branch settings, repository secrets, or
+  release approval.
+- **Administrator/operator:** controls configuration, module and helper paths,
+  keys, destinations, and service permissions. Ordinary use of that authority
+  is not a privilege gain; a finding needs a lower-privileged path across the
+  boundary.
+
+### Trust boundaries
+
+### TB-NET-IN — Remote transport to input session
+
+Remote bytes and connection behavior cross into listener, TLS, framing,
+decompression, authentication, and protocol state. Controls must remain bounded
+and must apply before data reaches sensitive parsing or allocation. imtcp caps
+configured frame sizes and has secure-mode checks for TLS and zstd resource
+policy (`plugins/imtcp/imtcp.c:341-351`, `plugins/imtcp/imtcp.c:445-529`);
+imbeats exposes explicit frame, decompression, batch, in-flight, ratio, timeout,
+and session limits (`plugins/imbeats/imbeats.c:1775-1810`).
+
+### TB-LOCAL-IN — Local producer to daemon
+
+Local sockets, files, journals, FIFOs, and program output cross from other
+processes into the same message and parser pipeline. Locality changes exposure
+and severity but does not make content memory-safe or semantically trusted.
+
+### TB-CONFIG — Administrator policy to runtime authority
+
+Configuration, YAML, includes, environment, module paths, credentials, helper
+paths, output destinations, and privilege settings grant administrator-level
+authority. Dynamic module loading reaches `dlopen`, and the module search path
+can come from the environment before command-line override
+(`runtime/modules.c:1183-1208`, `runtime/modules.c:1403-1420`). A report must
+show how a less-privileged actor obtains that control under a realistic
+deployment.
+
+### TB-PRIV — Privileged startup to reduced-privilege runtime
+
+Resources may be acquired before `setgid` and `setuid`; input modules run after
+the configured drop (`runtime/rsconf.c:893-985`, `runtime/rsconf.c:1067-1113`).
+The boundary must not retain unintended privileged operations or writable
+control paths after the transition.
+
+### TB-PIPELINE — Message data to parsing, rules, and queues
+
+Untrusted fields become message properties, structured data, JSON, templates,
+and queue entries. The core checks configured maximum message size before
+enqueue and applies the configured split, truncate, or accept behavior
+(`tools/rsyslogd.c:1247-1295`). Every parser or transformation retains its own
+type, length, depth, ownership, and lifecycle obligations.
+
+### TB-STORAGE — Daemon to queue, state, spool, and output files
+
+Configured paths cross into filesystem operations and persistent state. Queue
+types and disk/resource limits are configuration-dependent
+(`runtime/queue.c:449-505`). omfile bounds normalized dynafile paths to a derived
+static base, with an explicit administrator-controlled path-escape opt-in
+(`tools/omfile.c:364-399`, `tools/omfile.c:1133-1138`). Separately, its effective
+final-component symlink policy controls `O_NOFOLLOW`, and configured ownership
+is applied with `fchown` when a file is created (`tools/omfile.c:939-1058`).
+Strict dynafile policy also replaces unsafe message-derived path characters
+(`runtime/template.c:100-158`). Host permissions and directory ownership remain
+deployment controls rather than guarantees established by this repository.
+
+### TB-OUTBOUND — Message pipeline to remote destinations
+
+Actions transfer potentially sensitive or attacker-influenced content to
+operator-selected network, database, broker, or cloud destinations. Templates
+and protocol libraries must preserve data/syntax separation, and remote
+responses must not create unbounded retry or resource behavior.
+
+### TB-EXEC — Daemon to external helper process
+
+Operator-selected programs execute with inherited runtime authority and receive
+message data over pipes. omprog uses `execv` with configured arguments rather
+than a shell (`plugins/omprog/omprog.c:143-222`); helper input parsing and
+process lifecycle remain separate boundaries.
+
+### TB-MODULE — Core to optional, contrib, and third-party code
+
+Enabled modules execute inside the daemon or broker authority to external
+libraries. Optional status reduces default exposure but does not remove an
+enabled component from scope. Vulnerabilities in third-party libraries belong
+upstream, while unsafe rsyslog integration remains in scope
+(`SECURITY.md:17-31`).
+
+### TB-CI — Pull-request content to build and release automation
+
+Repository content is processed by lint, analysis, build, packaging, and
+release workflows. Jobs must use minimal permissions and keep untrusted PR
+execution separate from release credentials. CodeQL declares read-only source
+permissions plus the security-event write needed for results
+(`.github/workflows/codeql.yml:25-44`); release workflow authority is separate
+and conditional (`.github/workflows/draft_release.yml:20-65`).
+
+### Security invariants
+
+### SI-INPUT-BOUNDS-01 — Bound hostile input work
+
+Attacker-controlled length, nesting, compression, sessions, retries, file
+descriptors, allocations, and CPU work must have effective limits before
+resource exhaustion or memory-unsafe operations.
+
+### SI-PARSER-SAFETY-01 — Parse with explicit extent and ownership
+
+Parsers and transformations must preserve length, type, termination, depth,
+allocation, and object-lifecycle invariants for every supported format.
+
+### SI-PEER-IDENTITY-01 — Preserve configured peer identity
+
+When authentication or sender restrictions are configured, the accepted peer
+must be the peer validated by the effective driver and policy. Name,
+fingerprint, certificate, address, and authenticated identity must not be
+confused or replaced by message-controlled metadata.
+
+### SI-TLS-EFFECTIVE-01 — Do not imply inactive transport protection
+
+TLS-related configuration must either activate the expected transport and
+authentication mode or produce the configured warning/error behavior. Plain
+TCP/UDP and anonymous TLS do not provide authenticated sender identity.
+
+### SI-CONFIG-AUTHORITY-01 — Keep runtime policy administrator-controlled
+
+Unprivileged actors must not modify effective configuration, included files,
+module search paths, loaded modules, credentials, helper paths, or privilege-
+drop policy.
+
+### SI-PRIV-DROP-01 — Complete the privilege transition
+
+Configured UID/GID changes must complete before ordinary input processing, and
+post-drop behavior must not regain or misuse startup authority.
+
+### SI-MESSAGE-TRUST-01 — Keep message content untrusted
+
+Authenticated transport proves a peer property, not the safety of message
+fields. Message-controlled content must not silently become trusted provenance,
+configuration, a filesystem path, query syntax, or executable arguments.
+
+### SI-PATH-CONTROL-01 — Contain message-derived filesystem access
+
+Every message-derived path component must use the applicable secure-path and
+symlink policy; configured base directories, ownership, and permissions must
+remain operator-controlled.
+
+### SI-QUEUE-INTEGRITY-01 — Preserve queue durability and boundedness
+
+Queue state, recovery, acknowledgement, discard, and disk limits must preserve
+documented delivery semantics without unbounded resource use or unsafe local
+tampering assumptions.
+
+### SI-EXEC-DATA-01 — Separate helper selection from helper data
+
+Only the operator selects executable paths and fixed arguments. Message data is
+delivered as data, and helper failure, confirmation, timeout, and shutdown paths
+must remain bounded.
+
+### SI-SECRET-HANDLING-01 — Do not expose sensitive configuration
+
+Keys, credentials, tokens, and private configuration must not be copied into
+messages, diagnostics, public review artifacts, or release outputs.
+
+### SI-CI-TRUST-01 — Keep untrusted source away from release authority
+
+PR-controlled code must not gain write tokens, repository secrets, artifact
+publication, or release authority without a separately authorized and
+revision-bound workflow.
+
+### Assumptions and exclusions
+
+- Administrator configuration, module directories, keys, queue directories,
+  and output directories are protected by deployment permissions. Violations
+  require deployment evidence and are not inferred from a configurable path.
+- Optional modules are exposed only when built, installed, loaded, configured,
+  and reachable. Severity records those prerequisites.
+- Plain syslog does not provide sender authenticity. Spoofing without a
+  configured authentication boundary is expected behavior, not an auth bypass.
+- Test and developer tools are not production surfaces by default, but build,
+  test, packaging, or documentation logic remains in scope when it can affect a
+  released artifact, consistent with `SECURITY.md:17-23`.
+- Third-party library defects are reported upstream; rsyslog-owned validation,
+  configuration, lifecycle, and API use remain reviewable.
+- Distribution defaults, host MAC policy, service sandboxing, branch
+  protection, and secret configuration are not fully observable from this
+  repository. Missing deployment evidence lowers confidence; it is not proof
+  that a code-level boundary is safe or exposed.
+
+## 3. Attack Surface, Mitigations, and Attacker Stories
+
+These are hypotheses for delta review, not confirmed vulnerabilities.
+
+| Priority | Scenario and capability gain | Prerequisites | Impact | Existing controls | Review focus and evidence |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Remote input turns malformed framing, compression, handshake, or message data into memory corruption or a cheap daemon crash | Enabled and reachable input | Availability or code execution | Per-input sizes, sessions, timeouts, secure-mode limits | Verify source-to-sink bounds and alternate encodings; `plugins/imtcp/imtcp.c:341-351`, `plugins/imbeats/imbeats.c:1775-1810` |
+| 1 | A peer bypasses configured certificate, fingerprint, name, or sender restrictions and is accepted as trusted | Authenticated transport or ACL enabled | Forged trusted-source logs or broader compromise | Auth modes and permitted-peer matching | Trace the exact validated identity to accepted session; `runtime/nsd_ossl.c:650-725`, `runtime/nsd_gtls.c:1086-1117` |
+| 1 | A lower-privileged actor changes an include, module path, helper, or effective policy consumed during privileged startup | Writable control path in a realistic deployment | Privilege escalation or arbitrary daemon code | Expected administrative ownership and privilege drop | Prove the lower-privileged write path and effective consumer; `runtime/modules.c:1183-1208`, `runtime/rsconf.c:971-985` |
+| 2 | Message properties escape a dynamic output base or exploit an independently permissive final-symlink policy | Message-derived dynafile plus the relevant explicit policy or weak deployment permissions | File overwrite, file sprawl, or integrity loss | Secure-path replacement, base containment, and independently configured final-component `O_NOFOLLOW` | Check path rendering, base validation, opt-ins, and both opens separately; `runtime/template.c:100-158`, `tools/omfile.c:364-399`, `tools/omfile.c:939-1058`, `tools/omfile.c:1133-1138` |
+| 2 | A sender exhausts sessions, decompression, DNS, queues, disk, retries, or downstream workers | Reachable input and insufficient effective limits | Denial of service or message loss | Input limits, rate controls, queue watermarks and disk caps | Establish resource asymmetry and effective configured limit; `runtime/queue.c:475-505` |
+| 2 | Message content becomes query, JSON, template, or helper syntax without the required encoding boundary | Vulnerable template or downstream consumer | Forged output or downstream injection | Typed templates, escaping modes, `execv` helper launch | Separate operator-selected destination/program from message data; `plugins/omprog/omprog.c:143-222` |
+| 2 | A PR changes a workflow so untrusted code reaches credentials or publication authority | Affected workflow and privileged trigger | Supply-chain compromise | Pinned actions, job permissions, separate release triggers | Trace event, checkout revision, permissions, secrets, and published digest; `.github/workflows/draft_release.yml:20-65` |
+| 3 | Local producer input reaches a parser or state machine that assumed remote controls already ran | Writable local surface and affected parser | Local denial of service or integrity loss | Shared maximum-message and parser controls | Verify the local entry path uses equivalent bounds; `tools/rsyslogd.c:1247-1295` |
+
+## 4. Severity Calibration
+
+- **Critical:** clear, realistic default/common unauthenticated remote code
+  execution; reliable attacker-controlled memory corruption with equivalent
+  control; or a lower-privileged path that changes privileged configuration or
+  loaded code in common packaging. A severe bug class without reachability and
+  impact proof is not Critical.
+- **High:** attacker-controlled memory corruption, major authenticated-identity
+  bypass, privileged file replacement, or major integrity/confidentiality
+  impact with a realistic enabled component and deployment. Optional status is
+  a prerequisite, not an automatic suppression.
+- **Medium:** meaningful integrity, confidentiality, routing, forgery, or denial
+  of service that needs a non-default but realistic deployment, or a narrower
+  local/optional surface without major privilege gain.
+- **Low:** strong local or operator preconditions, low-impact defense in depth,
+  diagnostic-only effects, or bounded hardening. Config-only behavior is
+  normally administrator-equivalent unless a separate lower-privileged path is
+  proven.
+- **None/not actionable:** intended plain-transport behavior, already enforced
+  controls, unreachable code, self-only effects, best-effort statistics, or
+  missing attacker control/impact.
+
+Final classification follows `doc/ai/security_triage_rubric.md`: a confirmed
+issue needs a working reproducer or direct code proof of attacker-controlled
+input, reachability, and impact. Potential issues and hardening guidance must
+state the missing proof and must not use confirmed-vulnerability wording.

--- a/doc/security/threat-model-components.json
+++ b/doc/security/threat-model-components.json
@@ -19,7 +19,7 @@
       "invariants": ["SI-INPUT-BOUNDS-01", "SI-PARSER-SAFETY-01", "SI-PEER-IDENTITY-01", "SI-TLS-EFFECTIVE-01"],
       "exposure": "explicitly-enabled-network-input",
       "evidence": ["plugins/imtcp/imtcp.c", "plugins/imbeats/imbeats.c"],
-      "test_hints": ["tests/imtcp-basic.sh", "tests/imptcp-basic.sh", "tests/imudp-basic.sh"],
+      "test_hints": ["tests/imtcp-basic.sh", "tests/imptcp-basic-hup.sh", "tests/imudp_error_msg.sh"],
       "requires_lead": false
     },
     {
@@ -39,7 +39,7 @@
       "invariants": ["SI-PEER-IDENTITY-01", "SI-TLS-EFFECTIVE-01", "SI-INPUT-BOUNDS-01"],
       "exposure": "configured-network-transport",
       "evidence": ["runtime/nsd_ossl.c", "runtime/nsd_gtls.c", "runtime/net.c"],
-      "test_hints": ["tests/ossl-basic.sh", "tests/gnutls-basic.sh"],
+      "test_hints": ["tests/imtcp-tls-ossl-basic.sh", "tests/imtcp-multi-drvr-basic-ptcp_gtls_ossl.sh"],
       "requires_lead": true
     },
     {
@@ -69,17 +69,17 @@
       "invariants": ["SI-PATH-CONTROL-01", "SI-MESSAGE-TRUST-01", "SI-INPUT-BOUNDS-01"],
       "exposure": "configured-local-filesystem",
       "evidence": ["tools/omfile.c", "runtime/template.c", "plugins/imfile/imfile.c"],
-      "test_hints": ["tests/imfile-basic.sh", "tests/omfile-basic.sh"],
+      "test_hints": ["tests/imfile-basic.sh", "tests/omfile-addlf.sh"],
       "requires_lead": true
     },
     {
       "id": "external-programs",
-      "paths": ["plugins/improg/**", "plugins/mmexternal/**", "plugins/omprog/**", "tools/omshell.c", "tools/ompipe.c"],
+      "paths": ["contrib/improg/**", "plugins/mmexternal/**", "plugins/omprog/**", "tools/omshell.c", "tools/ompipe.c"],
       "boundaries": ["TB-EXEC", "TB-LOCAL-IN", "TB-OUTBOUND"],
       "invariants": ["SI-EXEC-DATA-01", "SI-MESSAGE-TRUST-01", "SI-SECRET-HANDLING-01"],
       "exposure": "administrator-configured-helper",
       "evidence": ["plugins/omprog/omprog.c", "plugins/mmexternal/mmexternal.c"],
-      "test_hints": ["tests/omprog-basic.sh", "tests/mmexternal-basic.sh"],
+      "test_hints": ["tests/omprog-defaults.sh", "tests/mmexternal-single-instance.sh"],
       "requires_lead": true
     },
     {

--- a/doc/security/threat-model-components.json
+++ b/doc/security/threat-model-components.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": 1,
+  "model_revision": 1,
+  "components": [
+    {
+      "id": "core-message-pipeline",
+      "paths": ["runtime/parser.*", "runtime/msg.*", "runtime/ruleset.*", "tools/pm*.c", "tools/rsyslogd.c"],
+      "boundaries": ["TB-PIPELINE", "TB-NET-IN", "TB-LOCAL-IN"],
+      "invariants": ["SI-INPUT-BOUNDS-01", "SI-PARSER-SAFETY-01", "SI-MESSAGE-TRUST-01"],
+      "exposure": "shared-runtime",
+      "evidence": ["tools/rsyslogd.c", "runtime/parser.c", "runtime/msg.c"],
+      "test_hints": ["tests/fuzz-syslog-message-smoke.sh", "tests/validation-run.sh"],
+      "requires_lead": false
+    },
+    {
+      "id": "network-inputs",
+      "paths": ["plugins/imtcp/**", "plugins/imptcp/**", "plugins/imudp/**", "plugins/imrelp/**", "plugins/imdtls/**", "plugins/imgssapi/**", "plugins/imbeats/**"],
+      "boundaries": ["TB-NET-IN", "TB-PIPELINE", "TB-MODULE"],
+      "invariants": ["SI-INPUT-BOUNDS-01", "SI-PARSER-SAFETY-01", "SI-PEER-IDENTITY-01", "SI-TLS-EFFECTIVE-01"],
+      "exposure": "explicitly-enabled-network-input",
+      "evidence": ["plugins/imtcp/imtcp.c", "plugins/imbeats/imbeats.c"],
+      "test_hints": ["tests/imtcp-basic.sh", "tests/imptcp-basic.sh", "tests/imudp-basic.sh"],
+      "requires_lead": false
+    },
+    {
+      "id": "rainerscript-runtime-expressions",
+      "paths": ["grammar/rainerscript.c", "grammar/rainerscript.h"],
+      "boundaries": ["TB-PIPELINE", "TB-CONFIG"],
+      "invariants": ["SI-INPUT-BOUNDS-01", "SI-PARSER-SAFETY-01", "SI-MESSAGE-TRUST-01"],
+      "exposure": "shared-expression-runtime",
+      "evidence": ["grammar/rainerscript.c"],
+      "test_hints": ["tests/rscript*.sh"],
+      "requires_lead": false
+    },
+    {
+      "id": "transport-security",
+      "paths": ["runtime/net.*", "runtime/netstrm.*", "runtime/netstrms.*", "runtime/nsd*", "runtime/tcpsrv.*", "runtime/tcps_sess.*", "tools/omfwd.c", "plugins/omrelp/**"],
+      "boundaries": ["TB-NET-IN", "TB-OUTBOUND"],
+      "invariants": ["SI-PEER-IDENTITY-01", "SI-TLS-EFFECTIVE-01", "SI-INPUT-BOUNDS-01"],
+      "exposure": "configured-network-transport",
+      "evidence": ["runtime/nsd_ossl.c", "runtime/nsd_gtls.c", "runtime/net.c"],
+      "test_hints": ["tests/ossl-basic.sh", "tests/gnutls-basic.sh"],
+      "requires_lead": true
+    },
+    {
+      "id": "configuration-and-modules",
+      "paths": ["grammar/**", "runtime/conf.*", "runtime/glbl.*", "runtime/modules.*", "runtime/rsconf.*", "runtime/yamlconf.*", "tools/rsyslogd.c"],
+      "boundaries": ["TB-CONFIG", "TB-MODULE", "TB-PRIV"],
+      "invariants": ["SI-CONFIG-AUTHORITY-01", "SI-PRIV-DROP-01", "SI-SECRET-HANDLING-01"],
+      "exposure": "administrator-controlled",
+      "evidence": ["runtime/modules.c", "runtime/rsconf.c", "runtime/yamlconf.c"],
+      "test_hints": ["tests/validation-run.sh"],
+      "requires_lead": true
+    },
+    {
+      "id": "queues-and-state",
+      "paths": ["runtime/queue*", "runtime/segdisk_store*", "runtime/wti.*", "runtime/wtp.*", "tools/rsyslog-segqueue*"],
+      "boundaries": ["TB-PIPELINE", "TB-STORAGE"],
+      "invariants": ["SI-QUEUE-INTEGRITY-01", "SI-INPUT-BOUNDS-01", "SI-MESSAGE-TRUST-01"],
+      "exposure": "shared-runtime-and-local-storage",
+      "evidence": ["runtime/queue.c", "runtime/segdisk_store.c"],
+      "test_hints": ["tests/queue-persist.sh"],
+      "requires_lead": true
+    },
+    {
+      "id": "filesystem-inputs-and-outputs",
+      "paths": ["plugins/imfile/**", "plugins/imfifo/**", "tools/omfile.c", "tools/ompipe.c", "runtime/stream.*", "runtime/template.*"],
+      "boundaries": ["TB-LOCAL-IN", "TB-STORAGE", "TB-PIPELINE"],
+      "invariants": ["SI-PATH-CONTROL-01", "SI-MESSAGE-TRUST-01", "SI-INPUT-BOUNDS-01"],
+      "exposure": "configured-local-filesystem",
+      "evidence": ["tools/omfile.c", "runtime/template.c", "plugins/imfile/imfile.c"],
+      "test_hints": ["tests/imfile-basic.sh", "tests/omfile-basic.sh"],
+      "requires_lead": true
+    },
+    {
+      "id": "external-programs",
+      "paths": ["plugins/improg/**", "plugins/mmexternal/**", "plugins/omprog/**", "tools/omshell.c", "tools/ompipe.c"],
+      "boundaries": ["TB-EXEC", "TB-LOCAL-IN", "TB-OUTBOUND"],
+      "invariants": ["SI-EXEC-DATA-01", "SI-MESSAGE-TRUST-01", "SI-SECRET-HANDLING-01"],
+      "exposure": "administrator-configured-helper",
+      "evidence": ["plugins/omprog/omprog.c", "plugins/mmexternal/mmexternal.c"],
+      "test_hints": ["tests/omprog-basic.sh", "tests/mmexternal-basic.sh"],
+      "requires_lead": true
+    },
+    {
+      "id": "contrib-network-surfaces",
+      "paths": ["contrib/imhttp/**", "contrib/omhttp/**", "contrib/imkubernetes/**", "contrib/mmkubernetes/**"],
+      "boundaries": ["TB-NET-IN", "TB-OUTBOUND", "TB-MODULE"],
+      "invariants": ["SI-INPUT-BOUNDS-01", "SI-PARSER-SAFETY-01", "SI-PEER-IDENTITY-01", "SI-SECRET-HANDLING-01"],
+      "exposure": "optional-contrib-component",
+      "evidence": ["contrib/imhttp/imhttp.c", "contrib/omhttp/omhttp.c"],
+      "test_hints": [],
+      "requires_lead": false
+    },
+    {
+      "id": "ci-build-and-release",
+      "paths": [".github/**", "packaging/**", "devtools/**", "scripts/**", "Makefile.am", "configure.ac", "m4/**"],
+      "boundaries": ["TB-CI", "TB-MODULE"],
+      "invariants": ["SI-CI-TRUST-01", "SI-CONFIG-AUTHORITY-01", "SI-SECRET-HANDLING-01"],
+      "exposure": "repository-and-release-automation",
+      "evidence": [".github/workflows/codeql.yml", ".github/workflows/draft_release.yml"],
+      "test_hints": ["python3 devtools/check-flake-evidence-coverage.py"],
+      "requires_lead": true
+    },
+    {
+      "id": "test-infrastructure",
+      "paths": ["tests/**"],
+      "boundaries": ["TB-CI"],
+      "invariants": ["SI-CI-TRUST-01", "SI-INPUT-BOUNDS-01"],
+      "exposure": "developer-and-ci",
+      "evidence": ["tests/AGENTS.md", "tests/diag.sh"],
+      "test_hints": ["devtools/check-test-antipatterns.sh"],
+      "requires_lead": false
+    },
+    {
+      "id": "security-review-policy",
+      "paths": ["SECURITY.md", "AGENTS.md", ".gitignore", "doc/ai/security_triage_rubric.md", "doc/security/project-threat-model.md", "doc/security/threat-model-components.json", ".agent/skills/rsyslog-security-pr-review/**", ".agent/skills/rsyslog_local_container_testing/SKILL.md"],
+      "boundaries": ["TB-CI"],
+      "invariants": ["SI-CI-TRUST-01", "SI-SECRET-HANDLING-01"],
+      "exposure": "repository-policy",
+      "evidence": ["SECURITY.md", "doc/ai/security_triage_rubric.md"],
+      "test_hints": ["skill quick validation"],
+      "requires_lead": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a sanitized, versioned project threat model with stable trust-boundary and security-invariant IDs
- add a standard-JSON component map and deterministic local PR input builder
- add a bounded local Codex review/fix skill with digest-bound ignored receipts
- integrate the review gate into agent `FINISH` and PR-ready container guidance
- keep the process local-only: no GitHub workflow, external service call, or shell-enforced security gate

## Why

Security reviews should reuse stable project context and inspect only the PR delta in the normal case. This keeps routine reviews fast while escalating model, boundary, unmapped, or plausible-finding changes to independent validation and lead triage.

## Validation

- `python3 -m unittest devtools.tests.test_security_review_input` (15 passed)
- Python style check passed
- skill `quick_validate.py` passed
- JSON parse/cross-reference and `git diff --check` passed
- local security review: `passed`, 9/9 expected files, no candidates
- Ubuntu 26.04 change-gated container run: 1,385 passed, 73 skipped, 0 failed/errors
- container image: `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`)

The Clang static-analyzer lane rebuilt successfully but exited nonzero for the existing `runtime/modules.c:412` null-dereference warning. That file and location are unchanged from `main`; this PR changes no C source. The explicit pre-push validation override was used for this documented baseline blocker after the green container test run.

## Security review behavior

The normal path performs deterministic routing and one compact diff discovery pass. Discovery candidates do not block by themselves. Confirmed PR-introduced or worsened Medium/High/Critical findings block agent-led completion. Fixes require a separate explicit `SECURITY RESOLVE <candidate-id>` invocation and independent post-fix verification.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

