### PR TITLE
omelasticsearch: enable TCP keepalive for bulk posts

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -2344,6 +2344,15 @@ static void ATTR_NONNULL(1) curlPostSetup(wrkrInstanceData_t *const pWrkrData) {
     curlSetupCommon(pWrkrData, pWrkrData->curlPostHandle);
     curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_POST, 1L);
     curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_TIMEOUT_MS, pWrkrData->pData->indexTimeout);
+
+    CURLcode cRet;
+    /* Enable TCP keep-alive for idle reusable bulk POST connections. */
+    cRet = curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_TCP_KEEPALIVE, 1L);
+    if (cRet != CURLE_OK) DBGPRINTF("omelasticsearch: curlPostSetup unknown option CURLOPT_TCP_KEEPALIVE\n");
+    cRet = curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_TCP_KEEPIDLE, 120L);
+    if (cRet != CURLE_OK) DBGPRINTF("omelasticsearch: curlPostSetup unknown option CURLOPT_TCP_KEEPIDLE\n");
+    cRet = curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_TCP_KEEPINTVL, 60L);
+    if (cRet != CURLE_OK) DBGPRINTF("omelasticsearch: curlPostSetup unknown option CURLOPT_TCP_KEEPINTVL\n");
 }
 
 #define CONTENT_JSON "Content-Type: application/json; charset=utf-8"


### PR DESCRIPTION
## Summary

Enable TCP keepalive on each reusable omelasticsearch bulk POST handle. This mirrors omhttp: probes begin after 120 seconds idle and repeat every 60 seconds, while unsupported libcurl options are logged and otherwise harmless.

## Validation

- `make -j10 check TESTS=""` (pass; omelasticsearch compiled)
- `./tests/es-basic-bulk.sh` (pass; Elasticsearch 7.14.1, 10,000 events sequence-checked)
- C formatting check (pass)
- C lifecycle and concurrency audit (clean; no ownership or shared-state changes)
- Ubuntu 26.04 static analyzer completed with one pre-existing `runtime/modules.c:412` warning; its standard configuration disables omelasticsearch.
- Ubuntu 26.04 change-gated CI lane is running with `plugins/omelasticsearch/omelasticsearch.c` as the changed-file set; it compiled omelasticsearch and is executing the relevant suite.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->