### PR TITLE
queue: retain final batch count for checkpoints

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -3665,10 +3665,13 @@ static rsRetVal batchProcessed(qqueue_t *pThis, wti_t *pWti) {
     ISOBJ_TYPE_assert(pWti, wti);
 
     int iCancelStateSave;
+    /* DeleteProcessedBatch() defers final message destruction by resetting
+     * the batch counters, so retain the dequeue count for checkpointing. */
+    const int nElemDeq = pWti->batch.nElemDeq;
     /* at this spot, we must not be cancelled */
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &iCancelStateSave);
     DeleteProcessedBatch(pThis, pWti);
-    qqueueChkPersist(pThis, pWti->batch.nElemDeq);
+    qqueueChkPersist(pThis, nElemDeq);
     qqueueDrainDeferredLocked(pThis, pWti);
     pthread_setcancelstate(iCancelStateSave, NULL);
 


### PR DESCRIPTION
## Summary

Preserve the completed dequeue count before deferred batch disposal clears it, so a worker’s final completed batch advances classic disk-queue checkpoint accounting.

## Change

- Snapshot `nElemDeq` before `DeleteProcessedBatch()`.
- Pass that saved value to `qqueueChkPersist()`.
- Retain the current deferred-drain and cancellation lifecycle unchanged.

## Scope

This replaces the obsolete worker-wakeup experiment formerly carried by this PR. The cancellation-locking and deferred-disposal work is already in `main` via #7567; this PR retains only the missing checkpoint-accounting follow-up.

## Validation

- Focused host build and classic DA persistence coverage passed.
- C formatting and static-analyzer container checks passed.
- Hosted CI is the remaining validation authority; the broad local container gate was not completed.