### PR TITLE
pmrfc3164: fix stack write past bracketed hostname buffer

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -366,6 +366,7 @@ TESTS_DEFAULT = \
 	rfc5424parser.sh \
 	pmrfc3164-msgFirstSpace.sh \
 	pmrfc3164-AtSignsInHostname.sh \
+	pmrfc3164-SquareBracketsInHostname-oversize.sh \
 	pmrfc3164-AtSignsInHostname_off.sh \
 	pmrfc3164-tagEndingByColon.sh \
 	pmrfc3164-parsehostnameandtag-off.sh \

--- a/tests/pmrfc3164-SquareBracketsInHostname-oversize.sh
+++ b/tests/pmrfc3164-SquareBracketsInHostname-oversize.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+#
+# Regression test: with permit.SquareBracketsInHostname="on" a bracketed
+# hostname that exactly fills bufParseHOSTNAME made pmrfc3164 append the
+# closing bracket at the last usable slot and then write the string
+# terminator one byte past the end of the stack buffer. Such a hostname
+# must not be accepted, and rsyslog must not corrupt its stack.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" address="127.0.0.1" port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="customparser")
+parser(name="custom.rfc3164" type="pmrfc3164" permit.SquareBracketsInHostname="on")
+template(name="outfmt" type="string" string="-%hostname%-\n")
+
+ruleset(name="customparser" parser="custom.rfc3164") {
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+# CONF_HOSTNAME_MAXSIZE is 512, so "[" + 510 chars + "]" is exactly the
+# buffer size and used to trigger the off-by-one write.
+oversize_host="[$(printf 'A%.0s' $(seq 1 510))]"
+short_host="[192.0.2.1]"
+
+startup
+tcpflood -m1 -M "\"<129>Mar 10 01:00:00 $short_host tag: msgnum:1\""
+tcpflood -m1 -M "\"<129>Mar 10 01:00:00 $oversize_host tag: msgnum:2\""
+shutdown_when_empty
+wait_shutdown
+
+# The first message yields the bracketed hostname. The second one is not a
+# representable hostname, so pmrfc3164 falls back to the receiver's own
+# hostname - the important part is that rsyslog survives and does not emit
+# the oversized token as HOSTNAME.
+if ! grep -qF -- "-$short_host-" $RSYSLOG_OUT_LOG; then
+	echo "FAIL: bracketed hostname not parsed, $RSYSLOG_OUT_LOG is:"
+	cat $RSYSLOG_OUT_LOG
+	error_exit 1
+fi
+if grep -qF -- "-[AAAA" $RSYSLOG_OUT_LOG; then
+	echo "FAIL: oversized bracketed hostname was accepted, $RSYSLOG_OUT_LOG is:"
+	cat $RSYSLOG_OUT_LOG
+	error_exit 1
+fi
+exit_test

--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -431,7 +431,12 @@ BEGINparse2
                 int isHostName = 0;
                 if (i > 0) {
                     if (bHadSBracket) {
-                        if (p2parse[i] == ']') {
+                        /* the scan loop above only reserves room for the string
+                         * terminator, so we must check that the closing bracket
+                         * still fits as well - otherwise this is not a hostname
+                         * we can represent.
+                         */
+                        if (p2parse[i] == ']' && i < CONF_HOSTNAME_MAXSIZE - 1) {
                             bufParseHOSTNAME[i] = ']';
                             ++i;
                             isHostName = 1;


### PR DESCRIPTION
## Problem

The HOSTNAME scan loop in `pmrfc3164`'s `parse2()` stops at
`CONF_HOSTNAME_MAXSIZE - 1`, which only reserves room for the string
terminator. When `permit.SquareBracketsInHostname` is enabled, the code
afterwards appends the closing bracket at that last usable slot and advances
the index:

```c
if (p2parse[i] == ']') {
    bufParseHOSTNAME[i] = ']';
    ++i;
    isHostName = 1;
}
...
bufParseHOSTNAME[i] = '\0';   /* i == CONF_HOSTNAME_MAXSIZE here */
```

so the terminator is written one byte past the end of the stack array.

## Reproducer

A message whose hostname token is `[` plus 510 hostname characters plus `]`
followed by a space, i.e. exactly the buffer size, sent to an `imtcp` listener
whose parser has `permit.SquareBracketsInHostname="on"`. AddressSanitizer:

```
ERROR: AddressSanitizer: stack-buffer-overflow ... WRITE of size 1 thread T6 (rs:main Q:Reg)
    #0 parse2 tools/pmrfc3164.c:451
    [672, 1184) 'bufParseHOSTNAME' <== Memory access at offset 1184 overflows this variable
```

The input is entirely remote-controlled, so this is reachable by any sender
allowed to reach the listener.

## Fix

Only append the closing bracket while the index still leaves room for the
terminator. An oversized bracketed token is then not recognised as a hostname,
which matches what already happens for other unparsable hostnames.

## Validation

New testbench case `pmrfc3164-SquareBracketsInHostname-oversize.sh` covers the
boundary and checks that a normal bracketed hostname still parses. It reports
the sanitizer error on unpatched `main` and passes with the fix.
`pmrfc3164-AtSignsInHostname.sh`, `pmrfc3164-defaultTag.sh`,
`pmrfc3164-tagEndingByColon.sh` and `hostname-with-slash-pmrfc3164.sh` still
pass under AddressSanitizer.