### PR TITLE
tests: deflake Debian rebuild checks

### DIFF
--- a/tests/diskqueue-oncorruption-missing-segment.sh
+++ b/tests/diskqueue-oncorruption-missing-segment.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Validate queue.onCorruption behavior when a middle disk-queue segment
 # is missing at startup.
+# In-memory recovery is proven by its two internal diagnostics before an
+# immediate shutdown; waiting for them avoids racing the asynchronous omfile
+# action on loaded parallel test runners.
 # added 2026-02-07 by AI-assisted development, released under ASL 2.0
 
 . ${srcdir:=.}/diag.sh init
@@ -60,7 +63,7 @@ create_missing_middle_segment() {
 		seg_files+=("$base")
 	done
 	if [ "${#seg_files[@]}" -gt 0 ]; then
-		IFS=$'\n' seg_files=($(printf '%s\n' "${seg_files[@]}" | sort -t. -k2,2n))
+		mapfile -t seg_files < <(printf '%s\n' "${seg_files[@]}" | sort -t. -k2,2n)
 		unset IFS
 	fi
 
@@ -94,7 +97,10 @@ run_mode_check() {
 	: > "$STARTED_LOG"
 
 	startup
-	$TESTTOOL_DIR/msleep 500
+	if [ "$mode" = "inMemory" ]; then
+		wait_content "Queue corruption detected. Entering emergency in-memory mode" "$STARTED_LOG"
+		wait_content "pure in-memory emergency mode" "$STARTED_LOG"
+	fi
 	shutdown_immediate
 	if [ "$mode" = "ignore" ]; then
 		wait_shutdown "" "${TB_TEST_TIMEOUT:-90}"

--- a/tests/imfile-bad-state-file.sh
+++ b/tests/imfile-bad-state-file.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Verify that imfile ignores a malformed state file and falls back to a fresh read.
+# The sequence wait proves imfile reached EOF before each shutdown, so the
+# persisted state and the fallback assertion cannot depend on runner timing.
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
@@ -21,6 +23,7 @@ if $msg contains "msgnum:" then
 
 ./inputfilegen -m5 > "$RSYSLOG_DYNNAME.input"
 startup
+wait_seq_check 0 4
 shutdown_when_empty
 wait_shutdown
 seq_check 0 4
@@ -36,6 +39,7 @@ printf '{"curr_offs":\n' > "$statefile"
 rm -f "$RSYSLOG_OUT_LOG"
 
 startup
+wait_seq_check 0 4
 shutdown_when_empty
 wait_shutdown
 seq_check 0 4

--- a/tests/imfile-persist-state-1.sh
+++ b/tests/imfile-persist-state-1.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Verify imfile persists its state after consuming a complete multiline input.
+# Waiting for the expected sequence before shutdown prevents a loaded runner
+# from persisting a partial read and turning this into a timing-dependent test.
 # added 2016-11-02 by rgerhards
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . ${srcdir:=.}/diag.sh init
@@ -24,6 +27,7 @@ if $msg contains "msgnum:" then
 # soon as it start up (so the file should exist at that point).
 ./inputfilegen -m5 -d4000 > $RSYSLOG_DYNNAME.input
 startup
+wait_seq_check 0 3
 shutdown_when_empty
 wait_shutdown
 seq_check 0 3


### PR DESCRIPTION
## Summary
- wait for imfile input consumption before shutting down state-file tests
- wait for in-memory disk queue recovery diagnostics instead of a fixed startup sleep
- use a ShellCheck-safe Bash array sort

## Validation
- Earlier focused Ubuntu 26.04 container run: the three affected tests passed.
- Static analyzer: no bugs found.
- The broad container suite had unrelated failures:  hit a MySQL action-queue timeout;  passed when rerun serially.
- Per maintainer instruction, no additional tests were run after the final ShellCheck-only amendment.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

