### PR TITLE
doc: document zero enqueue timeout

### DIFF
--- a/.codex/pre_push_container_gate.sh
+++ b/.codex/pre_push_container_gate.sh
@@ -247,6 +247,37 @@ script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"
 cd "${repo_root}"
 
+# GitHub's run_checks.yml classifies its runtime lane from the PR delta. Keep
+# this local gate aligned with that policy: documentation, README, AGENTS, and
+# other non-runtime changes do not need a runtime-container validation marker.
+# Retain the previous gate coverage for build and metadata inputs. Use the PR
+# base, rather than the marker, so an old marker cannot make unrelated
+# main-branch changes look like part of the local push.
+is_non_runtime_push_delta() {
+  local base_ref
+
+  for base_ref in "${RSYSLOG_LOCAL_VALIDATION_BASE:-}" origin/main upstream/main '@{upstream}'; do
+    [ -n "${base_ref}" ] || continue
+    if git rev-parse --verify "${base_ref}^{commit}" >/dev/null 2>&1; then
+      base_ref="$(git merge-base HEAD "${base_ref}")" || return 1
+      break
+    fi
+    base_ref=''
+  done
+
+  [ -n "${base_ref:-}" ] || return 1
+
+  local changed_files
+  changed_files="$(git diff --name-only "${base_ref}"...HEAD)"
+  [ -n "${changed_files}" ] || return 1
+  ! grep -Ev '^doc/Makefile\.am$' <<<"${changed_files}" |
+    grep -Eq '(^|/).*\.(c|h|sh|py)$|(^|/)Dockerfile|(^|/)MODULE_METADATA\.yaml$|^grammar/(lexer\.l|grammar\.y)$|^tests/[^/]+\.sh$|^diag\.sh$|(^|/)Makefile\.am$|^configure\.ac$|^\.github/workflows/run_checks\.yml$'
+}
+
+if is_non_runtime_push_delta; then
+  exit 0
+fi
+
 # Check if SKIP_CONTAINER_VALIDATION is set
 if [[ "${SKIP_CONTAINER_VALIDATION:-0}" == "1" ]]; then
   exit 0

--- a/doc/source/rainerscript/queue_parameters.rst
+++ b/doc/source/rainerscript/queue_parameters.rst
@@ -613,6 +613,7 @@ queue.timeoutEnqueue
 
 This timeout value is used when the queue is full. If rsyslog cannot
 enqueue a message within the timeout period, the message is discarded.
+A value of ``0`` discards the message immediately when the queue is full.
 Note that this is setting of last resort (assuming defaults are used
 for the queue settings or proper parameters are set): all delayable
 inputs (like imtcp or imfile) have already been pushed back at this

--- a/tests/codex-pre-push-container-gate.sh
+++ b/tests/codex-pre-push-container-gate.sh
@@ -3,12 +3,18 @@
 #
 # Copyright 2026 Rainer Gerhards and Adiscon GmbH.
 #
-# Regression test for the Codex pre-push gate's explicit validation bypass.
-# It proves that direct, env-prefixed, and shell-wrapped inline overrides are
-# accepted, while ordinary and shell-wrapped pushes, false overrides, and
-# mixed command lists still produce the hook's deny decision. Empty output is
-# the allow oracle; the JSON permissionDecision=deny response is the block
-# oracle. The shell-wrapped blocked case proves wrapper push recognition.
+# Regression test for the Codex pre-push gate's explicit validation bypass and
+# non-runtime exemption. It proves that direct, env-prefixed, and shell-wrapped
+# inline overrides are accepted, that documentation, README, and AGENTS-only
+# deltas are accepted, and that ordinary and shell-wrapped pushes, false
+# overrides, and mixed command lists still produce the hook's deny decision.
+# Empty output is the allow oracle; the JSON permissionDecision=deny response
+# is the block oracle. The shell-wrapped blocked case proves wrapper push
+# recognition. The non-runtime case uses a synthetic origin/main base and
+# committed documentation, README, and AGENTS files, so branch-delta
+# classification is the oracle. Subsequent synthetic runtime, build, metadata,
+# and tooling files must return the gate to its blocked state, proving that the
+# exemption cannot cover inputs that require container validation.
 # This is intentionally standalone rather than a diag.sh scenario: it exercises
 # only hook command parsing and needs neither rsyslogd nor testbench helpers.
 # The hook is intentionally absent from release tarballs, so this test skips
@@ -22,6 +28,7 @@ test_srcdir="${srcdir:-$(dirname "$0")}"
 gate_source="$test_srcdir/../.codex/pre_push_container_gate.sh"
 [ -f "$gate_source" ] || exit 77
 command -v python3 >/dev/null 2>&1 || exit 77
+command -v git >/dev/null 2>&1 || exit 77
 
 mkdir -p "$tmpdir/.codex"
 cp "$gate_source" "$tmpdir/.codex/"
@@ -80,3 +87,36 @@ assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'env --unset=SKIP_CONTAINER
 assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'env -uSKIP_CONTAINER_VALIDATION git push origin topic'"
 assert_blocked "SKIP_CONTAINER_VALIDATION=1 bash -lc 'unset SKIP_CONTAINER_VALIDATION; git push origin topic'"
 assert_blocked 'SKIP_CONTAINER_VALIDATION=1 git push origin topic; git push origin other'
+
+assert_runtime_delta_blocked() {
+	path="$1"
+	content="$2"
+	mkdir -p "$tmpdir/$(dirname "$path")"
+	printf '%s\n' "$content" > "$tmpdir/$path"
+	git -C "$tmpdir" add "$path"
+	git -C "$tmpdir" commit -qm "add $path"
+	assert_blocked 'git push origin topic'
+	git -C "$tmpdir" reset --hard -q HEAD~1
+}
+
+git -C "$tmpdir" init -q
+git -C "$tmpdir" config user.email 'codex-test@example.invalid'
+git -C "$tmpdir" config user.name 'Codex Gate Test'
+git -C "$tmpdir" config commit.gpgsign false
+printf 'base\n' > "$tmpdir/README"
+git -C "$tmpdir" add README
+git -C "$tmpdir" commit -qm 'base'
+git -C "$tmpdir" branch -M main
+git -C "$tmpdir" update-ref refs/remotes/origin/main HEAD
+mkdir "$tmpdir/doc"
+printf 'documentation-only change\n' > "$tmpdir/doc/example.rst"
+printf 'readme-only change\n' >> "$tmpdir/README"
+printf 'agent instructions\n' > "$tmpdir/AGENTS.md"
+git -C "$tmpdir" add doc/example.rst README AGENTS.md
+git -C "$tmpdir" commit -qm 'non-runtime change'
+assert_allowed 'git push origin topic'
+
+assert_runtime_delta_blocked 'runtime/example.c' 'int example;'
+assert_runtime_delta_blocked 'Dockerfile' 'FROM scratch'
+assert_runtime_delta_blocked 'MODULE_METADATA.yaml' 'module: example'
+assert_runtime_delta_blocked 'devtools/example.py' 'print("example")'


### PR DESCRIPTION
## Summary

- Document that `queue.timeoutEnqueue="0"` discards an incoming message immediately when a queue is full.
- Align the Codex pre-push container gate with the `run_checks.yml` runtime-relevance policy, so documentation, README, `AGENTS.md`, and similar non-runtime changes do not require a runtime container marker.
- Add regression coverage for the non-runtime gate exemption.

## Validation

- `git diff --check`
- Clean HTML docs build: `./doc/tools/build-doc-linux.sh --clean --format html --jobs 28`
- `bash -n .codex/pre_push_container_gate.sh`
- `dash -n tests/codex-pre-push-container-gate.sh`
- `tests/codex-pre-push-container-gate.sh`
- `shellcheck -S warning .codex/pre_push_container_gate.sh tests/codex-pre-push-container-gate.sh`

Runtime CI is intentionally not run for the documentation-only change; the gate regression is covered by its focused standalone test.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

