### PR TITLE
fix imdtls with OpenSSL 4.0

### DIFF
--- a/plugins/imdtls/imdtls.c
+++ b/plugins/imdtls/imdtls.c
@@ -763,6 +763,9 @@ static void DTLSHandleSessions(instanceConf_t *inst) {
 
         // Start DTLS Listen and Session
         do {
+            /* Clear stale queue entries so a non-empty queue after the call
+             * reliably indicates a failure of this call. */
+            ERR_clear_error();
             ret = DTLSv1_listen(ssl, client_addr);
             if (ret > 0) {
                 dbgprintf("imdtls: DTLSHandleSessions DTLSv1_listen SUCCESS\n");
@@ -833,7 +836,9 @@ static void DTLSHandleSessions(instanceConf_t *inst) {
                 break;
             } else {
                 err = SSL_get_error(ssl, ret);
-                if ((ret == 0 && err == SSL_ERROR_SYSCALL) || (err == SSL_ERROR_SYSCALL && errno == EAGAIN)) {
+                /* Retry on EAGAIN (recv timeout, no datagram) and on ret == 0
+                 * with an empty error queue (no usable handshake data yet). */
+                if (err == SSL_ERROR_SYSCALL && (errno == EAGAIN || (ret == 0 && ERR_peek_error() == 0))) {
                     DBGPRINTF("imdtls: DTLSv1_listen RET %d (ERR %d / ERRNO %d), retry\n", ret, err, errno);
                     // Wait little and retry DTLSv1_listen
                     srSleep(0, 100000);

--- a/plugins/imdtls/imdtls.c
+++ b/plugins/imdtls/imdtls.c
@@ -764,8 +764,10 @@ static void DTLSHandleSessions(instanceConf_t *inst) {
         // Start DTLS Listen and Session
         do {
             /* Clear stale queue entries so a non-empty queue after the call
-             * reliably indicates a failure of this call. */
+             * reliably indicates a failure of this call.  Also reset errno so
+             * the post-call errno check is meaningful. */
             ERR_clear_error();
+            errno = 0;
             ret = DTLSv1_listen(ssl, client_addr);
             if (ret > 0) {
                 dbgprintf("imdtls: DTLSHandleSessions DTLSv1_listen SUCCESS\n");


### PR DESCRIPTION
OpenSSL 4.0 reports DTLSv1_listen() hard failures as SSL_ERROR_SYSCALL with errno 0 instead of SSL_ERROR_SSL as OpenSSL 3.x did. imdtls treated that as a transient condition and silently retried forever, so no server-side error was logged and the input thread ignored termination until cancelled. This broke tests/imdtls-basic-tlscommands.sh, whose oracle is the server-side DTLSv1_listen/OpenSSL error diagnostic.

Retry when errno is EAGAIN or when DTLSv1_listen() returns 0 and the error queue is empty.

I'm not super sure about clearing the error queue when starting the DTLS session, since the documentation about the new SSL_get_error() clearly states that it no longer relies on the queue, but it felt like a good approach to be sure that if ERR_peek_error() later one found an error in the queue, that it is from this session, and not a left over. But I don't know if this error queue is local per session (must be, but...) or not.

Co-authored-by: Claude Opus 5 (GitHub Copilot CLI) <223556219+Copilot@users.noreply.github.com>

Fixes: #7553

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->
OpenSSL4 changed behavior of `SSL_get_error()`, which affects how `imdtls` is used in rsyslog. This was caught by rsyslog's own `tests/imdtls-basic-tlscommands.sh` test, which looped for 60s and didn't manage to find the error message it was looking for in the rsyslog logs.

### References
https://github.com/rsyslog/rsyslog/issues/7553
[Upstream documentation](https://docs.openssl.org/4.0/man3/DTLSv1_listen/#return-values) about `DTLSv1_listen()` does say that a return value of 0 usually indicates a non-fatal error and should be retried, but errors are placed in the error queue.
[Upstream documentation](https://docs.openssl.org/4.0/man3/SSL_get_error/#history) about `SSL_get_error()` also mentions the change in behavior introduced with openssl 4.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

