### PR TITLE
omelasticsearch: expose request duration pstats

### DIFF
--- a/doc/source/configuration/modules/omelasticsearch.rst
+++ b/doc/source/configuration/modules/omelasticsearch.rst
@@ -302,6 +302,19 @@ Parameters are:
    times a failure occurred (a potentially much smaller number). Counting messages
    would be quite performance-intense and is thus not done.
 
+-  **requests.count** - number of attempted index or bulk HTTP requests. This
+   includes requests that later fail at the transport or HTTP level.
+
+-  **requests.time_ms** - accumulated libcurl total time in milliseconds for
+   these requests. It includes name resolution, connection setup, TLS, request
+   transmission, and response transfer, but excludes request preparation,
+   response parsing, health checks, and platform detection. The average request
+   duration for an impstats interval is ``requests.time_ms / requests.count``.
+
+-  **requests.time_ms.min** and **requests.time_ms.max** - shortest and longest
+   observed request duration in milliseconds for the interval. A value of zero
+   means no request was observed in that interval.
+
 The following counters are available when `retryfailures="on"` is used:
 
 -  **response.success** - number of records successfully sent in bulk index

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -82,8 +82,38 @@ STATSCOUNTER_DEF(indexBadArgument, mutIndexBadArgument)
 STATSCOUNTER_DEF(indexBulkRejection, mutIndexBulkRejection)
 STATSCOUNTER_DEF(indexOtherResponse, mutIndexOtherResponse)
 STATSCOUNTER_DEF(rebinds, mutRebinds)
+STATSCOUNTER_DEF(indexRequestCount, mutIndexRequestCount)
+STATSCOUNTER_DEF(indexRequestTimeMs, mutIndexRequestTimeMs)
+STATSCOUNTER_DEF(indexRequestTimeMsMin, mutIndexRequestTimeMsMin)
+STATSCOUNTER_DEF(indexRequestTimeMsMax, mutIndexRequestTimeMsMax)
 
 static prop_t *pInputName = NULL;
+
+/*
+ * Keep the request-duration summary lock-free. The statistics subsystem
+ * deliberately permits a scrape/reset race, and these compare-and-swap loops
+ * preserve that best-effort behavior without serializing output workers.
+ * A value of zero marks an empty reporting interval, so callers clamp an
+ * observed duration to at least one millisecond before calling this helper.
+ */
+static inline void updateRequestDurationStats(const uint64_t duration_ms) {
+    uint64_t old_value;
+
+    STATSCOUNTER_INC(indexRequestCount, mutIndexRequestCount);
+    STATSCOUNTER_ADD(indexRequestTimeMs, mutIndexRequestTimeMs, duration_ms);
+
+    old_value = ATOMIC_LOAD_uint64(&indexRequestTimeMsMin, &mutIndexRequestTimeMsMin);
+    while ((old_value == 0 || duration_ms < old_value) &&
+           !ATOMIC_CAS_uint64(&indexRequestTimeMsMin, old_value, duration_ms, &mutIndexRequestTimeMsMin)) {
+        old_value = ATOMIC_LOAD_uint64(&indexRequestTimeMsMin, &mutIndexRequestTimeMsMin);
+    }
+
+    old_value = ATOMIC_LOAD_uint64(&indexRequestTimeMsMax, &mutIndexRequestTimeMsMax);
+    while (duration_ms > old_value &&
+           !ATOMIC_CAS_uint64(&indexRequestTimeMsMax, old_value, duration_ms, &mutIndexRequestTimeMsMax)) {
+        old_value = ATOMIC_LOAD_uint64(&indexRequestTimeMsMax, &mutIndexRequestTimeMsMax);
+    }
+}
 
 #define META_STRT "{\"index\":{\"_index\": \""
 #define META_STRT_CREATE "{\"create\":{" /* \"_index\": \" */
@@ -2136,6 +2166,16 @@ static rsRetVal ATTR_NONNULL(1, 2)
     curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
     code = curl_easy_perform(curl);
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &pWrkrData->httpStatusCode);
+    if (STATSCOUNTER_ENABLED()) {
+        double total_time = 0;
+        uint64_t total_time_ms;
+
+        /* libcurl exposes total transfer time after every completed attempt. */
+        (void)curl_easy_getinfo(curl, CURLINFO_TOTAL_TIME, &total_time);
+        total_time_ms = (uint64_t)(total_time * 1000);
+        if (total_time_ms == 0) total_time_ms = 1;
+        updateRequestDurationStats(total_time_ms);
+    }
     DBGPRINTF("curl returned %lld\n", (long long)code);
     if (code != CURLE_OK && code != CURLE_HTTP_RETURNED_ERROR) {
         STATSCOUNTER_INC(indexHTTPReqFail, mutIndexHTTPReqFail);
@@ -2939,6 +2979,18 @@ BEGINmodInit()
                                 &indexOtherResponse));
     STATSCOUNTER_INIT(rebinds, mutRebinds);
     CHKiRet(statsobj.AddCounter(indexStats, (uchar *)"rebinds", ctrType_IntCtr, CTR_FLAG_RESETTABLE, &rebinds));
+    STATSCOUNTER_INIT(indexRequestCount, mutIndexRequestCount);
+    CHKiRet(statsobj.AddCounter(indexStats, (uchar *)"requests.count", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &indexRequestCount));
+    STATSCOUNTER_INIT(indexRequestTimeMs, mutIndexRequestTimeMs);
+    CHKiRet(statsobj.AddCounter(indexStats, (uchar *)"requests.time_ms", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &indexRequestTimeMs));
+    STATSCOUNTER_INIT(indexRequestTimeMsMin, mutIndexRequestTimeMsMin);
+    CHKiRet(statsobj.AddCounter(indexStats, (uchar *)"requests.time_ms.min", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &indexRequestTimeMsMin));
+    STATSCOUNTER_INIT(indexRequestTimeMsMax, mutIndexRequestTimeMsMax);
+    CHKiRet(statsobj.AddCounter(indexStats, (uchar *)"requests.time_ms.max", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &indexRequestTimeMsMax));
     CHKiRet(statsobj.ConstructFinalize(indexStats));
     CHKiRet(prop.Construct(&pInputName));
     CHKiRet(prop.SetString(pInputName, UCHAR_CONSTANT("omelasticsearch"), sizeof("omelasticsearch") - 1));

--- a/tests/es-basic.sh
+++ b/tests/es-basic.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
+# Verify omelasticsearch publishes per-request duration summaries through
+# impstats. The oracle checks algebraic bounds rather than timing thresholds,
+# because Elasticsearch and the test host determine the actual request time.
 . ${srcdir:=.}/diag.sh init
 export ES_PORT=19200
 export NUMMESSAGES=1000 # 1000 is sufficient, as this test is pretty slow
@@ -55,7 +58,16 @@ for line in sys.stdin:
 		hsh = json.loads(line[jstart:])
 		if hsh["origin"] == "omelasticsearch":
 			actual = hsh
-if not expected == actual:
+for name, value in expected.items():
+	if actual.get(name) != value:
+		sys.stderr.write("ERROR: unexpected value for {}: expected {}, got {}\n".format(name, value, actual.get(name)))
+		sys.exit(1)
+request_count = actual.get("requests.count", 0)
+request_time = actual.get("requests.time_ms", 0)
+request_min = actual.get("requests.time_ms.min", 0)
+request_max = actual.get("requests.time_ms.max", 0)
+if not (request_count > 0 and request_time >= request_count and
+		1 <= request_min <= request_max <= request_time):
 	sys.stderr.write("ERROR: expected stats not equal to actual stats\n")
 	sys.stderr.write("ERROR: expected {}\n".format(expected))
 	sys.stderr.write("ERROR: actual {}\n".format(actual))

--- a/tests/omelasticsearch-maxbytes-boundary.sh
+++ b/tests/omelasticsearch-maxbytes-boundary.sh
@@ -141,7 +141,7 @@ python3 - "$STATS_FILE" <<'PY'
 import json
 import sys
 
-stats = None
+stats = []
 for line in open(sys.argv[1], encoding="utf-8"):
     json_start = line.find("{")
     if json_start < 0:
@@ -151,15 +151,15 @@ for line in open(sys.argv[1], encoding="utf-8"):
     except json.JSONDecodeError:
         continue
     if record.get("origin") == "omelasticsearch" and record.get("requests.count"):
-        stats = record
+        stats.append(record)
 
-if stats is None:
+if not stats:
     raise SystemExit("missing omelasticsearch request-duration impstats record")
 
-count = stats["requests.count"]
-total = stats["requests.time_ms"]
-minimum = stats["requests.time_ms.min"]
-maximum = stats["requests.time_ms.max"]
+count = sum(record["requests.count"] for record in stats)
+total = sum(record["requests.time_ms"] for record in stats)
+minimum = min(record["requests.time_ms.min"] for record in stats)
+maximum = max(record["requests.time_ms.max"] for record in stats)
 if count != 2 or total < count or not 1 <= minimum < maximum <= total or maximum - minimum < 20:
     raise SystemExit(f"invalid request-duration stats: {stats}")
 PY

--- a/tests/omelasticsearch-maxbytes-boundary.sh
+++ b/tests/omelasticsearch-maxbytes-boundary.sh
@@ -3,18 +3,23 @@
 #
 # Copyright 2026 Rainer Gerhards and Adiscon GmbH.
 #
-# Regression test for omelasticsearch bulk maxbytes boundaries. The local HTTP
-# endpoint records every bulk body. The oracle proves that fixed bulk metadata
-# is included in the size estimate: two records must be split at the configured
-# boundary. It also proves that an oversized first record produces one request,
-# not an empty flush followed by that record. The helper writes its port only
-# after bind and is terminated during test cleanup.
+# Regression test for omelasticsearch bulk maxbytes boundaries and request
+# duration stats. The local HTTP endpoint records every bulk body. The oracle
+# proves that fixed bulk metadata is included in the size estimate: two records
+# must be split at the configured boundary. It also proves the impstats request
+# count and min/mean/max invariants: the helper deliberately delays the first
+# response, so the oracle requires distinct extrema without relying on host
+# scheduling. An oversized first record must produce one request, not an empty
+# flush followed by that record. The helper writes its port only after bind and
+# is terminated during test cleanup.
 . ${srcdir:=.}/diag.sh init
 require_plugin omelasticsearch
+require_plugin impstats
 check_command_available python3
 
 PORT_FILE="$RSYSLOG_DYNNAME.esfake.port"
 REQUESTS_FILE="$RSYSLOG_DYNNAME.esfake.requests"
+STATS_FILE="$RSYSLOG_DYNNAME.esfake.stats"
 
 test_error_exit_handler() {
 	if [ -n "${SERVER_PID:-}" ]; then
@@ -26,12 +31,15 @@ python3 - "$PORT_FILE" "$REQUESTS_FILE" <<'PY' &
 import base64
 import json
 import sys
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 port_file, requests_file = sys.argv[1:3]
 
 
 class Handler(BaseHTTPRequestHandler):
+    post_count = 0
+
     def log_message(self, fmt, *args):
         pass
 
@@ -52,6 +60,7 @@ class Handler(BaseHTTPRequestHandler):
         })
 
     def do_POST(self):
+        Handler.post_count += 1
         length = int(self.headers.get("Content-Length", "0"))
         body = self.rfile.read(length)
         with open(requests_file, "a", encoding="ascii") as fh:
@@ -60,6 +69,9 @@ class Handler(BaseHTTPRequestHandler):
         operation = "index"
         if body:
             operation = next(iter(json.loads(body.splitlines()[0])))
+        # Give the two boundary-split requests distinct, deterministic transfer
+        # durations so the min/max counters must observe different values.
+        time.sleep(0.040 if Handler.post_count == 1 else 0.005)
         self.send_json({
             "errors": False,
             "items": [{operation: {"status": 201}} for _ in range(operations)],
@@ -78,6 +90,12 @@ ES_PORT=$(cat "$PORT_FILE")
 
 generate_conf
 add_conf '
+ruleset(name="stats") {
+  action(type="omfile" file="'"$STATS_FILE"'")
+}
+
+module(load="../plugins/impstats/.libs/impstats" interval="1" severity="7"
+       resetCounters="on" Ruleset="stats" bracketing="on" format="json")
 module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
 template(name="msgTpl" type="string" string="{\"msg\":\"x\"}")
 
@@ -97,7 +115,10 @@ action(type="omelasticsearch"
 '
 
 startup
+wait_for_stats_flush "$STATS_FILE"
 injectmsg 0 2
+wait_queueempty
+wait_for_stats_flush "$STATS_FILE"
 shutdown_when_empty
 wait_shutdown
 
@@ -111,6 +132,36 @@ if len(bodies) != 2:
     raise SystemExit(f"expected two boundary-limited bulk requests, got {len(bodies)}")
 if any(not body or len(body) > 109 for body in bodies):
     raise SystemExit("boundary-limited bulk request was empty or exceeded 109 bytes")
+PY
+if [ $? -ne 0 ]; then
+	error_exit 1
+fi
+
+python3 - "$STATS_FILE" <<'PY'
+import json
+import sys
+
+stats = None
+for line in open(sys.argv[1], encoding="utf-8"):
+    json_start = line.find("{")
+    if json_start < 0:
+        continue
+    try:
+        record = json.loads(line[json_start:])
+    except json.JSONDecodeError:
+        continue
+    if record.get("origin") == "omelasticsearch" and record.get("requests.count"):
+        stats = record
+
+if stats is None:
+    raise SystemExit("missing omelasticsearch request-duration impstats record")
+
+count = stats["requests.count"]
+total = stats["requests.time_ms"]
+minimum = stats["requests.time_ms.min"]
+maximum = stats["requests.time_ms.max"]
+if count != 2 or total < count or not 1 <= minimum < maximum <= total or maximum - minimum < 20:
+    raise SystemExit(f"invalid request-duration stats: {stats}")
 PY
 if [ $? -ne 0 ]; then
 	error_exit 1


### PR DESCRIPTION
## Summary
- expose request count, total request time, and interval minimum/maximum via impstats
- compute the average as requests.time_ms / requests.count
- cover pstats semantics with a deterministic local HTTP endpoint and Elasticsearch integration assertions

## Validation
- targeted omelasticsearch-maxbytes-boundary.sh
- change-gated Ubuntu 26.04 local container validation
- clang static analyzer: no bugs found
- mock make distcheck TEST_RUN_TYPE=MOCK-OK -j10
- documentation build and C/shell formatting checks

The local pre-push hook uses a marker in the main checkout rather than the validated worktree. The push was explicitly authorized with its documented skip switch after the full Tier-1 validation completed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

