### PR TITLE
runtime: add printf format attributes to translate.c helpers

### DIFF
--- a/runtime/translate.c
+++ b/runtime/translate.c
@@ -48,7 +48,8 @@ struct rsconfTranslateWarning_s {
     struct rsconfTranslateWarning_s *next;
 };
 
-static void addWarning(struct rsconfTranslateWarning_s **head, const char *fmt, ...);
+static void addWarning(struct rsconfTranslateWarning_s **head, const char *fmt, ...)
+    __attribute__((format(printf, 2, 3)));
 
 struct rsconfTranslateYamlAction_s {
     struct nvlst *nvlst;
@@ -192,7 +193,8 @@ int rsconfTranslateHasFatal(void) {
 }
 
 PRAGMA_DIAGNOSTIC_PUSH
-PRAGMA_IGNORE_Wformat_nonliteral static char *translateVasprintf(const char *fmt, va_list ap) {
+PRAGMA_IGNORE_Wformat_nonliteral static char *__attribute__((format(printf, 1, 0)))
+translateVasprintf(const char *fmt, va_list ap) {
     va_list ap_copy;
     char *buf;
     int len;
@@ -213,7 +215,8 @@ PRAGMA_IGNORE_Wformat_nonliteral static char *translateVasprintf(const char *fmt
     return buf;
 }
 
-PRAGMA_IGNORE_Wformat_nonliteral static void addWarning(struct rsconfTranslateWarning_s **head, const char *fmt, ...) {
+PRAGMA_IGNORE_Wformat_nonliteral static void __attribute__((format(printf, 2, 3)))
+addWarning(struct rsconfTranslateWarning_s **head, const char *fmt, ...) {
     va_list ap;
     char *buf;
     struct rsconfTranslateWarning_s *w;

--- a/runtime/translate.c
+++ b/runtime/translate.c
@@ -193,8 +193,8 @@ int rsconfTranslateHasFatal(void) {
 }
 
 PRAGMA_DIAGNOSTIC_PUSH
-PRAGMA_IGNORE_Wformat_nonliteral static char *__attribute__((format(printf, 1, 0)))
-translateVasprintf(const char *fmt, va_list ap) {
+PRAGMA_IGNORE_Wformat_nonliteral static char *__attribute__((format(printf, 1, 0))) translateVasprintf(const char *fmt,
+                                                                                                       va_list ap) {
     va_list ap_copy;
     char *buf;
     int len;
@@ -215,8 +215,8 @@ translateVasprintf(const char *fmt, va_list ap) {
     return buf;
 }
 
-PRAGMA_IGNORE_Wformat_nonliteral static void __attribute__((format(printf, 2, 3)))
-addWarning(struct rsconfTranslateWarning_s **head, const char *fmt, ...) {
+PRAGMA_IGNORE_Wformat_nonliteral static void __attribute__((format(printf, 2, 3))) addWarning(
+    struct rsconfTranslateWarning_s **head, const char *fmt, ...) {
     va_list ap;
     char *buf;
     struct rsconfTranslateWarning_s *w;


### PR DESCRIPTION
GCC 15 flags helpers that forward a fmt string to the printf family as format-attribute candidates, which fails the build when using `-Wmissing-format-attribute` plus `-Werror`. Annotate the affected helpers with `__attribute__((format(printf, ...)))`, matching the existing format-string forwarders in the tree.

With the help of AI-Agents: Copilot (Claude Opus 4.8)

Fixes: #7501

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->
This fixes the build when using compiler flags that treat warnings as errors.

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/7501
