### PR TITLE
runtime: bound classic PRI separator scan

### DIFF
--- a/runtime/conf.c
+++ b/runtime/conf.c
@@ -367,7 +367,7 @@ rsRetVal DecodePRIFilter(uchar *pline, uchar pmask[]) {
 
         /* skip cruft */
         if (*q) {
-            while (strchr(",;", *q)) q++;
+            while (*q && strchr(",;", *q)) q++;
         }
 
         /* decode priority name */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -59,6 +59,9 @@ EXTRA_DIST += $(TESTS_RSCRIPT_OBJECT_STRINGS)
 TESTS_RSCRIPT_REPLACE_OVERLAP = rscript_replace-overlap.sh
 EXTRA_DIST += $(TESTS_RSCRIPT_REPLACE_OVERLAP)
 
+TESTS_PRIFILT_TRAILING_SEPARATOR = prifilt-trailing-separator.sh prifilt-trailing-separator-vg.sh
+EXTRA_DIST += $(TESTS_PRIFILT_TRAILING_SEPARATOR)
+
 TESTS_TEMPLATE_PARAMETER_ERRORS = template-parameter-errors.sh
 EXTRA_DIST += $(TESTS_TEMPLATE_PARAMETER_ERRORS)
 
@@ -543,6 +546,7 @@ TESTS_DEFAULT = \
 	rscript_stop2.sh \
 	rscript_prifilt.sh \
 	rscript_prifilt_negated_exact.sh \
+	$(TESTS_PRIFILT_TRAILING_SEPARATOR) \
 	rscript_optimizer1.sh \
 	rscript_optimizer_const_cmp.sh \
 	rscript_ruleset_call.sh \

--- a/tests/prifilt-trailing-separator-vg.sh
+++ b/tests/prifilt-trailing-separator-vg.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Run the trailing PRI separator regression under Valgrind so an invalid read
+# in DecodePRIFilter makes the otherwise accepted configuration test fail.
+# Sanitizer builds exercise the base test directly; Valgrind cannot launch
+# binaries compiled with AddressSanitizer or ThreadSanitizer.
+case "${CFLAGS:-}" in
+    *-fsanitize=*)
+        exit 77
+        ;;
+esac
+
+# Some distribution images ship Valgrind without the loader symbols it needs
+# to start. Keep the ordinary regression active and skip only this unavailable
+# Valgrind oracle in that environment.
+if ! valgrind --error-exitcode=10 true >/dev/null 2>&1; then
+    exit 77
+fi
+
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/prifilt-trailing-separator.sh

--- a/tests/prifilt-trailing-separator.sh
+++ b/tests/prifilt-trailing-separator.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Regression test for https://github.com/rsyslog/rsyslog/issues/7546, reported
+# by LuciyVI. A classic PRI selector ending in ';' must complete configuration
+# validation without reading past its terminating NUL. The Valgrind wrapper
+# makes any invalid read fail with its distinct exit status.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+local0.info; stop
+'
+
+rsyslogd_command=(../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR")
+if [ "$USE_VALGRIND" = "YES" ]; then
+    rsyslogd_command=(valgrind --error-exitcode=10 --leak-check=no --malloc-fill=ff --free-fill=fe \
+        --suppressions="$srcdir/known_issues.supp" "${rsyslogd_command[@]}")
+fi
+
+"${rsyslogd_command[@]}" >"${RSYSLOG_DYNNAME}.log" 2>&1
+rsyslogd_status=$?
+if [ "$rsyslogd_status" -ne 0 ]; then
+    echo "FAIL: trailing PRI separator config validation returned $rsyslogd_status"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit "$rsyslogd_status"
+fi
+
+content_check "End of config validation run" "${RSYSLOG_DYNNAME}.log"
+
+exit_test


### PR DESCRIPTION
## Summary

- Bound the classic PRI separator scan at the selector NUL terminator.
- Add normal and Valgrind regression coverage for `local0.info; stop`.
- Credit @LuciyVI for the report and focused reproducer.

Closes https://github.com/rsyslog/rsyslog/issues/7546

## Validation

- Focused normal and Valgrind regressions: passed.
- `validation-run.sh`: passed.
- Ubuntu 26.04 static analyzer: passed with no reports.
- Ubuntu 26.04 change-gated check: both new tests passed. The broader run had five unrelated failures in imfile state, per-source rate-limit reload, and omprog restart tests (1549 passed, 69 skipped, 5 failed).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

