### PR TITLE
core: fix crash on negative position.to underflow

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -4381,6 +4381,19 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg,
                 if (pTpe->data.field.options.bFixedWidth == 0) iTo = bufLen - 1;
 
             iLen = iTo - iFrom + 1; /* the +1 is for an actual char, NOT \0! */
+            if (iLen < 0) {
+                /* A negative position.to may push iTo in front of iFrom, e.g.
+                 * position.from="5" position.to="-2" on a 5-character value.
+                 * The requested substring is empty in that case. Without this
+                 * guard iLen stays negative, malloc(0) succeeds and the copy
+                 * loop below never terminates.
+                 */
+                DBGPRINTF(
+                    "msgGetProp: iTo %d is in front of iFrom %d, "
+                    "returning empty string\n",
+                    iTo, iFrom);
+                iLen = 0;
+            }
             pBufStart = pBuf = malloc(iLen + 1);
             if (pBuf == NULL) {
                 if (*pbMustBeFreed == 1) free(pRes);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -347,6 +347,7 @@ TESTS_DEFAULT = \
 	template-const-jsonf.sh \
 	$(TESTS_TEMPLATE_REGEX_BOUNDS) \
 	template-topos-neg.sh \
+	template-topos-neg-underflow.sh \
 	fac_authpriv.sh \
 	fac_local0.sh \
 	fac_local7.sh \

--- a/tests/template-topos-neg-underflow.sh
+++ b/tests/template-topos-neg-underflow.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+#
+# Regression test: a negative "position.to" may resolve to a position in
+# front of "position.from" when the property value is short. msgGetProp()
+# then computed a negative substring length, malloc(0) succeeded and the
+# copy loop never terminated, which crashed rsyslog. The substring must
+# simply be empty in that case.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="list") {
+	constant(value="short=<")
+	property(name="$!short" position.from="5" position.to="-2")
+	constant(value="> long=<")
+	property(name="$!long" position.from="5" position.to="-2")
+	constant(value=">\n")
+}
+
+set $!short = "abcde";
+set $!long = "abcdefghij";
+
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+				 file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='short=<> long=<efgh>'
+cmp_exact
+exit_test


### PR DESCRIPTION
## Problem

A negative `position.to` is resolved against the actual value length
(`iTo = bufLen - 1 + iToPos`). For a short value this can place `iTo` in front
of `iFrom`. The config-time sanity check in `template.c` cannot catch this
because it only compares non-negative positions:

```c
if ((topos >= 0) && (topos < frompos)) {   /* negative topos skips the check */
```

`msgGetProp()` then computes `iLen = iTo - iFrom + 1` as a negative number.
For `iLen == -1` the following `malloc(iLen + 1)` is `malloc(0)`, which succeeds
and returns a minimal chunk, so the `pBuf == NULL` guard does not help. The
subsequent copy loop uses `while (iLen)` rather than `while (iLen > 0)`, so it
decrements `iLen` away from zero and never terminates, writing past the
allocation until the process dies.

## Reproducer

```rainerscript
template(name="sub" type="list") {
    property(name="$!v" position.from="5" position.to="-2")
    constant(value="\n")
}
set $!v = "abcde";
```

`rsyslogd` segfaults while formatting the first message. Under an
AddressSanitizer build:

```
ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 1 thread T3 (rs:main Q:Reg)
    #0 MsgGetProp runtime/msg.c:4403
```

The trigger condition is `position.from >= 3`, `position.to <= -2` and a value
whose length happens to be `from - to - 2`. Property values are frequently
attacker-influenced (parsed message fields, `$!` variables), so any config
using a negative `position.to` is exposed to a remote crash.

Note the documented example `position.from="2" position.to="-1"` is *not*
affected, which is likely why this went unnoticed.

## Fix

The requested substring is simply empty whenever `iTo` precedes `iFrom`, so
clamp a negative `iLen` to `0` before the allocation. Both the allocation size
and the copy loop are then well defined again.

## Validation

New testbench case `template-topos-neg-underflow.sh`. Fails (segfault) on
unpatched `main`, passes with the fix, and is clean under AddressSanitizer.
Existing `template-topos-neg.sh`, `template-pos-from-to*.sh` and
`template-property-transformations.sh` still pass.

## Note

This resubmits the change previously opened as #7528, which I closed by
mistake; the branch had been deleted so it could not be reopened. The commit
is unchanged (`a116e36`) and still applies cleanly to current `main`.

With the help of AI-Agents: Claude Opus 5

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

