### PR TITLE
packaging: retry EL10 mirrorlist outages

### DIFF
--- a/.github/workflows/el10_daily_stable.yml
+++ b/.github/workflows/el10_daily_stable.yml
@@ -213,7 +213,12 @@ jobs:
                     dnf -q -y install \
                       curl git mock mock-core-configs python3 rpm-build tar gzip
                 ) 2>&1 | tee "$bootstrap_log"
-                bootstrap_status="${PIPESTATUS[0]}"
+                pipeline_status=("${PIPESTATUS[@]}")
+                bootstrap_status="${pipeline_status[0]}"
+                tee_status="${pipeline_status[1]}"
+                if [ "$bootstrap_status" -eq 0 ] && [ "$tee_status" -ne 0 ]; then
+                  bootstrap_status="$tee_status"
+                fi
                 set -e
                 [ "$bootstrap_status" -eq 0 ] && break
                 if ! grep -Fq "No URLs in mirrorlist" "$bootstrap_log"; then

--- a/.github/workflows/el10_daily_stable.yml
+++ b/.github/workflows/el10_daily_stable.yml
@@ -204,9 +204,28 @@ jobs:
             -w /workspace \
             quay.io/rockylinux/rockylinux:10 bash -lc '
               set -euo pipefail
-              dnf -q -y install epel-release >/dev/null
-              dnf -q -y install \
-                curl git mock mock-core-configs python3 rpm-build tar gzip >/dev/null
+              bootstrap_log=/tmp/el10-bootstrap.log
+              bootstrap_status=1
+              for attempt in 1 2 3; do
+                set +e
+                (
+                  dnf -q -y install epel-release &&
+                    dnf -q -y install \
+                      curl git mock mock-core-configs python3 rpm-build tar gzip
+                ) 2>&1 | tee "$bootstrap_log"
+                bootstrap_status="${PIPESTATUS[0]}"
+                set -e
+                [ "$bootstrap_status" -eq 0 ] && break
+                if ! grep -Fq "No URLs in mirrorlist" "$bootstrap_log"; then
+                  exit "$bootstrap_status"
+                fi
+                echo "CentOS mirrorlist was unavailable (attempt $attempt/3)"
+                [ "$attempt" -eq 3 ] || {
+                  dnf -q clean all || true
+                  sleep "$((attempt * 15))"
+                }
+              done
+              [ "$bootstrap_status" -eq 0 ] || exit "$bootstrap_status"
               "$RPM_DAILY_STABLE_HELPER" prepare-sources \
                 /runner-temp/el10-packaging \
                 "$DIST_TARBALL" \


### PR DESCRIPTION
## Summary

Retries only the known transient Rocky 10/CentOS `No URLs in mirrorlist` failure while installing EL10 build dependencies. It cleans DNF metadata and uses bounded 15/30-second backoff; unrelated bootstrap and package-build failures remain fail-fast.

Closes https://github.com/rsyslog/rsyslog/issues/7498

## Validation

- actionlint and pinned zizmor
- Rocky 10 bootstrap smoke test
- Ubuntu 26.04 CI-equivalent container run: 1,618 total; 1,549 passed; 69 skipped; 0 failed; 0 errors
- Security delta review: passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

