### PR TITLE
tests: wait for imfile fd-check pid readiness

### DIFF
--- a/tests/imfile-inotify-fd-release-on-delete.sh
+++ b/tests/imfile-inotify-fd-release-on-delete.sh
@@ -25,7 +25,9 @@ if $msg contains "msgnum:" then
 startup
 wait_file_lines "$RSYSLOG_OUT_LOG" $TESTMESSAGES $RETRIES
 
-PID=$(cat "$RSYSLOG_PIDBASE".pid)
+# The imdiag startup marker can precede pid-file creation on slow CI workers.
+# Wait for a populated, valid pid before inspecting the daemon's file handles.
+PID=$(getpid)
 if [ -z "$PID" ]; then
 	printf 'FAIL: could not read rsyslog PID\n'
 	error_exit 1


### PR DESCRIPTION
The imfile FD-release test can observe the imdiag startup marker and all expected output before rsyslogd has populated its pid file on slow CI workers. Use the existing getpid helper, which waits for a valid pid file, before inspecting the daemon file descriptors.\n\nValidation: focused Ubuntu 24.04 container check passed: imfile-inotify-fd-release-on-delete.sh. The testbench antipattern scan also passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

