### PR TITLE
packaging: retry Alpine baseline fetches

### DIFF
--- a/.github/workflows/alpine324_daily_stable.yml
+++ b/.github/workflows/alpine324_daily_stable.yml
@@ -157,7 +157,7 @@ jobs:
             if timeout 90s git clone --depth 1 --branch "$ALPINE_BRANCH" \
               --filter=blob:none --sparse \
               https://gitlab.alpinelinux.org/alpine/aports.git "$baseline_dir"; then
-              if git -C "$baseline_dir" sparse-checkout set main/rsyslog; then
+              if timeout 90s git -C "$baseline_dir" sparse-checkout set main/rsyslog; then
                 baseline_fetched=true
                 break
               fi
@@ -169,7 +169,6 @@ jobs:
             echo "::error::could not fetch the Alpine $ALPINE_BRANCH packaging baseline"
             exit 1
           }
-          git -C "$baseline_dir" sparse-checkout set main/rsyslog
           baseline_sha="$(git -C "$baseline_dir" rev-parse HEAD)"
           echo "baseline_sha=$baseline_sha" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/alpine324_daily_stable.yml
+++ b/.github/workflows/alpine324_daily_stable.yml
@@ -150,11 +150,25 @@ jobs:
       - name: Fetch official Alpine 3.24 packaging baseline
         id: packaging
         run: |
-          git clone --depth 1 --branch "$ALPINE_BRANCH" --filter=blob:none \
-            --sparse https://gitlab.alpinelinux.org/alpine/aports.git \
-            "$RUNNER_TEMP/alpine-aports"
-          git -C "$RUNNER_TEMP/alpine-aports" sparse-checkout set main/rsyslog
-          baseline_sha="$(git -C "$RUNNER_TEMP/alpine-aports" rev-parse HEAD)"
+          baseline_dir="$RUNNER_TEMP/alpine-aports"
+          baseline_fetched=false
+          for attempt in 1 2 3; do
+            rm -rf "$baseline_dir"
+            if timeout 90s git clone --depth 1 --branch "$ALPINE_BRANCH" \
+              --filter=blob:none --sparse \
+              https://gitlab.alpinelinux.org/alpine/aports.git "$baseline_dir"; then
+              baseline_fetched=true
+              break
+            fi
+            echo "::warning::Alpine baseline fetch failed (attempt $attempt/3)"
+            [ "$attempt" -eq 3 ] || sleep "$((attempt * 15))"
+          done
+          [ "$baseline_fetched" = true ] || {
+            echo "::error::could not fetch the Alpine $ALPINE_BRANCH packaging baseline"
+            exit 1
+          }
+          git -C "$baseline_dir" sparse-checkout set main/rsyslog
+          baseline_sha="$(git -C "$baseline_dir" rev-parse HEAD)"
           echo "baseline_sha=$baseline_sha" >> "$GITHUB_OUTPUT"
 
       - name: Generate rsyslog dist tarball

--- a/.github/workflows/alpine324_daily_stable.yml
+++ b/.github/workflows/alpine324_daily_stable.yml
@@ -157,8 +157,10 @@ jobs:
             if timeout 90s git clone --depth 1 --branch "$ALPINE_BRANCH" \
               --filter=blob:none --sparse \
               https://gitlab.alpinelinux.org/alpine/aports.git "$baseline_dir"; then
-              baseline_fetched=true
-              break
+              if git -C "$baseline_dir" sparse-checkout set main/rsyslog; then
+                baseline_fetched=true
+                break
+              fi
             fi
             echo "::warning::Alpine baseline fetch failed (attempt $attempt/3)"
             [ "$attempt" -eq 3 ] || sleep "$((attempt * 15))"


### PR DESCRIPTION
## Summary

Retry the canonical Alpine aports baseline fetch up to three times, with a 90-second timeout per attempt and 15/30-second backoff. Partial clones are removed before retry and sparse checkout is only attempted after a successful clone.

The workflow deliberately continues to use the official GitLab repository. The GitHub mirror was considered but is not used because its `3.24-stable` branch can lag the authoritative baseline.

Closes https://github.com/rsyslog/rsyslog/issues/7536

## Validation

- `actionlint .github/workflows/alpine324_daily_stable.yml`
- `zizmor --strict-collection .github/workflows` (pinned 1.29.0)
- Ubuntu 26.04 CI-equivalent container run: 1,618 total; 1,549 passed; 69 skipped; 0 failed; 0 errors
- Local security delta review: passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

