### PR TITLE
runtime: target classic queue worker wakeups

### DIFF
--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -16,6 +16,13 @@ runtime_queue:
   notes:
     - Disk-assisted mode is an in-memory parent plus a first-class disk child; disk queue semantics apply to the child.
     - The queue mutex is shared by a disk-assisted parent and child; segmented store operations and idle dematerialization callbacks run under that lock.
+    - >-
+      Targeted worker wakeups in wtpAdviseMaxWorkers track registered waiters
+      with bWaitingForWork and bWakeupReserved under each pool's pmutUsr (the
+      queue mutex paired with pcondBusy); producers reserve a waiter before
+      signaling, and normal or cancellation wait cleanup clears the
+      reservation under that mutex. Both wtpAdviseMaxWorkers and
+      wtpWakeupAllWrkr require callers to hold pmutUsr.
     - Completed message references move to a bounded worker buffer after store completion and are destroyed outside the queue mutex, before callbacks or waits; cancellation is disabled during this transfer and disposal.
     - RAM retirement releases completed counts independently of batch order; segmentedDisk retains its ordered persistent frontier.
     - queue_da resolves the durable disk-child engine at startup and atomically publishes its marker before first persistent data; engines never switch while a process is running.

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -4093,7 +4093,15 @@ rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis) /* this is the Construction
     /* if the queue already contains data, we need to start the correct number of worker threads. This can be
      * the case when a disk queue has been loaded. If we did not start it here, it would never start.
      */
+    /* qqueueAdviseMaxWorkers() publishes worker wakeup reservations under
+     * the queue mutex. A top-level queue is started without that mutex held;
+     * a DA child is started from InitDA(), which already holds its parent's
+     * shared mutex. Keep the child path lock-free here to avoid relocking the
+     * non-recursive parent mutex. */
+    const int bNeedQueueLock = pThis->pqParent == NULL;
+    if (bNeedQueueLock) qqueueLock(pThis);
     qqueueAdviseMaxWorkers(pThis);
+    if (bNeedQueueLock) d_pthread_mutex_unlock(pThis->mut);
 
     /* support statistics gathering */
     qName = obj.GetName((obj_t *)pThis);

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -4336,7 +4336,13 @@ static rsRetVal DoSaveOnShutdown(qqueue_t *pThis) {
     qqueueSetShutdownImmediate(pThis, 0); /* would terminate the DA worker! */
     pThis->iLowWtrMrk = 0;
     wtpSetState(pThis->pWtpDA, wtpState_SHUTDOWN); /* shutdown worker (only) when done (was _IMMEDIATE!) */
+    /* Unlike the normal enqueue advice path, destruction does not already
+     * hold this pool's queue mutex. The targeted-wakeup predicates are
+     * protected by that mutex, including a worker's exiting transition.
+     */
+    d_pthread_mutex_lock(pThis->pWtpDA->pmutUsr);
     wtpAdviseMaxWorkers(pThis->pWtpDA, 1, PERMIT_WORKER_START_DURING_SHUTDOWN); /* restart DA worker */
+    d_pthread_mutex_unlock(pThis->pWtpDA->pmutUsr);
 
     DBGOPRINT((obj_t *)pThis, "waiting for DA worker to terminate...\n");
     timeoutComp(&tTimeout, QUEUE_TIMEOUT_ETERNAL);

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -361,7 +361,13 @@ static void wtiWorkerCancelCleanup(void *arg) {
 }
 
 static void wtiWaitCancelCleanup(void *arg) {
-    wtiClearWaitReservation((wti_t *)arg);
+    wti_t *const pThis = (wti_t *)arg;
+
+    wtiClearWaitReservation(pThis);
+    /* POSIX cancellation of pthread_cond_wait() invokes cleanup handlers
+     * after reacquiring the associated mutex. Release it before the outer
+     * worker cleanup handler restores the queue batch under that mutex. */
+    d_pthread_mutex_unlock(pThis->pWtp->pmutUsr);
 }
 
 

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -292,6 +292,7 @@ ENDobjDestruct(wti)
 BEGINobjConstruct(wti) /* be sure to specify the object type also in END macro! */
     INIT_ATOMIC_HELPER_MUT(pThis->mutIsRunning);
     pthread_cond_init(&pThis->pcondBusy, NULL);
+    pThis->bExiting = 0;
 ENDobjConstruct(wti)
 
 
@@ -348,6 +349,18 @@ static void wtiWorkerCancelCleanup(void *arg) {
      * work. Restoring or committing its batch, including deferred cleanup,
      * must use the same mutex as the ordinary callback path. */
     d_pthread_mutex_lock(pWtp->pmutUsr);
+    /* Cancellation is enabled only while the queue consumer has released
+     * pmutUsr. Publish that this slot will not consume further queue work
+     * before restoring its batch: an enqueue during batch cleanup must wake or
+     * replace another consumer instead of counting this cancelling worker.
+     */
+    d_pthread_mutex_lock(pWtp->pmutUsr);
+    /* Regular classic pools keep w0 always-running, so it remains the final
+     * consumer while an additional worker exits. The segmented DA child
+     * explicitly permits its non-always-running w0 to time out for store
+     * dematerialization; preserve that established lifecycle unchanged.
+     */
+    if (pThis->workerIndex != 0 || pThis->bAlwaysRunning) wtiMarkExiting(pThis);
     pWtp->pfObjProcessed(pWtp->pUsr, pThis);
     d_pthread_mutex_unlock(pWtp->pmutUsr);
     DBGPRINTF("%s: done cancellation cleanup handler.\n", wtiGetDbgHdr(pThis));
@@ -505,6 +518,12 @@ PRAGMA_IGNORE_Wempty_body rsRetVal wtiWorker(wti_t *__restrict__ const pThis) {
         bInactivityTOOccurred = 0; /* reset for next run */
     }
 
+    /* While the action-worker objects are released below an additional or
+     * always-running worker can no longer consume queue data. Publish that
+     * transition before releasing the queue mutex so an enqueue does not
+     * count this slot as active capacity.
+     */
+    wtiMarkExiting(pThis);
     d_pthread_mutex_unlock(pWtp->pmutUsr);
 
     DBGPRINTF("DDDD: wti %p: worker cleanup action instances\n", pThis);

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -353,6 +353,10 @@ static void wtiWorkerCancelCleanup(void *arg) {
     DBGPRINTF("%s: done cancellation cleanup handler.\n", wtiGetDbgHdr(pThis));
 }
 
+static void wtiWaitCancelCleanup(void *arg) {
+    wtiClearWaitReservation((wti_t *)arg);
+}
+
 
 /* wait for queue to become non-empty or timeout
  * this is introduced as helper to support queue minimum batch sizes, but may
@@ -365,11 +369,16 @@ int ATTR_NONNULL() wtiWaitNonEmpty(wti_t *const pThis, const struct timespec tim
     int r;
 
     DBGOPRINT((obj_t *)pThis, "waiting on queue to become non-empty\n");
+    pThis->bWaitingForWork = 1;
+    pThis->bWakeupReserved = 0;
+    pthread_cleanup_push(wtiWaitCancelCleanup, pThis);
     if (d_pthread_cond_timedwait(&pThis->pcondBusy, pWtp->pmutUsr, &timeout) != 0) {
         r = 0;
     } else {
         r = 1;
     }
+    pthread_cleanup_pop(0);
+    wtiClearWaitReservation(pThis);
     DBGOPRINT((obj_t *)pThis, "waited on queue to become non-empty, result %d\n", r);
     return r;
 }
@@ -385,6 +394,9 @@ static void ATTR_NONNULL() doIdleProcessing(wti_t *const pThis, wtp_t *const pWt
 
     DBGPRINTF("%s: worker IDLE, waiting for work.\n", wtiGetDbgHdr(pThis));
 
+    pThis->bWaitingForWork = 1;
+    pThis->bWakeupReserved = 0;
+    pthread_cleanup_push(wtiWaitCancelCleanup, pThis);
     if (pThis->bAlwaysRunning) {
         /* never shut down any started worker */
         d_pthread_cond_wait(&pThis->pcondBusy, pWtp->pmutUsr);
@@ -397,6 +409,8 @@ static void ATTR_NONNULL() doIdleProcessing(wti_t *const pThis, wtp_t *const pWt
             *pbInactivityTOOccurred = 1; /* indicate we had a timeout */
         }
     }
+    pthread_cleanup_pop(0);
+    wtiClearWaitReservation(pThis);
     DBGOPRINT((obj_t *)pThis, "worker awoke from idle processing\n");
 }
 

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -361,63 +361,6 @@ static void wtiWorkerCancelCleanup(void *arg) {
     DBGPRINTF("%s: done cancellation cleanup handler.\n", wtiGetDbgHdr(pThis));
 }
 
-int wtiReserveWakeup(wti_t *const pWti) {
-    if (ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) || !pWti->bWaitingForWork || pWti->bWakeupReserved)
-        return 0;
-    pWti->bWakeupReserved = 1;
-    return 1;
-}
-
-int wtiCountsTowardWorkerBudget(wti_t *const pWti) {
-    const int state = ATOMIC_LOAD_32BIT(&pWti->bIsRunning, &pWti->mutIsRunning);
-
-    return state == WRKTHRD_RUNNING && !ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) &&
-           (!pWti->bWaitingForWork || pWti->bWakeupReserved);
-}
-
-int wtiCountsTowardWorkerStartBudget(wti_t *const pWti) {
-    const int state = ATOMIC_LOAD_32BIT(&pWti->bIsRunning, &pWti->mutIsRunning);
-
-    return !ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) &&
-           (state == WRKTHRD_INITIALIZING || state == WRKTHRD_RUNNING);
-}
-
-int wtiGetWorkerStartBudget(wti_t *const *const ppWti, const int nWorkers, const int nMaxWrkr) {
-    int i;
-    int nLive = 0;
-
-    for (i = 0; i < nWorkers; ++i) {
-        if (wtiCountsTowardWorkerStartBudget(ppWti[i])) ++nLive;
-    }
-
-    return nLive < nMaxWrkr ? nMaxWrkr - nLive : 0;
-}
-
-int wtiGetWakeupBudget(wti_t *const *const ppWti, const int nWorkers, const int nMaxWrkr) {
-    int i;
-    int nAvailable = 0;
-
-    for (i = 0; i < nWorkers; ++i) {
-        if (wtiCountsTowardWorkerBudget(ppWti[i])) ++nAvailable;
-    }
-
-    return nAvailable < nMaxWrkr ? nMaxWrkr - nAvailable : 0;
-}
-
-void wtiClearWaitReservation(wti_t *const pWti) {
-    pWti->bWaitingForWork = 0;
-    pWti->bWakeupReserved = 0;
-}
-
-void wtiMarkExiting(wti_t *const pWti) {
-    ATOMIC_STORE_32BIT(&pWti->bExiting, &pWti->mutIsRunning, 1);
-    wtiClearWaitReservation(pWti);
-}
-
-void wtiClearExiting(wti_t *const pWti) {
-    ATOMIC_STORE_32BIT(&pWti->bExiting, &pWti->mutIsRunning, 0);
-}
-
 static void wtiWaitCancelCleanup(void *arg) {
     wtiClearWaitReservation((wti_t *)arg);
 }

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -347,12 +347,11 @@ static void wtiWorkerCancelCleanup(void *arg) {
     DBGPRINTF("%s: cancellation cleanup handler called.\n", wtiGetDbgHdr(pThis));
     /* The consumer releases the queue mutex only around cancel-safe output
      * work. Restoring or committing its batch, including deferred cleanup,
-     * must use the same mutex as the ordinary callback path. */
-    d_pthread_mutex_lock(pWtp->pmutUsr);
-    /* Cancellation is enabled only while the queue consumer has released
-     * pmutUsr. Publish that this slot will not consume further queue work
-     * before restoring its batch: an enqueue during batch cleanup must wake or
-     * replace another consumer instead of counting this cancelling worker.
+     * must use the same mutex as the ordinary callback path. Cancellation is
+     * enabled only while the queue consumer has released pmutUsr. Publish
+     * that this slot will not consume further queue work before restoring its
+     * batch: an enqueue during batch cleanup must wake or replace another
+     * consumer instead of counting this cancelling worker.
      */
     d_pthread_mutex_lock(pWtp->pmutUsr);
     wtiMarkExiting(pThis);

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -355,15 +355,67 @@ static void wtiWorkerCancelCleanup(void *arg) {
      * replace another consumer instead of counting this cancelling worker.
      */
     d_pthread_mutex_lock(pWtp->pmutUsr);
-    /* Regular classic pools keep w0 always-running, so it remains the final
-     * consumer while an additional worker exits. The segmented DA child
-     * explicitly permits its non-always-running w0 to time out for store
-     * dematerialization; preserve that established lifecycle unchanged.
-     */
-    if (pThis->workerIndex != 0 || pThis->bAlwaysRunning) wtiMarkExiting(pThis);
+    wtiMarkExiting(pThis);
     pWtp->pfObjProcessed(pWtp->pUsr, pThis);
     d_pthread_mutex_unlock(pWtp->pmutUsr);
     DBGPRINTF("%s: done cancellation cleanup handler.\n", wtiGetDbgHdr(pThis));
+}
+
+int wtiReserveWakeup(wti_t *const pWti) {
+    if (ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) || !pWti->bWaitingForWork || pWti->bWakeupReserved)
+        return 0;
+    pWti->bWakeupReserved = 1;
+    return 1;
+}
+
+int wtiCountsTowardWorkerBudget(wti_t *const pWti) {
+    const int state = ATOMIC_LOAD_32BIT(&pWti->bIsRunning, &pWti->mutIsRunning);
+
+    return state == WRKTHRD_RUNNING && !ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) &&
+           (!pWti->bWaitingForWork || pWti->bWakeupReserved);
+}
+
+int wtiCountsTowardWorkerStartBudget(wti_t *const pWti) {
+    const int state = ATOMIC_LOAD_32BIT(&pWti->bIsRunning, &pWti->mutIsRunning);
+
+    return !ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) &&
+           (state == WRKTHRD_INITIALIZING || state == WRKTHRD_RUNNING);
+}
+
+int wtiGetWorkerStartBudget(wti_t *const *const ppWti, const int nWorkers, const int nMaxWrkr) {
+    int i;
+    int nLive = 0;
+
+    for (i = 0; i < nWorkers; ++i) {
+        if (wtiCountsTowardWorkerStartBudget(ppWti[i])) ++nLive;
+    }
+
+    return nLive < nMaxWrkr ? nMaxWrkr - nLive : 0;
+}
+
+int wtiGetWakeupBudget(wti_t *const *const ppWti, const int nWorkers, const int nMaxWrkr) {
+    int i;
+    int nAvailable = 0;
+
+    for (i = 0; i < nWorkers; ++i) {
+        if (wtiCountsTowardWorkerBudget(ppWti[i])) ++nAvailable;
+    }
+
+    return nAvailable < nMaxWrkr ? nMaxWrkr - nAvailable : 0;
+}
+
+void wtiClearWaitReservation(wti_t *const pWti) {
+    pWti->bWaitingForWork = 0;
+    pWti->bWakeupReserved = 0;
+}
+
+void wtiMarkExiting(wti_t *const pWti) {
+    ATOMIC_STORE_32BIT(&pWti->bExiting, &pWti->mutIsRunning, 1);
+    wtiClearWaitReservation(pWti);
+}
+
+void wtiClearExiting(wti_t *const pWti) {
+    ATOMIC_STORE_32BIT(&pWti->bExiting, &pWti->mutIsRunning, 0);
 }
 
 static void wtiWaitCancelCleanup(void *arg) {

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -95,6 +95,12 @@ struct wti_s {
          */
         uint8_t bWaitingForWork;
         uint8_t bWakeupReserved;
+        /* Set immediately before wtiWorker leaves its queue loop. The thread
+         * may still release action-worker state afterwards, but it must no
+         * longer be budgeted as a queue consumer. It is atomic because cancel
+         * cleanup may race a producer holding pmutUsr.
+         */
+        int bExiting;
         DEF_ATOMIC_HELPER_MUT(mutIsRunning);
         struct {
             uint8_t script_errno; /* errno-type interface for RainerScript functions */
@@ -119,9 +125,61 @@ static inline int wtiIsShutdownImmediate(const wti_t *const pWti) {
 
 /* The caller must hold pWti->pWtp->pmutUsr. */
 static inline int ATTR_NONNULL(1) wtiReserveWakeup(wti_t *const pWti) {
-    if (!pWti->bWaitingForWork || pWti->bWakeupReserved) return 0;
+    if (ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) || !pWti->bWaitingForWork || pWti->bWakeupReserved)
+        return 0;
     pWti->bWakeupReserved = 1;
     return 1;
+}
+
+/* The caller must hold every worker's pWtp->pmutUsr. A worker that is
+ * executing queue work counts toward the requested parallelism. A registered
+ * waiter counts only after a producer has reserved its signal: until then it
+ * cannot make progress on the current enqueue. WAIT_JOIN is deliberately not
+ * counted, because it can no longer consume queue work even before its slot
+ * is reset to STOPPED.
+ */
+static inline int ATTR_NONNULL(1) wtiCountsTowardWorkerBudget(wti_t *const pWti) {
+    const int state = ATOMIC_LOAD_32BIT(&pWti->bIsRunning, &pWti->mutIsRunning);
+
+    return state == WRKTHRD_RUNNING && !ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) &&
+           (!pWti->bWaitingForWork || pWti->bWakeupReserved);
+}
+
+/* The caller must hold every worker's pWtp->pmutUsr. A registered waiter is
+ * live capacity because it can be signalled; an exiting worker is not, even
+ * though its thread has not yet reached WAIT_JOIN.
+ */
+static inline int ATTR_NONNULL(1) wtiCountsTowardWorkerStartBudget(wti_t *const pWti) {
+    const int state = ATOMIC_LOAD_32BIT(&pWti->bIsRunning, &pWti->mutIsRunning);
+
+    return !ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) &&
+           (state == WRKTHRD_INITIALIZING || state == WRKTHRD_RUNNING);
+}
+
+/* The caller must hold every worker's pWtp->pmutUsr. */
+static inline int ATTR_NONNULL(1)
+    wtiGetWorkerStartBudget(wti_t *const *const ppWti, const int nWorkers, const int nMaxWrkr) {
+    int i;
+    int nLive = 0;
+
+    for (i = 0; i < nWorkers; ++i) {
+        if (wtiCountsTowardWorkerStartBudget(ppWti[i])) ++nLive;
+    }
+
+    return nLive < nMaxWrkr ? nMaxWrkr - nLive : 0;
+}
+
+/* The caller must hold every worker's pWtp->pmutUsr. */
+static inline int ATTR_NONNULL(1)
+    wtiGetWakeupBudget(wti_t *const *const ppWti, const int nWorkers, const int nMaxWrkr) {
+    int i;
+    int nAvailable = 0;
+
+    for (i = 0; i < nWorkers; ++i) {
+        if (wtiCountsTowardWorkerBudget(ppWti[i])) ++nAvailable;
+    }
+
+    return nAvailable < nMaxWrkr ? nMaxWrkr - nAvailable : 0;
 }
 
 /* The caller must hold pWti->pWtp->pmutUsr. */
@@ -129,6 +187,18 @@ static inline void ATTR_NONNULL(1) wtiClearWaitReservation(wti_t *const pWti) {
     pWti->bWaitingForWork = 0;
     pWti->bWakeupReserved = 0;
 }
+
+/* The caller must hold pWti->pWtp->pmutUsr. */
+static inline void ATTR_NONNULL(1) wtiMarkExiting(wti_t *const pWti) {
+    ATOMIC_STORE_32BIT(&pWti->bExiting, &pWti->mutIsRunning, 1);
+    wtiClearWaitReservation(pWti);
+}
+
+/* The caller must hold pWti->pWtp->pmutUsr. */
+static inline void ATTR_NONNULL(1) wtiClearExiting(wti_t *const pWti) {
+    ATOMIC_STORE_32BIT(&pWti->bExiting, &pWti->mutIsRunning, 0);
+}
+
 /* prototypes */
 rsRetVal wtiConstruct(wti_t **ppThis);
 rsRetVal wtiConstructFinalize(wti_t *const pThis);

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -124,12 +124,7 @@ static inline int wtiIsShutdownImmediate(const wti_t *const pWti) {
 }
 
 /* The caller must hold pWti->pWtp->pmutUsr. */
-static inline int ATTR_NONNULL(1) wtiReserveWakeup(wti_t *const pWti) {
-    if (ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) || !pWti->bWaitingForWork || pWti->bWakeupReserved)
-        return 0;
-    pWti->bWakeupReserved = 1;
-    return 1;
-}
+int ATTR_NONNULL(1) wtiReserveWakeup(wti_t *const pWti);
 
 /* The caller must hold every worker's pWtp->pmutUsr. A worker that is
  * executing queue work counts toward the requested parallelism. A registered
@@ -138,66 +133,28 @@ static inline int ATTR_NONNULL(1) wtiReserveWakeup(wti_t *const pWti) {
  * counted, because it can no longer consume queue work even before its slot
  * is reset to STOPPED.
  */
-static inline int ATTR_NONNULL(1) wtiCountsTowardWorkerBudget(wti_t *const pWti) {
-    const int state = ATOMIC_LOAD_32BIT(&pWti->bIsRunning, &pWti->mutIsRunning);
-
-    return state == WRKTHRD_RUNNING && !ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) &&
-           (!pWti->bWaitingForWork || pWti->bWakeupReserved);
-}
+int ATTR_NONNULL(1) wtiCountsTowardWorkerBudget(wti_t *const pWti);
 
 /* The caller must hold every worker's pWtp->pmutUsr. A registered waiter is
  * live capacity because it can be signalled; an exiting worker is not, even
  * though its thread has not yet reached WAIT_JOIN.
  */
-static inline int ATTR_NONNULL(1) wtiCountsTowardWorkerStartBudget(wti_t *const pWti) {
-    const int state = ATOMIC_LOAD_32BIT(&pWti->bIsRunning, &pWti->mutIsRunning);
-
-    return !ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) &&
-           (state == WRKTHRD_INITIALIZING || state == WRKTHRD_RUNNING);
-}
+int ATTR_NONNULL(1) wtiCountsTowardWorkerStartBudget(wti_t *const pWti);
 
 /* The caller must hold every worker's pWtp->pmutUsr. */
-static inline int ATTR_NONNULL(1)
-    wtiGetWorkerStartBudget(wti_t *const *const ppWti, const int nWorkers, const int nMaxWrkr) {
-    int i;
-    int nLive = 0;
-
-    for (i = 0; i < nWorkers; ++i) {
-        if (wtiCountsTowardWorkerStartBudget(ppWti[i])) ++nLive;
-    }
-
-    return nLive < nMaxWrkr ? nMaxWrkr - nLive : 0;
-}
+int ATTR_NONNULL(1) wtiGetWorkerStartBudget(wti_t *const *const ppWti, int nWorkers, int nMaxWrkr);
 
 /* The caller must hold every worker's pWtp->pmutUsr. */
-static inline int ATTR_NONNULL(1)
-    wtiGetWakeupBudget(wti_t *const *const ppWti, const int nWorkers, const int nMaxWrkr) {
-    int i;
-    int nAvailable = 0;
-
-    for (i = 0; i < nWorkers; ++i) {
-        if (wtiCountsTowardWorkerBudget(ppWti[i])) ++nAvailable;
-    }
-
-    return nAvailable < nMaxWrkr ? nMaxWrkr - nAvailable : 0;
-}
+int ATTR_NONNULL(1) wtiGetWakeupBudget(wti_t *const *const ppWti, int nWorkers, int nMaxWrkr);
 
 /* The caller must hold pWti->pWtp->pmutUsr. */
-static inline void ATTR_NONNULL(1) wtiClearWaitReservation(wti_t *const pWti) {
-    pWti->bWaitingForWork = 0;
-    pWti->bWakeupReserved = 0;
-}
+void ATTR_NONNULL(1) wtiClearWaitReservation(wti_t *const pWti);
 
 /* The caller must hold pWti->pWtp->pmutUsr. */
-static inline void ATTR_NONNULL(1) wtiMarkExiting(wti_t *const pWti) {
-    ATOMIC_STORE_32BIT(&pWti->bExiting, &pWti->mutIsRunning, 1);
-    wtiClearWaitReservation(pWti);
-}
+void ATTR_NONNULL(1) wtiMarkExiting(wti_t *const pWti);
 
 /* The caller must hold pWti->pWtp->pmutUsr. */
-static inline void ATTR_NONNULL(1) wtiClearExiting(wti_t *const pWti) {
-    ATOMIC_STORE_32BIT(&pWti->bExiting, &pWti->mutIsRunning, 0);
-}
+void ATTR_NONNULL(1) wtiClearExiting(wti_t *const pWti);
 
 /* prototypes */
 rsRetVal wtiConstruct(wti_t **ppThis);

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -89,6 +89,12 @@ struct wti_s {
         /* Queue-local deferred batch cleanup is bounded by batch.maxElem. */
         smsg_t **p_deferred_msgs;
         int n_deferred_msgs;
+        /* Both fields are protected by pWtp->pmutUsr, the queue mutex used
+         * with pcondBusy. A producer reserves a registered waiter before it
+         * signals, preventing one enqueue from being spent on a running slot.
+         */
+        uint8_t bWaitingForWork;
+        uint8_t bWakeupReserved;
         DEF_ATOMIC_HELPER_MUT(mutIsRunning);
         struct {
             uint8_t script_errno; /* errno-type interface for RainerScript functions */
@@ -111,6 +117,18 @@ static inline int wtiIsShutdownImmediate(const wti_t *const pWti) {
 #endif
 }
 
+/* The caller must hold pWti->pWtp->pmutUsr. */
+static inline int ATTR_NONNULL(1) wtiReserveWakeup(wti_t *const pWti) {
+    if (!pWti->bWaitingForWork || pWti->bWakeupReserved) return 0;
+    pWti->bWakeupReserved = 1;
+    return 1;
+}
+
+/* The caller must hold pWti->pWtp->pmutUsr. */
+static inline void ATTR_NONNULL(1) wtiClearWaitReservation(wti_t *const pWti) {
+    pWti->bWaitingForWork = 0;
+    pWti->bWakeupReserved = 0;
+}
 /* prototypes */
 rsRetVal wtiConstruct(wti_t **ppThis);
 rsRetVal wtiConstructFinalize(wti_t *const pThis);

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -124,7 +124,12 @@ static inline int wtiIsShutdownImmediate(const wti_t *const pWti) {
 }
 
 /* The caller must hold pWti->pWtp->pmutUsr. */
-int ATTR_NONNULL(1) wtiReserveWakeup(wti_t *const pWti);
+static inline int ATTR_NONNULL(1) wtiReserveWakeup(wti_t *const pWti) {
+    if (ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) || !pWti->bWaitingForWork || pWti->bWakeupReserved)
+        return 0;
+    pWti->bWakeupReserved = 1;
+    return 1;
+}
 
 /* The caller must hold every worker's pWtp->pmutUsr. A worker that is
  * executing queue work counts toward the requested parallelism. A registered
@@ -133,28 +138,66 @@ int ATTR_NONNULL(1) wtiReserveWakeup(wti_t *const pWti);
  * counted, because it can no longer consume queue work even before its slot
  * is reset to STOPPED.
  */
-int ATTR_NONNULL(1) wtiCountsTowardWorkerBudget(wti_t *const pWti);
+static inline int ATTR_NONNULL(1) wtiCountsTowardWorkerBudget(wti_t *const pWti) {
+    const int state = ATOMIC_LOAD_32BIT(&pWti->bIsRunning, &pWti->mutIsRunning);
+
+    return state == WRKTHRD_RUNNING && !ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) &&
+           (!pWti->bWaitingForWork || pWti->bWakeupReserved);
+}
 
 /* The caller must hold every worker's pWtp->pmutUsr. A registered waiter is
  * live capacity because it can be signalled; an exiting worker is not, even
  * though its thread has not yet reached WAIT_JOIN.
  */
-int ATTR_NONNULL(1) wtiCountsTowardWorkerStartBudget(wti_t *const pWti);
+static inline int ATTR_NONNULL(1) wtiCountsTowardWorkerStartBudget(wti_t *const pWti) {
+    const int state = ATOMIC_LOAD_32BIT(&pWti->bIsRunning, &pWti->mutIsRunning);
+
+    return !ATOMIC_LOAD_32BIT(&pWti->bExiting, &pWti->mutIsRunning) &&
+           (state == WRKTHRD_INITIALIZING || state == WRKTHRD_RUNNING);
+}
 
 /* The caller must hold every worker's pWtp->pmutUsr. */
-int ATTR_NONNULL(1) wtiGetWorkerStartBudget(wti_t *const *const ppWti, int nWorkers, int nMaxWrkr);
+static inline int ATTR_NONNULL(1)
+    wtiGetWorkerStartBudget(wti_t *const *const ppWti, const int nWorkers, const int nMaxWrkr) {
+    int i;
+    int nLive = 0;
+
+    for (i = 0; i < nWorkers; ++i) {
+        if (wtiCountsTowardWorkerStartBudget(ppWti[i])) ++nLive;
+    }
+
+    return nLive < nMaxWrkr ? nMaxWrkr - nLive : 0;
+}
 
 /* The caller must hold every worker's pWtp->pmutUsr. */
-int ATTR_NONNULL(1) wtiGetWakeupBudget(wti_t *const *const ppWti, int nWorkers, int nMaxWrkr);
+static inline int ATTR_NONNULL(1)
+    wtiGetWakeupBudget(wti_t *const *const ppWti, const int nWorkers, const int nMaxWrkr) {
+    int i;
+    int nAvailable = 0;
+
+    for (i = 0; i < nWorkers; ++i) {
+        if (wtiCountsTowardWorkerBudget(ppWti[i])) ++nAvailable;
+    }
+
+    return nAvailable < nMaxWrkr ? nMaxWrkr - nAvailable : 0;
+}
 
 /* The caller must hold pWti->pWtp->pmutUsr. */
-void ATTR_NONNULL(1) wtiClearWaitReservation(wti_t *const pWti);
+static inline void ATTR_NONNULL(1) wtiClearWaitReservation(wti_t *const pWti) {
+    pWti->bWaitingForWork = 0;
+    pWti->bWakeupReserved = 0;
+}
 
 /* The caller must hold pWti->pWtp->pmutUsr. */
-void ATTR_NONNULL(1) wtiMarkExiting(wti_t *const pWti);
+static inline void ATTR_NONNULL(1) wtiMarkExiting(wti_t *const pWti) {
+    ATOMIC_STORE_32BIT(&pWti->bExiting, &pWti->mutIsRunning, 1);
+    wtiClearWaitReservation(pWti);
+}
 
 /* The caller must hold pWti->pWtp->pmutUsr. */
-void ATTR_NONNULL(1) wtiClearExiting(wti_t *const pWti);
+static inline void ATTR_NONNULL(1) wtiClearExiting(wti_t *const pWti) {
+    ATOMIC_STORE_32BIT(&pWti->bExiting, &pWti->mutIsRunning, 0);
+}
 
 /* prototypes */
 rsRetVal wtiConstruct(wti_t **ppThis);

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -191,7 +191,6 @@ static inline void ATTR_NONNULL(1) wtiClearWaitReservation(wti_t *const pWti) {
 /* The caller must hold pWti->pWtp->pmutUsr. */
 static inline void ATTR_NONNULL(1) wtiMarkExiting(wti_t *const pWti) {
     ATOMIC_STORE_32BIT(&pWti->bExiting, &pWti->mutIsRunning, 1);
-    wtiClearWaitReservation(pWti);
 }
 
 /* The caller must hold pWti->pWtp->pmutUsr. */

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -374,6 +374,9 @@ static void wtpWrkrExecCancelCleanup(void *arg) {
     ISOBJ_TYPE_assert(pThis, wtp);
     DBGPRINTF("%s: Worker thread %lx requested to be cancelled.\n", wtpGetDbgHdr(pThis), (unsigned long)pWti);
 
+    d_pthread_mutex_lock(pThis->pmutUsr);
+    wtiMarkExiting(pWti);
+    d_pthread_mutex_unlock(pThis->pmutUsr);
     wtpWrkrExecCleanup(pWti);
 
     pthread_cond_broadcast(&pThis->condThrdTrm); /* activate anyone waiting on thread shutdown */
@@ -507,6 +510,9 @@ static rsRetVal ATTR_NONNULL() wtpStartWrkr(wtp_t *const pThis, const int permit
     }
 
     pWti = pThis->pWrkr[i];
+    /* The caller holds pmutUsr. A reused slot may still carry the marker from
+     * its previous normal exit until it is started again. */
+    wtiClearExiting(pWti);
     iState = pthread_create(&(pWti->thrdID), &pThis->attrThrd, wtpWorker, (void *)pWti);
     if (iState != 0) {
         wtiSetState(pWti, WRKTHRD_STOPPED);
@@ -556,7 +562,9 @@ finalize_it:
 rsRetVal ATTR_NONNULL() wtpAdviseMaxWorkers(wtp_t *const pThis, int nMaxWrkr, const int permit_during_shutdown) {
     DEFiRet;
     int nMissing; /* number workers missing to run */
-    int i, nRunning;
+    int nWakeups;
+    int nStartable;
+    int i;
 
     ISOBJ_TYPE_assert(pThis, wtp);
 
@@ -566,7 +574,7 @@ rsRetVal ATTR_NONNULL() wtpAdviseMaxWorkers(wtp_t *const pThis, int nMaxWrkr, co
         nMaxWrkr = pThis->iNumWorkerThreads;
 
     const int curNumWrkThrd = ATOMIC_LOAD_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd);
-    nMissing = nMaxWrkr - curNumWrkThrd;
+    nMissing = wtiGetWorkerStartBudget(pThis->pWrkr, pThis->iNumWorkerThreads, nMaxWrkr);
 
     if (nMissing > 0) {
         if (curNumWrkThrd > 0) {
@@ -575,23 +583,34 @@ rsRetVal ATTR_NONNULL() wtpAdviseMaxWorkers(wtp_t *const pThis, int nMaxWrkr, co
                    "currently %d active worker threads.",
                    wtpGetDbgHdr(pThis), nMissing, curNumWrkThrd);
         }
-        /* start the rqtd nbr of workers */
-        for (i = 0; i < nMissing; ++i) {
-            CHKiRet(wtpStartWrkr(pThis, permit_during_shutdown));
-        }
-    } else {
-        /* The queue mutex is held by qqueueAdviseMaxWorkers(). Select actual
-         * condvar waiters and reserve each before signalling, so a burst
-         * cannot repeatedly spend wakeups on workers that are still running.
+        /* Start only actually free slots. Exiting slots remain owned by their
+         * terminating threads; the persistent first worker remains available
+         * in regular classic queue pools. A start failure still falls through
+         * to the useful waiter-wakeup pass below.
          */
-        for (i = 0, nRunning = 0; i < pThis->iNumWorkerThreads && nRunning < nMaxWrkr; ++i) {
-            if (wtiGetState(pThis->pWrkr[i]) != WRKTHRD_STOPPED && wtiReserveWakeup(pThis->pWrkr[i])) {
-                pthread_cond_signal(&pThis->pWrkr[i]->pcondBusy);
-                nRunning++;
-            }
+        nStartable = 0;
+        for (i = 0; i < pThis->iNumWorkerThreads; ++i) {
+            const int workerState = wtiGetState(pThis->pWrkr[i]);
+            if (workerState == WRKTHRD_STOPPED || workerState == WRKTHRD_WAIT_JOIN) ++nStartable;
+        }
+        if (nStartable > nMissing) nStartable = nMissing;
+        for (i = 0; i < nStartable; ++i) {
+            const rsRetVal startRet = wtpStartWrkr(pThis, permit_during_shutdown);
+            if (startRet != RS_RET_OK && iRet == RS_RET_OK) iRet = startRet;
         }
     }
 
+    /* The queue mutex is held by qqueueAdviseMaxWorkers(). Re-evaluate after
+     * each synchronous worker start: initialized workers consume budget, while
+     * existing waiters still need individual signals for the remaining slots.
+     */
+    nWakeups = wtiGetWakeupBudget(pThis->pWrkr, pThis->iNumWorkerThreads, nMaxWrkr);
+    for (i = 0; i < pThis->iNumWorkerThreads && nWakeups > 0; ++i) {
+        if (wtiReserveWakeup(pThis->pWrkr[i])) {
+            pthread_cond_signal(&pThis->pWrkr[i]->pcondBusy);
+            --nWakeups;
+        }
+    }
 
 finalize_it:
     RETiRet;

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -580,9 +580,12 @@ rsRetVal ATTR_NONNULL() wtpAdviseMaxWorkers(wtp_t *const pThis, int nMaxWrkr, co
             CHKiRet(wtpStartWrkr(pThis, permit_during_shutdown));
         }
     } else {
-        /* we have needed number of workers, but they may be sleeping */
+        /* The queue mutex is held by qqueueAdviseMaxWorkers(). Select actual
+         * condvar waiters and reserve each before signalling, so a burst
+         * cannot repeatedly spend wakeups on workers that are still running.
+         */
         for (i = 0, nRunning = 0; i < pThis->iNumWorkerThreads && nRunning < nMaxWrkr; ++i) {
-            if (wtiGetState(pThis->pWrkr[i]) != WRKTHRD_STOPPED) {
+            if (wtiGetState(pThis->pWrkr[i]) != WRKTHRD_STOPPED && wtiReserveWakeup(pThis->pWrkr[i])) {
                 pthread_cond_signal(&pThis->pWrkr[i]->pcondBusy);
                 nRunning++;
             }
@@ -597,11 +600,11 @@ finalize_it:
 
 rsRetVal wtpWakeupAllWrkr(wtp_t *pThis) {
     if (pThis == NULL) return RS_RET_PARAM_ERROR;
-    d_pthread_mutex_lock(&pThis->mutWtp);
+    /* The caller holds pmutUsr, which is the mutex associated with pcondBusy.
+     * Do not use mutWtp here: it cannot serialize condition predicates. */
     for (int i = 0; i < pThis->iNumWorkerThreads; ++i) {
         if (wtiGetState(pThis->pWrkr[i]) != WRKTHRD_STOPPED) pthread_cond_signal(&pThis->pWrkr[i]->pcondBusy);
     }
-    d_pthread_mutex_unlock(&pThis->mutWtp);
     return RS_RET_OK;
 }
 

--- a/runtime/wtp.h
+++ b/runtime/wtp.h
@@ -94,8 +94,8 @@ rsRetVal wtpSetState(wtp_t *pThis, wtpState_t iNewState);
 /** Wake every existing worker without creating a stopped worker.
  *
  * The caller must hold the pool's pmutUsr mutex so the queue predicate and
- * pthread condition signal cannot race. The helper serializes only the worker
- * table walk with mutWtp; it does not acquire pmutUsr itself.
+ * pthread condition signal cannot race. The caller supplies all pmutUsr
+ * serialization; this helper does not independently lock the worker table.
  */
 rsRetVal wtpWakeupAllWrkr(wtp_t *pThis);
 rsRetVal wtpCancelAll(wtp_t *pThis, const uchar *const cancelobj);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2799,7 +2799,8 @@ runtime_unit_segdisk_state_CPPFLAGS = \
 runtime_unit_queue_da_CPPFLAGS = \
 	$(runtime_unit_linkedlist_CPPFLAGS)
 runtime_unit_wtp_wakeup_CPPFLAGS = \
-	$(runtime_unit_linkedlist_CPPFLAGS)
+	$(runtime_unit_linkedlist_CPPFLAGS) \
+	-Wno-inline
 
 runtime_unit_linkedlist_LDADD = $(RSRT_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
 runtime_unit_stringbuf_LDADD = $(LIBESTR_LIBS) $(LIBFASTJSON_LIBS) $(LIBSYSTEMD_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
@@ -2808,7 +2809,7 @@ runtime_unit_msg_replace_LDADD = $(runtime_unit_linkedlist_LDADD)
 runtime_unit_ommongodb_date_LDADD = $(runtime_unit_linkedlist_LDADD)
 runtime_unit_segdisk_state_LDADD =
 runtime_unit_queue_da_LDADD =
-runtime_unit_wtp_wakeup_LDADD = ../runtime/librsyslog.la $(PTHREADS_LIBS) $(SOL_LIBS)
+runtime_unit_wtp_wakeup_LDADD = $(PTHREADS_LIBS) $(SOL_LIBS)
 
 if ENABLE_LIBLOGGING_STDLOG
 runtime_unit_linkedlist_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -67,6 +67,8 @@ EXTRA_DIST += $(TESTS_TEMPLATE_PARAMETER_ERRORS)
 
 TESTS_QUEUE_DEFERRED_IDLE_WAKEUP = queue-deferred-idle-wakeup.sh queue-deferred-idle-shutdown.sh
 EXTRA_DIST += $(TESTS_QUEUE_DEFERRED_IDLE_WAKEUP) override_queue_disposal.c
+TESTS_WTP_TARGETED_WAKEUP = wtp-targeted-wakeup.sh
+EXTRA_DIST += $(TESTS_WTP_TARGETED_WAKEUP) unit/wtp_wakeup_test.c
 
 TESTS_SEGQUEUE_TOOL = rsyslog-segqueue-tool.py rsyslog-segqueue-runtime.sh
 EXTRA_DIST += $(TESTS_SEGQUEUE_TOOL)
@@ -2683,9 +2685,11 @@ check_LTLIBRARIES =
 
 # TODO: reenable TESTRUNS = rt_init rscript
 check_PROGRAMS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace \
-	runtime_unit_ommongodb_date runtime_unit_segdisk_state runtime_unit_queue_da runtime_unit_omazuredce_utils
+	runtime_unit_ommongodb_date runtime_unit_segdisk_state runtime_unit_queue_da runtime_unit_omazuredce_utils \
+	runtime_unit_wtp_wakeup
 TESTS = runtime_unit_linkedlist runtime_unit_stringbuf runtime_unit_parser_pri runtime_unit_msg_replace \
-	runtime_unit_ommongodb_date runtime_unit_segdisk_state runtime_unit_queue_da runtime_unit_omazuredce_utils
+	runtime_unit_ommongodb_date runtime_unit_segdisk_state runtime_unit_queue_da runtime_unit_omazuredce_utils \
+	runtime_unit_wtp_wakeup
 
 if ENABLE_FUZZING
 TESTS += $(TESTS_FUZZING)
@@ -2714,6 +2718,9 @@ runtime_unit_queue_da_SOURCES = \
 
 runtime_unit_omazuredce_utils_SOURCES = \
 	unit/omazuredce_utils_test.c
+
+runtime_unit_wtp_wakeup_SOURCES = \
+	unit/wtp_wakeup_test.c
 
 runtime_unit_omazuredce_utils_CPPFLAGS = \
 	$(runtime_unit_linkedlist_CPPFLAGS)
@@ -2791,6 +2798,8 @@ runtime_unit_segdisk_state_CPPFLAGS = \
 	$(runtime_unit_linkedlist_CPPFLAGS)
 runtime_unit_queue_da_CPPFLAGS = \
 	$(runtime_unit_linkedlist_CPPFLAGS)
+runtime_unit_wtp_wakeup_CPPFLAGS = \
+	$(runtime_unit_linkedlist_CPPFLAGS)
 
 runtime_unit_linkedlist_LDADD = $(RSRT_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
 runtime_unit_stringbuf_LDADD = $(LIBESTR_LIBS) $(LIBFASTJSON_LIBS) $(LIBSYSTEMD_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
@@ -2799,6 +2808,7 @@ runtime_unit_msg_replace_LDADD = $(runtime_unit_linkedlist_LDADD)
 runtime_unit_ommongodb_date_LDADD = $(runtime_unit_linkedlist_LDADD)
 runtime_unit_segdisk_state_LDADD =
 runtime_unit_queue_da_LDADD =
+runtime_unit_wtp_wakeup_LDADD = $(PTHREADS_LIBS) $(SOL_LIBS)
 
 if ENABLE_LIBLOGGING_STDLOG
 runtime_unit_linkedlist_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
@@ -2972,6 +2982,7 @@ endif # if ENABLE_ELASTICSEARCH_TESTS
 if ENABLE_DEFAULT_TESTS
 TESTS += $(TESTS_DEFAULT)
 TESTS += $(TESTS_QUEUE_DEFERRED_IDLE_WAKEUP)
+TESTS += $(TESTS_WTP_TARGETED_WAKEUP)
 TESTS += $(TESTS_JSON_OMITIFZERO)
 TESTS += $(TESTS_SEGMENTED_DISK_QUEUE)
 if ENABLE_SEGQUEUE_TOOL

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2808,7 +2808,7 @@ runtime_unit_msg_replace_LDADD = $(runtime_unit_linkedlist_LDADD)
 runtime_unit_ommongodb_date_LDADD = $(runtime_unit_linkedlist_LDADD)
 runtime_unit_segdisk_state_LDADD =
 runtime_unit_queue_da_LDADD =
-runtime_unit_wtp_wakeup_LDADD = $(PTHREADS_LIBS) $(SOL_LIBS)
+runtime_unit_wtp_wakeup_LDADD = ../runtime/librsyslog.la $(PTHREADS_LIBS) $(SOL_LIBS)
 
 if ENABLE_LIBLOGGING_STDLOG
 runtime_unit_linkedlist_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)

--- a/tests/unit/wtp_wakeup_test.c
+++ b/tests/unit/wtp_wakeup_test.c
@@ -251,6 +251,7 @@ int main(void) {
 
     memset(waiters, 0, sizeof(waiters));
     for (i = 0; i < 3; ++i) {
+        INIT_ATOMIC_HELPER_MUT(waiters[i].wti.mutIsRunning);
         CHECK(pthread_cond_init(&waiters[i].cond, NULL) == 0);
         waiters[i].mutex = &mutex;
         waiters[i].registered = &registered;
@@ -272,6 +273,7 @@ int main(void) {
         CHECK(waiters[i].result == 0);
         CHECK(!waiters[i].wti.bWaitingForWork && !waiters[i].wti.bWakeupReserved);
         CHECK(pthread_cond_destroy(&waiters[i].cond) == 0);
+        DESTROY_ATOMIC_HELPER_MUT(waiters[i].wti.mutIsRunning);
     }
 
     int timeout_gate_open = 0;
@@ -282,6 +284,7 @@ int main(void) {
                                .gate_open = &timeout_gate_open,
                                .timeout_ms = 0};
     pthread_t timeout_thread;
+    INIT_ATOMIC_HELPER_MUT(timeout_waiter.wti.mutIsRunning);
     CHECK(pthread_cond_init(&timeout_waiter.cond, NULL) == 0);
     CHECK(pthread_create(&timeout_thread, NULL, waiter_main, &timeout_waiter) == 0);
     CHECK(wait_until_registered(&mutex, &registered, &registered_count, 4) == 0);
@@ -295,6 +298,7 @@ int main(void) {
     CHECK(timeout_waiter.result == ETIMEDOUT);
     CHECK(!timeout_waiter.wti.bWaitingForWork && !timeout_waiter.wti.bWakeupReserved);
     CHECK(pthread_cond_destroy(&timeout_waiter.cond) == 0);
+    DESTROY_ATOMIC_HELPER_MUT(timeout_waiter.wti.mutIsRunning);
 
     int cancel_gate_open = 0;
     int cancel_entered_wait_count = 0;
@@ -307,6 +311,7 @@ int main(void) {
                               .entered_wait_count = &cancel_entered_wait_count,
                               .timeout_ms = -1};
     pthread_t cancel_thread;
+    INIT_ATOMIC_HELPER_MUT(cancel_waiter.wti.mutIsRunning);
     CHECK(pthread_cond_init(&cancel_waiter.cond, NULL) == 0);
     CHECK(pthread_create(&cancel_thread, NULL, waiter_main, &cancel_waiter) == 0);
     CHECK(wait_until_registered(&mutex, &registered, &registered_count, 5) == 0);
@@ -321,6 +326,7 @@ int main(void) {
     CHECK(pthread_join(cancel_thread, NULL) == 0);
     CHECK(!cancel_waiter.wti.bWaitingForWork && !cancel_waiter.wti.bWakeupReserved);
     CHECK(pthread_cond_destroy(&cancel_waiter.cond) == 0);
+    DESTROY_ATOMIC_HELPER_MUT(cancel_waiter.wti.mutIsRunning);
 
     CHECK(pthread_cond_destroy(&registered) == 0);
     CHECK(pthread_cond_destroy(&timeout_gate) == 0);

--- a/tests/unit/wtp_wakeup_test.c
+++ b/tests/unit/wtp_wakeup_test.c
@@ -1,0 +1,138 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Verify the queue-mutex-protected WTP waiter protocol. Real pthread waiters
+ * register under one mutex, are reserved before individual signals, and clear
+ * their reservation after signal, timeout, or deferred cancellation.
+ */
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <pthread.h>
+#include <time.h>
+
+#include "rsyslog.h"
+#include "wti.h"
+
+#define CHECK(condition)                                                                    \
+    do {                                                                                    \
+        if (!(condition)) {                                                                 \
+            fprintf(stderr, "CHECK failed at %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+            return 1;                                                                       \
+        }                                                                                   \
+    } while (0)
+
+typedef struct waiter_s {
+    wti_t wti;
+    pthread_cond_t cond;
+    pthread_mutex_t *mutex;
+    pthread_cond_t *registered;
+    int *registered_count;
+    int result;
+    int timeout_ms;
+} waiter_t;
+
+static void clear_reservation(void *arg) {
+    wtiClearWaitReservation(&((waiter_t *)arg)->wti);
+}
+
+static void unlock_mutex(void *arg) {
+    pthread_mutex_unlock((pthread_mutex_t *)arg);
+}
+
+static void *waiter_main(void *arg) {
+    waiter_t *const waiter = arg;
+    struct timespec deadline;
+
+    if (pthread_mutex_lock(waiter->mutex) != 0) abort();
+    waiter->wti.bWaitingForWork = 1;
+    waiter->wti.bWakeupReserved = 0;
+    ++*waiter->registered_count;
+    if (pthread_cond_broadcast(waiter->registered) != 0) abort();
+    pthread_cleanup_push(unlock_mutex, waiter->mutex);
+    pthread_cleanup_push(clear_reservation, waiter);
+    if (waiter->timeout_ms < 0) {
+        waiter->result = pthread_cond_wait(&waiter->cond, waiter->mutex);
+    } else {
+        if (clock_gettime(CLOCK_REALTIME, &deadline) != 0) abort();
+        deadline.tv_nsec += (long)waiter->timeout_ms * 1000000L;
+        if (deadline.tv_nsec >= 1000000000L) {
+            ++deadline.tv_sec;
+            deadline.tv_nsec -= 1000000000L;
+        }
+        waiter->result = pthread_cond_timedwait(&waiter->cond, waiter->mutex, &deadline);
+    }
+    pthread_cleanup_pop(0);
+    wtiClearWaitReservation(&waiter->wti);
+    pthread_cleanup_pop(1);
+    return NULL;
+}
+
+static int wait_until_registered(pthread_mutex_t *mutex, pthread_cond_t *registered, int *count, int expected) {
+    CHECK(pthread_mutex_lock(mutex) == 0);
+    while (*count < expected) CHECK(pthread_cond_wait(registered, mutex) == 0);
+    return pthread_mutex_unlock(mutex);
+}
+
+int main(void) {
+    pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+    pthread_cond_t registered = PTHREAD_COND_INITIALIZER;
+    waiter_t waiters[3];
+    pthread_t threads[3];
+    int registered_count = 0;
+    int i;
+
+    memset(waiters, 0, sizeof(waiters));
+    for (i = 0; i < 3; ++i) {
+        CHECK(pthread_cond_init(&waiters[i].cond, NULL) == 0);
+        waiters[i].mutex = &mutex;
+        waiters[i].registered = &registered;
+        waiters[i].registered_count = &registered_count;
+        waiters[i].timeout_ms = -1;
+        CHECK(pthread_create(&threads[i], NULL, waiter_main, &waiters[i]) == 0);
+    }
+    CHECK(wait_until_registered(&mutex, &registered, &registered_count, 3) == 0);
+
+    CHECK(pthread_mutex_lock(&mutex) == 0);
+    for (i = 0; i < 3; ++i) {
+        CHECK(wtiReserveWakeup(&waiters[i].wti));
+        CHECK(!wtiReserveWakeup(&waiters[i].wti));
+        CHECK(pthread_cond_signal(&waiters[i].cond) == 0);
+    }
+    CHECK(pthread_mutex_unlock(&mutex) == 0);
+    for (i = 0; i < 3; ++i) {
+        CHECK(pthread_join(threads[i], NULL) == 0);
+        CHECK(waiters[i].result == 0);
+        CHECK(!waiters[i].wti.bWaitingForWork && !waiters[i].wti.bWakeupReserved);
+        CHECK(pthread_cond_destroy(&waiters[i].cond) == 0);
+    }
+
+    waiter_t timeout_waiter = {
+        .mutex = &mutex, .registered = &registered, .registered_count = &registered_count, .timeout_ms = 20};
+    pthread_t timeout_thread;
+    CHECK(pthread_cond_init(&timeout_waiter.cond, NULL) == 0);
+    CHECK(pthread_create(&timeout_thread, NULL, waiter_main, &timeout_waiter) == 0);
+    CHECK(wait_until_registered(&mutex, &registered, &registered_count, 4) == 0);
+    CHECK(pthread_join(timeout_thread, NULL) == 0);
+    CHECK(timeout_waiter.result == ETIMEDOUT);
+    CHECK(!timeout_waiter.wti.bWaitingForWork && !timeout_waiter.wti.bWakeupReserved);
+    CHECK(pthread_cond_destroy(&timeout_waiter.cond) == 0);
+
+    waiter_t cancel_waiter = {
+        .mutex = &mutex, .registered = &registered, .registered_count = &registered_count, .timeout_ms = -1};
+    pthread_t cancel_thread;
+    CHECK(pthread_cond_init(&cancel_waiter.cond, NULL) == 0);
+    CHECK(pthread_create(&cancel_thread, NULL, waiter_main, &cancel_waiter) == 0);
+    CHECK(wait_until_registered(&mutex, &registered, &registered_count, 5) == 0);
+    CHECK(pthread_cancel(cancel_thread) == 0);
+    CHECK(pthread_join(cancel_thread, NULL) == 0);
+    CHECK(!cancel_waiter.wti.bWaitingForWork && !cancel_waiter.wti.bWakeupReserved);
+    CHECK(pthread_cond_destroy(&cancel_waiter.cond) == 0);
+
+    CHECK(pthread_cond_destroy(&registered) == 0);
+    CHECK(pthread_mutex_destroy(&mutex) == 0);
+    puts("WTP concurrent waiter reservation tests passed");
+    return 0;
+}

--- a/tests/unit/wtp_wakeup_test.c
+++ b/tests/unit/wtp_wakeup_test.c
@@ -30,6 +30,13 @@ typedef struct waiter_s {
     pthread_mutex_t *mutex;
     pthread_cond_t *registered;
     int *registered_count;
+    /* Optional deterministic gate: the controller reserves this worker before
+     * it may enter its timed wait. entered_wait reports that the next condvar
+     * wait is the actual wait being tested, not the setup gate. */
+    pthread_cond_t *gate;
+    int *gate_open;
+    pthread_cond_t *entered_wait;
+    int *entered_wait_count;
     int result;
     int timeout_ms;
 } waiter_t;
@@ -53,6 +60,13 @@ static void *waiter_main(void *arg) {
     if (pthread_cond_broadcast(waiter->registered) != 0) abort();
     pthread_cleanup_push(unlock_mutex, waiter->mutex);
     pthread_cleanup_push(clear_reservation, waiter);
+    while (waiter->gate != NULL && !*waiter->gate_open) {
+        if (pthread_cond_wait(waiter->gate, waiter->mutex) != 0) abort();
+    }
+    if (waiter->entered_wait != NULL) {
+        ++*waiter->entered_wait_count;
+        if (pthread_cond_broadcast(waiter->entered_wait) != 0) abort();
+    }
     if (waiter->timeout_ms < 0) {
         waiter->result = pthread_cond_wait(&waiter->cond, waiter->mutex);
     } else {
@@ -76,13 +90,164 @@ static int wait_until_registered(pthread_mutex_t *mutex, pthread_cond_t *registe
     return pthread_mutex_unlock(mutex);
 }
 
+static void init_budget_worker(wti_t *worker, const int state, const int waiting, const int reserved) {
+    memset(worker, 0, sizeof(*worker));
+    INIT_ATOMIC_HELPER_MUT(worker->mutIsRunning);
+    ATOMIC_STORE_32BIT(&worker->bIsRunning, &worker->mutIsRunning, state);
+    worker->bWaitingForWork = waiting;
+    worker->bWakeupReserved = reserved;
+    worker->bExiting = 0;
+}
+
+static void destruct_budget_worker(wti_t *worker) {
+    (void)worker;
+    DESTROY_ATOMIC_HELPER_MUT(worker->mutIsRunning);
+}
+
+/* This is the non-threaded half of wtpAdviseMaxWorkers(): its caller already
+ * holds the queue mutex, so each successful reservation is one exact future
+ * consumer and duplicate reservations are excluded by wtiReserveWakeup().
+ */
+static int reserve_wakeup_budget(wti_t *const *workers, const int nworkers, const int target) {
+    int i;
+    int reserved = 0;
+    int budget = wtiGetWakeupBudget(workers, nworkers, target);
+
+    for (i = 0; i < nworkers && budget > 0; ++i) {
+        if (wtiReserveWakeup(workers[i])) {
+            --budget;
+            ++reserved;
+        }
+    }
+    return reserved;
+}
+
+static int check_wakeup_budget(void) {
+    wti_t workers[4];
+    wti_t *worker_ptrs[4] = {&workers[0], &workers[1], &workers[2], &workers[3]};
+    int i;
+
+    /* Two busy workers plus two waiters need exactly one reserved wakeup for
+     * target parallelism three; the second waiter must remain unreserved.
+     */
+    init_budget_worker(&workers[0], WRKTHRD_RUNNING, 0, 0);
+    init_budget_worker(&workers[1], WRKTHRD_RUNNING, 0, 0);
+    init_budget_worker(&workers[2], WRKTHRD_RUNNING, 1, 0);
+    init_budget_worker(&workers[3], WRKTHRD_RUNNING, 1, 0);
+    CHECK(wtiGetWakeupBudget(worker_ptrs, 4, 3) == 1);
+    CHECK(reserve_wakeup_budget(worker_ptrs, 4, 3) == 1);
+    CHECK(workers[2].bWakeupReserved && !workers[3].bWakeupReserved);
+    CHECK(wtiGetWakeupBudget(worker_ptrs, 4, 3) == 0);
+    CHECK(reserve_wakeup_budget(worker_ptrs, 4, 3) == 0);
+
+    /* A previous producer's reservation is already effective parallelism.
+     * A stopped or terminating slot must not hide a needed wakeup. This models
+     * the last enqueue while a former busy worker has entered its exit window:
+     * marking it exiting makes the already-idle worker the one exact wakeup.
+     */
+    wtiMarkExiting(&workers[0]);
+    workers[1].bWaitingForWork = 1;
+    workers[1].bWakeupReserved = 0;
+    ATOMIC_STORE_32BIT(&workers[2].bIsRunning, &workers[2].mutIsRunning, WRKTHRD_WAIT_JOIN);
+    workers[2].bWaitingForWork = 0;
+    workers[2].bWakeupReserved = 0;
+    ATOMIC_STORE_32BIT(&workers[3].bIsRunning, &workers[3].mutIsRunning, WRKTHRD_STOPPED);
+    workers[3].bWaitingForWork = 0;
+    workers[3].bWakeupReserved = 0;
+    CHECK(wtiGetWakeupBudget(worker_ptrs, 4, 1) == 1);
+    CHECK(reserve_wakeup_budget(worker_ptrs, 4, 1) == 1);
+    CHECK(workers[1].bWakeupReserved);
+    CHECK(wtiGetWakeupBudget(worker_ptrs, 4, 1) == 0);
+
+    for (i = 0; i < 4; ++i) destruct_budget_worker(&workers[i]);
+    return 0;
+}
+
+static int check_start_missing_budget(void) {
+    wti_t workers[4];
+    wti_t *worker_ptrs[4] = {&workers[0], &workers[1], &workers[2], &workers[3]};
+    int i;
+
+    /* Two live waiters and target parallelism three require exactly one start.
+     * Once that started worker is RUNNING, the re-evaluated budget is two, so
+     * both established waiters are reserved rather than left idle.
+     */
+    init_budget_worker(&workers[0], WRKTHRD_RUNNING, 1, 0);
+    init_budget_worker(&workers[1], WRKTHRD_RUNNING, 1, 0);
+    init_budget_worker(&workers[2], WRKTHRD_STOPPED, 0, 0);
+    init_budget_worker(&workers[3], WRKTHRD_STOPPED, 0, 0);
+    CHECK(wtiGetWorkerStartBudget(worker_ptrs, 4, 3) == 1);
+    ATOMIC_STORE_32BIT(&workers[2].bIsRunning, &workers[2].mutIsRunning, WRKTHRD_RUNNING);
+    CHECK(wtiGetWakeupBudget(worker_ptrs, 4, 3) == 2);
+    CHECK(reserve_wakeup_budget(worker_ptrs, 4, 3) == 2);
+    CHECK(workers[0].bWakeupReserved && workers[1].bWakeupReserved);
+    CHECK(wtiGetWakeupBudget(worker_ptrs, 4, 3) == 0);
+
+    for (i = 0; i < 4; ++i) destruct_budget_worker(&workers[i]);
+    return 0;
+}
+
+static int check_persistent_first_worker_budget(void) {
+    wti_t workers[2];
+    wti_t *worker_ptrs[2] = {&workers[0], &workers[1]};
+
+    /* In regular classic queues, wtpStartWrkr marks w0 always-running. When
+     * an additional worker is in normal exit cleanup, the final enqueue still
+     * has w0 as a live waiter and must reserve exactly that one wakeup.
+     */
+    init_budget_worker(&workers[0], WRKTHRD_RUNNING, 1, 0);
+    workers[0].bAlwaysRunning = 1;
+    init_budget_worker(&workers[1], WRKTHRD_RUNNING, 0, 0);
+    wtiMarkExiting(&workers[1]);
+    CHECK(wtiGetWorkerStartBudget(worker_ptrs, 2, 1) == 0);
+    CHECK(wtiGetWakeupBudget(worker_ptrs, 2, 1) == 1);
+    CHECK(reserve_wakeup_budget(worker_ptrs, 2, 1) == 1);
+    CHECK(workers[0].bWakeupReserved);
+    CHECK(wtiGetWakeupBudget(worker_ptrs, 2, 1) == 0);
+
+    destruct_budget_worker(&workers[0]);
+    destruct_budget_worker(&workers[1]);
+    return 0;
+}
+
+static int check_cancel_exit_budget(void) {
+    wti_t workers[2];
+    wti_t *worker_ptrs[2] = {&workers[0], &workers[1]};
+
+    /* wtiWorkerCancelCleanup() uses wtiMarkExiting() before it restores the
+     * cancelled batch. A concurrently waiting peer must therefore become the
+     * one exact consumer for target one, rather than the cancelled slot being
+     * mistakenly counted as capacity during that cleanup window.
+     */
+    init_budget_worker(&workers[0], WRKTHRD_RUNNING, 1, 0);
+    workers[0].bAlwaysRunning = 1;
+    init_budget_worker(&workers[1], WRKTHRD_RUNNING, 0, 0);
+    wtiMarkExiting(&workers[1]);
+    CHECK(wtiGetWorkerStartBudget(worker_ptrs, 2, 1) == 0);
+    CHECK(wtiGetWakeupBudget(worker_ptrs, 2, 1) == 1);
+    CHECK(reserve_wakeup_budget(worker_ptrs, 2, 1) == 1);
+    CHECK(workers[0].bWakeupReserved);
+
+    destruct_budget_worker(&workers[0]);
+    destruct_budget_worker(&workers[1]);
+    return 0;
+}
+
 int main(void) {
     pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
     pthread_cond_t registered = PTHREAD_COND_INITIALIZER;
+    pthread_cond_t timeout_gate = PTHREAD_COND_INITIALIZER;
+    pthread_cond_t cancel_gate = PTHREAD_COND_INITIALIZER;
+    pthread_cond_t cancel_entered_wait = PTHREAD_COND_INITIALIZER;
     waiter_t waiters[3];
     pthread_t threads[3];
     int registered_count = 0;
     int i;
+
+    CHECK(check_wakeup_budget() == 0);
+    CHECK(check_start_missing_budget() == 0);
+    CHECK(check_persistent_first_worker_budget() == 0);
+    CHECK(check_cancel_exit_budget() == 0);
 
     memset(waiters, 0, sizeof(waiters));
     for (i = 0; i < 3; ++i) {
@@ -109,29 +274,58 @@ int main(void) {
         CHECK(pthread_cond_destroy(&waiters[i].cond) == 0);
     }
 
-    waiter_t timeout_waiter = {
-        .mutex = &mutex, .registered = &registered, .registered_count = &registered_count, .timeout_ms = 20};
+    int timeout_gate_open = 0;
+    waiter_t timeout_waiter = {.mutex = &mutex,
+                               .registered = &registered,
+                               .registered_count = &registered_count,
+                               .gate = &timeout_gate,
+                               .gate_open = &timeout_gate_open,
+                               .timeout_ms = 0};
     pthread_t timeout_thread;
     CHECK(pthread_cond_init(&timeout_waiter.cond, NULL) == 0);
     CHECK(pthread_create(&timeout_thread, NULL, waiter_main, &timeout_waiter) == 0);
     CHECK(wait_until_registered(&mutex, &registered, &registered_count, 4) == 0);
+    CHECK(pthread_mutex_lock(&mutex) == 0);
+    CHECK(wtiReserveWakeup(&timeout_waiter.wti));
+    CHECK(timeout_waiter.wti.bWakeupReserved);
+    timeout_gate_open = 1;
+    CHECK(pthread_cond_signal(&timeout_gate) == 0);
+    CHECK(pthread_mutex_unlock(&mutex) == 0);
     CHECK(pthread_join(timeout_thread, NULL) == 0);
     CHECK(timeout_waiter.result == ETIMEDOUT);
     CHECK(!timeout_waiter.wti.bWaitingForWork && !timeout_waiter.wti.bWakeupReserved);
     CHECK(pthread_cond_destroy(&timeout_waiter.cond) == 0);
 
-    waiter_t cancel_waiter = {
-        .mutex = &mutex, .registered = &registered, .registered_count = &registered_count, .timeout_ms = -1};
+    int cancel_gate_open = 0;
+    int cancel_entered_wait_count = 0;
+    waiter_t cancel_waiter = {.mutex = &mutex,
+                              .registered = &registered,
+                              .registered_count = &registered_count,
+                              .gate = &cancel_gate,
+                              .gate_open = &cancel_gate_open,
+                              .entered_wait = &cancel_entered_wait,
+                              .entered_wait_count = &cancel_entered_wait_count,
+                              .timeout_ms = -1};
     pthread_t cancel_thread;
     CHECK(pthread_cond_init(&cancel_waiter.cond, NULL) == 0);
     CHECK(pthread_create(&cancel_thread, NULL, waiter_main, &cancel_waiter) == 0);
     CHECK(wait_until_registered(&mutex, &registered, &registered_count, 5) == 0);
+    CHECK(pthread_mutex_lock(&mutex) == 0);
+    CHECK(wtiReserveWakeup(&cancel_waiter.wti));
+    CHECK(cancel_waiter.wti.bWakeupReserved);
+    cancel_gate_open = 1;
+    CHECK(pthread_cond_signal(&cancel_gate) == 0);
+    while (cancel_entered_wait_count == 0) CHECK(pthread_cond_wait(&cancel_entered_wait, &mutex) == 0);
+    CHECK(pthread_mutex_unlock(&mutex) == 0);
     CHECK(pthread_cancel(cancel_thread) == 0);
     CHECK(pthread_join(cancel_thread, NULL) == 0);
     CHECK(!cancel_waiter.wti.bWaitingForWork && !cancel_waiter.wti.bWakeupReserved);
     CHECK(pthread_cond_destroy(&cancel_waiter.cond) == 0);
 
     CHECK(pthread_cond_destroy(&registered) == 0);
+    CHECK(pthread_cond_destroy(&timeout_gate) == 0);
+    CHECK(pthread_cond_destroy(&cancel_gate) == 0);
+    CHECK(pthread_cond_destroy(&cancel_entered_wait) == 0);
     CHECK(pthread_mutex_destroy(&mutex) == 0);
     puts("WTP concurrent waiter reservation tests passed");
     return 0;

--- a/tests/wtp-targeted-wakeup.sh
+++ b/tests/wtp-targeted-wakeup.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Verify targeted WTP wakeups across repeated queue-idle lifecycles. The first
+# phase proves that a main-queue worker enters wtiWaitNonEmpty and the
+# minimum-dequeue-batch wait times out. Worker scheduling intentionally does
+# not decide whether w0 or w1 dequeues that partial batch. A separate ordered
+# debug-log oracle also proves that w1 idles, times out, and completes
+# its worker-exit cleanup before a later filtered enqueue restarts w1. This
+# avoids a fixed sleep while preserving exact two-ID delivery as the data
+# oracle.
+. ${srcdir:=.}/diag.sh init
+export RSYSLOG_DEBUG="debug nostdout"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.wtp-debug.log"
+
+count_w1_starts() {
+	if test -f "$RSYSLOG_DEBUGLOG"; then
+		grep -c 'main Q:Reg/w1.*worker starting' "$RSYSLOG_DEBUGLOG" || true
+	else
+		echo 0
+	fi
+}
+
+# queue.c emits the first two events around wtiWaitNonEmpty(). wtp.c emits the
+# last event only after w1's state has become WAIT_JOIN and its active-worker
+# count has been decremented. The w1 lifecycle is ordered, while the generic
+# min-batch events may occur on either side of it.
+completed_w1_lifecycle() {
+	if test ! -f "$RSYSLOG_DEBUGLOG"; then
+		echo 0
+		return
+	fi
+	awk '
+		/waiting on queue to become non-empty/ { saw_wait = 1 }
+		/minDeqBatchSize timeout/ { saw_minbatch_timeout = 1 }
+		/main Q:Reg\/w1: worker IDLE, waiting for work/ { saw_w1_idle = 1 }
+		saw_w1_idle && /main Q:Reg\/w1: inactivity timeout, worker terminating/ { saw_w1_timeout = 1 }
+		saw_w1_timeout && /main Q:Reg\/w1.*Worker thread [0-9a-f]+, terminated/ { saw_w1_exit = 1 }
+		END { print saw_wait && saw_minbatch_timeout && saw_w1_exit ? 1 : 0 }
+	' "$RSYSLOG_DEBUGLOG"
+}
+
+generate_conf
+add_conf '
+# Keep worker-termination status messages from creating an unrelated main-queue
+# enqueue; only the explicit filtered trigger may restart the stopped w1 slot.
+global(processInternalMessages="off")
+main_queue(queue.type="LinkedList" queue.workerThreads="2"
+	queue.workerThreadMinimumMessages="1" queue.dequeueBatchSize="1"
+	queue.minDequeueBatchSize="2" queue.minDequeueBatchSize.timeout="200"
+	queue.timeoutWorkerthreadShutdown="1000")
+template(name="outfmt" type="string" string="id=%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt" file="'"$RSYSLOG_OUT_LOG"'")
+'
+startup
+
+injectmsg 0 2
+wait_file_lines --abort-on-oversize "$RSYSLOG_OUT_LOG" 2
+wait_file_lines --count-function completed_w1_lifecycle "$RSYSLOG_DEBUGLOG" 1
+
+# This reaches the same queue but is filtered from the output action. Its
+# lifecycle effect is to require the already-terminated nonzero worker slot to
+# restart. The preceding ordered predicate makes this start count a post-exit
+# baseline rather than an observation of a still-running worker.
+w1_starts_before_restart=$(count_w1_starts)
+injectmsg_literal 'wtp targeted restart trigger'
+wait_file_lines --count-function count_w1_starts "$RSYSLOG_DEBUGLOG" $((w1_starts_before_restart + 1))
+
+shutdown_when_empty
+wait_shutdown
+for message in $(seq 0 1); do
+	printf -v formatted_message '%08d' "$message"
+	content_count_check --regex "^id=$formatted_message$" 1 "$RSYSLOG_OUT_LOG"
+done
+exit_test

--- a/tests/wtp-targeted-wakeup.sh
+++ b/tests/wtp-targeted-wakeup.sh
@@ -19,6 +19,18 @@ count_w1_starts() {
 	fi
 }
 
+first_worker_remains_live() {
+	if test ! -f "$RSYSLOG_DEBUGLOG"; then
+		echo 0
+		return
+	fi
+	awk '
+		/main Q:Reg\/w0.*:.*worker starting/ { ++starts }
+		/main Q:Reg\/w0.*Worker thread [0-9a-f]+, terminated/ { exited = 1 }
+		END { print starts == 1 && !exited ? 1 : 0 }
+	' "$RSYSLOG_DEBUGLOG"
+}
+
 # queue.c emits the first two events around wtiWaitNonEmpty(). wtp.c emits the
 # last event only after w1's state has become WAIT_JOIN and its active-worker
 # count has been decremented. The w1 lifecycle is ordered, while the generic
@@ -55,6 +67,10 @@ startup
 injectmsg 0 2
 wait_file_lines --abort-on-oversize "$RSYSLOG_OUT_LOG" 2
 wait_file_lines --count-function completed_w1_lifecycle "$RSYSLOG_DEBUGLOG" 1
+# For regular classic queues w0 is always-running: w1 may time out, but the
+# final consumer remains available to handle the next burst without any
+# exit/re-entry handoff.
+wait_file_lines --count-function first_worker_remains_live "$RSYSLOG_DEBUGLOG" 1
 
 # This reaches the same queue but is filtered from the output action. Its
 # lifecycle effect is to require the already-terminated nonzero worker slot to
@@ -63,6 +79,7 @@ wait_file_lines --count-function completed_w1_lifecycle "$RSYSLOG_DEBUGLOG" 1
 w1_starts_before_restart=$(count_w1_starts)
 injectmsg_literal 'wtp targeted restart trigger'
 wait_file_lines --count-function count_w1_starts "$RSYSLOG_DEBUGLOG" $((w1_starts_before_restart + 1))
+wait_file_lines --count-function first_worker_remains_live "$RSYSLOG_DEBUGLOG" 1
 
 shutdown_when_empty
 wait_shutdown


### PR DESCRIPTION
## Summary

Use per-worker wait reservations to wake only classic WTP workers that are actually waiting, and budget starts/wakeups from executable queue capacity. Exiting workers no longer count as consumers, including save-on-shutdown and cancellation paths.

## Validation

- Ubuntu 26.04 change-gated container: 1,551 PASS, 69 SKIP, 0 FAIL/ERROR
- Focused unit and lifecycle coverage, including timeout, cancellation, W0 persistence, restart, exact delivery, LinkedList, FixedArray, min-batch and DA paths
- TSAN identified two `bExiting` races during development; both were fixed. Final TSAN run showed no WTP/`bExiting` report, but had one isolated `omhttp-retry` failure without a sanitizer report.
- 160 A/B, LinkedList/legacy, 8 imtcp connections, 20,000 messages, 11 alternating pairs: sender Patch/Baseline median 1.0107 (MAD 1.22%); drain Baseline/Patch median 1.0053 (MAD 2.60%). All 22 trials had exact three-target delivery and clean shutdown.

## Notes

The branch has two commits: the targeted wakeup handshake and its corrected capacity accounting/TSAN hardening.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

