### PR TITLE
ompgsql: support longer default database syslog tags

### DIFF
--- a/plugins/ompgsql/createDB.sql
+++ b/plugins/ompgsql/createDB.sql
@@ -22,7 +22,7 @@ CREATE TABLE SystemEvents
         MinUsage int NULL,
         MaxUsage int NULL,
         InfoUnitID int NULL ,
-        SysLogTag varchar(60),
+        SysLogTag varchar(128),
         EventLogType varchar(60),
         GenericFileName VarChar(60),
         SystemID int NULL

--- a/plugins/ompgsql/ompgsql.c
+++ b/plugins/ompgsql/ompgsql.c
@@ -236,7 +236,8 @@ static int tryExec(uchar *pszCmd, wrkrInstanceData_t *pWrkrData) {
     execState = PQresultStatus(pgRet);
     if (execState != PGRES_COMMAND_OK && execState != PGRES_TUPLES_OK) {
         // complain a lot in case any issues with DB communication
-        LogError(0, execState, "postgres query execution failed: %s", PQresStatus(PQresultStatus(pgRet)));
+        LogError(0, execState, "postgres query execution failed: %s: %s", PQresStatus(execState),
+                 PQresultErrorMessage(pgRet));
         bHadError = 1;
     }
     PQclear(pgRet);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1107,6 +1107,7 @@ TESTS_PGSQL_CONFIG = \
 
 TESTS_PGSQL = \
 	pgsql-basic.sh \
+	pgsql-long-syslogtag.sh \
 	pgsql-basic-cnf6.sh \
 	pgsql-basic-threads-cnf6.sh \
 	pgsql-template.sh \
@@ -3227,7 +3228,8 @@ TESTS += $(TESTS_PGSQL_CONFIG)
 if ENABLE_PGSQL_TESTS
 TESTS += $(TESTS_PGSQL)
 
-pgsql-basic-cnf6.log: pgsql-basic.log
+pgsql-long-syslogtag.log: pgsql-basic.log
+pgsql-basic-cnf6.log: pgsql-long-syslogtag.log
 pgsql-basic-threads-cnf6.log: pgsql-basic-cnf6.log
 pgsql-template.log: pgsql-basic-threads-cnf6.log
 pgsql-template-cnf6.log: pgsql-template.log

--- a/tests/pgsql-long-syslogtag.sh
+++ b/tests/pgsql-long-syslogtag.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Verify that the default ompgsql schema accepts a Docker-style syslog tag
+# longer than the historical 60-character column. The exact value selected
+# from PostgreSQL after synchronized shutdown is the regression oracle.
+
+. ${srcdir:=.}/diag.sh init
+
+psql -h localhost -U postgres -f ${srcdir}/testsuites/pgsql-basic.sql
+
+generate_conf
+add_conf '
+module(load="../plugins/ompgsql/.libs/ompgsql")
+:msg, contains, "ompgsql-i7559-long-tag" :ompgsql:127.0.0.1,syslogtest,postgres,testbench
+'
+startup
+
+LONG_TAG="docker-compose_project_long-service-name_with-very-descriptive-instance-identifier"
+injectmsg_literal "<13>Mar 10 01:00:00 docker-host ${LONG_TAG}: ompgsql-i7559-long-tag"
+shutdown_when_empty
+wait_shutdown
+
+psql -h localhost -U postgres -d syslogtest -c \
+	'SELECT SysLogTag FROM SystemEvents;' -t -A > "$RSYSLOG_OUT_LOG"
+
+export EXPECTED="${LONG_TAG}:"
+cmp_exact
+
+echo cleaning up test database
+psql -h localhost -U postgres -c 'DROP DATABASE IF EXISTS syslogtest;'
+
+exit_test

--- a/tests/testsuites/pgsql-basic.sql
+++ b/tests/testsuites/pgsql-basic.sql
@@ -23,7 +23,7 @@ CREATE TABLE systemevents (
 	MinUsage int NULL,
 	MaxUsage int NULL,
 	InfoUnitID int NULL ,
-	SysLogTag varchar(60),
+	SysLogTag varchar(128),
 	EventLogType varchar(60),
 	GenericFileName VarChar(60),
 	SystemID int NULL


### PR DESCRIPTION
## Summary
- widen the supplied PostgreSQL `SysLogTag` column from 60 to 128 characters
- include PostgreSQL result details in failed-query diagnostics
- add a PostgreSQL round-trip regression for an 83-character Docker-style tag

## Migration
Existing databases retain their current schema. Operators needing longer tags can run:

```sql
ALTER TABLE SystemEvents ALTER COLUMN SysLogTag TYPE varchar(128);
```

Closes https://github.com/rsyslog/rsyslog/issues/7559

## Validation
- PostgreSQL 16 regression test
- Ubuntu 26.04 static analyzer (clean)
- change-gated Ubuntu 26.04 CI check (one unrelated imfile flake passed on isolated rerun)
- mock distcheck, formatting, ShellCheck, checkbashisms, and test-antipattern scan

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

