### PR TITLE
tests: make segmented DA idle cleanup check stable

### DIFF
--- a/tests/segmented-da-idle-cleanup-failure.sh
+++ b/tests/segmented-da-idle-cleanup-failure.sh
@@ -27,6 +27,24 @@ wait_path() {
 	done
 }
 
+wait_restored_empty_store() {
+	local timeoutend=$((SECONDS + 30)) segment_count
+	while true; do
+		# Cleanup retries may briefly leave only the deliberately foreign blocker
+		# between deleting the old topology and recreating the empty one.  Inspect
+		# the replacement state as one predicate rather than treating those
+		# independent filesystem observations as a stable snapshot.
+		if [ -f "$SEG_DIR/state" ] &&
+			find "$SEG_DIR" -maxdepth 1 -name '*.open' -print -quit | grep -q .; then
+			segment_count=$(find "$SEG_DIR" -maxdepth 1 -type f -name 'segment-*' -print | wc -l)
+			[ "$segment_count" -eq 1 ] && return
+		fi
+		[ "$SECONDS" -lt "$timeoutend" ] ||
+			error_exit 1 "cleanup failure did not restore one active segment"
+		./msleep 50
+	done
+}
+
 generate_conf
 add_conf '
 global(workDirectory="'"$SPOOL_DIR"'")
@@ -47,12 +65,7 @@ wait_path present "$SEG_DIR"
 touch "$SEG_DIR/blocker"
 wait_file_lines "$RSYSLOG_OUT_LOG" "$NUMMESSAGES" 300
 wait_content 'store.idleCleanupFailures=1' "$STATS_FILE"
-wait_path present "$SEG_DIR/state"
-find "$SEG_DIR" -maxdepth 1 -name '*.open' -print -quit | grep -q . ||
-	error_exit 1 "cleanup failure did not restore an active segment"
-segment_count=$(find "$SEG_DIR" -maxdepth 1 -type f -name 'segment-*' -print | wc -l)
-[ "$segment_count" -eq 1 ] ||
-	error_exit 1 "cleanup failure retained $segment_count segments instead of one replacement active segment"
+wait_restored_empty_store
 rm -f "$SEG_DIR/blocker"
 wait_path absent "$SEG_DIR"
 wait_content 'store.idleDematerializations=1' "$STATS_FILE"


### PR DESCRIPTION
## Summary

Fixes a filesystem snapshot race in the segmented disk-assisted idle-cleanup failure test.

The cleanup retry intentionally has a short interval after deleting the old topology and before rebuilding the empty store. The test now waits for the state file, active segment, and exact segment count as one coherent predicate instead of inspecting them independently.

## Validation

- Focused test: 10 consecutive passes
- Ubuntu 26.04 CI-equivalent container: the changed test passed
- ShellCheck, test-antipattern scan, and mock distcheck passed
- Broad container suite: 1409 passed, 74 skipped, 2 unrelated failures: imudp-headerless-fromhost-ip.sh and parsertest-parse2-udp.sh
- Static analyzer: one unrelated pre-existing runtime/modules.c finding

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

