### PR TITLE
omelasticsearch: skip needless successful bulk parsing

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -1424,12 +1424,23 @@ static rsRetVal parseRequestAndResponseForContext(wrkrInstanceData_t *pWrkrData,
     numitems = fjson_object_array_length(items);
 
     int errors = 0;
-    if (fjson_object_object_get_ex(replyRoot, "errors", &jo_errors)) {
+    const int has_errors = fjson_object_object_get_ex(replyRoot, "errors", &jo_errors);
+    const int errors_is_boolean = has_errors && fjson_object_is_type(jo_errors, fjson_type_boolean);
+    if (errors_is_boolean) {
         errors = fjson_object_get_boolean(jo_errors);
         if (!errors && pWrkrData->pData->retryFailures) {
             STATSCOUNTER_ADD(indexSuccess, mutIndexSuccess, numitems);
             return RS_RET_OK;
         }
+    }
+
+    /* Both Elasticsearch and OpenSearch set errors to false only when every
+     * item in a bulk response succeeded. Without retry or error-file handling,
+     * there is no per-item work left to do. Keep the full parsing path for
+     * absent or failing errors fields so malformed responses stay conservative.
+     */
+    if (errors_is_boolean && !errors && !pWrkrData->pData->retryFailures && pWrkrData->pData->errorFile == NULL) {
+        return RS_RET_OK;
     }
 
     if (reqmsg) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -202,6 +202,7 @@ TESTS_ELASTICSEARCH_SERVER = \
 
 TESTS_ELASTICSEARCH_IMPSTATS = \
 	es-basic-ha.sh \
+	es-bulk-response-errors.sh \
 	es-bulk-retry.sh
 
 TESTS_ELASTICSEARCH_IMFILE = \
@@ -2898,7 +2899,8 @@ if ENABLE_IMPSTATS
 TESTS += $(TESTS_ELASTICSEARCH_IMPSTATS)
 
 es-basic-ha.log: es-writeoperation.log
-es-bulk-retry.log: es-basic-ha.log
+es-bulk-response-errors.log: es-basic-ha.log
+es-bulk-retry.log: es-bulk-response-errors.log
 elasticsearch-stop.log: es-bulk-retry.log
 endif
 

--- a/tests/es-bulk-response-errors.sh
+++ b/tests/es-bulk-response-errors.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+# Verify that a Bulk API response with errors=true is inspected even when
+# retryfailures and errorfile are unset. Invalid integer documents must raise
+# omelasticsearch's failed.es counter; a successful-response fast path would
+# leave it at zero. Queue and stats-flush helpers provide the completion oracle.
+. ${srcdir:=.}/diag.sh init
+export ES_PORT=19200
+export NUMMESSAGES=100
+ensure_elasticsearch_ready
+
+init_elasticsearch
+curl -s -H 'Content-Type: application/json' -XPUT "localhost:${ES_PORT}/rsyslog_testbench/" -d '{
+  "mappings": {
+    "properties": {
+      "msgnum": {
+        "type": "integer"
+      }
+    }
+  }
+}' >/dev/null
+
+generate_conf
+add_conf '
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"x%msg:F,58:2%\"}")
+
+module(load="../plugins/impstats/.libs/impstats" interval="1"
+	   log.file="'"$RSYSLOG_DYNNAME"'.spool/omelasticsearch-stats.log"
+	   log.syslog="off" format="cee" bracketing="on")
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+
+if $msg contains "msgnum:" then
+	action(type="omelasticsearch"
+	       serverport="'"$ES_PORT"'"
+	       template="tpl"
+	       searchIndex="rsyslog_testbench"
+	       bulkmode="on")
+'
+
+startup
+injectmsg 0 "$NUMMESSAGES"
+wait_queueempty
+wait_for_stats_flush "${RSYSLOG_DYNNAME}.spool/omelasticsearch-stats.log"
+shutdown_when_empty
+wait_shutdown
+
+$PYTHON <"${RSYSLOG_DYNNAME}.spool/omelasticsearch-stats.log" -c '
+import json
+import sys
+
+expected_submitted = int(sys.argv[1])
+stats = None
+for line in sys.stdin:
+    start = line.find("{")
+    if start >= 0:
+        record = json.loads(line[start:])
+        if record.get("origin") == "omelasticsearch":
+            stats = record
+
+if stats is None:
+    raise SystemExit("FAIL: omelasticsearch statistics were not emitted")
+if stats.get("submitted") != expected_submitted:
+    raise SystemExit("FAIL: expected {} submitted messages, got {}".format(
+        expected_submitted, stats.get("submitted")))
+if stats.get("failed.es", 0) < 1:
+    raise SystemExit("FAIL: expected failed.es to record the bulk item errors")
+' "$NUMMESSAGES" || error_exit 1
+
+exit_test


### PR DESCRIPTION
## Summary

Avoid per-item JSON response processing for successful Bulk API replies when neither retry routing nor error-file handling is configured. The guarded fast path requires an explicit top-level `"errors": false`, which is shared by supported Elasticsearch and OpenSearch Bulk responses.

## Validation

- `make -j10 check TESTS=""` (pass; omelasticsearch compiled)
- `./tests/es-basic-bulk.sh` (pass; Elasticsearch 7.14.1, 10,000 records sequence-checked)
- `./tests/es-bulk-response-errors.sh` (pass; 100 invalid bulk documents produced `failed.es: 2` with retry and error-file handling disabled)
- C formatting check (pass for the changed module source)
- Mock `make distcheck TEST_RUN_TYPE=MOCK-OK -j10` did not reach a final result in the shared local environment; it is not claimed as passing.
- Ubuntu 26.04 static analyzer completed with one pre-existing `runtime/modules.c` warning; its CI configuration disables omelasticsearch.
- Ubuntu 26.04 change-gated check compiled omelasticsearch and completed with 1,409 passes, 2 unrelated failures: `segmented-da-idle-cleanup-failure.sh` and `sndrcv_tls_mbedtls_gnutlspriorityString_no_suite_in_common.sh`. Elasticsearch tests were unexpectedly configured out by the local relevance selection; focused host integration coverage above exercised both success and errors=true paths.

Container validation is therefore not fully clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->