### PR TITLE
runtime: avoid JSON expression string temporaries

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3726,25 +3726,27 @@ static void evalVar(struct cnfvar *__restrict__ const var,
             DBGPRINTF("rainerscript: (json) var %d:%s: '%s'\n", var->prop.id, var->prop.name,
                       (ret->d.json == NULL) ? "" : json_object_get_string(ret->d.json));
         } else { /* we have a string */
-            debugStr = (jsonVar.d.estr == NULL) ? (const uchar *)"" : es_getBufAddr(jsonVar.d.estr);
-            debugStrLen = (jsonVar.d.estr == NULL) ? 0 : es_strlen(jsonVar.d.estr);
-            DBGPRINTF("rainerscript: (json/string) var %d: '", var->prop.id);
-            while (debugStrLen != 0) {
-                const uchar *const nul = memchr(debugStr, '\0', debugStrLen);
-                es_size_t chunkLen = (nul == NULL) ? debugStrLen : (es_size_t)(nul - debugStr);
+            if (Debug) {
+                debugStr = (jsonVar.d.estr == NULL) ? (const uchar *)"" : es_getBufAddr(jsonVar.d.estr);
+                debugStrLen = (jsonVar.d.estr == NULL) ? 0 : es_strlen(jsonVar.d.estr);
+                DBGPRINTF("rainerscript: (json/string) var %d: '", var->prop.id);
+                while (debugStrLen != 0) {
+                    const uchar *const nul = memchr(debugStr, '\0', debugStrLen);
+                    es_size_t chunkLen = (nul == NULL) ? debugStrLen : (es_size_t)(nul - debugStr);
 
-                while (chunkLen != 0) {
-                    const int printLen = (chunkLen > INT_MAX) ? INT_MAX : (int)chunkLen;
-                    DBGPRINTF("%.*s", printLen, debugStr);
-                    debugStr += printLen;
-                    chunkLen -= printLen;
-                    debugStrLen -= printLen;
+                    while (chunkLen != 0) {
+                        const int printLen = (chunkLen > INT_MAX) ? INT_MAX : (int)chunkLen;
+                        DBGPRINTF("%.*s", printLen, debugStr);
+                        debugStr += printLen;
+                        chunkLen -= printLen;
+                        debugStrLen -= printLen;
+                    }
+                    if (nul == NULL) break;
+                    ++debugStr;
+                    --debugStrLen;
                 }
-                if (nul == NULL) break;
-                ++debugStr;
-                --debugStrLen;
+                DBGPRINTF("'\n");
             }
-            DBGPRINTF("'\n");
             ret->datatype = 'S';
             ret->d.estr = (localRet != RS_RET_OK || jsonVar.d.estr == NULL) ? es_newStr(1) : jsonVar.d.estr;
         }

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3715,6 +3715,8 @@ static void evalVar(struct cnfvar *__restrict__ const var,
     unsigned short bMustBeFreed = 0;
     rsRetVal localRet;
     struct svar jsonVar;
+    const uchar *debugStr;
+    es_size_t debugStrLen;
 
     if (var->prop.id == PROP_CEE || var->prop.id == PROP_LOCAL_VAR || var->prop.id == PROP_GLOBAL_VAR) {
         localRet = msgGetJSONPropSVar((smsg_t *)usrptr, &var->prop, &jsonVar);
@@ -3724,8 +3726,25 @@ static void evalVar(struct cnfvar *__restrict__ const var,
             DBGPRINTF("rainerscript: (json) var %d:%s: '%s'\n", var->prop.id, var->prop.name,
                       (ret->d.json == NULL) ? "" : json_object_get_string(ret->d.json));
         } else { /* we have a string */
-            DBGPRINTF("rainerscript: (json/string) var %d: '%s'\n", var->prop.id,
-                      (jsonVar.d.estr == NULL) ? "" : (char *)es_getBufAddr(jsonVar.d.estr));
+            debugStr = (jsonVar.d.estr == NULL) ? (const uchar *)"" : es_getBufAddr(jsonVar.d.estr);
+            debugStrLen = (jsonVar.d.estr == NULL) ? 0 : es_strlen(jsonVar.d.estr);
+            DBGPRINTF("rainerscript: (json/string) var %d: '", var->prop.id);
+            while (debugStrLen != 0) {
+                const uchar *const nul = memchr(debugStr, '\0', debugStrLen);
+                es_size_t chunkLen = (nul == NULL) ? debugStrLen : (es_size_t)(nul - debugStr);
+
+                while (chunkLen != 0) {
+                    const int printLen = (chunkLen > INT_MAX) ? INT_MAX : (int)chunkLen;
+                    DBGPRINTF("%.*s", printLen, debugStr);
+                    debugStr += printLen;
+                    chunkLen -= printLen;
+                    debugStrLen -= printLen;
+                }
+                if (nul == NULL) break;
+                ++debugStr;
+                --debugStrLen;
+            }
+            DBGPRINTF("'\n");
             ret->datatype = 'S';
             ret->d.estr = (localRet != RS_RET_OK || jsonVar.d.estr == NULL) ? es_newStr(1) : jsonVar.d.estr;
         }

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3714,25 +3714,21 @@ static void evalVar(struct cnfvar *__restrict__ const var,
     uchar *pszProp = NULL;
     unsigned short bMustBeFreed = 0;
     rsRetVal localRet;
-    struct json_object *json;
-    uchar *cstr = NULL;
+    struct svar jsonVar;
 
     if (var->prop.id == PROP_CEE || var->prop.id == PROP_LOCAL_VAR || var->prop.id == PROP_GLOBAL_VAR) {
-        localRet = msgGetJSONPropJSONorString((smsg_t *)usrptr, &var->prop, &json, &cstr);
-        if (json != NULL) {
-            assert(cstr == NULL);
+        localRet = msgGetJSONPropSVar((smsg_t *)usrptr, &var->prop, &jsonVar);
+        if (jsonVar.datatype == 'J') {
             ret->datatype = 'J';
-            ret->d.json = (localRet == RS_RET_OK) ? json : NULL;
+            ret->d.json = (localRet == RS_RET_OK) ? jsonVar.d.json : NULL;
             DBGPRINTF("rainerscript: (json) var %d:%s: '%s'\n", var->prop.id, var->prop.name,
                       (ret->d.json == NULL) ? "" : json_object_get_string(ret->d.json));
         } else { /* we have a string */
-            DBGPRINTF("rainerscript: (json/string) var %d: '%s'\n", var->prop.id, cstr);
+            DBGPRINTF("rainerscript: (json/string) var %d: '%s'\n", var->prop.id,
+                      (jsonVar.d.estr == NULL) ? "" : (char *)es_getBufAddr(jsonVar.d.estr));
             ret->datatype = 'S';
-            ret->d.estr = (localRet != RS_RET_OK || cstr == NULL)
-                              ? es_newStr(1)
-                              : es_newStrFromCStr((char *)cstr, strlen((char *)cstr));
+            ret->d.estr = (localRet != RS_RET_OK || jsonVar.d.estr == NULL) ? es_newStr(1) : jsonVar.d.estr;
         }
-        free(cstr);
     } else {
         ret->datatype = 'S';
         pszProp = (uchar *)MsgGetProp((smsg_t *)usrptr, NULL, &var->prop, &propLen, &bMustBeFreed, NULL);

--- a/runtime/modules.c
+++ b/runtime/modules.c
@@ -400,6 +400,8 @@ rsRetVal ATTR_NONNULL(1) addModToCnfList(cfgmodules_etry_t **const pNew, cfgmodu
     DEFiRet;
     assert(*pNew != NULL);
 
+    if (*pNew == NULL) ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+
     if (loadConf == NULL) {
         abortCnfUse(pNew);
         FINALIZE; /* we are in an early init state */
@@ -419,6 +421,7 @@ rsRetVal ATTR_NONNULL(1) addModToCnfList(cfgmodules_etry_t **const pNew, cfgmodu
     }
 
 finalize_it:
+    if (iRet != RS_RET_OK) abortCnfUse(pNew);
     *pNew = NULL;
     RETiRet;
 }

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -76,6 +76,7 @@
 #include "atomic.h"
 #include "unicode-helper.h"
 #include "ruleset.h"
+#include "rainerscript.h"
 #include "prop.h"
 #include "msg_replace_helper.h"
 #include "net.h"
@@ -3327,6 +3328,86 @@ finalize_it:
 }
 
 
+/* Get a JSON-based variable as an expression value.
+ *
+ * JSON strings are copied directly into an es_str_t while the selected root
+ * lock is held. This avoids the temporary strdup() result used by
+ * msgGetJSONPropJSONorString(). The C-string getter historically truncates
+ * JSON strings at their first embedded NUL, so retain that behavior here.
+ * Non-string values remain deep-copied JSON objects because message mutation
+ * may otherwise invalidate them after the lock is released.
+ */
+rsRetVal msgGetJSONPropSVar(smsg_t *const pMsg, msgPropDescr_t *pProp, struct svar *out) {
+    struct json_object **jroot;
+    uchar *leaf;
+    struct json_object *parent;
+    pthread_mutex_t *mut = NULL;
+    DEFiRet;
+
+    out->datatype = 'S';
+    out->d.estr = NULL;
+
+#ifdef HAVE_LOGNORM_TURBO
+    /* Keep the existing snapshot precedence guard: once $! was mutated, the
+     * merge-aware path below must materialize and read the message JSON. */
+    if (pProp->id == PROP_CEE && pMsg->json == NULL && pMsg->turbo_result != NULL &&
+        pMsg->turbo_result_get_str != NULL) {
+        const uchar *val;
+        rs_size_t vlen;
+        if (pMsg->turbo_result_get_str(pMsg->turbo_result, pProp->name, pProp->nameLen, &val, &vlen) == 0) {
+            const size_t len = strnlen((const char *)val, vlen);
+            out->d.estr = es_newStrFromCStr((const char *)val, len);
+            if (out->d.estr != NULL) {
+                return RS_RET_OK;
+            }
+        }
+    }
+#endif
+
+    CHKiRet(getJSONRootAndMutex(pMsg, pProp->id, &jroot, &mut));
+    pthread_mutex_lock(mut);
+#ifdef HAVE_LOGNORM_TURBO
+    msgMaterializeTurboJSON(pMsg);
+#endif
+    if (!strcmp((char *)pProp->name, "!")) {
+        out->d.json = *jroot;
+        if (out->d.json != NULL) {
+            out->datatype = 'J';
+        }
+        FINALIZE;
+    }
+    if (*jroot == NULL) {
+        ABORT_FINALIZE(RS_RET_NOT_FOUND);
+    }
+    leaf = jsonPathGetLeaf(pProp->name, pProp->nameLen);
+    CHKiRet(jsonPathFindParent(*jroot, pProp->name, leaf, &parent, 0));
+    if (jsonVarExtract(parent, (char *)leaf, &out->d.json) == FALSE) {
+        ABORT_FINALIZE(RS_RET_NOT_FOUND);
+    }
+    if (out->d.json == NULL) {
+        /* A JSON null is represented as an empty expression string. */
+        out->d.estr = es_newStrFromCStr("", 0);
+    } else if (json_object_get_type(out->d.json) == json_type_string) {
+        const char *const str = json_object_get_string(out->d.json);
+        const size_t len = strnlen(str, json_object_get_string_len(out->d.json));
+        out->d.estr = es_newStrFromCStr(str, len);
+    } else {
+        out->datatype = 'J';
+    }
+
+finalize_it:
+    if (out->datatype == 'J') {
+        out->d.json = jsonDeepCopy(out->d.json);
+        if (out->d.json == NULL) {
+            out->datatype = 'S';
+            out->d.estr = NULL;
+        }
+    }
+    if (mut != NULL) pthread_mutex_unlock(mut);
+    RETiRet;
+}
+
+
 /* Get a JSON-based-variable as native json object */
 rsRetVal msgGetJSONPropJSON(smsg_t *const pMsg, msgPropDescr_t *pProp, struct json_object **pjson) {
     struct json_object **jroot;
@@ -5370,11 +5451,19 @@ rsRetVal msgSetJSONFromVar(smsg_t *const pMsg, uchar *varname, struct svar *v, i
     char *cstr;
     DEFiRet;
     switch (v->datatype) {
-        case 'S': /* string */
-            CHKmalloc(cstr = es_str2cstr(v->d.estr, NULL));
-            json = json_object_new_string(cstr);
-            free(cstr);
+        case 'S': { /* string */
+            const es_size_t len = es_strlen(v->d.estr);
+            if (len <= INT_MAX && memchr(es_getBufAddr(v->d.estr), '\0', len) == NULL) {
+                json = json_object_new_string_len((const char *)es_getBufAddr(v->d.estr), (int)len);
+            } else {
+                /* es_str2cstr(..., NULL) drops every embedded NUL. Retain
+                 * that established behavior for values outside the fast path. */
+                CHKmalloc(cstr = es_str2cstr(v->d.estr, NULL));
+                json = json_object_new_string(cstr);
+                free(cstr);
+            }
             break;
+        }
         case 'N': /* number (integer) */
             json = json_object_new_int64(v->d.n);
             break;

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -308,6 +308,7 @@ rsRetVal msgGetJSONPropJSONorString(smsg_t *const pMsg,
                                     msgPropDescr_t *pProp,
                                     struct json_object **pjson,
                                     uchar **pcstr);
+rsRetVal msgGetJSONPropSVar(smsg_t *const pMsg, msgPropDescr_t *pProp, struct svar *out);
 rsRetVal getJSONPropVal(
     smsg_t *pMsg, msgPropDescr_t *pProp, uchar **pRes, rs_size_t *buflen, unsigned short *pbMustBeFreed);
 rsRetVal msgSetJSONFromVar(smsg_t *pMsg, uchar *varname, struct svar *var, int force_reset);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -531,6 +531,7 @@ TESTS_DEFAULT = \
 	rcvr_fail_restore.sh \
 	snd-array-cmp-json.sh \
 	rscript_b64_decode.sh \
+	rscript-json-var-eval-semantics.sh \
 	rscript_tocef.sh \
 	rscript_contains.sh \
 	rscript_bare_var_root.sh \
@@ -732,6 +733,7 @@ TESTS_DEFAULT_VALGRIND = \
 	include-obj-in-if-vg.sh \
 	include-obj-text-vg.sh \
 	rscript_b64_decode-vg.sh \
+	rscript-json-var-eval-semantics-vg.sh \
 	rscript_parse_json-vg.sh \
 	rscript_backticks-vg.sh \
 	rscript_backticks_empty_envvar.sh \

--- a/tests/mmnormalize-turbo-message-lifecycle.sh
+++ b/tests/mmnormalize-turbo-message-lifecycle.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Verify that turbo mmnormalize CEE fields survive both MsgDup() through a
-# queued ruleset and disk-queue serialization. The output files are the
-# oracle: each must contain the normalized field after synchronized shutdown.
+# queued ruleset and disk-queue serialization. Also exercise RainerScript JSON
+# expression reads before and after a mutation: the first read may use the
+# Turbo snapshot, while the second must observe the materialized later write.
+# The output files are the exact oracle after synchronized shutdown.
 . ${srcdir:=.}/diag.sh init
 require_plugin imtcp
 require_plugin mmnormalize
@@ -12,7 +14,7 @@ module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="normalize")
 
-template(name="outfmt" type="string" string="%$!host% %$!tag%\n")
+template(name="outfmt" type="string" string="%$!before% %$!after% %$!host% %$!tag%\n")
 
 ruleset(name="copy" queue.type="LinkedList") {
 	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
@@ -21,6 +23,9 @@ ruleset(name="copy" queue.type="LinkedList") {
 ruleset(name="normalize") {
 	action(type="mmnormalize" useRawMsg="on" turbo="on"
 	       rule="rule=:%host:word% %tag:char-to:\\x3a%: no longer listening on %ip:ipv4%#%port:number%")
+	set $!before = $!host;
+	set $!host = "override";
+	set $!after = $!host;
 	call copy
 	action(type="omfile" file="'$RSYSLOG2_OUT_LOG'" template="outfmt"
 	       queue.type="disk" queue.filename="turbo-lifecycle")
@@ -30,7 +35,7 @@ startup
 tcpflood -m1 -M "\"ubuntu tag1: no longer listening on 127.168.0.1#10514\""
 shutdown_when_empty
 wait_shutdown
-export EXPECTED='ubuntu tag1'
+export EXPECTED='ubuntu override override tag1'
 cmp_exact "$RSYSLOG_OUT_LOG"
 cmp_exact "$RSYSLOG2_OUT_LOG"
 exit_test

--- a/tests/rscript-json-var-eval-semantics-vg.sh
+++ b/tests/rscript-json-var-eval-semantics-vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Run the JSON-variable expression semantics regression under Valgrind.
+# This file is part of the rsyslog project, released under ASL 2.0.
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/rscript-json-var-eval-semantics.sh

--- a/tests/rscript-json-var-eval-semantics.sh
+++ b/tests/rscript-json-var-eval-semantics.sh
@@ -3,9 +3,12 @@
 # missing/null, root, and NUL semantics while values flow through set. Exact
 # serialized output after synchronized shutdown is the oracle: it detects a
 # type/value change as well as the legacy set-side NUL removal and read-side
-# first-NUL truncation rules.
+# first-NUL truncation rules. With internal debugging enabled, the debug log is
+# also an oracle: embedded NUL bytes must be dropped without creating a cstr.
 # This file is part of the rsyslog project, released under ASL 2.0.
 . ${srcdir:=.}/diag.sh init
+export RSYSLOG_DEBUG="debug nostdout"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
 
 generate_conf
 add_conf '
@@ -16,6 +19,7 @@ template(name="outfmt" type="string" string="%$!out%\n")
 if $msg contains "msgnum:" then {
 	# es_str2cstr(..., NULL) historically removes all embedded NUL bytes.
 	set $!out!set_nul = b64_decode("YWIAY2QAZWY=");
+	set $.nul_debug = b64_decode("YWIAY2QAZWY=");
 	set $.ret = parse_json("{\"flat.key\":\"flat\",\"nested\":{\"value\":\"nested\"},\"string\":\"text\",\"empty\":\"\",\"null\":null,\"integer\":42,\"boolean\":true,\"double\":1.5,\"array\":[\"one\",2],\"object\":{\"child\":\"value\"},\"nul\":\"ab\\u0000cd\"}", "\$!src");
 	set $.ret = parse_json("{\"string\":\"local\",\"integer\":7,\"boolean\":false}", "\$.src");
 	set $.ret = parse_json("{\"string\":\"global\",\"integer\":9,\"boolean\":true}", "\$/src");
@@ -32,6 +36,7 @@ if $msg contains "msgnum:" then {
 	set $!out!array = $!src!array;
 	set $!out!object = $!src!object;
 	set $!out!nul_read = $!src!nul;
+	set $.nul_debug_copy = $.nul_debug;
 	set $!out!whole = $!src;
 	set $!out!local_string = $.src!string;
 	set $!out!local_integer = $.src!integer;
@@ -49,6 +54,9 @@ startup
 injectmsg 0 1
 shutdown_when_empty
 wait_shutdown
+
+content_check "rainerscript: (json/string) var" "$RSYSLOG_DEBUGLOG"
+content_check --regex "rainerscript: (json/string) var [0-9][0-9]*: 'abcdef'" "$RSYSLOG_DEBUGLOG"
 
 export EXPECTED='{ "set_nul": "abcdef", "flat": "flat", "nested": "nested", "string": "text", "empty": "", "missing": "", "null": "", "integer": 42, "boolean": true, "double": 1.5, "array": [ "one", 2 ], "object": { "child": "value" }, "nul_read": "ab", "whole": { "flat.key": "flat", "nested": { "value": "nested" }, "string": "text", "empty": "", "null": null, "integer": 42, "boolean": true, "double": 1.5, "array": [ "one", 2 ], "object": { "child": "value" }, "nul": "ab" }, "local_string": "local", "local_integer": 7, "local_boolean": false, "local_whole": { "string": "local", "integer": 7, "boolean": false }, "global_string": "global", "global_integer": 9, "global_boolean": true, "global_whole": { "string": "global", "integer": 9, "boolean": true } }'
 cmp_exact

--- a/tests/rscript-json-var-eval-semantics.sh
+++ b/tests/rscript-json-var-eval-semantics.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Verify that RainerScript JSON-variable reads preserve scalar, native JSON,
+# missing/null, root, and NUL semantics while values flow through set. Exact
+# serialized output after synchronized shutdown is the oracle: it detects a
+# type/value change as well as the legacy set-side NUL removal and read-side
+# first-NUL truncation rules.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" address="127.0.0.1" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%$!out%\n")
+
+if $msg contains "msgnum:" then {
+	# es_str2cstr(..., NULL) historically removes all embedded NUL bytes.
+	set $!out!set_nul = b64_decode("YWIAY2QAZWY=");
+	set $.ret = parse_json("{\"flat.key\":\"flat\",\"nested\":{\"value\":\"nested\"},\"string\":\"text\",\"empty\":\"\",\"null\":null,\"integer\":42,\"boolean\":true,\"double\":1.5,\"array\":[\"one\",2],\"object\":{\"child\":\"value\"},\"nul\":\"ab\\u0000cd\"}", "\$!src");
+	set $.ret = parse_json("{\"string\":\"local\",\"integer\":7,\"boolean\":false}", "\$.src");
+	set $.ret = parse_json("{\"string\":\"global\",\"integer\":9,\"boolean\":true}", "\$/src");
+
+	set $!out!flat = $!src!flat.key;
+	set $!out!nested = $!src!nested!value;
+	set $!out!string = $!src!string;
+	set $!out!empty = $!src!empty;
+	set $!out!missing = $!src!missing;
+	set $!out!null = $!src!null;
+	set $!out!integer = $!src!integer;
+	set $!out!boolean = $!src!boolean;
+	set $!out!double = $!src!double;
+	set $!out!array = $!src!array;
+	set $!out!object = $!src!object;
+	set $!out!nul_read = $!src!nul;
+	set $!out!whole = $!src;
+	set $!out!local_string = $.src!string;
+	set $!out!local_integer = $.src!integer;
+	set $!out!local_boolean = $.src!boolean;
+	set $!out!local_whole = $.src;
+	set $!out!global_string = $/src!string;
+	set $!out!global_integer = $/src!integer;
+	set $!out!global_boolean = $/src!boolean;
+	set $!out!global_whole = $/src;
+	action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
+}
+'
+
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='{ "set_nul": "abcdef", "flat": "flat", "nested": "nested", "string": "text", "empty": "", "missing": "", "null": "", "integer": 42, "boolean": true, "double": 1.5, "array": [ "one", 2 ], "object": { "child": "value" }, "nul_read": "ab", "whole": { "flat.key": "flat", "nested": { "value": "nested" }, "string": "text", "empty": "", "null": null, "integer": 42, "boolean": true, "double": 1.5, "array": [ "one", 2 ], "object": { "child": "value" }, "nul": "ab" }, "local_string": "local", "local_integer": 7, "local_boolean": false, "local_whole": { "string": "local", "integer": 7, "boolean": false }, "global_string": "global", "global_integer": 9, "global_boolean": true, "global_whole": { "string": "global", "integer": 9, "boolean": true } }'
+cmp_exact
+exit_test


### PR DESCRIPTION
## Summary
- remove the normal-path temporary C string from JSON string assignments
- return owned expression strings directly from the internal JSON getter
- retain existing locks, native JSON deep copies, errors, and embedded-NUL semantics
- add exact-output normal, Valgrind, and Turbo materialization coverage

## Validation
- focused normal and Valgrind regressions: passed
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j10`: passed (970 tests)
- ASAN/UBSAN Ubuntu 26.04 container: passed (1,399 passed; 51 expected skips)
- CI-equivalent Ubuntu 26.04 container: passed after final formatting (1,551 passed; 69 expected skips)
- clang-format dry-run, shell syntax, and whitespace checks: passed
- clang static analyzer found one existing `runtime/modules.c` finding, none in changed code

## Performance acceptance
The PANW workload artifacts are external and were not available locally. Before merge, run the specified paired baseline/candidate A/B procedure at 1, 4, and 16 workers; retain only if both sessions meet the >=5% median improvement criterion at one or more worker counts with no median regression worse than 3%.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

