### PR TITLE
core: honor no-match policy for absent regex submatch

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -4286,27 +4286,30 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg,
                             pRes = UCHAR_CONSTANT("");
                         }
                     }
-                } else {
-                    /* Match- but did it match the one we wanted? */
-                    /* we got no match! */
-                    if (pmatch[pTpe->data.field.iSubMatchToUse].rm_so == -1) {
-                        if (pTpe->data.field.nomatchAction != TPL_REGEX_NOMATCH_USE_WHOLE_FIELD) {
-                            if (*pbMustBeFreed == 1) {
-                                free(pRes);
-                                *pbMustBeFreed = 0;
-                            }
-                            if (pTpe->data.field.nomatchAction == TPL_REGEX_NOMATCH_USE_DFLTSTR) {
-                                bufLen = sizeof("**NO MATCH**") - 1;
-                                pRes = UCHAR_CONSTANT("**NO MATCH**");
-                            } else if (pTpe->data.field.nomatchAction == TPL_REGEX_NOMATCH_USE_ZERO) {
-                                bufLen = 1;
-                                pRes = UCHAR_CONSTANT("0");
-                            } else {
-                                bufLen = 0;
-                                pRes = UCHAR_CONSTANT("");
-                            }
+                } else if (pmatch[pTpe->data.field.iSubMatchToUse].rm_so == -1) {
+                    /* the regex matched, but the requested submatch did not
+                     * take part in that match. This is a "no match" for the
+                     * property, so the configured no-match policy applies.
+                     * Note: we must NOT fall through to the extraction below,
+                     * as rm_so/rm_eo are -1 for an absent submatch.
+                     */
+                    if (pTpe->data.field.nomatchAction != TPL_REGEX_NOMATCH_USE_WHOLE_FIELD) {
+                        if (*pbMustBeFreed == 1) {
+                            free(pRes);
+                            *pbMustBeFreed = 0;
+                        }
+                        if (pTpe->data.field.nomatchAction == TPL_REGEX_NOMATCH_USE_DFLTSTR) {
+                            bufLen = sizeof("**NO MATCH**") - 1;
+                            pRes = UCHAR_CONSTANT("**NO MATCH**");
+                        } else if (pTpe->data.field.nomatchAction == TPL_REGEX_NOMATCH_USE_ZERO) {
+                            bufLen = 1;
+                            pRes = UCHAR_CONSTANT("0");
+                        } else {
+                            bufLen = 0;
+                            pRes = UCHAR_CONSTANT("");
                         }
                     }
+                } else {
                     /* OK, we have a usable match - we now need to malloc pB */
                     int iLenBuf;
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -347,6 +347,7 @@ TESTS_DEFAULT = \
 	template-const-jsonf.sh \
 	$(TESTS_TEMPLATE_REGEX_BOUNDS) \
 	template-topos-neg.sh \
+	template-regex-submatch-nomatch.sh \
 	fac_authpriv.sh \
 	fac_local0.sh \
 	fac_local7.sh \

--- a/tests/template-regex-submatch-nomatch.sh
+++ b/tests/template-regex-submatch-nomatch.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+#
+# Regression test for
+# https://github.com/rsyslog/rsyslog/issues/7399
+#
+# When a regex matches but the requested optional submatch did not take
+# part in that match, msgGetProp() picked the configured no-match result
+# and then fell through into the regular submatch extraction. All four
+# regex.nomatchmode policies therefore rendered as an empty string.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="list") {
+	constant(value="dflt=<")
+	property(name="$!value" regex.expression="([a-z]+)(-([0-9]+))?"
+		 regex.type="ERE" regex.submatch="3" regex.nomatchmode="DFLT")
+	constant(value="> zero=<")
+	property(name="$!value" regex.expression="([a-z]+)(-([0-9]+))?"
+		 regex.type="ERE" regex.submatch="3" regex.nomatchmode="ZERO")
+	constant(value="> blank=<")
+	property(name="$!value" regex.expression="([a-z]+)(-([0-9]+))?"
+		 regex.type="ERE" regex.submatch="3" regex.nomatchmode="BLANK")
+	constant(value="> field=<")
+	property(name="$!value" regex.expression="([a-z]+)(-([0-9]+))?"
+		 regex.type="ERE" regex.submatch="3" regex.nomatchmode="FIELD")
+	constant(value="> present=<")
+	property(name="$!present" regex.expression="([a-z]+)(-([0-9]+))?"
+		 regex.type="ERE" regex.submatch="3" regex.nomatchmode="DFLT")
+	constant(value=">\n")
+}
+
+set $!value = "abc";
+set $!present = "abc-42";
+
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+				 file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='dflt=<**NO MATCH**> zero=<0> blank=<> field=<abc> present=<42>'
+cmp_exact
+exit_test


### PR DESCRIPTION
Fixes https://github.com/rsyslog/rsyslog/issues/7399

## Problem

When a regex matches but the requested optional submatch did not take part in
that match, `MsgGetProp()` selected the configured no-match result and then fell
through into the regular submatch extraction. That path overwrote the
just-selected value with an empty string, so `DFLT`, `ZERO` and `FIELD` all
degraded to `BLANK`.

The fall-through also evaluated `pRes + iOffs + rm_so` with `rm_so == -1`. The
resulting copy length is zero, but forming a pointer in front of the object is
undefined behavior.

## Fix

Turn the submatch check into a branch of the same `if`/`else` chain that already
handles the "no match at all" case, so the extraction only runs for a submatch
that actually took part in the match.

## Validation

New testbench case `template-regex-submatch-nomatch.sh` covers all four
policies plus a present submatch. Reproduces the issue exactly on unpatched
`main`:

```
before: dflt=<> zero=<> blank=<> field=<> present=<42>
after:  dflt=<**NO MATCH**> zero=<0> blank=<> field=<abc> present=<42>
```

Ran under an AddressSanitizer build together with `template-topos-neg.sh`,
`template-pos-from-to*.sh` and `template-property-transformations.sh` - all
pass, no sanitizer reports.

With the help of AI-Agents: Claude Opus 5

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

