### PR TITLE
core: add experimental reserved batch egress engine

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2210,6 +2210,25 @@ fi
 AM_CONDITIONAL(ENABLE_RESERVED_EGRESS_TEST_HOOKS,
                test x$enable_reserved_egress_test_hooks = xyes)
 
+# Reserved-egress publication diagnostics are compile-time optional so the
+# performance experiment's ordinary timing builds carry no shared stats RMWs.
+AC_ARG_ENABLE(reserved-egress-stats,
+        [AS_HELP_STRING([--enable-reserved-egress-stats],
+         [reserved-egress publication diagnostics enabled @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_reserved_egress_stats="yes" ;;
+          no) enable_reserved_egress_stats="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-reserved-egress-stats) ;;
+         esac],
+        [enable_reserved_egress_stats=no]
+)
+if test "x$enable_reserved_egress_stats" = "xyes"; then
+	AC_DEFINE([ENABLE_RESERVED_EGRESS_STATS], [1],
+	          [Enable reserved-egress publication diagnostic counters])
+fi
+AM_CONDITIONAL(ENABLE_RESERVED_EGRESS_STATS,
+               test x$enable_reserved_egress_stats = xyes)
+
 # Add a capability to turn off libfaketime tests. Unfortunately, libfaketime
 # becomes more and more problematic in newer versions and causes aborts
 # on some platforms. This provides the ability to turn it off. In the

--- a/configure.ac
+++ b/configure.ac
@@ -2191,6 +2191,25 @@ AC_ARG_ENABLE(testbench,
         [enable_testbench=no]
 )
 
+# Internal reserved-egress fault/probe hooks. These are deliberately separate
+# from imdiag so ordinary diagnostic and benchmark builds carry no hook code.
+AC_ARG_ENABLE(reserved-egress-test-hooks,
+        [AS_HELP_STRING([--enable-reserved-egress-test-hooks],
+         [reserved-egress internal test hooks enabled @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_reserved_egress_test_hooks="yes" ;;
+          no) enable_reserved_egress_test_hooks="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-reserved-egress-test-hooks) ;;
+         esac],
+        [enable_reserved_egress_test_hooks=no]
+)
+if test "x$enable_reserved_egress_test_hooks" = "xyes"; then
+	AC_DEFINE([ENABLE_RESERVED_EGRESS_TEST_HOOKS], [1],
+	          [Enable internal reserved-egress test fault and selector hooks])
+fi
+AM_CONDITIONAL(ENABLE_RESERVED_EGRESS_TEST_HOOKS,
+               test x$enable_reserved_egress_test_hooks = xyes)
+
 # Add a capability to turn off libfaketime tests. Unfortunately, libfaketime
 # becomes more and more problematic in newer versions and causes aborts
 # on some platforms. This provides the ability to turn it off. In the

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -61,6 +61,7 @@ EXTRA_DIST = \
     ai/drift_monitoring.md \
     ai/mermaid_rules.md \
     ai/module_map.yaml \
+    ai/reserved_batch_egress.md \
     ai/security_triage_rubric.md \
     ai/structure_and_paths.md \
     ai/templates/template-concept.rst \

--- a/doc/ai/reserved_batch_egress.md
+++ b/doc/ai/reserved_batch_egress.md
@@ -1,0 +1,96 @@
+# Experimental reserved-batch ruleset egress
+
+`global(executionEngine="reservedBatch")` selects an experimental execution
+adapter. The default, `legacy`, does not enter this code. Phase 1 handles only
+asynchronous `call` and `call_indirect` targets backed by bounded, memory-only
+LinkedList or FixedArray ruleset queues. Direct calls, action queues, plugin
+callbacks, messages, and disk formats are unchanged.
+An explicitly configured `queue.type="Direct"` ruleset is not an asynchronous
+target: `rulesetHasQueue()` remains false for it, so calls execute synchronously
+and may mutate the current message exactly like queue-less ruleset calls.
+
+## Ownership and state
+
+A WTI ledger exists only for one source dequeue batch. Its states are
+`EMPTY`, `EXECUTING`, `PUBLISHING`, and `PUBLISHED`. Each accepted branch owns
+one `MsgDup()` result, one target capacity reservation, and (for LinkedList) a
+prepared node. Cancellation is disabled from reservation through installation
+in the ledger. Publication transfers all three exactly once; cancellation
+cleanup publishes accepted branches before normal source-batch cleanup.
+
+The target invariant, under its queue mutex, is:
+
+```
+physical queue entries + unpublished reservations <= queue.size
+```
+
+Publication is a bounded cancellation-disabled section. Each target bucket is
+published with one lock acquisition, accounting/persistence update, and worker
+advice. Prepared publication has no allocation or capacity failure path.
+If a new reservation encounters exhausted physical-plus-reserved capacity, a
+slow path first publishes every bucket currently staged by this WTI and then
+retries the ordinary wait/timeout/drop admission loop. Buckets are visited in
+their encounter order, and one target lock is released before the next is
+acquired. Flushing all buckets prevents crossed-target reservation cycles
+between WTIs while retaining end-of-source-batch publication on the normal
+path.
+Encounter order from one WTI to one target is retained. Concurrent WTIs are
+ordered by target publication order, not by global call encounter time.
+
+## Source and action relation
+
+The WTI captures the config pointer and selector at source-batch entry. Every
+call in that batch uses the captured selector; no statement rereads `runConf`.
+The current daemon does not swap the active main configuration during live
+processing (HUP deliberately does not reload it), so the source queue worker
+lifetime also covers the captured config and target queues.
+
+Source `BATCH_STATE_*` transitions remain legacy: a successful `scriptExec()`
+marks its source element committed; an interrupted element remains ready for
+retry. A prepare/allocation failure is returned through the internal main-queue
+consumer adapter so its source state is not overwritten by the historical
+blanket commit. Reserved branches publish before `actionCommitAllDirect()`,
+matching the legacy relation in which queued calls have already submitted
+before the end-of-batch direct transaction commit. The action state machine,
+plugin callbacks, and action transaction cleanup are not adapted.
+
+Legacy does not guarantee exactly-once across hard cancellation: a queued call
+may submit before its source message is interrupted and retried. Reserved-batch
+cleanup deliberately preserves that behavior by publishing every accepted
+branch, including branches encountered by an incomplete source element.
+
+Each branch ledger record retains its source batch index and transitions from
+`STAGED` to `PUBLISHED`; published records have no message or prepared-node
+ownership. Slow-path publication updates that state before cancellation is
+restored, so cleanup publishes only the remaining staged suffix.
+
+Admission counters retain legacy meanings. `enqueued` and inbound bytes are
+counted once when a branch first attempts admission. A pressure probe used to
+trigger the slow path does not increment `full`; the subsequent ordinary
+admission loop increments `full` for each full observation and increments the
+full-discard counter only on the same immediate/timeout rejection paths as
+legacy.
+
+Queue impstats expose `egress.published.batches`,
+`egress.published.messages`, and `egress.publication.advice`. They are regular
+stats-enabled counters updated once under the existing target publication
+lock, so ordinary builds do not add a diagnostic shared RMW when statistics
+collection is disabled. On the no-pressure path, one populated target bucket
+for a source dequeue batch increments batches and advice once regardless of
+its branch count.
+
+## Internal test hooks
+
+`--enable-reserved-egress-test-hooks` is a default-off configure option for
+deterministic selector-capture and allocation-failure tests. It is independent
+of imdiag on purpose: ordinary imdiag and benchmark builds compile neither the
+environment probes nor their shared hook state. The hook-dependent tests are
+registered only when both imdiag and this option are enabled.
+
+## Exclusions
+
+Disk, segmentedDisk, disk-assisted or unbounded queued rulesets, sampling
+queues, Direct source queues, persistent continuations, producer lanes, SCQ,
+and wCQ are outside this phase. Queue-less ruleset calls remain synchronous on
+the legacy path. Configuration activation rejects unsupported queues rather
+than silently mixing execution engines.

--- a/doc/ai/reserved_batch_egress.md
+++ b/doc/ai/reserved_batch_egress.md
@@ -58,11 +58,19 @@ Legacy does not guarantee exactly-once across hard cancellation: a queued call
 may submit before its source message is interrupted and retried. Reserved-batch
 cleanup deliberately preserves that behavior by publishing every accepted
 branch, including branches encountered by an incomplete source element.
+The same rule applies when a later branch fails to allocate: an earlier accepted
+branch is published and normal source retry may publish it again, just as the
+legacy engine may retry a source after its earlier `submitMsg2()` already
+succeeded. Filtering publication by source commit state would silently strengthen
+legacy delivery semantics and could lose an accepted branch if termination wins
+before the source retry. The focused late-failure test therefore asserts the
+permitted duplicate and, critically, the absence of branch loss.
 
-Each branch ledger record retains its source batch index and transitions from
-`STAGED` to `PUBLISHED`; published records have no message or prepared-node
-ownership. Slow-path publication updates that state before cancellation is
-restored, so cleanup publishes only the remaining staged suffix.
+Each branch ledger record transitions from `STAGED` to `PUBLISHED`; published
+records have no message or prepared-node ownership. Slow-path publication
+updates that state before cancellation is restored, so cleanup publishes only
+the remaining staged suffix. No source index is retained because Phase 1 never
+filters publication by source commit state.
 
 Admission counters retain legacy meanings. `enqueued` and inbound bytes are
 counted once when a branch first attempts admission. A pressure probe used to
@@ -71,21 +79,31 @@ admission loop increments `full` for each full observation and increments the
 full-discard counter only on the same immediate/timeout rejection paths as
 legacy.
 
-Queue impstats expose `egress.published.batches`,
+When configured with the default-off `--enable-reserved-egress-stats`, queue
+impstats expose `egress.published.batches`,
 `egress.published.messages`, and `egress.publication.advice`. They are regular
-stats-enabled counters updated once under the existing target publication
-lock, so ordinary builds do not add a diagnostic shared RMW when statistics
-collection is disabled. On the no-pressure path, one populated target bucket
-for a source dequeue batch increments batches and advice once regardless of
-its branch count.
+stats counters updated once under the existing target publication lock. The
+fields, registration, and updates are compiled out unless this dedicated
+diagnostic option is enabled, so ordinary legacy and reserved-batch timing
+builds add no shared diagnostic RMW. On the no-pressure path, one populated
+target bucket for a source dequeue batch increments batches and advice once
+regardless of its branch count.
 
 ## Internal test hooks
 
 `--enable-reserved-egress-test-hooks` is a default-off configure option for
 deterministic selector-capture and allocation-failure tests. It is independent
 of imdiag on purpose: ordinary imdiag and benchmark builds compile neither the
-environment probes nor their shared hook state. The hook-dependent tests are
-registered only when both imdiag and this option are enabled.
+environment probes nor their shared hook state. A worker-advice gate lets tests
+form a source dequeue batch from already available messages without enabling
+`queue.minDequeueBatchSize`; removing the gate and submitting one release message
+returns immediately to ordinary advice. The hook-dependent tests are registered
+only when both imdiag and this option are enabled.
+The publication-counter oracle additionally requires
+`--enable-reserved-egress-stats` and impstats. A separate non-hook test submits
+a quiet-queue singleton, a burst, and a final singleton tail, observing each
+before any later arrival; this proves dequeue and publication batch sizes are
+ceilings rather than fill requirements.
 
 ## Exclusions
 

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -1411,13 +1411,17 @@ rsRetVal glblDoneLoadCnf(void) {
         } else if (!strcmp(paramblk.descr[i].name, "executionengine")) {
             const char *const engine = es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
             if (engine == NULL) {
-                parser_errmsg("out of memory processing global parameter executionEngine");
+                LogError(0, RS_RET_OUT_OF_MEMORY, "out of memory processing global parameter executionEngine");
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
             } else if (!strcmp(engine, "legacy")) {
                 loadConf->executionEngine = 0;
             } else if (!strcmp(engine, "reservedBatch")) {
                 loadConf->executionEngine = 1;
             } else {
-                parser_errmsg("invalid global executionEngine '%s'; expected 'legacy' or 'reservedBatch'", engine);
+                LogError(0, RS_RET_ERR, "invalid global executionEngine '%s'; expected 'legacy' or 'reservedBatch'",
+                         engine);
+                free((void *)engine);
+                ABORT_FINALIZE(RS_RET_ERR);
             }
             free((void *)engine);
         } else if (!strcmp(paramblk.descr[i].name, "localhostname")) {

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -204,6 +204,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
     {"debug.whitelist", eCmdHdlrBinary, 0},
     {"libcapng.default", eCmdHdlrBinary, 0},
     {"libcapng.enable", eCmdHdlrBinary, 0},
+    {"executionengine", eCmdHdlrGetWord, 0},
 };
 static struct cnfparamblk paramblk = {CNFPARAMBLK_VERSION, sizeof(cnfparamdescr) / sizeof(struct cnfparamdescr),
                                       cnfparamdescr};
@@ -1171,6 +1172,7 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) * pp, void __
     loadConf->globals.oversizeMsgErrorFile = NULL;
     loadConf->globals.oversizeMsgInputMode = glblOversizeMsgInputMode_Accept;
     loadConf->globals.reportChildProcessExits = REPORT_CHILD_PROCESS_EXITS_ERRORS;
+    loadConf->executionEngine = 0;
     free(loadConf->globals.pszWorkDir);
     loadConf->globals.pszWorkDir = NULL;
     free((void *)loadConf->globals.operatingStateFile);
@@ -1406,6 +1408,18 @@ rsRetVal glblDoneLoadCnf(void) {
             const int val = (int)cnfparamvals[i].val.d.n;
             fjson_global_do_case_sensitive_comparison(val);
             DBGPRINTF("global/config: set case sensitive variables to %d\n", val);
+        } else if (!strcmp(paramblk.descr[i].name, "executionengine")) {
+            const char *const engine = es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+            if (engine == NULL) {
+                parser_errmsg("out of memory processing global parameter executionEngine");
+            } else if (!strcmp(engine, "legacy")) {
+                loadConf->executionEngine = 0;
+            } else if (!strcmp(engine, "reservedBatch")) {
+                loadConf->executionEngine = 1;
+            } else {
+                parser_errmsg("invalid global executionEngine '%s'; expected 'legacy' or 'reservedBatch'", engine);
+            }
+            free((void *)engine);
         } else if (!strcmp(paramblk.descr[i].name, "localhostname")) {
             free(LocalHostNameOverride);
             LocalHostNameOverride = (uchar *)es_str2cstr(cnfparamvals[i].val.d.estr, NULL);

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -4036,6 +4036,16 @@ rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis) /* this is the Construction
     CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("discarded.nf"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
                                 &pThis->ctrNFDscrd));
 
+    STATSCOUNTER_INIT(pThis->ctrEgressPublishedBatches, pThis->mutCtrEgressPublishedBatches);
+    CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("egress.published.batches"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &pThis->ctrEgressPublishedBatches));
+    STATSCOUNTER_INIT(pThis->ctrEgressPublishedMessages, pThis->mutCtrEgressPublishedMessages);
+    CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("egress.published.messages"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &pThis->ctrEgressPublishedMessages));
+    STATSCOUNTER_INIT(pThis->ctrEgressPublicationAdvice, pThis->mutCtrEgressPublicationAdvice);
+    CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("egress.publication.advice"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &pThis->ctrEgressPublicationAdvice));
+
     pThis->ctrMaxqsize = 0; /* no mutex needed, thus no init call */
     CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("maxqsize"), ctrType_Int, CTR_FLAG_NONE,
                                 &pThis->ctrMaxqsize));
@@ -4263,6 +4273,7 @@ static rsRetVal DoSaveOnShutdown(qqueue_t *pThis) {
 /* destructor for the queue object */
 BEGINobjDestruct(qqueue) /* be sure to specify the object type also in END and CODESTART macros! */
     CODESTARTobjDestruct(qqueue);
+    assert(pThis->nEgressReservations == 0);
     DBGOPRINT((obj_t *)pThis, "shutdown: begin to destruct queue\n");
     if (ourConf->globals.shutdownQueueDoubleSize) {
         pThis->iHighWtrMrk *= 2;
@@ -4436,7 +4447,7 @@ static rsRetVal doEnqSingleObj(qqueue_t *pThis, flowControl_t flowCtlType, smsg_
     STATSCOUNTER_ADD(pThis->ctrSizeEnqueued, pThis->mutCtrSizeEnqueued, (uint64_t)pMsg->iLenRawMsg);
     /* first check if we need to discard this message (which will cause CHKiRet() to exit)
      */
-    CHKiRet(qqueueChkDiscardMsg(pThis, pThis->iQueueSize, pMsg));
+    CHKiRet(qqueueChkDiscardMsg(pThis, pThis->iQueueSize + pThis->nEgressReservations, pMsg));
 
     /* handle flow control
      * There are two different flow control mechanisms: basic and advanced flow control.
@@ -4514,7 +4525,7 @@ static rsRetVal doEnqSingleObj(qqueue_t *pThis, flowControl_t flowCtlType, smsg_
      * is not the case, basic flow control enters the field, which means we wait for
      * the queue to become ready or drop the new message. -- rgerhards, 2008-03-14
      */
-    while ((pThis->iMaxQueueSize > 0 && pThis->iQueueSize >= pThis->iMaxQueueSize) ||
+    while ((pThis->iMaxQueueSize > 0 && pThis->iQueueSize + pThis->nEgressReservations >= pThis->iMaxQueueSize) ||
            ((pThis->qType == QUEUETYPE_DISK || pThis->bIsDA) && pThis->sizeOnDiskMax != 0 &&
             pThis->tVars.disk.sizeOnDisk > pThis->sizeOnDiskMax) ||
            (pThis->qType == QUEUETYPE_SEGMENTED_DISK && pThis->sizeOnDiskMax != 0 &&
@@ -4676,6 +4687,129 @@ finalize_it:
     RETiRet;
 }
 
+int qqueueSupportsReservedEgress(const qqueue_t *const pThis) {
+    return pThis != NULL && (pThis->qType == QUEUETYPE_LINKEDLIST || pThis->qType == QUEUETYPE_FIXED_ARRAY) &&
+           pThis->pszFilePrefix == NULL && !pThis->bIsDA && pThis->iSmpInterval == 0 && pThis->iMaxQueueSize > 0;
+}
+
+rsRetVal qqueueEgressPrepare(qqueue_t *const pThis,
+                             smsg_t *const pMsg,
+                             const int sourceIndex,
+                             qqueue_egress_entry_t *const pEntry) {
+    DEFiRet;
+    memset(pEntry, 0, sizeof(*pEntry));
+    pEntry->pMsg = pMsg;
+    pEntry->sourceIndex = sourceIndex;
+    if (!qqueueSupportsReservedEgress(pThis)) ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    if (pThis->qType == QUEUETYPE_LINKEDLIST) {
+        CHKmalloc(pEntry->pLinkedListEntry = malloc(sizeof(qLinkedList_t)));
+        pEntry->pLinkedListEntry->pNext = NULL;
+        pEntry->pLinkedListEntry->pMsg = pMsg;
+    }
+finalize_it:
+    RETiRet;
+}
+
+/* tryOnly reports pressure without counters, waits, or ownership transfer so
+ * the WTI can first publish its own invisible reservations. */
+rsRetVal qqueueEgressReserve(qqueue_t *const pThis, qqueue_egress_entry_t *const pEntry, const int tryOnly) {
+    struct timespec t;
+    DEFiRet;
+
+    assert(pEntry != NULL);
+    assert(pEntry->pMsg != NULL);
+    if (!qqueueSupportsReservedEgress(pThis)) ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+
+    d_pthread_mutex_lock(pThis->mut);
+    if (!pEntry->admissionCounted) {
+        STATSCOUNTER_INC(pThis->ctrEnqueued, pThis->mutCtrEnqueued);
+        STATSCOUNTER_ADD(pThis->ctrSizeEnqueued, pThis->mutCtrSizeEnqueued, (uint64_t)pEntry->pMsg->iLenRawMsg);
+        pEntry->admissionCounted = 1;
+        const int occupancy = pThis->iQueueSize + pThis->nEgressReservations;
+        iRet = qqueueChkDiscardMsg(pThis, occupancy, pEntry->pMsg);
+        if (iRet != RS_RET_OK) {
+            pEntry->pMsg = NULL;
+            goto unlock;
+        }
+    }
+    if (tryOnly && pThis->iMaxQueueSize > 0 && pThis->iQueueSize + pThis->nEgressReservations >= pThis->iMaxQueueSize) {
+        iRet = RS_RET_RETRY;
+        goto unlock;
+    }
+    while (pThis->iMaxQueueSize > 0 && pThis->iQueueSize + pThis->nEgressReservations >= pThis->iMaxQueueSize) {
+        STATSCOUNTER_INC(pThis->ctrFull, pThis->mutCtrFull);
+        if (pThis->toEnq == 0 || pThis->bEnqOnly) {
+            STATSCOUNTER_INC(pThis->ctrFDscrd, pThis->mutCtrFDscrd);
+            msgDestruct(&pEntry->pMsg);
+            iRet = RS_RET_QUEUE_FULL;
+            goto unlock;
+        }
+        qqueueAdviseMaxWorkers(pThis);
+        if (glbl.GetGlobalInputTermState()) {
+            msgDestruct(&pEntry->pMsg);
+            iRet = RS_RET_FORCE_TERM;
+            goto unlock;
+        }
+        timeoutComp(&t, pThis->toEnq);
+        const int r = pthread_cond_timedwait(&pThis->notFull, pThis->mut, &t);
+        if (r != 0) {
+            STATSCOUNTER_INC(pThis->ctrFDscrd, pThis->mutCtrFDscrd);
+            msgDestruct(&pEntry->pMsg);
+            iRet = RS_RET_QUEUE_FULL;
+            goto unlock;
+        }
+    }
+    ++pThis->nEgressReservations;
+    pEntry->state = QQUEUE_EGRESS_STAGED;
+
+unlock:
+    d_pthread_mutex_unlock(pThis->mut);
+finalize_it:
+    if (iRet != RS_RET_OK && iRet != RS_RET_RETRY) {
+        free(pEntry->pLinkedListEntry);
+        pEntry->pLinkedListEntry = NULL;
+        if (pEntry->pMsg != NULL) msgDestruct(&pEntry->pMsg);
+    }
+    RETiRet;
+}
+
+void qqueueEgressPublish(qqueue_t *const pThis, qqueue_egress_entry_t *const pEntries, const size_t nEntries) {
+    assert(qqueueSupportsReservedEgress(pThis));
+    assert(nEntries <= INT_MAX);
+    d_pthread_mutex_lock(pThis->mut);
+    assert(pThis->nEgressReservations >= (int)nEntries);
+    for (size_t i = 0; i < nEntries; ++i) {
+        assert(pEntries[i].pMsg != NULL);
+        if (pThis->qType == QUEUETYPE_LINKEDLIST) {
+            qLinkedList_t *const node = pEntries[i].pLinkedListEntry;
+            assert(node != NULL);
+            if (pThis->tVars.linklist.pDelRoot == NULL) {
+                pThis->tVars.linklist.pDelRoot = pThis->tVars.linklist.pDeqRoot = node;
+            } else {
+                pThis->tVars.linklist.pLast->pNext = node;
+                if (pThis->tVars.linklist.pDeqRoot == NULL) pThis->tVars.linklist.pDeqRoot = node;
+            }
+            pThis->tVars.linklist.pLast = node;
+            pEntries[i].pLinkedListEntry = NULL;
+        } else {
+            const rsRetVal r = qAddFixedArray(pThis, pEntries[i].pMsg);
+            assert(r == RS_RET_OK);
+            (void)r;
+        }
+        pEntries[i].pMsg = NULL;
+        pEntries[i].state = QQUEUE_EGRESS_PUBLISHED;
+    }
+    pThis->nEgressReservations -= (int)nEntries;
+    qqueueAddPhysicalQueueSize(pThis, (int)nEntries);
+    qqueueAddOverallQueueSize((int)nEntries);
+    STATSCOUNTER_SETMAX_NOMUT(pThis->ctrMaxqsize, pThis->iQueueSize);
+    qqueueChkPersist(pThis, (int)nEntries);
+    STATSCOUNTER_INC(pThis->ctrEgressPublishedBatches, pThis->mutCtrEgressPublishedBatches);
+    STATSCOUNTER_ADD(pThis->ctrEgressPublishedMessages, pThis->mutCtrEgressPublishedMessages, nEntries);
+    qqueueAdviseMaxWorkers(pThis);
+    STATSCOUNTER_INC(pThis->ctrEgressPublicationAdvice, pThis->mutCtrEgressPublicationAdvice);
+    d_pthread_mutex_unlock(pThis->mut);
+}
 
 /* are any queue params set at all? 1 - yes, 0 - no
  * We need to evaluate the param block for this function, which is somewhat

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -681,6 +681,14 @@ static rsRetVal qqueueAdviseMaxWorkers(qqueue_t *pThis) {
 
     ISOBJ_TYPE_assert(pThis, qqueue);
 
+#ifdef ENABLE_RESERVED_EGRESS_TEST_HOOKS
+    /* A test-only gate lets focused tests form a source batch without
+     * queue.minDequeueBatchSize. Removing the named file and submitting one
+     * release message restores the ordinary immediate worker advice path. */
+    const char *const egressWorkerGate = getenv("RSYSLOG_TEST_EGRESS_WORKER_GATE");
+    if (egressWorkerGate != NULL && access(egressWorkerGate, F_OK) == 0) return RS_RET_OK;
+#endif
+
     if (!pThis->bEnqOnly) {
         if (pThis->bIsDA && getLogicalQueueSize(pThis) >= pThis->iHighWtrMrk) {
             DBGOPRINT((obj_t *)pThis, "(re)activating DA worker\n");
@@ -4036,6 +4044,7 @@ rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis) /* this is the Construction
     CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("discarded.nf"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
                                 &pThis->ctrNFDscrd));
 
+#ifdef ENABLE_RESERVED_EGRESS_STATS
     STATSCOUNTER_INIT(pThis->ctrEgressPublishedBatches, pThis->mutCtrEgressPublishedBatches);
     CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("egress.published.batches"), ctrType_IntCtr,
                                 CTR_FLAG_RESETTABLE, &pThis->ctrEgressPublishedBatches));
@@ -4045,6 +4054,7 @@ rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis) /* this is the Construction
     STATSCOUNTER_INIT(pThis->ctrEgressPublicationAdvice, pThis->mutCtrEgressPublicationAdvice);
     CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("egress.publication.advice"), ctrType_IntCtr,
                                 CTR_FLAG_RESETTABLE, &pThis->ctrEgressPublicationAdvice));
+#endif
 
     pThis->ctrMaxqsize = 0; /* no mutex needed, thus no init call */
     CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("maxqsize"), ctrType_Int, CTR_FLAG_NONE,
@@ -4692,14 +4702,10 @@ int qqueueSupportsReservedEgress(const qqueue_t *const pThis) {
            pThis->pszFilePrefix == NULL && !pThis->bIsDA && pThis->iSmpInterval == 0 && pThis->iMaxQueueSize > 0;
 }
 
-rsRetVal qqueueEgressPrepare(qqueue_t *const pThis,
-                             smsg_t *const pMsg,
-                             const int sourceIndex,
-                             qqueue_egress_entry_t *const pEntry) {
+rsRetVal qqueueEgressPrepare(qqueue_t *const pThis, smsg_t *const pMsg, qqueue_egress_entry_t *const pEntry) {
     DEFiRet;
     memset(pEntry, 0, sizeof(*pEntry));
     pEntry->pMsg = pMsg;
-    pEntry->sourceIndex = sourceIndex;
     if (!qqueueSupportsReservedEgress(pThis)) ABORT_FINALIZE(RS_RET_PARAM_ERROR);
     if (pThis->qType == QUEUETYPE_LINKEDLIST) {
         CHKmalloc(pEntry->pLinkedListEntry = malloc(sizeof(qLinkedList_t)));
@@ -4710,8 +4716,12 @@ finalize_it:
     RETiRet;
 }
 
-/* tryOnly reports pressure without counters, waits, or ownership transfer so
- * the WTI can first publish its own invisible reservations. */
+/* The first attempt accounts admission and checks discard policy exactly once,
+ * including when it is a tryOnly probe. If that probe finds capacity pressure,
+ * it returns RS_RET_RETRY without incrementing full/discard counters, waiting,
+ * or transferring ownership so the WTI can first publish its own invisible
+ * reservations. A later non-tryOnly retry reuses the recorded admission and
+ * performs the ordinary full observation, wait, timeout, and drop accounting. */
 rsRetVal qqueueEgressReserve(qqueue_t *const pThis, qqueue_egress_entry_t *const pEntry, const int tryOnly) {
     struct timespec t;
     DEFiRet;
@@ -4804,10 +4814,14 @@ void qqueueEgressPublish(qqueue_t *const pThis, qqueue_egress_entry_t *const pEn
     qqueueAddOverallQueueSize((int)nEntries);
     STATSCOUNTER_SETMAX_NOMUT(pThis->ctrMaxqsize, pThis->iQueueSize);
     qqueueChkPersist(pThis, (int)nEntries);
+#ifdef ENABLE_RESERVED_EGRESS_STATS
     STATSCOUNTER_INC(pThis->ctrEgressPublishedBatches, pThis->mutCtrEgressPublishedBatches);
     STATSCOUNTER_ADD(pThis->ctrEgressPublishedMessages, pThis->mutCtrEgressPublishedMessages, nEntries);
+#endif
     qqueueAdviseMaxWorkers(pThis);
+#ifdef ENABLE_RESERVED_EGRESS_STATS
     STATSCOUNTER_INC(pThis->ctrEgressPublicationAdvice, pThis->mutCtrEgressPublicationAdvice);
+#endif
     d_pthread_mutex_unlock(pThis->mut);
 }
 

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -82,6 +82,17 @@ typedef struct qLinkedList_S {
     smsg_t *pMsg;
 } qLinkedList_t;
 
+typedef struct qqueue_egress_entry_s {
+    smsg_t *pMsg;
+    qLinkedList_t *pLinkedListEntry;
+    int sourceIndex;
+    unsigned char state;
+    unsigned char admissionCounted;
+} qqueue_egress_entry_t;
+
+#define QQUEUE_EGRESS_STAGED 1
+#define QQUEUE_EGRESS_PUBLISHED 2
+
 /**
  * @brief The "queue object for the queueing subsystem".
  *
@@ -264,6 +275,11 @@ struct queue_s {
         int segdiskIdleCleanupFailures;
         int iSmpInterval; /* line interval of sampling logs */
         int isRunning;
+        /* Append-only: queue_s is visible to loadable modules and is allocated by core. */
+        int nEgressReservations; /* accepted, prepared, but not yet published entries */
+        STATSCOUNTER_DEF(ctrEgressPublishedBatches, mutCtrEgressPublishedBatches)
+        STATSCOUNTER_DEF(ctrEgressPublishedMessages, mutCtrEgressPublishedMessages)
+        STATSCOUNTER_DEF(ctrEgressPublicationAdvice, mutCtrEgressPublicationAdvice)
 };
 
 
@@ -277,6 +293,10 @@ struct queue_s {
 /* prototypes */
 rsRetVal qqueueDestruct(qqueue_t **ppThis);
 rsRetVal qqueueEnqMsg(qqueue_t *pThis, flowControl_t flwCtlType, smsg_t *pMsg);
+rsRetVal qqueueEgressPrepare(qqueue_t *pThis, smsg_t *pMsg, int sourceIndex, qqueue_egress_entry_t *pEntry);
+rsRetVal qqueueEgressReserve(qqueue_t *pThis, qqueue_egress_entry_t *pEntry, int tryOnly);
+void qqueueEgressPublish(qqueue_t *pThis, qqueue_egress_entry_t *pEntries, size_t nEntries);
+int qqueueSupportsReservedEgress(const qqueue_t *pThis);
 rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis);
 rsRetVal qqueueSetMaxFileSize(qqueue_t *pThis, size_t iMaxFileSize);
 rsRetVal qqueueSetFilePrefix(qqueue_t *pThis, uchar *pszPrefix, size_t iLenPrefix);

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -85,7 +85,6 @@ typedef struct qLinkedList_S {
 typedef struct qqueue_egress_entry_s {
     smsg_t *pMsg;
     qLinkedList_t *pLinkedListEntry;
-    int sourceIndex;
     unsigned char state;
     unsigned char admissionCounted;
 } qqueue_egress_entry_t;
@@ -277,9 +276,11 @@ struct queue_s {
         int isRunning;
         /* Append-only: queue_s is visible to loadable modules and is allocated by core. */
         int nEgressReservations; /* accepted, prepared, but not yet published entries */
+#ifdef ENABLE_RESERVED_EGRESS_STATS
         STATSCOUNTER_DEF(ctrEgressPublishedBatches, mutCtrEgressPublishedBatches)
         STATSCOUNTER_DEF(ctrEgressPublishedMessages, mutCtrEgressPublishedMessages)
         STATSCOUNTER_DEF(ctrEgressPublicationAdvice, mutCtrEgressPublicationAdvice)
+#endif
 };
 
 
@@ -293,7 +294,7 @@ struct queue_s {
 /* prototypes */
 rsRetVal qqueueDestruct(qqueue_t **ppThis);
 rsRetVal qqueueEnqMsg(qqueue_t *pThis, flowControl_t flwCtlType, smsg_t *pMsg);
-rsRetVal qqueueEgressPrepare(qqueue_t *pThis, smsg_t *pMsg, int sourceIndex, qqueue_egress_entry_t *pEntry);
+rsRetVal qqueueEgressPrepare(qqueue_t *pThis, smsg_t *pMsg, qqueue_egress_entry_t *pEntry);
 rsRetVal qqueueEgressReserve(qqueue_t *pThis, qqueue_egress_entry_t *pEntry, int tryOnly);
 void qqueueEgressPublish(qqueue_t *pThis, qqueue_egress_entry_t *pEntries, size_t nEntries);
 int qqueueSupportsReservedEgress(const qqueue_t *pThis);

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -1753,7 +1753,9 @@ static rsRetVal load(rsconf_t **cnf, uchar *confFile) {
     tellModulesCheckConfig();
     CHKiRet(checkParserInstances());
     CHKiRet(validateConf(loadConf));
+    CHKiRet(rulesetValidateQueues(loadConf));
     CHKiRet(loadMainQueue());
+    CHKiRet(rulesetValidateMainQueue(loadConf));
 
     if (iConfigVerify && !rsconfTranslateEnabled()) {
         if (iRet == RS_RET_OK) iRet = RS_RET_VALIDATION_RUN;

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -291,6 +291,8 @@ struct rsconf_s {
         timezones_t timezones;
         qqueue_t *pMsgQueue; /* the main message queue */
         ratelimit_cfgs_t ratelimit_cfgs;
+        /* Append-only: rsconf_s is visible to loadable modules and is allocated by core. */
+        int executionEngine; /* 0: legacy, 1: experimental reserved-batch queued ruleset calls */
 };
 
 

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -684,7 +684,6 @@ static rsRetVal processBatch(batch_t *pBatch, wti_t *pWti) {
 
     /* execution phase */
     for (i = 0; i < batchNumMsgs(pBatch) && !wtiIsShutdownImmediate(pWti); ++i) {
-        if (pWti->egress.enabled) pWti->egress.sourceIndex = i;
         pMsg = pBatch->pElem[i].pMsg;
         DBGPRINTF("processBATCH: next msg %d: %.128s\n", i, pMsg->pszRawMsg);
         pRuleset = (pMsg->pRuleset == NULL) ? batchConfig->rulesets.pDflt : pMsg->pRuleset;

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -33,6 +33,9 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <ctype.h>
+#ifdef ENABLE_RESERVED_EGRESS_TEST_HOOKS
+    #include <pthread.h>
+#endif
 
 #include "rsyslog.h"
 #include "obj.h"
@@ -41,6 +44,7 @@
 #include "ruleset.h"
 #include "errmsg.h"
 #include "parser.h"
+#include "parserif.h"
 #include "batch.h"
 #include "unicode-helper.h"
 #include "rsconf.h"
@@ -66,6 +70,62 @@ static struct cnfparamblk rspblk = {CNFPARAMBLK_VERSION, sizeof(rspdescr) / size
 /* forward definitions */
 static rsRetVal processBatch(batch_t *pBatch, wti_t *pWti);
 static rsRetVal scriptExec(struct cnfstmt *root, smsg_t *pMsg, wti_t *pWti);
+
+#ifdef ENABLE_RESERVED_EGRESS_TEST_HOOKS
+static int egressSelectorFlipConsumed;
+static int egressSelectorOverride = -1;
+static pthread_mutex_t egressSelectorOverrideMut ATTR_UNUSED = PTHREAD_MUTEX_INITIALIZER;
+
+static int executionEngineSelectedForBatch(const rsconf_t *const batchConfig) {
+    if (getenv("RSYSLOG_TEST_EGRESS_FLIP_AFTER_FIRST") != NULL) {
+        const int override = ATOMIC_LOAD_32BIT(&egressSelectorOverride, &egressSelectorOverrideMut);
+        if (override != -1) return override;
+    }
+    return batchConfig->executionEngine;
+}
+
+static void testFlipEgressSelectorAfterFirst(const int capturedEngine,
+                                             const int sourceIndex,
+                                             const smsg_t *const pMsg) {
+    if (sourceIndex != 0 || getenv("RSYSLOG_TEST_EGRESS_FLIP_AFTER_FIRST") == NULL ||
+        strstr((const char *)pMsg->pszRawMsg, "msgnum:00000000") == NULL)
+        return;
+    if (ATOMIC_CAS(&egressSelectorFlipConsumed, 0, 1, &egressSelectorOverrideMut))
+        ATOMIC_STORE_32BIT(&egressSelectorOverride, &egressSelectorOverrideMut, capturedEngine == 1 ? 0 : 1);
+}
+#else
+    #define executionEngineSelectedForBatch(batchConfig) ((batchConfig)->executionEngine)
+#endif
+
+static rsRetVal validateReservedEgressQueue(const rsconf_t *const conf,
+                                            const ruleset_t *const ruleset,
+                                            const qqueue_t *const queue) {
+    if (conf->executionEngine != 1 || queue == NULL || queue->qType == QUEUETYPE_DIRECT) return RS_RET_OK;
+    if (qqueueSupportsReservedEgress(queue)) return RS_RET_OK;
+    parser_errmsg(
+        "ruleset '%s': global executionEngine=reservedBatch supports only non-disk-assisted "
+        "bounded LinkedList and FixedArray queued rulesets",
+        ruleset->pszName);
+    return RS_RET_PARAM_ERROR;
+}
+
+DEFFUNC_llExecFunc(doValidateReservedEgressQueues) {
+    ruleset_t *const ruleset = (ruleset_t *)pData;
+    const rsconf_t *const conf = (const rsconf_t *)pParam;
+    return validateReservedEgressQueue(conf, ruleset, ruleset->pQueue);
+}
+
+rsRetVal rulesetValidateQueues(rsconf_t *const conf) {
+    return llExecFunc(&conf->rulesets.llRulesets, doValidateReservedEgressQueues, conf);
+}
+
+rsRetVal rulesetValidateMainQueue(rsconf_t *const conf) {
+    if (conf->executionEngine == 1 && (conf->pMsgQueue == NULL || conf->pMsgQueue->qType == QUEUETYPE_DIRECT)) {
+        parser_errmsg("global executionEngine=reservedBatch requires a non-Direct main queue");
+        return RS_RET_PARAM_ERROR;
+    }
+    return RS_RET_OK;
+}
 
 
 /* ---------- linked-list key handling functions (ruleset) ---------- */
@@ -157,13 +217,16 @@ DEFFUNC_llExecFunc(doActivateRulesetQueues) {
     DEFiRet;
     ruleset_t *pThis = (ruleset_t *)pData;
     dbgprintf("Activating Ruleset Queue[%p] for Ruleset %s\n", pThis->pQueue, pThis->pszName);
-    if (pThis->pQueue != NULL) startMainQueue(runConf, pThis->pQueue);
+    if (pThis->pQueue != NULL) {
+        CHKiRet(validateReservedEgressQueue(runConf, pThis, pThis->pQueue));
+        CHKiRet(startMainQueue(runConf, pThis->pQueue));
+    }
+finalize_it:
     RETiRet;
 }
 /* activate all ruleset queues */
 rsRetVal activateRulesetQueues(void) {
-    llExecFunc(&(runConf->rulesets.llRulesets), doActivateRulesetQueues, NULL);
-    return RS_RET_OK;
+    return llExecFunc(&(runConf->rulesets.llRulesets), doActivateRulesetQueues, NULL);
 }
 
 
@@ -245,7 +308,7 @@ static rsRetVal execCallIndirect(struct cnfstmt *const __restrict__ stmt,
 
     cnfexprEval(stmt->d.s_call_ind.expr, &result, pMsg, pWti);
     uchar *const rsName = (uchar *)var2CString(&result, &bMustFree);
-    const rsRetVal localRet = rulesetGetRuleset(runConf, &pRuleset, rsName);
+    const rsRetVal localRet = rulesetGetRuleset((rsconf_t *)pWti->egress.batchConfig, &pRuleset, rsName);
     if (localRet != RS_RET_OK) {
         /* in that case, we accept that a NOP will "survive" */
         LogError(0, RS_RET_RULESET_NOT_FOUND,
@@ -264,7 +327,11 @@ static rsRetVal execCallIndirect(struct cnfstmt *const __restrict__ stmt,
         /* Note: we intentionally use submitMsg2() here, as we process messages
          * that were already run through the rate-limiter.
          */
-        submitMsg2(pMsg);
+        if (pWti->egress.enabled) {
+            CHKiRet(wtiEgressStage(pWti, pRuleset->pQueue, pMsg));
+        } else {
+            submitMsg2(pMsg);
+        }
     } else {
         CHKiRet(execSynchronousRulesetCall(pRuleset->root, (const char *)rsName, ustrlen(rsName), pMsg, pWti));
     }
@@ -287,7 +354,11 @@ static rsRetVal execCall(struct cnfstmt *stmt, smsg_t *pMsg, wti_t *pWti) {
         /* Note: we intentionally use submitMsg2() here, as we process messages
          * that were already run through the rate-limiter.
          */
-        submitMsg2(pMsg);
+        if (pWti->egress.enabled) {
+            CHKiRet(wtiEgressStage(pWti, stmt->d.s_call.ruleset->pQueue, pMsg));
+        } else {
+            submitMsg2(pMsg);
+        }
     }
 finalize_it:
     RETiRet;
@@ -601,17 +672,22 @@ static rsRetVal processBatch(batch_t *pBatch, wti_t *pWti) {
     smsg_t *pMsg;
     ruleset_t *pRuleset;
     rsRetVal localRet;
+    rsRetVal egressRet = RS_RET_OK;
     DEFiRet;
 
     DBGPRINTF("processBATCH: batch of %d elements must be processed\n", pBatch->nElem);
 
     wtiResetExecState(pWti, pBatch);
+    rsconf_t *const batchConfig = runConf;
+    const int batchExecutionEngine = executionEngineSelectedForBatch(batchConfig);
+    wtiEgressBegin(pWti, batchConfig, batchExecutionEngine == 1);
 
     /* execution phase */
     for (i = 0; i < batchNumMsgs(pBatch) && !wtiIsShutdownImmediate(pWti); ++i) {
+        if (pWti->egress.enabled) pWti->egress.sourceIndex = i;
         pMsg = pBatch->pElem[i].pMsg;
         DBGPRINTF("processBATCH: next msg %d: %.128s\n", i, pMsg->pszRawMsg);
-        pRuleset = (pMsg->pRuleset == NULL) ? runConf->rulesets.pDflt : pMsg->pRuleset;
+        pRuleset = (pMsg->pRuleset == NULL) ? batchConfig->rulesets.pDflt : pMsg->pRuleset;
         localRet = scriptExec(pRuleset->root, pMsg, pWti);
         /* the most important case here is that processing may be aborted
          * due to pbShutdownImmediate, in which case we MUST NOT flag this
@@ -622,6 +698,9 @@ static rsRetVal processBatch(batch_t *pBatch, wti_t *pWti) {
             batchSetElemState(pBatch, i, BATCH_STATE_COMM);
         else if (localRet == RS_RET_SUSPENDED)
             --i;
+#ifdef ENABLE_RESERVED_EGRESS_TEST_HOOKS
+        testFlipEgressSelectorAfterFirst(batchExecutionEngine, i, pMsg);
+#endif
     }
 
     /* commit phase */
@@ -629,9 +708,13 @@ static rsRetVal processBatch(batch_t *pBatch, wti_t *pWti) {
         "END batch execution phase, entering to commit phase "
         "[processed %d of %d messages]\n",
         i, batchNumMsgs(pBatch));
+    if (pWti->egress.enabled) wtiEgressPublish(pWti);
     actionCommitAllDirect(pWti);
+    if (pWti->egress.enabled) egressRet = pWti->egress.error;
+    wtiEgressCleanup(pWti);
 
     DBGPRINTF("processBATCH: batch of %d elements has been processed\n", pBatch->nElem);
+    iRet = egressRet;
     RETiRet;
 }
 
@@ -1035,6 +1118,7 @@ rsRetVal rulesetProcessCnf(struct cnfobj *o) {
         }
         DBGPRINTF("adding a ruleset-specific \"main\" queue for ruleset '%s', mode %d\n", rsname, qtype);
         CHKiRet(createMainQueue(&pRuleset->pQueue, rsname, o->nvlst));
+        CHKiRet(validateReservedEgressQueue(loadConf, pRuleset, pRuleset->pQueue));
     }
 
 finalize_it:

--- a/runtime/ruleset.h
+++ b/runtime/ruleset.h
@@ -100,6 +100,8 @@ rsRetVal rulesetKeyDestruct(void __attribute__((unused)) * pData);
 rsRetVal rulesetGetRuleset(rsconf_t *conf, ruleset_t **ppRuleset, uchar *pszName);
 rsRetVal rulesetOptimizeAll(rsconf_t *conf);
 rsRetVal rulesetProcessCnf(struct cnfobj *o);
+rsRetVal rulesetValidateQueues(rsconf_t *conf);
+rsRetVal rulesetValidateMainQueue(rsconf_t *conf);
 rsRetVal activateRulesetQueues(void);
 
 /* Set a current rule set to already-known pointer */

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -56,6 +56,26 @@ DEFobjCurrIf(glbl)
 
     pthread_key_t thrd_wti_key;
 
+/* Testbench-only, process-local one-shot allocator fault. Ordinary builds do
+ * not carry the branch or shared state. */
+#ifdef ENABLE_RESERVED_EGRESS_TEST_HOOKS
+static pthread_mutex_t egressTestFaultMut = PTHREAD_MUTEX_INITIALIZER;
+static int egressTestFaultConsumed;
+
+static int egressTestAllocFault(const char *const point) {
+    const char *const requested = getenv("RSYSLOG_TEST_EGRESS_ALLOC_FAIL");
+    if (requested == NULL || strcmp(requested, point)) return 0;
+    pthread_mutex_lock(&egressTestFaultMut);
+    const int inject = !egressTestFaultConsumed;
+    egressTestFaultConsumed = 1;
+    pthread_mutex_unlock(&egressTestFaultMut);
+    DBGPRINTF("reserved egress test allocation fault point=%s inject=%d\n", point, inject);
+    return inject;
+}
+#else
+    #define egressTestAllocFault(point) 0
+#endif
+
 
 /* methods */
 
@@ -264,6 +284,120 @@ finalize_it:
     RETiRet;
 }
 
+void wtiEgressBegin(wti_t *const pThis, const rsconf_t *const batchConfig, const int enabled) {
+    assert(pThis->egress.state == EGRESS_EMPTY);
+    pThis->egress.sourceIndex = -1;
+    pThis->egress.enabled = enabled;
+    pThis->egress.batchConfig = batchConfig;
+    pThis->egress.error = RS_RET_OK;
+    pThis->egress.state = enabled ? EGRESS_EXECUTING : EGRESS_EMPTY;
+}
+
+static void wtiEgressPublishBucket(egress_bucket_t *const bucket) {
+    const size_t nStaged = bucket->nEntries - bucket->nPublished;
+    if (nStaged == 0) return;
+    qqueueEgressPublish(bucket->pQueue, bucket->entries + bucket->nPublished, nStaged);
+    bucket->nPublished = bucket->nEntries;
+}
+
+rsRetVal wtiEgressStage(wti_t *const pThis, qqueue_t *const pQueue, smsg_t *const pMsg) {
+    egress_bucket_t *bucket = NULL;
+    qqueue_egress_entry_t prepared = {0};
+    int preparedOwned = 0;
+    int cancelState;
+    DEFiRet;
+
+    assert(pThis->egress.state == EGRESS_EXECUTING);
+    pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cancelState);
+    /* Ownership transfers at entry. Until reserve() either installs or
+     * destroys it, prepared.pMsg is the unique cleanup handle. */
+    prepared.pMsg = pMsg;
+    for (size_t i = 0; i < pThis->egress.nBuckets; ++i) {
+        if (pThis->egress.buckets[i].pQueue == pQueue) bucket = &pThis->egress.buckets[i];
+    }
+    if (bucket == NULL) {
+        if (pThis->egress.nBuckets == pThis->egress.nAllocated) {
+            if (egressTestAllocFault("bucket")) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            if (pThis->egress.nAllocated > SIZE_MAX / 2) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            const size_t n = pThis->egress.nAllocated == 0 ? 4 : pThis->egress.nAllocated * 2;
+            if (n > SIZE_MAX / sizeof(egress_bucket_t)) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            egress_bucket_t *const buckets = realloc(pThis->egress.buckets, n * sizeof(egress_bucket_t));
+            CHKmalloc(buckets);
+            pThis->egress.buckets = buckets;
+            memset(pThis->egress.buckets + pThis->egress.nAllocated, 0,
+                   (n - pThis->egress.nAllocated) * sizeof(egress_bucket_t));
+            pThis->egress.nAllocated = n;
+        }
+        bucket = &pThis->egress.buckets[pThis->egress.nBuckets++];
+        bucket->pQueue = pQueue;
+    }
+    if (bucket->nEntries == bucket->nAllocated) {
+        if (egressTestAllocFault("entry")) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        if (bucket->nAllocated > SIZE_MAX / 2) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        const size_t n = bucket->nAllocated == 0 ? 16 : bucket->nAllocated * 2;
+        if (n > SIZE_MAX / sizeof(qqueue_egress_entry_t)) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        qqueue_egress_entry_t *const entries = realloc(bucket->entries, n * sizeof(qqueue_egress_entry_t));
+        CHKmalloc(entries);
+        bucket->entries = entries;
+        bucket->nAllocated = n;
+    }
+    if (egressTestAllocFault("prepare")) {
+        prepared.pMsg = pMsg;
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    iRet = qqueueEgressPrepare(pQueue, pMsg, pThis->egress.sourceIndex, &prepared);
+    if (iRet != RS_RET_OK) FINALIZE;
+    preparedOwned = 1;
+    iRet = qqueueEgressReserve(pQueue, &prepared, 1);
+    if (iRet == RS_RET_RETRY) {
+        /* Slow path: expose every reservation held by this WTI before any
+         * capacity wait. Buckets are visited in encounter order and each
+         * publication releases its target lock before the next is acquired. */
+        for (size_t i = 0; i < pThis->egress.nBuckets; ++i) wtiEgressPublishBucket(&pThis->egress.buckets[i]);
+        iRet = qqueueEgressReserve(pQueue, &prepared, 0);
+    }
+    if (iRet == RS_RET_OK) bucket->entries[bucket->nEntries++] = prepared;
+    if (iRet == RS_RET_QUEUE_FULL || iRet == RS_RET_FORCE_TERM) iRet = RS_RET_OK;
+
+finalize_it:
+    if (iRet != RS_RET_OK) pThis->egress.error = iRet;
+    if (iRet != RS_RET_OK && !preparedOwned) {
+        if (prepared.pMsg != NULL) msgDestruct(&prepared.pMsg);
+        free(prepared.pLinkedListEntry);
+    }
+    pthread_setcancelstate(cancelState, NULL);
+    RETiRet;
+}
+
+void wtiEgressPublish(wti_t *const pThis) {
+    int cancelState;
+    if (pThis->egress.state != EGRESS_EXECUTING) return;
+    pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cancelState);
+    pThis->egress.state = EGRESS_PUBLISHING;
+    for (size_t i = 0; i < pThis->egress.nBuckets; ++i) {
+        egress_bucket_t *const bucket = &pThis->egress.buckets[i];
+        wtiEgressPublishBucket(bucket);
+    }
+    pThis->egress.state = EGRESS_PUBLISHED;
+    pthread_setcancelstate(cancelState, NULL);
+}
+
+void wtiEgressCleanup(wti_t *const pThis) {
+    if (pThis->egress.state == EGRESS_EXECUTING) wtiEgressPublish(pThis);
+    assert(pThis->egress.state == EGRESS_PUBLISHED || pThis->egress.state == EGRESS_EMPTY);
+    for (size_t i = 0; i < pThis->egress.nBuckets; ++i) {
+        pThis->egress.buckets[i].nEntries = 0;
+        pThis->egress.buckets[i].nPublished = 0;
+        pThis->egress.buckets[i].pQueue = NULL;
+    }
+    pThis->egress.nBuckets = 0;
+    pThis->egress.state = EGRESS_EMPTY;
+    pThis->egress.sourceIndex = -1;
+    pThis->egress.enabled = 0;
+    pThis->egress.batchConfig = NULL;
+    pThis->egress.error = RS_RET_OK;
+}
+
 
 /* Destructor */
 BEGINobjDestruct(wti) /* be sure to specify the object type also in END and CODESTART macros! */
@@ -277,6 +411,9 @@ BEGINobjDestruct(wti) /* be sure to specify the object type also in END and CODE
         }
     }
     /* actual destruction */
+    assert(pThis->egress.state == EGRESS_EMPTY);
+    for (size_t i = 0; i < pThis->egress.nAllocated; ++i) free(pThis->egress.buckets[i].entries);
+    free(pThis->egress.buckets);
     batchFree(&pThis->batch);
     free(pThis->actWrkrInfo);
     pthread_cond_destroy(&pThis->pcondBusy);
@@ -340,6 +477,7 @@ static void wtiWorkerCancelCleanup(void *arg) {
     ISOBJ_TYPE_assert(pWtp, wtp);
 
     DBGPRINTF("%s: cancellation cleanup handler called.\n", wtiGetDbgHdr(pThis));
+    wtiEgressCleanup(pThis);
     pWtp->pfObjProcessed(pWtp->pUsr, pThis);
     DBGPRINTF("%s: done cancellation cleanup handler.\n", wtiGetDbgHdr(pThis));
 }

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -60,16 +60,29 @@ DEFobjCurrIf(glbl)
  * not carry the branch or shared state. */
 #ifdef ENABLE_RESERVED_EGRESS_TEST_HOOKS
 static pthread_mutex_t egressTestFaultMut = PTHREAD_MUTEX_INITIALIZER;
-static int egressTestFaultConsumed;
+static unsigned int egressTestFaultMatches;
 
 static int egressTestAllocFault(const char *const point) {
     const char *const requested = getenv("RSYSLOG_TEST_EGRESS_ALLOC_FAIL");
-    if (requested == NULL || strcmp(requested, point)) return 0;
+    if (requested == NULL) return 0;
+    const size_t pointLen = strlen(point);
+    if (strncmp(requested, point, pointLen) != 0 || (requested[pointLen] != '\0' && requested[pointLen] != ':'))
+        return 0;
+    unsigned long requestedMatch = 1;
+    if (requested[pointLen] == ':') {
+        char *end = NULL;
+        errno = 0;
+        requestedMatch = strtoul(requested + pointLen + 1, &end, 10);
+        if (errno != 0 || end == requested + pointLen + 1 || *end != '\0' || requestedMatch == 0 ||
+            requestedMatch > UINT_MAX)
+            return 0;
+    }
     pthread_mutex_lock(&egressTestFaultMut);
-    const int inject = !egressTestFaultConsumed;
-    egressTestFaultConsumed = 1;
+    const unsigned int match = ++egressTestFaultMatches;
+    const int inject = match == requestedMatch;
     pthread_mutex_unlock(&egressTestFaultMut);
-    DBGPRINTF("reserved egress test allocation fault point=%s inject=%d\n", point, inject);
+    DBGPRINTF("reserved egress test allocation fault point=%s match=%u requested=%lu inject=%d\n", point, match,
+              requestedMatch, inject);
     return inject;
 }
 #else
@@ -286,7 +299,6 @@ finalize_it:
 
 void wtiEgressBegin(wti_t *const pThis, const rsconf_t *const batchConfig, const int enabled) {
     assert(pThis->egress.state == EGRESS_EMPTY);
-    pThis->egress.sourceIndex = -1;
     pThis->egress.enabled = enabled;
     pThis->egress.batchConfig = batchConfig;
     pThis->egress.error = RS_RET_OK;
@@ -345,7 +357,7 @@ rsRetVal wtiEgressStage(wti_t *const pThis, qqueue_t *const pQueue, smsg_t *cons
         prepared.pMsg = pMsg;
         ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
     }
-    iRet = qqueueEgressPrepare(pQueue, pMsg, pThis->egress.sourceIndex, &prepared);
+    iRet = qqueueEgressPrepare(pQueue, pMsg, &prepared);
     if (iRet != RS_RET_OK) FINALIZE;
     preparedOwned = 1;
     iRet = qqueueEgressReserve(pQueue, &prepared, 1);
@@ -392,7 +404,6 @@ void wtiEgressCleanup(wti_t *const pThis) {
     }
     pThis->egress.nBuckets = 0;
     pThis->egress.state = EGRESS_EMPTY;
-    pThis->egress.sourceIndex = -1;
     pThis->egress.enabled = 0;
     pThis->egress.batchConfig = NULL;
     pThis->egress.error = RS_RET_OK;

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -81,7 +81,6 @@ typedef struct egress_ledger_s {
     egress_bucket_t *buckets;
     size_t nBuckets;
     size_t nAllocated;
-    int sourceIndex;
     int enabled;
     const rsconf_t *batchConfig;
     rsRetVal error;

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -67,6 +67,27 @@ typedef struct actWrkrInfo {
     } p; /* short name for "parameters" */
 } actWrkrInfo_t;
 
+typedef struct egress_bucket_s {
+    qqueue_t *pQueue;
+    qqueue_egress_entry_t *entries;
+    size_t nEntries;
+    size_t nPublished;
+    size_t nAllocated;
+} egress_bucket_t;
+
+typedef enum { EGRESS_EMPTY = 0, EGRESS_EXECUTING, EGRESS_PUBLISHING, EGRESS_PUBLISHED } egress_state_t;
+
+typedef struct egress_ledger_s {
+    egress_bucket_t *buckets;
+    size_t nBuckets;
+    size_t nAllocated;
+    int sourceIndex;
+    int enabled;
+    const rsconf_t *batchConfig;
+    rsRetVal error;
+    egress_state_t state;
+} egress_ledger_t;
+
 /* the worker thread instance class */
 struct wti_s {
     BEGINobjInstance
@@ -94,6 +115,7 @@ struct wti_s {
                                     */
             uint16_t rulesetCallDepth; /* synchronous ruleset call nesting depth */
         } execState; /* state for the execution engine */
+        egress_ledger_t egress;
 };
 
 
@@ -155,4 +177,8 @@ static inline void __attribute__((unused)) wtiResetExecState(wti_t *const pWti, 
 
 
 rsRetVal wtiNewIParam(wti_t *const pWti, action_t *const pAction, actWrkrIParams_t **piparams);
+void wtiEgressBegin(wti_t *pThis, const rsconf_t *batchConfig, int enabled);
+rsRetVal wtiEgressStage(wti_t *pThis, qqueue_t *pQueue, smsg_t *pMsg);
+void wtiEgressPublish(wti_t *pThis);
+void wtiEgressCleanup(wti_t *pThis);
 #endif /* #ifndef WTI_H_INCLUDED */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,6 +16,7 @@ EXTRA_DIST = \
 
 TESTS_RESERVED_EGRESS = \
 	reserved-egress-basic.sh \
+	reserved-egress-immediate-tail.sh \
 	reserved-egress-concurrent.sh \
 	reserved-egress-crossed-targets.sh \
 	reserved-egress-crossed-targets-immediate.sh \
@@ -2971,9 +2972,11 @@ if ENABLE_IMDIAG
 TESTS += $(TESTS_RESERVED_EGRESS)
 if ENABLE_RESERVED_EGRESS_TEST_HOOKS
 TESTS += $(TESTS_RESERVED_EGRESS_HOOKS)
-endif
+if ENABLE_RESERVED_EGRESS_STATS
 if ENABLE_IMPSTATS
 TESTS += $(TESTS_RESERVED_EGRESS_IMPSTATS)
+endif
+endif
 endif
 if HAVE_LIBYAML
 if ENABLE_IMTCP_TESTS

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,6 +14,26 @@ EXTRA_DIST = \
 	proprepltest-rfctag.sh \
 	unit/README.md
 
+TESTS_RESERVED_EGRESS = \
+	reserved-egress-basic.sh \
+	reserved-egress-concurrent.sh \
+	reserved-egress-crossed-targets.sh \
+	reserved-egress-crossed-targets-immediate.sh \
+	reserved-egress-immediate.sh \
+	reserved-egress-legacy.sh \
+	reserved-egress-unsupported.sh
+EXTRA_DIST += $(TESTS_RESERVED_EGRESS)
+
+TESTS_RESERVED_EGRESS_HOOKS = \
+	reserved-egress-oom.sh \
+	reserved-egress-selector-batch.sh
+TESTS_RESERVED_EGRESS_IMPSTATS = reserved-egress-batching-stats.sh
+TESTS_RESERVED_EGRESS_LIBYAML_IMTCP = reserved-egress-yaml.sh
+EXTRA_DIST += \
+	$(TESTS_RESERVED_EGRESS_HOOKS) \
+	$(TESTS_RESERVED_EGRESS_IMPSTATS) \
+	$(TESTS_RESERVED_EGRESS_LIBYAML_IMTCP)
+
 TESTS_FUZZING = \
 	fuzz-syslog-message-smoke.sh \
 	fuzz-imtcp-session-smoke.sh
@@ -2947,6 +2967,20 @@ endif # if ENABLE_ELASTICSEARCH_TESTS
 
 if ENABLE_DEFAULT_TESTS
 TESTS += $(TESTS_DEFAULT)
+if ENABLE_IMDIAG
+TESTS += $(TESTS_RESERVED_EGRESS)
+if ENABLE_RESERVED_EGRESS_TEST_HOOKS
+TESTS += $(TESTS_RESERVED_EGRESS_HOOKS)
+endif
+if ENABLE_IMPSTATS
+TESTS += $(TESTS_RESERVED_EGRESS_IMPSTATS)
+endif
+if HAVE_LIBYAML
+if ENABLE_IMTCP_TESTS
+TESTS += $(TESTS_RESERVED_EGRESS_LIBYAML_IMTCP)
+endif
+endif
+endif
 TESTS += $(TESTS_JSON_OMITIFZERO)
 TESTS += $(TESTS_SEGMENTED_DISK_QUEUE)
 if ENABLE_SEGQUEUE_TOOL

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -456,13 +456,18 @@ generate_conf() {
 			RSTB_NET_IPPROTO="ipv4-only"
 		fi
 		local ipproto_line=""
+		local execution_engine_line=""
 		if [ -n "$RSTB_NET_IPPROTO" ]; then
 			ipproto_line="  net.ipprotocol: \"${RSTB_NET_IPPROTO}\""
+		fi
+		if [ -n "$RSTB_EXECUTION_ENGINE" ]; then
+			execution_engine_line="  executionEngine: \"${RSTB_EXECUTION_ENGINE}\""
 		fi
 		{
 			printf 'version: 2\n\nglobal:\n'
 			printf '  debug.abortOnProgramError: "on"\n'
 			[ -n "$ipproto_line" ] && printf '%s\n' "$ipproto_line"
+			[ -n "$execution_engine_line" ] && printf '%s\n' "$execution_engine_line"
 			printf '\ntestbench_modules:\n'
 			printf '  - load: "../plugins/imdiag/.libs/imdiag"\n'
 			printf '    listenportfilename: "%s.imdiag%s.port"\n' "$RSYSLOG_DYNNAME" "$1"

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -523,6 +523,9 @@ generate_conf() {
 		if [ -n "$RSTB_NET_IPPROTO" ]; then
 			add_conf "global(net.ipprotocol=\"${RSTB_NET_IPPROTO}\")" "$1"
 		fi
+		if [ -n "$RSTB_EXECUTION_ENGINE" ]; then
+			add_conf "global(executionEngine=\"${RSTB_EXECUTION_ENGINE}\")" "$1"
+		fi
 	fi
 }
 

--- a/tests/reserved-egress-basic.sh
+++ b/tests/reserved-egress-basic.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Verify the opt-in reserved-batch engine publishes snapshots from conditional
 # call and foreach/call_indirect statements to LinkedList and FixedArray targets.
 # An explicitly configured Direct ruleset must execute synchronously and mutate

--- a/tests/reserved-egress-basic.sh
+++ b/tests/reserved-egress-basic.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Verify the opt-in reserved-batch engine publishes snapshots from conditional
+# call and foreach/call_indirect statements to LinkedList and FixedArray targets.
+# An explicitly configured Direct ruleset must execute synchronously and mutate
+# the current message before the queued snapshots are taken, while the source
+# direct action retains its normal result. Exact output is the oracle.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(executionEngine="reservedBatch")
+template(name="snap" type="string" string="%msg%|%$!snap%|%$!direct_ruleset%\n")
+
+ruleset(name="explicit_direct" queue.type="Direct") {
+  set $!direct_ruleset = "synchronous";
+}
+
+ruleset(name="linked" queue.type="LinkedList" queue.size="1" queue.timeoutEnqueue="5000") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'.linked" template="snap")
+}
+ruleset(name="fixed" queue.type="FixedArray" queue.size="1" queue.timeoutEnqueue="5000") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'.fixed" template="snap")
+}
+
+if $msg contains "msgnum" then {
+  set $!snap = "encounter";
+  call explicit_direct
+  call linked
+  set $.parse_result = parse_json('\''["fixed"]'\'', "\$!routes");
+  foreach ($.route in $!routes) do {
+    call_indirect $.route;
+  }
+  set $!snap = "mutated";
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'.direct" template="snap")
+}
+'
+startup
+injectmsg 0 5
+issue_HUP
+injectmsg 5 5
+shutdown_when_empty
+wait_shutdown
+content_count_check "encounter" 10 "$RSYSLOG_OUT_LOG.linked"
+content_count_check "encounter" 10 "$RSYSLOG_OUT_LOG.fixed"
+content_count_check "mutated" 10 "$RSYSLOG_OUT_LOG.direct"
+content_count_check "synchronous" 10 "$RSYSLOG_OUT_LOG.linked"
+content_count_check "synchronous" 10 "$RSYSLOG_OUT_LOG.fixed"
+content_count_check "synchronous" 10 "$RSYSLOG_OUT_LOG.direct"
+exit_test

--- a/tests/reserved-egress-batching-stats.sh
+++ b/tests/reserved-egress-batching-stats.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Prove the no-pressure path retains target batching. A guaranteed 32-message
+# source dequeue batch executes three queued calls per source message to one
+# roomy target. Exact delivery proves all 96 branches published; impstats must
+# report one publication batch and one publication advice for those 96
+# messages. The initial 1.5-second wait lets startup messages pass the main
+# queue's one-second minimum-batch timeout before the 32-message stimulus.
+. ${srcdir:=.}/diag.sh init
+export STATSFILE="$RSYSLOG_DYNNAME.stats"
+generate_conf
+add_conf '
+global(executionEngine="reservedBatch")
+module(load="../plugins/impstats/.libs/impstats" interval="1" log.syslog="off"
+       resetCounters="off" log.file="'$STATSFILE'")
+main_queue(queue.type="LinkedList" queue.dequeueBatchSize="32"
+           queue.minDequeueBatchSize="32" queue.minDequeueBatchSize.timeout="1000")
+template(name="outfmt" type="string" string="%msg%\n")
+ruleset(name="target" queue.type="LinkedList" queue.size="128") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+if $msg contains "msgnum" then {
+  call target
+  call target
+  set $.target_name = "target";
+  call_indirect $.target_name;
+}
+'
+startup
+"$TESTTOOL_DIR/msleep" 1500
+injectmsg 0 32
+wait_file_lines "$RSYSLOG_OUT_LOG" 96
+
+i=0
+while ! grep -E 'target: origin=core.queue .*egress\.published\.messages=96 ' \
+    "$STATSFILE" >/dev/null 2>&1; do
+  i=$((i + 1))
+  if [ "$i" -ge 50 ]; then
+    echo "expected reserved-egress publication counters for 96 normal-path branches"
+    test -f "$STATSFILE" && tail -20 "$STATSFILE"
+    error_exit 1
+  fi
+  "$TESTTOOL_DIR/msleep" 100
+done
+
+stats_line=$(grep -E 'target: origin=core.queue .*egress\.published\.messages=96 ' "$STATSFILE" | tail -1)
+published_batches=$(printf '%s\n' "$stats_line" | sed -n 's/.*egress\.published\.batches=\([0-9][0-9]*\).*/\1/p')
+publication_advice=$(printf '%s\n' "$stats_line" | sed -n 's/.*egress\.publication\.advice=\([0-9][0-9]*\).*/\1/p')
+if [ "$published_batches" != 1 ] || [ "$publication_advice" != 1 ]; then
+  echo "expected one publication batch/advice for 96 normal-path branches: $stats_line"
+  error_exit 1
+fi
+
+shutdown_when_empty
+wait_shutdown
+content_count_check "msgnum" 96 "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/reserved-egress-batching-stats.sh
+++ b/tests/reserved-egress-batching-stats.sh
@@ -1,19 +1,25 @@
 #!/bin/bash
-# Prove the no-pressure path retains target batching. A guaranteed 32-message
-# source dequeue batch executes three queued calls per source message to one
-# roomy target. Exact delivery proves all 96 branches published; impstats must
-# report one publication batch and one publication advice for those 96
-# messages. The initial 1.5-second wait lets startup messages pass the main
-# queue's one-second minimum-batch timeout before the 32-message stimulus.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
+# Prove the no-pressure path retains target batching without using queue-side
+# minimum-batch waiting. A test-only worker gate holds all source work while 32
+# messages are submitted; after the gate is removed, one nonmatching release
+# message triggers ordinary worker advice. The source dequeue ceiling is large
+# enough to claim startup messages, the 32-message stimulus, and the release as
+# one immediately available batch. Exact delivery proves all 96 branches were
+# published; impstats must report one publication batch and one advice.
 . ${srcdir:=.}/diag.sh init
 export STATSFILE="$RSYSLOG_DYNNAME.stats"
+export RSYSLOG_TEST_EGRESS_WORKER_GATE="$RSYSLOG_DYNNAME.egress-worker-gate"
+: > "$RSYSLOG_TEST_EGRESS_WORKER_GATE"
 generate_conf
 add_conf '
 global(executionEngine="reservedBatch")
 module(load="../plugins/impstats/.libs/impstats" interval="1" log.syslog="off"
        resetCounters="off" log.file="'$STATSFILE'")
-main_queue(queue.type="LinkedList" queue.dequeueBatchSize="32"
-           queue.minDequeueBatchSize="32" queue.minDequeueBatchSize.timeout="1000")
+main_queue(queue.type="LinkedList" queue.dequeueBatchSize="1024")
 template(name="outfmt" type="string" string="%msg%\n")
 ruleset(name="target" queue.type="LinkedList" queue.size="128") {
   action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
@@ -26,8 +32,9 @@ if $msg contains "msgnum" then {
 }
 '
 startup
-"$TESTTOOL_DIR/msleep" 1500
 injectmsg 0 32
+rm -f "$RSYSLOG_TEST_EGRESS_WORKER_GATE"
+injectmsg_literal "egress worker release"
 wait_file_lines "$RSYSLOG_OUT_LOG" 96
 
 i=0

--- a/tests/reserved-egress-concurrent.sh
+++ b/tests/reserved-egress-concurrent.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Exercise the pressure slow path with four source WTIs sharing a two-slot
+# FixedArray target. Without partial publication, WTIs can hold both slots as
+# invisible reservations and then self-block. Exact 500-line delivery after
+# synchronized shutdown proves progress and ownership; the 5s enqueue timeout
+# is hang protection, not the success oracle.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(executionEngine="reservedBatch")
+main_queue(queue.type="LinkedList" queue.workerThreads="4" queue.workerThreadMinimumMessages="1"
+           queue.timeoutWorkerThreadShutdown="-1" queue.dequeueBatchSize="64")
+template(name="outfmt" type="string" string="%msg%\n")
+ruleset(name="target" queue.type="FixedArray" queue.size="2"
+        queue.workerThreads="2" queue.timeoutEnqueue="5000") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+if $msg contains "msgnum" then call target
+'
+startup
+injectmsg 0 500
+shutdown_when_empty
+wait_shutdown
+content_count_check "msgnum" 500 "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/reserved-egress-concurrent.sh
+++ b/tests/reserved-egress-concurrent.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Exercise the pressure slow path with four source WTIs sharing a two-slot
 # FixedArray target. Without partial publication, WTIs can hold both slots as
 # invisible reservations and then self-block. Exact 500-line delivery after

--- a/tests/reserved-egress-crossed-targets-immediate.sh
+++ b/tests/reserved-egress-crossed-targets-immediate.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Repeat the crossed-target two-WTI schedule with timeoutEnqueue=0. Immediate
 # admission may drop either crossed branch, so clean bounded shutdown plus one
 # published prefix at each target is the delivery oracle. The direct barrier

--- a/tests/reserved-egress-crossed-targets-immediate.sh
+++ b/tests/reserved-egress-crossed-targets-immediate.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Repeat the crossed-target two-WTI schedule with timeoutEnqueue=0. Immediate
+# admission may drop either crossed branch, so clean bounded shutdown plus one
+# published prefix at each target is the delivery oracle. The direct barrier
+# makes the crossed reservation schedule deterministic without timing sleeps.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(executionEngine="reservedBatch")
+main_queue(queue.type="LinkedList" queue.workerThreads="2"
+           queue.workerThreadMinimumMessages="1" queue.dequeueBatchSize="1")
+module(load="../plugins/omtesting/.libs/omtesting")
+template(name="outfmt" type="string" string="%msg%\n")
+ruleset(name="barrier") {
+  :omtesting:barrier_error 2
+}
+ruleset(name="target_a" queue.type="LinkedList" queue.size="1" queue.timeoutEnqueue="0") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'.a" template="outfmt")
+}
+ruleset(name="target_b" queue.type="FixedArray" queue.size="1" queue.timeoutEnqueue="0") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'.b" template="outfmt")
+}
+if $msg contains "00000000" then {
+  call target_a
+  call barrier
+  call target_b
+} else if $msg contains "00000001" then {
+  call target_b
+  call barrier
+  call target_a
+}
+'
+startup
+injectmsg 0 2
+shutdown_when_empty
+wait_shutdown
+content_check "msgnum" "$RSYSLOG_OUT_LOG.a"
+content_check "msgnum" "$RSYSLOG_OUT_LOG.b"
+exit_test

--- a/tests/reserved-egress-crossed-targets.sh
+++ b/tests/reserved-egress-crossed-targets.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Force two source WTIs to reserve different one-slot targets, synchronize at a
+# direct-action barrier, and then request the other WTI's target. Both targets
+# receiving both messages is the deterministic oracle: flushing only the
+# pressured bucket times out and loses the crossed branches, whereas flushing
+# all locally held buckets starts both target workers and permits progress.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(executionEngine="reservedBatch")
+main_queue(queue.type="LinkedList" queue.workerThreads="2"
+           queue.workerThreadMinimumMessages="1" queue.dequeueBatchSize="1")
+module(load="../plugins/omtesting/.libs/omtesting")
+template(name="outfmt" type="string" string="%msg%\n")
+ruleset(name="barrier") {
+  :omtesting:barrier_error 2
+}
+ruleset(name="target_a" queue.type="LinkedList" queue.size="1" queue.timeoutEnqueue="5000") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'.a" template="outfmt")
+}
+ruleset(name="target_b" queue.type="FixedArray" queue.size="1" queue.timeoutEnqueue="5000") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'.b" template="outfmt")
+}
+if $msg contains "00000000" then {
+  call target_a
+  call barrier
+  call target_b
+} else if $msg contains "00000001" then {
+  call target_b
+  call barrier
+  call target_a
+}
+'
+startup
+injectmsg 0 2
+shutdown_when_empty
+wait_shutdown
+content_count_check "msgnum" 2 "$RSYSLOG_OUT_LOG.a"
+content_count_check "msgnum" 2 "$RSYSLOG_OUT_LOG.b"
+exit_test

--- a/tests/reserved-egress-crossed-targets.sh
+++ b/tests/reserved-egress-crossed-targets.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Force two source WTIs to reserve different one-slot targets, synchronize at a
 # direct-action barrier, and then request the other WTI's target. Both targets
 # receiving both messages is the deterministic oracle: flushing only the

--- a/tests/reserved-egress-immediate-tail.sh
+++ b/tests/reserved-egress-immediate-tail.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
+# Verify reserved egress never treats either the source dequeue ceiling or a
+# publication batch as a minimum fill requirement. A quiet-queue singleton
+# must reach the target before any later arrival. After a burst drains, its
+# singleton tail must likewise arrive before shutdown supplies another event.
+# workerThreadMinimumMessages=1 makes worker activation explicit; no queue uses
+# minDequeueBatchSize. Each wait_file_lines is the pre-next-arrival oracle.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(executionEngine="reservedBatch")
+main_queue(queue.type="LinkedList" queue.dequeueBatchSize="1024"
+           queue.workerThreads="1" queue.workerThreadMinimumMessages="1")
+template(name="outfmt" type="string" string="%msg%\n")
+ruleset(name="target" queue.type="LinkedList" queue.size="256"
+        queue.dequeueBatchSize="1024" queue.workerThreads="1"
+        queue.workerThreadMinimumMessages="1") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+if $msg contains "msgnum" then call target
+'
+startup
+
+# The first singleton is observed while the input queue is otherwise quiet.
+injectmsg 0 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 1
+
+# Drain a burst, then verify a final singleton/tail without a later wakeup.
+injectmsg 1 32
+wait_file_lines "$RSYSLOG_OUT_LOG" 33
+injectmsg 33 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 34
+
+shutdown_when_empty
+wait_shutdown
+content_count_check "msgnum" 34 "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/reserved-egress-immediate.sh
+++ b/tests/reserved-egress-immediate.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Exercise immediate shutdown while reserved egress is under sustained one-slot
+# target pressure. A deliberately slow target and short queue shutdown limits
+# make worker cancellation reachable. Clean bounded termination (including the
+# runtime zero-reservation assertions and core checks in diag.sh) is the oracle;
+# delivery count is intentionally unspecified for immediate shutdown.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(executionEngine="reservedBatch")
+module(load="../plugins/omtesting/.libs/omtesting")
+ruleset(name="target" queue.type="FixedArray" queue.size="1"
+        queue.timeoutEnqueue="50" queue.timeoutShutdown="100"
+        queue.timeoutActionCompletion="100") {
+  :omtesting:sleep 1 0
+}
+if $msg contains "msgnum" then call target
+'
+startup
+injectmsg 0 1000
+shutdown_immediate
+wait_shutdown "" 10
+exit_test

--- a/tests/reserved-egress-immediate.sh
+++ b/tests/reserved-egress-immediate.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Exercise immediate shutdown while reserved egress is under sustained one-slot
 # target pressure. A deliberately slow target and short queue shutdown limits
 # make worker cancellation reachable. Clean bounded termination (including the

--- a/tests/reserved-egress-legacy.sh
+++ b/tests/reserved-egress-legacy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Verify both the explicit legacy selector and an omitted selector leave queued
+# ruleset calls on the existing submitMsg2 path. The omitted case deliberately
+# uses queue.size="0", which reservedBatch rejects as unbounded, so successful
+# configuration and exact delivery also prove the default selector is legacy.
+# Exact delivery after synchronized shutdown is the runtime oracle.
+if [[ "$1" != "--case" ]]; then
+    for selector_case in explicit omitted; do
+        RSTB_SELECTOR_CASE="$selector_case" "$0" --case || exit $?
+    done
+    exit 0
+fi
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+if [[ "$RSTB_SELECTOR_CASE" == "explicit" ]]; then
+    add_conf 'global(executionEngine="legacy")'
+    target_queue_size=1
+else
+    target_queue_size=0
+fi
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+ruleset(name="target" queue.type="LinkedList" queue.size="'$target_queue_size'" queue.timeoutEnqueue="5000") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+if $msg contains "msgnum" then call target
+'
+startup
+injectmsg 0 10
+shutdown_when_empty
+wait_shutdown
+content_count_check "msgnum" 10 "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/reserved-egress-legacy.sh
+++ b/tests/reserved-egress-legacy.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Verify both the explicit legacy selector and an omitted selector leave queued
 # ruleset calls on the existing submitMsg2 path. The omitted case deliberately
 # uses queue.size="0", which reservedBatch rejects as unbounded, so successful

--- a/tests/reserved-egress-oom.sh
+++ b/tests/reserved-egress-oom.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Inject one allocation failure at each WTI ledger growth/prepare boundary.
+# Each failure must leave the source uncommitted, release its duplicate exactly
+# once, and leave the source retryable. A second, nonmatching source message
+# wakes the main queue after the injected failure; exact one-line target
+# delivery in every isolated child is the retry/ownership oracle.
+if [ "$1" != "--case" ]; then
+  for fault in bucket entry prepare; do
+    RSYSLOG_TEST_EGRESS_ALLOC_FAIL=$fault "$0" --case || exit $?
+  done
+  exit 0
+fi
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(executionEngine="reservedBatch")
+template(name="outfmt" type="string" string="%msg%\n")
+ruleset(name="target" queue.type="LinkedList" queue.size="2") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+if $msg contains "msgnum:00000000" then call target
+'
+startup
+injectmsg 0 1
+injectmsg 1 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 1
+shutdown_when_empty
+wait_shutdown
+content_count_check "msgnum" 1 "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/reserved-egress-oom.sh
+++ b/tests/reserved-egress-oom.sh
@@ -1,19 +1,43 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Inject one allocation failure at each WTI ledger growth/prepare boundary.
-# Each failure must leave the source uncommitted, release its duplicate exactly
-# once, and leave the source retryable. A second, nonmatching source message
-# wakes the main queue after the injected failure; exact one-line target
-# delivery in every isolated child is the retry/ownership oracle.
+# Each first-branch failure must leave the source uncommitted, release its
+# duplicate exactly once, and leave the source retryable. The late case fails
+# the second prepare after an earlier branch was accepted: target A appearing
+# twice and target B once is the deliberate legacy-equivalent replay oracle.
+# It proves accepted work is not lost while documenting that source retry can
+# duplicate a branch already submitted before the later failure. A second,
+# nonmatching source message provides an additional deterministic worker wake.
 if [ "$1" != "--case" ]; then
   for fault in bucket entry prepare; do
-    RSYSLOG_TEST_EGRESS_ALLOC_FAIL=$fault "$0" --case || exit $?
+    RSTB_EGRESS_OOM_CASE=first RSYSLOG_TEST_EGRESS_ALLOC_FAIL=$fault "$0" --case || exit $?
   done
+  RSTB_EGRESS_OOM_CASE=late RSYSLOG_TEST_EGRESS_ALLOC_FAIL=prepare:2 "$0" --case || exit $?
   exit 0
 fi
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-add_conf '
+if [ "$RSTB_EGRESS_OOM_CASE" = "late" ]; then
+  add_conf '
+global(executionEngine="reservedBatch")
+template(name="outfmt" type="string" string="%msg%\n")
+ruleset(name="target_a" queue.type="LinkedList" queue.size="4") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'.a" template="outfmt")
+}
+ruleset(name="target_b" queue.type="LinkedList" queue.size="4") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'.b" template="outfmt")
+}
+if $msg contains "msgnum:00000000" then {
+  call target_a
+  call target_b
+}
+'
+else
+  add_conf '
 global(executionEngine="reservedBatch")
 template(name="outfmt" type="string" string="%msg%\n")
 ruleset(name="target" queue.type="LinkedList" queue.size="2") {
@@ -21,11 +45,22 @@ ruleset(name="target" queue.type="LinkedList" queue.size="2") {
 }
 if $msg contains "msgnum:00000000" then call target
 '
+fi
 startup
 injectmsg 0 1
 injectmsg 1 1
-wait_file_lines "$RSYSLOG_OUT_LOG" 1
+if [ "$RSTB_EGRESS_OOM_CASE" = "late" ]; then
+  wait_file_lines "$RSYSLOG_OUT_LOG.a" 2
+  wait_file_lines "$RSYSLOG_OUT_LOG.b" 1
+else
+  wait_file_lines "$RSYSLOG_OUT_LOG" 1
+fi
 shutdown_when_empty
 wait_shutdown
-content_count_check "msgnum" 1 "$RSYSLOG_OUT_LOG"
+if [ "$RSTB_EGRESS_OOM_CASE" = "late" ]; then
+  content_count_check "msgnum:00000000" 2 "$RSYSLOG_OUT_LOG.a"
+  content_count_check "msgnum:00000000" 1 "$RSYSLOG_OUT_LOG.b"
+else
+  content_count_check "msgnum" 1 "$RSYSLOG_OUT_LOG"
+fi
 exit_test

--- a/tests/reserved-egress-selector-batch.sh
+++ b/tests/reserved-egress-selector-batch.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
-# Atomically flip a test-only selector override after the first element of a
-# guaranteed two-element source batch. This does not emulate configuration
-# reload; it probes that both legacy->reserved and reserved->legacy cases keep
-# the selector captured at batch entry. Ordered 0,1 target output is the oracle;
-# rereading the override can reverse publication order or use an uninitialized
-# ledger.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
+# Atomically flip a test-only selector override after the first selected element
+# of one source batch. A test-only worker gate forms the batch from already
+# available work without queue-side minimum-batch waiting; removing it and
+# submitting a nonmatching release message takes the ordinary immediate advice
+# path. This does not emulate reload. Ordered 0,1 target output proves both
+# legacy->reserved and reserved->legacy cases use the selector captured at batch
+# entry; rereading it could reorder publication or use an uninitialized ledger.
 if [ "$1" != "--case" ]; then
   for engine in legacy reservedBatch; do
     RSYSLOG_TEST_EGRESS_FLIP_AFTER_FIRST=1 RSTB_CASE_ENGINE=$engine "$0" --case || exit $?
@@ -13,11 +18,12 @@ if [ "$1" != "--case" ]; then
 fi
 
 . ${srcdir:=.}/diag.sh init
+export RSYSLOG_TEST_EGRESS_WORKER_GATE="$RSYSLOG_DYNNAME.egress-worker-gate"
+: > "$RSYSLOG_TEST_EGRESS_WORKER_GATE"
 generate_conf
 add_conf '
 global(executionEngine="'$RSTB_CASE_ENGINE'")
-main_queue(queue.type="LinkedList" queue.dequeueBatchSize="2"
-           queue.minDequeueBatchSize="2" queue.minDequeueBatchSize.timeout="5000")
+main_queue(queue.type="LinkedList" queue.dequeueBatchSize="1024")
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 ruleset(name="target" queue.type="LinkedList" queue.size="10") {
   action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
@@ -26,6 +32,8 @@ if $msg contains "msgnum" then call target
 '
 startup
 injectmsg 0 2
+rm -f "$RSYSLOG_TEST_EGRESS_WORKER_GATE"
+injectmsg_literal "egress worker release"
 shutdown_when_empty
 wait_shutdown
 seq_check 0 1

--- a/tests/reserved-egress-selector-batch.sh
+++ b/tests/reserved-egress-selector-batch.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Atomically flip a test-only selector override after the first element of a
+# guaranteed two-element source batch. This does not emulate configuration
+# reload; it probes that both legacy->reserved and reserved->legacy cases keep
+# the selector captured at batch entry. Ordered 0,1 target output is the oracle;
+# rereading the override can reverse publication order or use an uninitialized
+# ledger.
+if [ "$1" != "--case" ]; then
+  for engine in legacy reservedBatch; do
+    RSYSLOG_TEST_EGRESS_FLIP_AFTER_FIRST=1 RSTB_CASE_ENGINE=$engine "$0" --case || exit $?
+  done
+  exit 0
+fi
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(executionEngine="'$RSTB_CASE_ENGINE'")
+main_queue(queue.type="LinkedList" queue.dequeueBatchSize="2"
+           queue.minDequeueBatchSize="2" queue.minDequeueBatchSize.timeout="5000")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+ruleset(name="target" queue.type="LinkedList" queue.size="10") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+if $msg contains "msgnum" then call target
+'
+startup
+injectmsg 0 2
+shutdown_when_empty
+wait_shutdown
+seq_check 0 1
+exit_test

--- a/tests/reserved-egress-unsupported.sh
+++ b/tests/reserved-egress-unsupported.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Verify reservedBatch rejects disk-assisted and unbounded async targets plus
+# a Direct source queue. Each case requires a nonzero -N1 status and its
+# specific startup diagnostic; no runtime timing or external service is used.
+. ${srcdir:=.}/diag.sh init
+
+validate_rejected() {
+  label=$1
+  expected=$2
+  validation_log="$RSYSLOG_DYNNAME.$label.validation.log"
+  if ../tools/rsyslogd -N1 -M../runtime/.libs -f"${TESTCONF_NM}.conf" >"$validation_log" 2>&1; then
+    error_exit 1 "reservedBatch accepted unsupported $label queue"
+  fi
+  content_check "$expected" "$validation_log"
+}
+
+generate_conf
+add_conf '
+global(executionEngine="reservedBatch")
+ruleset(name="unsupported" queue.type="LinkedList" queue.filename="reserved") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+validate_rejected disk-assisted \
+  "supports only non-disk-assisted bounded LinkedList and FixedArray queued rulesets"
+
+generate_conf
+add_conf '
+global(executionEngine="reservedBatch")
+ruleset(name="unsupported" queue.type="LinkedList" queue.size="0") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+validate_rejected unbounded \
+  "supports only non-disk-assisted bounded LinkedList and FixedArray queued rulesets"
+
+generate_conf
+add_conf '
+global(executionEngine="reservedBatch")
+main_queue(queue.type="Direct")
+'
+validate_rejected direct-main "requires a non-Direct main queue"
+exit_test

--- a/tests/reserved-egress-unsupported.sh
+++ b/tests/reserved-egress-unsupported.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
-# Verify reservedBatch rejects disk-assisted and unbounded async targets plus
-# a Direct source queue. Each case requires a nonzero -N1 status and its
-# specific startup diagnostic; no runtime timing or external service is used.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
+# Verify the conf-mode RSTB_EXECUTION_ENGINE preamble selects reservedBatch and
+# rejects disk-assisted and unbounded async targets plus a Direct source queue.
+# It also verifies an invalid selector returns a configuration error through the
+# normal LogError path. Each case requires a nonzero -N1 status and its specific
+# startup diagnostic; no runtime timing or external service is used.
 . ${srcdir:=.}/diag.sh init
+export RSTB_EXECUTION_ENGINE=reservedBatch
 
 validate_rejected() {
   label=$1
@@ -16,7 +23,6 @@ validate_rejected() {
 
 generate_conf
 add_conf '
-global(executionEngine="reservedBatch")
 ruleset(name="unsupported" queue.type="LinkedList" queue.filename="reserved") {
   action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 }
@@ -26,7 +32,6 @@ validate_rejected disk-assisted \
 
 generate_conf
 add_conf '
-global(executionEngine="reservedBatch")
 ruleset(name="unsupported" queue.type="LinkedList" queue.size="0") {
   action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 }
@@ -36,8 +41,12 @@ validate_rejected unbounded \
 
 generate_conf
 add_conf '
-global(executionEngine="reservedBatch")
 main_queue(queue.type="Direct")
 '
 validate_rejected direct-main "requires a non-Direct main queue"
+
+RSTB_EXECUTION_ENGINE=notAnEngine
+generate_conf
+validate_rejected invalid-selector \
+  "invalid global executionEngine 'notAnEngine'; expected 'legacy' or 'reservedBatch'"
 exit_test

--- a/tests/reserved-egress-yaml.sh
+++ b/tests/reserved-egress-yaml.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Verify YAML global.executionEngine reaches the shared backend and enables a
+# reserved-batch queued ruleset call. Exact output after synchronized shutdown
+# is the oracle; startup alone is not sufficient.
+. ${srcdir:=.}/diag.sh init
+export RSTB_EXECUTION_ENGINE=reservedBatch
+generate_conf --yaml-only
+add_yaml_conf 'modules:'
+add_yaml_conf '  - load: "../plugins/imtcp/.libs/imtcp"'
+add_yaml_conf 'inputs:'
+add_yaml_conf '  - type: imtcp'
+add_yaml_conf '    port: "0"'
+add_yaml_conf '    listenPortFileName: "'${RSYSLOG_DYNNAME}'.tcpflood_port"'
+add_yaml_conf '    ruleset: main'
+add_yaml_conf 'rulesets:'
+add_yaml_conf '  - name: target'
+add_yaml_conf '    queue.type: LinkedList'
+add_yaml_conf '    script: |'
+add_yaml_conf '      action(type="omfile" file="'$RSYSLOG_OUT_LOG'")'
+add_yaml_conf '  - name: main'
+add_yaml_conf '    script: |'
+add_yaml_conf '      if $msg contains "msgnum" then call target'
+startup
+tcpflood -m 5
+shutdown_when_empty
+wait_shutdown
+content_count_check "msgnum" 5 "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/reserved-egress-yaml.sh
+++ b/tests/reserved-egress-yaml.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
 # Verify YAML global.executionEngine reaches the shared backend and enables a
 # reserved-batch queued ruleset call. Exact output after synchronized shutdown
 # is the oracle; startup alone is not sufficient.

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -866,13 +866,17 @@ static rsRetVal msgConsumer(void __attribute__((unused)) * notNeeded, batch_t *p
     DEFiRet;
     assert(pBatch != NULL);
     preprocessBatch(pBatch, pWti);
-    ruleset.ProcessBatch(pBatch, pWti);
+    /* The legacy ruleset engine returns OK and retains the historical blanket
+     * commit below. The experimental reserved-batch engine propagates prepare
+     * failures so its per-source states remain retryable. */
+    CHKiRet(ruleset.ProcessBatch(pBatch, pWti));
     // TODO: the BATCH_STATE_COMM must be set somewhere down the road, but we
     // do not have this yet and so we emulate -- 2010-06-10
     int i;
     for (i = 0; i < pBatch->nElem && !wtiIsShutdownImmediate(pWti); i++) {
         pBatch->eltState[i] = BATCH_STATE_COMM;
     }
+finalize_it:
     RETiRet;
 }
 


### PR DESCRIPTION
## DO NOT MERGE

This is an experimental prototype for discussion and further validation. The
legacy execution engine remains the default.

## Why

Queued ruleset calls currently duplicate and publish each message separately.
Dynamic fan-out therefore performs one contended target-queue admission for
every selected branch, even though the source worker already owns a batch.

This prototype evaluates whether reserving target capacity and publishing the
accepted branches in target-specific batches can reduce that overhead without
changing plugin or action APIs.

## What changes

- Adds the opt-in global `executionEngine="reservedBatch"`; `legacy` remains
  the default and preserves the existing path.
- Stages dynamically selected queued-ruleset branches in a worker-local ledger.
- Reserves bounded in-memory target capacity and publishes staged branches in
  batches, with pressure-path publication and cancellation cleanup.
- Keeps explicit Direct rulesets synchronous.
- Supports bounded LinkedList and FixedArray target queues. Unsupported disk,
  disk-assisted, sampling, and unbounded targets are rejected at startup.
- Adds publication statistics and focused lifecycle, pressure, compatibility,
  configuration, OOM, cancellation, and batching tests.

No plugin, action, message, or disk-queue contract is intentionally changed.

## Evidence so far

Two independent 11-pair sessions used 1,000,000 messages per listener, two
listeners, 16 source workers, 16 workers per target queue, and exact delivery
oracles. Across 96 accepted lifecycles there were no missing, duplicate,
discarded, or full-queue messages.

Compared with the legacy engine, median observed throughput improved by:

- 55-63% for the two-call baseline.
- 48-54% for the three-call no-op fan-out case.

User CPU, system CPU, futex samples, and RSS all decreased in both sessions.
The host was non-exclusive and some comparisons had high MAD, so these figures
are promising directional evidence rather than final performance claims.

This prototype does **not** eliminate proportional fan-out scaling. The third
call cost about 25-26% relative throughput with the legacy engine and about 30%
with the reserved engine; it raises the absolute processing level rather than
solving the complete fan-out architecture.

## Validation

- Focused reserved-egress tests: 11/11 pass.
- Mock distcheck and distribution archive checks pass.
- Ubuntu 26.04 container lane: 1,558 pass, 69 expected skips, 0 failures.
- Sphinx HTML build via `doc/tools/build-doc-linux.sh`: pass.
- Static analyzer: raw lane exits nonzero for one report in unchanged
  `runtime/modules.c`. The file is byte-identical to upstream `main`; an
  independent audit found the reported path infeasible and unrelated to this
  change. This is recorded as an understood upstream analyzer false positive,
  not as a green analyzer lane.

Container image:
`rsyslog/rsyslog_dev_base_ubuntu:26.04`
(`sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`).

## Before merge consideration

- Add rendered operator/configuration documentation.
- Run sanitizer and additional independent-output failure/recovery coverage.
- Continue ABI and reload/cancellation review.
- Repeat representative production-shaped workloads on a quieter host.
- Resolve or separately suppress the upstream static-analyzer false positive.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

