### PR TITLE
rainerscript: cache repeated selector variable reads

### DIFF
--- a/doc/source/rainerscript/control_structures.rst
+++ b/doc/source/rainerscript/control_structures.rst
@@ -39,6 +39,19 @@ if/else-if/else
    }
 
 
+Selector variable snapshots
+===========================
+
+Within one ``if``/``else if``/``else`` selector, repeated direct reads of the
+same variable use the value from its first evaluation in that selector. The
+snapshot is created lazily, applies only while conditions are being selected,
+and is discarded before the selected branch body runs. As a result, a
+condition-side operation that changes a variable after its first read does not
+affect a later condition in the same selector; the selected branch observes
+the message's actual current value. ``exists()`` keeps its normal independent
+existence check behavior.
+
+
 foreach
 =======
 
@@ -135,4 +148,3 @@ continue
 ========
 
 A NOP, useful e.g. inside the ``then`` part of an if-structure.
-

--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -88,6 +88,7 @@ extern int yyerror(const char*);
 %token IF
 %token THEN
 %token ELSE
+%token ELSEIF
 %token FOREACH
 %token ITERATOR_ASSIGNMENT
 %token DO
@@ -113,7 +114,7 @@ extern int yyerror(const char*);
 %type <obj> obj property constant
 %type <objlst> propconst
 %type <expr> expr
-%type <stmt> stmt s_act actlst block script
+%type <stmt> stmt s_act actlst block script elseif_tail
 %type <itr> iterator_decl
 %type <fparams> fparams
 %type <arr> array arrayelt
@@ -124,10 +125,9 @@ extern int yyerror(const char*);
 %left '*' '/' '%'
 %nonassoc UMINUS NOT
 
-%expect 1 /* dangling else */
-/* If more erors show up, Use "bison -v grammar.y" if more conflicts arise and
- * check grammar.output for were exactly these conflicts exits.
- */
+%nonassoc LOWER_THAN_ELSE
+%nonassoc ELSE ELSEIF
+
 %%
 /* note: we use left recursion below, because that saves stack space AND
  * offers the right sequence so that we can submit the top-layer objects
@@ -167,7 +167,8 @@ value:	  STRING			{ $$ = nvlstNewStr($1); }
 script:	  stmt				{ $$ = $1; }
 	| script stmt			{ $$ = scriptAddStmt($1, $2); }
 stmt:	  actlst			{ $$ = $1; }
-	| IF expr THEN block 		{ $$ = cnfstmtNew(S_IF);
+	| IF expr THEN block %prec LOWER_THAN_ELSE
+					{ $$ = cnfstmtNew(S_IF);
 					  $$->d.s_if.expr = $2;
 					  $$->d.s_if.t_then = $4;
 					  $$->d.s_if.t_else = NULL; }
@@ -175,6 +176,15 @@ stmt:	  actlst			{ $$ = $1; }
 					  $$->d.s_if.expr = $2;
 					  $$->d.s_if.t_then = $4;
 					  $$->d.s_if.t_else = $6; }
+	| IF expr THEN block ELSEIF expr THEN block elseif_tail
+					{ $$ = cnfstmtNew(S_IF);
+					  $$->d.s_if.expr = $2;
+					  $$->d.s_if.t_then = $4;
+					  $$->d.s_if.t_else = cnfstmtNew(S_IF);
+					  $$->d.s_if.t_else->d.s_if.expr = $6;
+					  $$->d.s_if.t_else->d.s_if.t_then = $8;
+					  $$->d.s_if.t_else->d.s_if.t_else = $9;
+					  $$->d.s_if.t_else->d.s_if.is_else_if = 1; }
 	| FOREACH iterator_decl DO block { $$ = cnfstmtNew(S_FOREACH);
 					  $$->d.s_foreach.iter = $2;
 					  $$->d.s_foreach.body = $4;}
@@ -186,6 +196,14 @@ stmt:	  actlst			{ $$ = $1; }
 	| RELOAD_LOOKUP_TABLE_PROCEDURE '(' fparams ')' { $$ = cnfstmtNewReloadLookupTable($3);}
 	| include			{ $$ = NULL; }
 	| BEGINOBJ			{ $$ = NULL; parser_errmsg("declarative object '%s' not permitted in action block [stmt]", yytext);}
+elseif_tail:			%prec LOWER_THAN_ELSE { $$ = NULL; }
+	| ELSE block			{ $$ = $2; }
+	| ELSEIF expr THEN block elseif_tail
+					{ $$ = cnfstmtNew(S_IF);
+					  $$->d.s_if.expr = $2;
+					  $$->d.s_if.t_then = $4;
+					  $$->d.s_if.t_else = $5;
+					  $$->d.s_if.is_else_if = 1; }
 block:    stmt				{ $$ = $1; }
 	| '{' script '}'		{ $$ = $2; }
 actlst:	  s_act				{ $$ = $1; }

--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -408,6 +408,7 @@ static void cnfPrintToken(const char *token);
 "{"				{ cnfPrintToken(yytext); return '{'; }
 "}"				{ cnfPrintToken(yytext); return '}'; }
 "stop"				{ cnfPrintToken(yytext); return STOP; }
+"else"[ \t\r\n]+"if"	{ cnfPrintToken(yytext); BEGIN EXPR; return ELSEIF; }
 "else"				{ cnfPrintToken(yytext); return ELSE; }
 "call"				{ cnfPrintToken(yytext); BEGIN INCALL; return CALL; }
 "call_indirect"			{ cnfPrintToken(yytext); BEGIN EXPR; return CALL_INDIRECT; }

--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -284,6 +284,8 @@ expand_backticks(char *const param)
 	 * wrote this ugly, but the price needed to pay in order to remain
 	 * compatible to the previous format.
 	 */
+%x ELSE_IF
+	/* ELSE_IF preserves the structural else-if link while skipping comments. */
 %{
 #include <ctype.h>
 #include <stdio.h>
@@ -408,8 +410,12 @@ static void cnfPrintToken(const char *token);
 "{"				{ cnfPrintToken(yytext); return '{'; }
 "}"				{ cnfPrintToken(yytext); return '}'; }
 "stop"				{ cnfPrintToken(yytext); return STOP; }
-"else"[ \t\r\n]+"if"	{ cnfPrintToken(yytext); BEGIN EXPR; return ELSEIF; }
-"else"				{ cnfPrintToken(yytext); return ELSE; }
+"else"				{ cnfPrintToken(yytext); BEGIN ELSE_IF; }
+<ELSE_IF>[ \t\r\n]+		{ cnfPrintToken(yytext); }
+<ELSE_IF>"/*"			{ cnfPrintToken(yytext); preCommentState = YY_START; BEGIN COMMENT; }
+<ELSE_IF>#.*\n			{ cnfPrintToken(yytext); }
+<ELSE_IF>"if"			{ cnfPrintToken(yytext); BEGIN EXPR; return ELSEIF; }
+<ELSE_IF>.				{ yyless(0); BEGIN INITIAL; return ELSE; }
 "call"				{ cnfPrintToken(yytext); BEGIN INCALL; return CALL; }
 "call_indirect"			{ cnfPrintToken(yytext); BEGIN EXPR; return CALL_INDIRECT; }
 "set"				{ cnfPrintToken(yytext); BEGIN EXPR; return SET; }

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3707,9 +3707,9 @@ finalize_it:
     if (nParamsEvaluated >= 2) varFreeMembers(&srcVal[2]);
 }
 
-static void evalVar(struct cnfvar *__restrict__ const var,
-                    void *__restrict__ const usrptr,
-                    struct svar *__restrict__ const ret) {
+static void evalVarUncached(struct cnfvar *__restrict__ const var,
+                            void *__restrict__ const usrptr,
+                            struct svar *__restrict__ const ret) {
     rs_size_t propLen;
     uchar *pszProp = NULL;
     unsigned short bMustBeFreed = 0;
@@ -3757,6 +3757,39 @@ static void evalVar(struct cnfvar *__restrict__ const var,
         DBGPRINTF("rainerscript: (string) var %d: '%s'\n", var->prop.id, pszProp);
         if (bMustBeFreed) free(pszProp);
     }
+}
+
+/* A selector cache owns the first value read for its lifetime.  Each
+ * expression evaluation receives its own reference/copy because normal
+ * evaluation releases returned svar members after use. */
+static void copyCachedVar(const struct svar *const src, struct svar *const dst) {
+    dst->datatype = src->datatype;
+    if (src->datatype == 'S') {
+        dst->d.estr = es_strdup(src->d.estr);
+    } else if (src->datatype == 'J') {
+        dst->d.json = json_object_get(src->d.json);
+    } else {
+        dst->d.n = src->d.n;
+    }
+}
+
+static void evalVar(struct cnfvar *__restrict__ const var,
+                    void *__restrict__ const usrptr,
+                    wti_t *const pWti,
+                    struct svar *__restrict__ const ret) {
+    struct rscript_var_cache *const cache = pWti->execState.var_cache;
+
+    if (cache == NULL || var->cache_slot < 0 || (unsigned int)var->cache_slot >= cache->n_entries) {
+        evalVarUncached(var, usrptr, ret);
+        return;
+    }
+
+    struct rscript_var_cache_entry *const entry = &cache->entries[var->cache_slot];
+    if (!entry->populated) {
+        evalVarUncached(var, usrptr, &entry->value);
+        entry->populated = 1;
+    }
+    copyCachedVar(&entry->value, ret);
 }
 
 /* perform a string comparision operation against a while array. Semantic is
@@ -4165,7 +4198,7 @@ void ATTR_NONNULL() cnfexprEval(const struct cnfexpr *__restrict__ const expr,
             ret->d.estr = es_strdup(((struct cnfarray *)expr)->arr[0]);
             break;
         case 'V':
-            evalVar((struct cnfvar *)expr, usrptr, ret);
+            evalVar((struct cnfvar *)expr, usrptr, pWti, ret);
             break;
         case '&':
             /* TODO: think about optimization, should be possible ;) */
@@ -5068,6 +5101,7 @@ struct cnfvar *cnfvarNew(char *name) {
         var->nodetype = 'V';
         var->name = name;
         msgPropDescrFill(&var->prop, (uchar *)var->name, strlen(var->name));
+        var->cache_slot = -1;
     }
     return var;
 }
@@ -5078,6 +5112,10 @@ struct cnfstmt *cnfstmtNew(unsigned s_type) {
         cnfstmt->nodetype = s_type;
         cnfstmt->printable = NULL;
         cnfstmt->next = NULL;
+        if (s_type == S_IF) {
+            cnfstmt->d.s_if.cache_slots = 0;
+            cnfstmt->d.s_if.is_else_if = 0;
+        }
     }
     return cnfstmt;
 }
@@ -5846,6 +5884,128 @@ static void cnfstmtOptimizeForeach(struct cnfstmt *stmt) {
     stmt->d.s_foreach.body = cnfstmtOptimize(stmt->d.s_foreach.body);
 }
 
+struct if_cache_var_use {
+    struct cnfvar *var;
+    unsigned short count;
+};
+
+static int same_var_property(const struct cnfvar *const a, const struct cnfvar *const b) {
+    if (a->prop.id != b->prop.id) return 0;
+
+    /* Native properties are identified solely by their fixed property ID.
+     * Their descriptor name fields are not initialized. */
+    if (a->prop.id != PROP_CEE && a->prop.id != PROP_LOCAL_VAR && a->prop.id != PROP_GLOBAL_VAR) return 1;
+
+    return a->prop.nameLen == b->prop.nameLen &&
+           (a->prop.nameLen == 0 || !memcmp(a->prop.name, b->prop.name, a->prop.nameLen));
+}
+
+static void collect_if_cache_vars(struct cnfexpr *expr, struct if_cache_var_use **uses, size_t *n_uses, size_t *cap) {
+    size_t i;
+    struct cnffunc *func;
+
+    if (expr == NULL) return;
+    switch (expr->nodetype) {
+        case 'V':
+            ((struct cnfvar *)expr)->cache_slot = -1;
+            for (i = 0; i < *n_uses; ++i) {
+                if (same_var_property((*uses)[i].var, (struct cnfvar *)expr)) {
+                    ++(*uses)[i].count;
+                    return;
+                }
+            }
+            if (*n_uses == *cap) {
+                const size_t new_cap = (*cap == 0) ? 8 : *cap * 2;
+                struct if_cache_var_use *const grown = realloc(*uses, new_cap * sizeof(**uses));
+                if (grown == NULL) return;
+                *uses = grown;
+                *cap = new_cap;
+            }
+            (*uses)[*n_uses].var = (struct cnfvar *)expr;
+            (*uses)[*n_uses].count = 1;
+            ++*n_uses;
+            break;
+        case 'F':
+            func = (struct cnffunc *)expr;
+            for (i = 0; i < func->nParams; ++i) collect_if_cache_vars(func->expr[i], uses, n_uses, cap);
+            break;
+        case NOT:
+        case 'M':
+            collect_if_cache_vars(expr->r, uses, n_uses, cap);
+            break;
+        case 'N':
+        case 'S':
+        case 'A':
+        case S_FUNC_EXISTS:
+            break;
+        default:
+            collect_if_cache_vars(expr->l, uses, n_uses, cap);
+            collect_if_cache_vars(expr->r, uses, n_uses, cap);
+            break;
+    }
+}
+
+static void assign_if_cache_slots(struct cnfexpr *expr, const struct if_cache_var_use *uses, const size_t n_uses) {
+    size_t i;
+    struct cnffunc *func;
+
+    if (expr == NULL) return;
+    switch (expr->nodetype) {
+        case 'V':
+            for (i = 0; i < n_uses; ++i) {
+                if (uses[i].var->cache_slot >= 0 && same_var_property(uses[i].var, (struct cnfvar *)expr)) {
+                    ((struct cnfvar *)expr)->cache_slot = uses[i].var->cache_slot;
+                    break;
+                }
+            }
+            break;
+        case 'F':
+            func = (struct cnffunc *)expr;
+            for (i = 0; i < func->nParams; ++i) assign_if_cache_slots(func->expr[i], uses, n_uses);
+            break;
+        case NOT:
+        case 'M':
+            assign_if_cache_slots(expr->r, uses, n_uses);
+            break;
+        case 'N':
+        case 'S':
+        case 'A':
+        case S_FUNC_EXISTS:
+            break;
+        default:
+            assign_if_cache_slots(expr->l, uses, n_uses);
+            assign_if_cache_slots(expr->r, uses, n_uses);
+            break;
+    }
+}
+
+/* A false if condition executes no branch body.  Consequently every direct
+ * variable read in one structural else-if selector may share a lazy snapshot
+ * until the selector chooses its branch. */
+static void cnfstmt_optimize_if_cache(struct cnfstmt *const stmt) {
+    struct cnfstmt *cur = stmt;
+    struct if_cache_var_use *uses = NULL;
+    size_t n_uses = 0, cap = 0, i;
+    unsigned short slot = 0;
+
+    do {
+        cur->d.s_if.cache_slots = 0;
+        collect_if_cache_vars(cur->d.s_if.expr, &uses, &n_uses, &cap);
+        cur = cur->d.s_if.t_else;
+    } while (cur != NULL && cur->nodetype == S_IF && cur->d.s_if.is_else_if);
+
+    for (i = 0; i < n_uses; ++i) {
+        if (uses[i].count >= 2 && slot < USHRT_MAX) uses[i].var->cache_slot = slot++;
+    }
+    cur = stmt;
+    do {
+        assign_if_cache_slots(cur->d.s_if.expr, uses, n_uses);
+        cur = cur->d.s_if.t_else;
+    } while (cur != NULL && cur->nodetype == S_IF && cur->d.s_if.is_else_if);
+    stmt->d.s_if.cache_slots = slot;
+    free(uses);
+}
+
 
 static void cnfstmtOptimizeIf(struct cnfstmt *stmt) {
     struct cnfstmt *t_then, *t_else;
@@ -5899,6 +6059,7 @@ static void cnfstmtOptimizeIf(struct cnfstmt *stmt) {
             cnfstmtOptimizePRIFilt(stmt);
         }
     }
+    if (stmt->nodetype == S_IF) cnfstmt_optimize_if_cache(stmt);
 done:
     return;
 }

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -6040,7 +6040,7 @@ static void cnfstmtOptimizeIf(struct cnfstmt *stmt) {
     }
 
     assert(stmt->nodetype == S_IF);
-    if (stmt->d.s_if.expr->nodetype == 'F') {
+    if (!stmt->d.s_if.is_else_if && stmt->d.s_if.expr->nodetype == 'F') {
         func = (struct cnffunc *)expr;
         if (func->fPtr == doFunct_Prifilt) {
             DBGPRINTF("optimizer: change IF to PRIFILT\n");

--- a/grammar/rainerscript.h
+++ b/grammar/rainerscript.h
@@ -136,6 +136,8 @@ struct cnfstmt {
             struct cnfexpr *expr;
             struct cnfstmt *t_then;
             struct cnfstmt *t_else;
+            unsigned short cache_slots;
+            sbool is_else_if;
         } s_if;
         struct {
             uchar *varname;
@@ -205,7 +207,18 @@ struct cnfvar {
     unsigned nodetype;
     char *name;
     msgPropDescr_t prop;
+    int cache_slot;
 } __attribute__((aligned(8)));
+
+struct rscript_var_cache_entry {
+    struct svar value;
+    sbool populated;
+};
+
+struct rscript_var_cache {
+    struct rscript_var_cache_entry *entries;
+    unsigned short n_entries;
+};
 
 struct cnfarray {
     unsigned nodetype;

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -295,15 +295,46 @@ finalize_it:
 
 static rsRetVal execIf(struct cnfstmt *const stmt, smsg_t *const pMsg, wti_t *const pWti) {
     int bRet;
+    struct cnfstmt *cur = stmt;
+    struct cnfstmt *selected = NULL;
+    struct rscript_var_cache cache = {0};
+    struct rscript_var_cache *const previous_cache = pWti->execState.var_cache;
     DEFiRet;
-    bRet = cnfexprEvalBool(stmt->d.s_if.expr, pMsg, pWti);
-    DBGPRINTF("if condition result is %d\n", bRet);
-    if (bRet) {
-        if (stmt->d.s_if.t_then != NULL) CHKiRet(scriptExec(stmt->d.s_if.t_then, pMsg, pWti));
+
+    if (stmt->d.s_if.cache_slots == 0) {
+        bRet = cnfexprEvalBool(stmt->d.s_if.expr, pMsg, pWti);
+        DBGPRINTF("if condition result is %d\n", bRet);
+        selected = bRet ? stmt->d.s_if.t_then : stmt->d.s_if.t_else;
     } else {
-        if (stmt->d.s_if.t_else != NULL) CHKiRet(scriptExec(stmt->d.s_if.t_else, pMsg, pWti));
+        cache.n_entries = stmt->d.s_if.cache_slots;
+        cache.entries = calloc(cache.n_entries, sizeof(*cache.entries));
+        if (cache.entries == NULL) {
+            /* Allocation failure preserves the old interpreter path. */
+            bRet = cnfexprEvalBool(stmt->d.s_if.expr, pMsg, pWti);
+            selected = bRet ? stmt->d.s_if.t_then : stmt->d.s_if.t_else;
+        } else {
+            pWti->execState.var_cache = &cache;
+            for (;;) {
+                bRet = cnfexprEvalBool(cur->d.s_if.expr, pMsg, pWti);
+                DBGPRINTF("if condition result is %d\n", bRet);
+                if (bRet) {
+                    selected = cur->d.s_if.t_then;
+                    break;
+                }
+                selected = cur->d.s_if.t_else;
+                if (selected == NULL || selected->nodetype != S_IF || !selected->d.s_if.is_else_if) break;
+                cur = selected;
+            }
+            pWti->execState.var_cache = previous_cache;
+            for (unsigned short i = 0; i < cache.n_entries; ++i) {
+                if (cache.entries[i].populated) varFreeMembers(&cache.entries[i].value);
+            }
+            free(cache.entries);
+        }
     }
+    if (selected != NULL) CHKiRet(scriptExec(selected, pMsg, pWti));
 finalize_it:
+    pWti->execState.var_cache = previous_cache;
     RETiRet;
 }
 

--- a/runtime/translate.c
+++ b/runtime/translate.c
@@ -1166,21 +1166,33 @@ static int stmtListToString(es_str_t **out,
                     estrAppendVarName(out, (char *)stmt->d.s_unset.varname) != 0 || estrAppendCstr(out, ";\n") != 0)
                     return -1;
                 break;
-            case S_IF:
-                if (appendIndent(out, indent) != 0 || estrAppendCstr(out, "if ") != 0 ||
-                    exprToString(out, stmt->d.s_if.expr, warnings) != 0 || estrAppendCstr(out, " then {\n") != 0 ||
-                    stmtListToString(out, stmt->d.s_if.t_then, indent + 1, warnings) != 0)
-                    return -1;
-                if (appendIndent(out, indent) != 0) return -1;
-                if (stmt->d.s_if.t_else != NULL) {
-                    if (estrAppendCstr(out, "} else {\n") != 0 ||
-                        stmtListToString(out, stmt->d.s_if.t_else, indent + 1, warnings) != 0 ||
-                        appendIndent(out, indent) != 0 || estrAppendCstr(out, "}\n") != 0)
+            case S_IF: {
+                const struct cnfstmt *if_stmt = stmt;
+
+                for (;;) {
+                    if (appendIndent(out, indent) != 0 ||
+                        estrAppendCstr(out, if_stmt == stmt ? "if " : "} else if ") != 0 ||
+                        exprToString(out, if_stmt->d.s_if.expr, warnings) != 0 ||
+                        estrAppendCstr(out, " then {\n") != 0 ||
+                        stmtListToString(out, if_stmt->d.s_if.t_then, indent + 1, warnings) != 0)
                         return -1;
-                } else if (estrAppendCstr(out, "}\n") != 0) {
-                    return -1;
+                    if (if_stmt->d.s_if.t_else != NULL && if_stmt->d.s_if.t_else->nodetype == S_IF &&
+                        if_stmt->d.s_if.t_else->next == NULL && if_stmt->d.s_if.t_else->d.s_if.is_else_if) {
+                        if_stmt = if_stmt->d.s_if.t_else;
+                        continue;
+                    }
+                    if (appendIndent(out, indent) != 0) return -1;
+                    if (if_stmt->d.s_if.t_else != NULL) {
+                        if (estrAppendCstr(out, "} else {\n") != 0 ||
+                            stmtListToString(out, if_stmt->d.s_if.t_else, indent + 1, warnings) != 0 ||
+                            appendIndent(out, indent) != 0 || estrAppendCstr(out, "}\n") != 0)
+                            return -1;
+                    } else if (estrAppendCstr(out, "}\n") != 0) {
+                        return -1;
+                    }
+                    break;
                 }
-                break;
+            } break;
             case S_FOREACH:
                 if (appendIndent(out, indent) != 0 || estrAppendCstr(out, "foreach (") != 0 ||
                     estrAppendVarName(out, stmt->d.s_foreach.iter->var) != 0 || estrAppendCstr(out, " in ") != 0 ||

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -29,6 +29,8 @@
 #include "batch.h"
 #include "action.h"
 
+struct rscript_var_cache;
+
 
 #define ACT_STATE_RDY 0 /* action ready, waiting for new transaction */
 #define ACT_STATE_ITX 1 /* transaction active, waiting for new data or commit */
@@ -93,6 +95,7 @@ struct wti_s {
                                     * also be added as a user-selectable option (not implemented yet)
                                     */
             uint16_t rulesetCallDepth; /* synchronous ruleset call nesting depth */
+            struct rscript_var_cache *var_cache; /* selector-local RainerScript snapshots */
         } execState; /* state for the execution engine */
 };
 
@@ -151,6 +154,7 @@ static inline void __attribute__((unused)) wtiResetExecState(wti_t *const pWti, 
     pWti->execState.bPrevWasSuspended = 0;
     pWti->execState.bDoAutoCommit = (batchNumMsgs(pBatch) == 1);
     pWti->execState.rulesetCallDepth = 0;
+    pWti->execState.var_cache = NULL;
 }
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -536,6 +536,7 @@ TESTS_DEFAULT = \
 	snd-array-cmp-json.sh \
 	rscript_b64_decode.sh \
 	rscript-json-var-eval-semantics.sh \
+	rscript-if-chain-snapshot.sh \
 	rscript_tocef.sh \
 	rscript_contains.sh \
 	rscript_bare_var_root.sh \
@@ -739,6 +740,7 @@ TESTS_DEFAULT_VALGRIND = \
 	include-obj-text-vg.sh \
 	rscript_b64_decode-vg.sh \
 	rscript-json-var-eval-semantics-vg.sh \
+	rscript-if-chain-snapshot-vg.sh \
 	rscript_parse_json-vg.sh \
 	rscript_backticks-vg.sh \
 	rscript_backticks_empty_envvar.sh \

--- a/tests/config-translate-rs-script-expressions.sh
+++ b/tests/config-translate-rs-script-expressions.sh
@@ -4,7 +4,7 @@
 # This is a cheap -N1 translation test for runtime/translate.c's script
 # serializer. It covers escaped strings, arrays, unary minus, set/reset/unset,
 # boolean/comparison expressions, exists(), foreach, call, call_indirect, and
-# if/else block formatting. The translated RainerScript is validated again so
+# if/else and else-if formatting. The translated RainerScript is validated again so
 # the exact-output oracle proves the emitted config remains parseable.
 #
 # Part of the testbench for rsyslog.
@@ -33,6 +33,13 @@ ruleset(name="main") {
   } else {
     call_indirect "tar" & "get";
   }
+  if $msg contains "first" then {
+    stop
+  } else if $msg contains "second" then {
+    stop
+  } else {
+    stop
+  }
 }
 RS_EOF
 sed "s|@TARGET_OUT@|${target_out}|g" "${RSYSLOG_DYNNAME}.conf" >"${RSYSLOG_DYNNAME}.conf.tmp" &&
@@ -58,6 +65,13 @@ ruleset(name="main") {
     }
   } else {
     call_indirect ("tar" & "get");
+  }
+  if ($msg contains "first") then {
+    stop
+  } else if ($msg contains "second") then {
+    stop
+  } else {
+    stop
   }
 }
 

--- a/tests/rscript-if-chain-snapshot-vg.sh
+++ b/tests/rscript-if-chain-snapshot-vg.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
+# Run the selector snapshot regression under Valgrind.
+# This file is part of the rsyslog project, released under ASL 2.0.
+export USE_VALGRIND="YES"
+. ${srcdir:=.}/rscript-if-chain-snapshot.sh

--- a/tests/rscript-if-chain-snapshot.sh
+++ b/tests/rscript-if-chain-snapshot.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+#
+# Verify that repeated direct variable reads in one if/else-if selector use a
+# lazy first-read snapshot. The first false condition changes $!snap; the next
+# condition must still match the cached original while the selected body sees
+# the actual changed message value. A braced else-body nested if must instead
+# see the live value. Exact output after synchronized shutdown is the oracle
+# for selector ordering, cache lifetime, and post-selection state.
+# This file is part of the rsyslog project, released under ASL 2.0.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%$.selector%|%$!snap%\n")
+
+if $msg contains "msgnum:" then {
+	set $!snap = "before";
+	if ($!snap == "before" and parse_json("{\"snap\":\"after\"}", "\$!") == 0 and $msg == "never") then {
+		set $.selector = "wrong";
+	} else if ($!snap == "before" and $msg contains "msgnum:") then {
+		set $.selector = "snapshot";
+	} else {
+		set $.selector = "wrong";
+	}
+	action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
+}
+
+if $msg contains "msgnum:" then {
+	set $!snap = "before";
+	if ($!snap == "before" and parse_json("{\"snap\":\"after\"}", "\$!") == 0 and $msg == "never") then {
+		set $.selector = "wrong";
+	} else {
+		if ($!snap == "after") then {
+			set $.selector = "nested-live";
+		} else {
+			set $.selector = "nested-stale";
+		}
+	}
+	action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
+}
+'
+
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='snapshot|after
+nested-live|after'
+cmp_exact
+exit_test

--- a/tests/rscript-if-chain-snapshot.sh
+++ b/tests/rscript-if-chain-snapshot.sh
@@ -20,7 +20,8 @@ if $msg contains "msgnum:" then {
 	set $!snap = "before";
 	if ($!snap == "before" and parse_json("{\"snap\":\"after\"}", "\$!") == 0 and $msg == "never") then {
 		set $.selector = "wrong";
-	} else if ($!snap == "before" and $msg contains "msgnum:") then {
+	} else /* block comments */ # line comments also retain else-if selector semantics
+	if ($!snap == "before" and $msg contains "msgnum:") then {
 		set $.selector = "snapshot";
 	} else {
 		set $.selector = "wrong";
@@ -41,6 +42,20 @@ if $msg contains "msgnum:" then {
 	}
 	action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
 }
+
+if $msg contains "msgnum:" then {
+	set $!snap = "before";
+	if ($!snap == "before" and parse_json("{\"snap\":\"after\"}", "\$!") == 0 and $msg == "never") then {
+		set $.selector = "wrong";
+	} else if (prifilt("local4.*") and $!snap == "before") then {
+		if ($!snap == "before") then {
+			set $.selector = "prifilt-snapshot";
+		} else {
+			set $.selector = "prifilt-live";
+		}
+	}
+	action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
+}
 '
 
 startup
@@ -49,6 +64,7 @@ shutdown_when_empty
 wait_shutdown
 
 export EXPECTED='snapshot|after
-nested-live|after'
+nested-live|after
+prifilt-live|after'
 cmp_exact
 exit_test


### PR DESCRIPTION
## Summary

- cache repeated direct variable reads while evaluating one structural `if / else if / else` selector chain
- discard lazy first-read snapshots before entering the selected branch
- distinguish structural `else if` from a nested `if` inside a braced `else` body
- document the selector-snapshot rule in a dedicated behavior commit

## Validation

- focused normal selector-cache regression passed
- focused Valgrind regression passed with zero errors
- parser grammar builds without shift/reduce or reduce/reduce conflicts
- the previous full hosted run was green except arm64 ASAN; this updated head has a fresh CI run
- broad local incremental `make check TESTS=""` is blocked by missing `rabbitmq-c/amqp.h` in the local environment