### PR TITLE
queue: reduce mutex contention during batch retirement

### DIFF
--- a/benchmarks/queue-contention/README.md
+++ b/benchmarks/queue-contention/README.md
@@ -1,0 +1,36 @@
+# Queue contention lifecycle benchmark
+
+Run from two separately configured and built source trees using the same
+Ubuntu 26.04 development image and compiler flags. The driver alternates order,
+discards one calibration pair, and records eleven paired lifecycle timings.
+Each daemon starts with fresh state, accepts 100,000 messages through imdiag,
+uses a four-worker FixedArray queue with 1024-message dequeue batches, attaches
+a JSON tree, drains, shuts down, and passes exact message-ID delivery checks.
+
+```
+python3 benchmarks/queue-contention/compare.py --before /path/to/baseline \
+  --after /path/to/candidate --output /path/to/ignored/session-1
+```
+
+Repeat the session independently. Before measurement, declare an improvement
+target (10% median lifecycle reduction here) and regression guardrail (5%).
+Compare one factor at a time using adjacent isolated revisions. Report median
+paired ratios and median absolute deviations; do not infer lock-hold time or
+production throughput from these lifecycle timings. Host exclusivity and cache
+state are uncontrolled. Raw logs and host paths belong in ignored artifacts.
+This compact workload is a screening result, not broad performance acceptance;
+small per-batch improvements may be hidden by startup and testbench overhead.
+
+Use the multi-producer screening workload for queue contention. It runs 16
+concurrent sending threads/connections, 8 imtcp input workers, and 4 main-queue
+consumers (configurable with `--consumer-workers 8`). Each trial checks exact
+IDs, generator success, complete drain, and clean daemon shutdown. The primary
+metric is generation plus drain; raw data also separates generation, drain,
+and full lifecycle. Drain polling uses 10 ms intervals to reduce quantization. Start with 3 measured pairs, then expand if the effect is
+clear. Keep the single-imdiag-producer workload as a low-contention guardrail.
+
+```
+python3 benchmarks/queue-contention/compare.py --before /path/to/baseline \
+  --after /path/to/candidate --output /path/to/ignored/multi-screen \
+  --workload multi --messages 1000000 --pairs 3
+```

--- a/benchmarks/queue-contention/README.md
+++ b/benchmarks/queue-contention/README.md
@@ -34,3 +34,64 @@ python3 benchmarks/queue-contention/compare.py --before /path/to/baseline \
   --after /path/to/candidate --output /path/to/ignored/multi-screen \
   --workload multi --messages 1000000 --pairs 3
 ```
+
+## Measured results, 2026-09-05
+
+The retained runtime candidate is `454b340a1`, compared with `8b8ffb19c`.
+It combines constant-time FixedArray retirement and bounded deferred message
+release. Measurements used GCC with `-g` in
+`rsyslog/rsyslog_dev_base_ubuntu:26.04` (image ID
+`sha256:32ade478a405e4f27f077b5268ec5ecc59dd572843ad67ca2b6723594960ae09`)
+on an x86-64 host with 28 logical CPUs. Both builds used identical configure
+options. The host was non-exclusive and caches were uncontrolled.
+
+Each row below has eleven alternating measured pairs after a discarded
+calibration pair. Ratios are candidate/baseline; lower is better. The two final
+multi-producer sessions were separated by sanitizer, portability, and
+distribution validation. No other local checks overlapped measurements.
+
+| Final candidate workload | Session | Median ratio | Ratio MAD |
+| --- | --- | ---: | ---: |
+| Multi-producer generation plus drain | 1 | 0.832291 | 0.017353 |
+| Multi-producer generation plus drain | 2 | 0.832193 | 0.015111 |
+| Multi-producer full lifecycle | 1 | 0.883916 | — |
+| Multi-producer full lifecycle | 2 | 0.880685 | — |
+| Single-producer full lifecycle | 1 | 1.011274 | 0.005241 |
+
+The multi-producer trials used four million messages, 16 sending threads and
+connections, eight configured imtcp input workers, and four queue consumers
+(all four started). Queue capacity was 32768, batch size 1024, and generated
+payload size 512 bytes plus the JSON tree. Every trial checked exact IDs and
+proper termination. Reproduce with the command above using
+`--workload multi --messages 4000000 --pairs 11`; the single-producer guardrail
+uses the driver's defaults. The retained combination reduced measured work
+time by about 16.8% in both sessions and stayed inside the 5% low-contention
+regression guardrail. This is workload-specific evidence, with no per-factor
+attribution or general production-throughput guarantee.
+
+Earlier isolated lifecycle screens explain the retained scope:
+
+| Isolated change | Session | Median ratio | Ratio MAD |
+| --- | --- | ---: | ---: |
+| FixedArray retirement | 1 | 1.000012 | 0.002498 |
+| FixedArray retirement | 2 | 1.001346 | 0.003521 |
+| Deferred release, before final shutdown correction | 1 | 1.010838 | 0.001791 |
+| Deferred release, before final shutdown correction | 2 | 1.009940 | 0.002437 |
+| Experimental waiter targeting | 1 | 1.229120 | 0.024719 |
+| Experimental waiter targeting with reservation cap | 1 | 1.230348 | 0.010424 |
+
+FixedArray retirement remains an O(batch-size) to O(1) simplification with
+neutral isolated lifecycle measurements. The waiter experiments were rejected
+because of their throughput regression and are excluded from the candidate.
+An earlier combined result predating the shutdown correction is not used as a
+final-candidate acceptance session.
+
+Deferred release preserves queue admission counts but can increase physical
+live-payload retention: each worker may retain one completed batch while its
+released capacity is reused. The extra reference count is bounded by the sum
+of worker batch capacities, plus one pointer buffer per worker; payload bytes
+depend on message and JSON/property sizes. References are drained before the
+next action callback or idle/minbatch wait. Final validation covered broad
+Ubuntu 26.04 tests, the static analyzer, ASan/UBSan, TSan, both compiler
+portability builds, mock distcheck, and deterministic enqueue/shutdown and
+out-of-order-retirement regressions.

--- a/benchmarks/queue-contention/README.md
+++ b/benchmarks/queue-contention/README.md
@@ -12,7 +12,8 @@ python3 benchmarks/queue-contention/compare.py --before /path/to/baseline \
   --after /path/to/candidate --output /path/to/ignored/session-1
 ```
 
-`--pairs`, `--messages`, and `--trial-timeout` must be positive; multi runs
+`--pairs`, `--messages`, and `--trial-timeout` must be positive; the timeout
+bounds each image setup and trial operation separately. Multi runs
 also require positive worker, connection, and payload values. The driver first
 resolves the image ID, then pins every trial to it. `result.json` records the
 requested and completed pairs, fixed queue settings, image ID, and the

--- a/benchmarks/queue-contention/README.md
+++ b/benchmarks/queue-contention/README.md
@@ -12,6 +12,14 @@ python3 benchmarks/queue-contention/compare.py --before /path/to/baseline \
   --after /path/to/candidate --output /path/to/ignored/session-1
 ```
 
+`--pairs`, `--messages`, and `--trial-timeout` must be positive; multi runs
+also require positive worker, connection, and payload values. The driver first
+resolves the image ID, then pins every trial to it. `result.json` records the
+requested and completed pairs, fixed queue settings, image ID, and the
+revision/dirty state of the harness and each build checkout. A failed or
+in-progress session has `status: "incomplete"` and `summary_accepted: false`;
+do not use it for a benchmark summary.
+
 Repeat the session independently. Before measurement, declare an improvement
 target (10% median lifecycle reduction here) and regression guardrail (5%).
 Compare one factor at a time using adjacent isolated revisions. Report median

--- a/benchmarks/queue-contention/compare.py
+++ b/benchmarks/queue-contention/compare.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Alternate full-lifecycle, exact-delivery trials in two isolated builds."""
+import argparse
+import json
+import os
+from pathlib import Path
+import statistics
+import subprocess
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--before', required=True, type=Path)
+parser.add_argument('--after', required=True, type=Path)
+parser.add_argument('--output', required=True, type=Path)
+parser.add_argument('--pairs', type=int, default=11)
+parser.add_argument('--messages', type=int, default=100000)
+parser.add_argument('--workload', choices=['lifecycle', 'multi'], default='lifecycle')
+parser.add_argument('--input-workers', type=int, default=8)
+parser.add_argument('--consumer-workers', type=int, default=4)
+parser.add_argument('--connections', type=int, default=16)
+parser.add_argument('--payload', type=int, default=512)
+parser.add_argument('--image', default='rsyslog/rsyslog_dev_base_ubuntu:26.04')
+args = parser.parse_args()
+args.output.mkdir(parents=True, exist_ok=True)
+output = args.output.resolve()
+harness = Path(__file__).resolve().parent
+results = []
+for pair in range(-1, args.pairs):
+    sample = {'pair': pair}
+    order = ['before', 'after'] if pair % 2 == 0 else ['after', 'before']
+    for label in order:
+        build = getattr(args, label).resolve()
+        name = f'{pair + 1:02d}-{label}'
+        metric = f'/results/{name}.ns'
+        command = ['docker', 'run', '--rm', '-u', f'{os.getuid()}:{os.getgid()}',
+                   '-v', f'{build}:/rsyslog', '-v', f'{harness}:/campaign:ro',
+                   '-v', f'{output}:/results', '-e', f'BENCH_METRIC_FILE={metric}',
+                   '-e', f'BENCH_MESSAGES={args.messages}', '-w', '/rsyslog/tests',
+                   '-e', f'BENCH_INPUT_WORKERS={args.input_workers}',
+                   '-e', f'BENCH_CONSUMER_WORKERS={args.consumer_workers}',
+                   '-e', f'BENCH_CONNECTIONS={args.connections}', '-e', f'BENCH_PAYLOAD={args.payload}',
+                   args.image, 'bash', f'/campaign/trial{"-multi" if args.workload == "multi" else ""}.sh']
+        with (output / f'{name}.log').open('w') as log:
+            subprocess.run(command, stdout=log, stderr=subprocess.STDOUT, check=True, timeout=180)
+        raw = (output / f'{name}.ns').read_text()
+        metrics = json.loads(raw) if args.workload == 'multi' else {'lifecycle_ns': int(raw)}
+        sample[label] = metrics.get('work_ns', metrics['lifecycle_ns']) / 1e9
+        sample[label + '_metrics'] = {key.replace('_ns', '_seconds'): value / 1e9 for key, value in metrics.items()}
+    sample['ratio'] = sample['after'] / sample['before']
+    if pair >= 0:
+        results.append(sample)
+    print(json.dumps(sample), flush=True)
+ratios = [row['ratio'] for row in results]
+median = statistics.median(ratios)
+report = {'schema_version': 1, 'messages': args.messages, 'workload': args.workload, 'pairs': results,
+          'input_workers': args.input_workers if args.workload == 'multi' else 1,
+          'consumer_workers': args.consumer_workers if args.workload == 'multi' else 4,
+          'connections': args.connections if args.workload == 'multi' else 0,
+          'median_after_before': median,
+          'ratio_mad': statistics.median(abs(value - median) for value in ratios),
+          'metric': 'generation plus drain seconds' if args.workload == 'multi' else 'full lifecycle seconds',
+          'limitations': ['Non-exclusive host', 'Uncontrolled caches',
+                          'Bounded JSON workload; exact delivery required; batch1024']}
+(output / 'result.json').write_text(json.dumps(report, indent=2) + '\n')
+print(json.dumps(report), flush=True)

--- a/benchmarks/queue-contention/compare.py
+++ b/benchmarks/queue-contention/compare.py
@@ -56,10 +56,12 @@ def checkout_state(path):
 
 def resolve_image():
     command = ['docker', 'image', 'inspect', '--format', '{{.Id}}', args.image]
-    inspected = subprocess.run(command, capture_output=True, check=False, text=True)
+    inspected = subprocess.run(command, capture_output=True, check=False, text=True,
+                               timeout=args.trial_timeout)
     if inspected.returncode != 0:
-        subprocess.run(['docker', 'pull', args.image], check=True)
-        inspected = subprocess.run(command, capture_output=True, check=True, text=True)
+        subprocess.run(['docker', 'pull', args.image], check=True, timeout=args.trial_timeout)
+        inspected = subprocess.run(command, capture_output=True, check=True, text=True,
+                                   timeout=args.trial_timeout)
     image_id = inspected.stdout.strip()
     if not image_id:
         raise ValueError('docker image inspect returned an empty image ID')

--- a/benchmarks/queue-contention/compare.py
+++ b/benchmarks/queue-contention/compare.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH
 # This file is part of rsyslog.
 # Released under ASL 2.0
 """Alternate full-lifecycle, exact-delivery trials in two isolated builds."""
@@ -32,6 +34,8 @@ if args.messages <= 0:
 if args.workload == 'multi' and min(args.input_workers, args.consumer_workers,
                                     args.connections, args.payload) <= 0:
     parser.error('--input-workers, --consumer-workers, --connections, and --payload must be positive for multi')
+if args.workload == 'multi' and args.messages % args.connections != 0:
+    parser.error('--messages must be divisible by --connections for multi')
 if not math.isfinite(args.trial_timeout) or args.trial_timeout <= 0:
     parser.error('--trial-timeout must be finite and positive')
 args.output.mkdir(parents=True, exist_ok=True)
@@ -48,6 +52,34 @@ def checkout_state(path):
                            check=False, text=True)
     return {'path': str(path), 'revision': revision.stdout.strip() if revision.returncode == 0 else None,
             'dirty': bool(dirty.stdout.strip()) if dirty.returncode == 0 else None}
+
+
+def resolve_image():
+    command = ['docker', 'image', 'inspect', '--format', '{{.Id}}', args.image]
+    inspected = subprocess.run(command, capture_output=True, check=False, text=True)
+    if inspected.returncode != 0:
+        subprocess.run(['docker', 'pull', args.image], check=True)
+        inspected = subprocess.run(command, capture_output=True, check=True, text=True)
+    image_id = inspected.stdout.strip()
+    if not image_id:
+        raise ValueError('docker image inspect returned an empty image ID')
+    return image_id
+
+
+def read_metrics(path):
+    raw = path.read_text()
+    if args.workload == 'lifecycle':
+        metrics = {'lifecycle_ns': int(raw)}
+    else:
+        metrics = json.loads(raw)
+        if not isinstance(metrics, dict):
+            raise ValueError(f'{path} must contain a JSON object')
+        required = ('lifecycle_ns', 'work_ns', 'generator_ns', 'drain_ns')
+        if any(name not in metrics for name in required):
+            raise ValueError(f'{path} is missing required metrics')
+    if any(not isinstance(value, int) or isinstance(value, bool) or value < 0 for value in metrics.values()):
+        raise ValueError(f'{path} contains invalid metric values')
+    return metrics
 
 
 image_id = None
@@ -100,8 +132,7 @@ def write_report(status, failure=None):
 
 
 try:
-    image_id = subprocess.run(['docker', 'image', 'inspect', '--format', '{{.Id}}', args.image],
-                              capture_output=True, check=True, text=True).stdout.strip()
+    image_id = resolve_image()
     for pair in range(-1, args.pairs):
         sample = {'pair': pair}
         order = ['before', 'after'] if pair % 2 == 0 else ['after', 'before']
@@ -125,11 +156,13 @@ try:
                                    timeout=args.trial_timeout)
                 except subprocess.TimeoutExpired:
                     subprocess.run(['docker', 'rm', '--force', container_name], stdout=log,
-                                   stderr=subprocess.STDOUT, check=False)
+                                   stderr=subprocess.STDOUT, check=False, timeout=30)
                     raise
-            raw = (output / f'{name}.ns').read_text()
-            metrics = json.loads(raw) if args.workload == 'multi' else {'lifecycle_ns': int(raw)}
-            sample[label] = metrics.get('work_ns', metrics['lifecycle_ns']) / 1e9
+            metrics = read_metrics(output / f'{name}.ns')
+            primary = 'work_ns' if args.workload == 'multi' else 'lifecycle_ns'
+            if metrics[primary] == 0:
+                raise ValueError(f'{name}.ns has a non-positive primary metric')
+            sample[label] = metrics[primary] / 1e9
             sample[label + '_metrics'] = {
                 key.replace('_ns', '_seconds'): value / 1e9 for key, value in metrics.items()
             }

--- a/benchmarks/queue-contention/compare.py
+++ b/benchmarks/queue-contention/compare.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
+# This file is part of rsyslog.
+# Released under ASL 2.0
 """Alternate full-lifecycle, exact-delivery trials in two isolated builds."""
 import argparse
 import json
+import math
 import os
 from pathlib import Path
 import statistics
@@ -19,46 +22,125 @@ parser.add_argument('--consumer-workers', type=int, default=4)
 parser.add_argument('--connections', type=int, default=16)
 parser.add_argument('--payload', type=int, default=512)
 parser.add_argument('--image', default='rsyslog/rsyslog_dev_base_ubuntu:26.04')
+parser.add_argument('--trial-timeout', type=float, default=180,
+                    help='maximum seconds allowed for each container trial')
 args = parser.parse_args()
+if args.pairs <= 0:
+    parser.error('--pairs must be positive')
+if args.messages <= 0:
+    parser.error('--messages must be positive')
+if args.workload == 'multi' and min(args.input_workers, args.consumer_workers,
+                                    args.connections, args.payload) <= 0:
+    parser.error('--input-workers, --consumer-workers, --connections, and --payload must be positive for multi')
+if not math.isfinite(args.trial_timeout) or args.trial_timeout <= 0:
+    parser.error('--trial-timeout must be finite and positive')
 args.output.mkdir(parents=True, exist_ok=True)
 output = args.output.resolve()
 harness = Path(__file__).resolve().parent
 results = []
-for pair in range(-1, args.pairs):
-    sample = {'pair': pair}
-    order = ['before', 'after'] if pair % 2 == 0 else ['after', 'before']
-    for label in order:
-        build = getattr(args, label).resolve()
-        name = f'{pair + 1:02d}-{label}'
-        metric = f'/results/{name}.ns'
-        command = ['docker', 'run', '--rm', '-u', f'{os.getuid()}:{os.getgid()}',
-                   '-v', f'{build}:/rsyslog', '-v', f'{harness}:/campaign:ro',
-                   '-v', f'{output}:/results', '-e', f'BENCH_METRIC_FILE={metric}',
-                   '-e', f'BENCH_MESSAGES={args.messages}', '-w', '/rsyslog/tests',
-                   '-e', f'BENCH_INPUT_WORKERS={args.input_workers}',
-                   '-e', f'BENCH_CONSUMER_WORKERS={args.consumer_workers}',
-                   '-e', f'BENCH_CONNECTIONS={args.connections}', '-e', f'BENCH_PAYLOAD={args.payload}',
-                   args.image, 'bash', f'/campaign/trial{"-multi" if args.workload == "multi" else ""}.sh']
-        with (output / f'{name}.log').open('w') as log:
-            subprocess.run(command, stdout=log, stderr=subprocess.STDOUT, check=True, timeout=180)
-        raw = (output / f'{name}.ns').read_text()
-        metrics = json.loads(raw) if args.workload == 'multi' else {'lifecycle_ns': int(raw)}
-        sample[label] = metrics.get('work_ns', metrics['lifecycle_ns']) / 1e9
-        sample[label + '_metrics'] = {key.replace('_ns', '_seconds'): value / 1e9 for key, value in metrics.items()}
-    sample['ratio'] = sample['after'] / sample['before']
-    if pair >= 0:
-        results.append(sample)
-    print(json.dumps(sample), flush=True)
-ratios = [row['ratio'] for row in results]
-median = statistics.median(ratios)
-report = {'schema_version': 1, 'messages': args.messages, 'workload': args.workload, 'pairs': results,
-          'input_workers': args.input_workers if args.workload == 'multi' else 1,
-          'consumer_workers': args.consumer_workers if args.workload == 'multi' else 4,
-          'connections': args.connections if args.workload == 'multi' else 0,
-          'median_after_before': median,
-          'ratio_mad': statistics.median(abs(value - median) for value in ratios),
-          'metric': 'generation plus drain seconds' if args.workload == 'multi' else 'full lifecycle seconds',
-          'limitations': ['Non-exclusive host', 'Uncontrolled caches',
-                          'Bounded JSON workload; exact delivery required; batch1024']}
-(output / 'result.json').write_text(json.dumps(report, indent=2) + '\n')
+
+
+def checkout_state(path):
+    """Record checkout state without treating it as binary-build provenance."""
+    revision = subprocess.run(['git', '-C', path, 'rev-parse', 'HEAD'], capture_output=True,
+                              check=False, text=True)
+    dirty = subprocess.run(['git', '-C', path, 'status', '--porcelain'], capture_output=True,
+                           check=False, text=True)
+    return {'path': str(path), 'revision': revision.stdout.strip() if revision.returncode == 0 else None,
+            'dirty': bool(dirty.stdout.strip()) if dirty.returncode == 0 else None}
+
+
+image_id = None
+builds = {label: checkout_state(getattr(args, label).resolve()) for label in ('before', 'after')}
+workload_checkout = checkout_state(harness.parents[1])
+
+
+def write_report(status, failure=None):
+    ratios = [row['ratio'] for row in results]
+    report = {
+        'schema_version': 2,
+        'status': status,
+        'requested_pairs': args.pairs,
+        'workload': {
+            'name': args.workload,
+            'script': f'trial{"-multi" if args.workload == "multi" else ""}.sh',
+            'revision': workload_checkout['revision'],
+            'dirty': workload_checkout['dirty'],
+            'messages': args.messages,
+            'input_workers': args.input_workers if args.workload == 'multi' else 1,
+            'consumer_workers': args.consumer_workers if args.workload == 'multi' else 4,
+            'connections': args.connections if args.workload == 'multi' else 0,
+            'payload': args.payload if args.workload == 'multi' else 0,
+            'queue': {
+                'type': 'FixedArray',
+                'size': 32768,
+                'dequeue_batch_size': 1024,
+                'worker_thread_minimum_messages': 1024,
+            },
+        },
+        'image': {'reference': args.image, 'id': image_id},
+        'builds': builds,
+        'trial_timeout_seconds': args.trial_timeout,
+        'pairs': results,
+        'completed_pairs': len(results),
+        'metric': 'generation plus drain seconds' if args.workload == 'multi' else 'full lifecycle seconds',
+        'limitations': ['Non-exclusive host', 'Uncontrolled caches',
+                        'Bounded JSON workload; exact delivery required; batch1024'],
+    }
+    if status == 'completed':
+        median = statistics.median(ratios)
+        report['median_after_before'] = median
+        report['ratio_mad'] = statistics.median(abs(value - median) for value in ratios)
+    else:
+        report['summary_accepted'] = False
+    if failure is not None:
+        report['failure'] = failure
+    (output / 'result.json').write_text(json.dumps(report, indent=2) + '\n')
+    return report
+
+
+try:
+    image_id = subprocess.run(['docker', 'image', 'inspect', '--format', '{{.Id}}', args.image],
+                              capture_output=True, check=True, text=True).stdout.strip()
+    for pair in range(-1, args.pairs):
+        sample = {'pair': pair}
+        order = ['before', 'after'] if pair % 2 == 0 else ['after', 'before']
+        for label in order:
+            build = getattr(args, label).resolve()
+            name = f'{pair + 1:02d}-{label}'
+            container_name = f'rsyslog-queue-contention-{os.getpid()}-{pair + 1}-{label}'
+            metric = f'/results/{name}.ns'
+            command = [
+                'docker', 'run', '--rm', '-u', f'{os.getuid()}:{os.getgid()}', '--name', container_name,
+                '-v', f'{build}:/rsyslog', '-v', f'{harness}:/campaign:ro', '-v', f'{output}:/results',
+                '-e', f'BENCH_METRIC_FILE={metric}', '-e', f'BENCH_MESSAGES={args.messages}',
+                '-w', '/rsyslog/tests', '-e', f'BENCH_INPUT_WORKERS={args.input_workers}',
+                '-e', f'BENCH_CONSUMER_WORKERS={args.consumer_workers}',
+                '-e', f'BENCH_CONNECTIONS={args.connections}', '-e', f'BENCH_PAYLOAD={args.payload}',
+                image_id, 'bash', f'/campaign/trial{"-multi" if args.workload == "multi" else ""}.sh',
+            ]
+            with (output / f'{name}.log').open('w') as log:
+                try:
+                    subprocess.run(command, stdout=log, stderr=subprocess.STDOUT, check=True,
+                                   timeout=args.trial_timeout)
+                except subprocess.TimeoutExpired:
+                    subprocess.run(['docker', 'rm', '--force', container_name], stdout=log,
+                                   stderr=subprocess.STDOUT, check=False)
+                    raise
+            raw = (output / f'{name}.ns').read_text()
+            metrics = json.loads(raw) if args.workload == 'multi' else {'lifecycle_ns': int(raw)}
+            sample[label] = metrics.get('work_ns', metrics['lifecycle_ns']) / 1e9
+            sample[label + '_metrics'] = {
+                key.replace('_ns', '_seconds'): value / 1e9 for key, value in metrics.items()
+            }
+        sample['ratio'] = sample['after'] / sample['before']
+        if pair >= 0:
+            results.append(sample)
+            write_report('incomplete')
+        print(json.dumps(sample), flush=True)
+except (subprocess.SubprocessError, OSError, ValueError, json.JSONDecodeError) as error:
+    write_report('incomplete', {'type': type(error).__name__, 'message': str(error)})
+    raise
+
+report = write_report('completed')
 print(json.dumps(report), flush=True)

--- a/benchmarks/queue-contention/trial-multi.sh
+++ b/benchmarks/queue-contention/trial-multi.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Eight imtcp workers consume concurrent TCP connections and submit to a
+# four/eight-worker FixedArray main queue. tcpflood -Y uses one sending thread
+# per connection and disjoint message-ID ranges; its supervised completion and
+# exact final IDs prove the generators and all daemon workers completed.
+# Timing separates startup/shutdown from generation-plus-drain work. The output
+# line count is the drain barrier; no fixed sleep participates in the oracle.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=${BENCH_MESSAGES:-1000000}
+: "${BENCH_INPUT_WORKERS:=8}" "${BENCH_CONSUMER_WORKERS:=4}"
+: "${BENCH_CONNECTIONS:=16}" "${BENCH_PAYLOAD:=512}"
+PORT_FILE="$PWD/$RSYSLOG_DYNNAME.input.port"
+generate_conf
+add_conf '
+global(processInternalMessages="off")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" address="127.0.0.1" port="0"
+    listenPortFileName="'$PORT_FILE'" workerThreads="'$BENCH_INPUT_WORKERS'")
+main_queue(queue.type="FixedArray" queue.size="32768"
+    queue.workerThreads="'$BENCH_CONSUMER_WORKERS'" queue.workerThreadMinimumMessages="1024"
+    queue.dequeueBatchSize="1024")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+if ($msg contains "msgnum:") then {
+    set $!payload = parse_json("{\"nested\":{\"array\":[1,2,3,4,5,6,7,8],\"text\":\"queue contention benchmark payload\"}}");
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+start_ns=$(date +%s%N)
+startup
+assign_file_content INPUT_PORT "$PORT_FILE"
+work_start_ns=$(date +%s%N)
+tcpflood -p"$INPUT_PORT" -c"$BENCH_CONNECTIONS" -Y -m"$NUMMESSAGES" -d"$BENCH_PAYLOAD" >/dev/null
+generator_end_ns=$(date +%s%N)
+wait_file_lines --delay 10 "$RSYSLOG_OUT_LOG" "$NUMMESSAGES" 120
+work_end_ns=$(date +%s%N)
+shutdown_when_empty
+wait_shutdown
+end_ns=$(date +%s%N)
+seq_check
+printf '{"lifecycle_ns":%d,"work_ns":%d,"generator_ns":%d,"drain_ns":%d}\n' \
+    "$((end_ns - start_ns))" "$((work_end_ns - work_start_ns))" \
+    "$((generator_end_ns - work_start_ns))" "$((work_end_ns - generator_end_ns))" > "$BENCH_METRIC_FILE"
+exit_test

--- a/benchmarks/queue-contention/trial-multi.sh
+++ b/benchmarks/queue-contention/trial-multi.sh
@@ -5,10 +5,21 @@
 # exact final IDs prove the generators and all daemon workers completed.
 # Timing separates startup/shutdown from generation-plus-drain work. The output
 # line count is the drain barrier; no fixed sleep participates in the oracle.
-. ${srcdir:=.}/diag.sh init
+#
+# This file is part of rsyslog.
+# Released under ASL 2.0
 export NUMMESSAGES=${BENCH_MESSAGES:-1000000}
 : "${BENCH_INPUT_WORKERS:=8}" "${BENCH_CONSUMER_WORKERS:=4}"
 : "${BENCH_CONNECTIONS:=16}" "${BENCH_PAYLOAD:=512}"
+if (( BENCH_CONNECTIONS <= 0 )); then
+    echo "BENCH_CONNECTIONS must be positive" >&2
+    exit 1
+fi
+if (( NUMMESSAGES % BENCH_CONNECTIONS != 0 )); then
+    echo "BENCH_MESSAGES ($NUMMESSAGES) must be divisible by BENCH_CONNECTIONS ($BENCH_CONNECTIONS)" >&2
+    exit 1
+fi
+. ${srcdir:=.}/diag.sh init
 PORT_FILE="$PWD/$RSYSLOG_DYNNAME.input.port"
 generate_conf
 add_conf '

--- a/benchmarks/queue-contention/trial-multi.sh
+++ b/benchmarks/queue-contention/trial-multi.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH
 # Eight imtcp workers consume concurrent TCP connections and submit to a
 # four/eight-worker FixedArray main queue. tcpflood -Y uses one sending thread
 # per connection and disjoint message-ID ranges; its supervised completion and

--- a/benchmarks/queue-contention/trial.sh
+++ b/benchmarks/queue-contention/trial.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Full daemon lifecycle, with exact delivery checked outside the timed phase.
+# Run from a configured build's tests directory using the standard testbench.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=${BENCH_MESSAGES:-100000}
+generate_conf
+add_conf '
+global(processInternalMessages="off")
+main_queue(queue.type="FixedArray" queue.size="32768"
+    queue.workerThreads="4" queue.workerThreadMinimumMessages="1024"
+    queue.dequeueBatchSize="1024")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+if ($msg contains "msgnum:") then {
+    set $!payload = parse_json("{\"nested\":{\"array\":[1,2,3,4,5,6,7,8],\"text\":\"queue lifecycle benchmark payload\"}}");
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+start_ns=$(date +%s%N)
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+end_ns=$(date +%s%N)
+seq_check
+printf '%s\n' "$((end_ns - start_ns))" > "$BENCH_METRIC_FILE"
+exit_test

--- a/benchmarks/queue-contention/trial.sh
+++ b/benchmarks/queue-contention/trial.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Rainer Gerhards and Adiscon GmbH
 # Full daemon lifecycle, with exact delivery checked outside the timed phase.
 # Run from a configured build's tests directory using the standard testbench.
 #

--- a/benchmarks/queue-contention/trial.sh
+++ b/benchmarks/queue-contention/trial.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Full daemon lifecycle, with exact delivery checked outside the timed phase.
 # Run from a configured build's tests directory using the standard testbench.
+#
+# This file is part of rsyslog.
+# Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=${BENCH_MESSAGES:-100000}
 generate_conf

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -8,12 +8,16 @@ runtime_queue:
     - "runtime/queue.h"
     - "runtime/queue_da.c"
     - "runtime/queue_da.h"
+    - "runtime/wti.c"
+    - "runtime/wti.h"
     - "runtime/segdisk_store.c"
     - "runtime/segdisk_store.h"
   requires_serialization: true
   notes:
     - Disk-assisted mode is an in-memory parent plus a first-class disk child; disk queue semantics apply to the child.
     - The queue mutex is shared by a disk-assisted parent and child; segmented store operations and idle dematerialization callbacks run under that lock.
+    - Completed message references move to a bounded worker buffer after store completion and are destroyed outside the queue mutex, before callbacks or waits; cancellation is disabled during this transfer and disposal.
+    - RAM retirement releases completed counts independently of batch order; segmentedDisk retains its ordered persistent frontier.
     - queue_da resolves the durable disk-child engine at startup and atomically publishes its marker before first persistent data; engines never switch while a process is running.
     - The segmented store is lazy only for a disk-assisted child, and dematerialization requires an empty store with no recovery, batch, retry, or completion work pending.
 

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -2950,7 +2950,15 @@ static rsRetVal ATTR_NONNULL(1) DoDeleteBatchFromQStore(qqueue_t *const pThis, c
             /* awake possibly waiting enq process */
             pthread_cond_signal(&pThis->notFull); /* we hold the mutex while we are in here! */
         }
-    } else { /* memory queue */
+    } else if (pThis->qType == QUEUETYPE_FIXED_ARRAY) {
+        /* RAM retirement releases completed counts, not the original slots of
+         * this batch: another worker may finish an older batch later. Batch
+         * pointers own the messages independently of these reusable slots.
+         * Subtraction avoids overflowing head + nElem near INT_MAX. */
+        const int remaining = pThis->iMaxQueueSize - pThis->tVars.farray.head;
+        assert(nElem >= 0 && nElem <= pThis->iMaxQueueSize);
+        pThis->tVars.farray.head = nElem >= remaining ? nElem - remaining : pThis->tVars.farray.head + nElem;
+    } else { /* linked-list memory queue */
         for (i = 0; i < nElem; ++i) {
             pThis->qDel(pThis);
         }
@@ -2991,9 +2999,9 @@ typedef enum tdlPhase_e { TDL_EMPTY, TDL_PROCESS_HEAD, TDL_QUEUE } tdlPhase_t;
  *   current batch.
  * - TDL_QUEUE:  current batch cannot be deleted and is queued for later.
  *
- * The dequeue identifier advances strictly monotonically, ensuring
- * deterministic order and proper resource release for both disk and
- * memory queue implementations.
+ * RAM batches release completed counts, including out-of-order worker
+ * completions when the list is empty. Do not turn this into an ordered RAM
+ * retirement frontier: workers already own independent message references.
  */
 static rsRetVal DeleteBatchFromQStore(qqueue_t *pThis, batch_t *pBatch) {
     toDeleteLst_t *pTdl;

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -3057,12 +3057,47 @@ finalize_it:
 }
 
 
+/* Concurrency & Locking: completed batch references move to a worker-owned
+ * buffer under the queue mutex, after store commit. The buffer holds at most
+ * one batch and is drained without the queue mutex and with cancellation
+ * disabled. No other worker, producer, or shutdown path accesses this buffer.
+ */
+static void qqueueDrainDeferred(wti_t *const pWti) {
+    for (int i = 0; i < pWti->nDeferredMsgs; ++i) {
+        msgDestruct(&pWti->pDeferredMsgs[i]);
+    }
+    pWti->nDeferredMsgs = 0;
+}
+
+/* Exceptional idle/minbatch/cleanup path: never retain a completed batch
+ * across a condition wait. Recheck queue predicates after reacquiring. */
+static void qqueueDrainDeferredLocked(qqueue_t *const pThis, wti_t *const pWti) {
+    if (pWti->nDeferredMsgs != 0) {
+        d_pthread_mutex_unlock(pThis->mut);
+        qqueueDrainDeferred(pWti);
+        qqueueLock(pThis);
+    }
+}
+
+static void qqueueDeferBatch(wti_t *const pWti) {
+    batch_t *const pBatch = &pWti->batch;
+    assert(pWti->nDeferredMsgs == 0);
+    assert(pBatch->nElem <= pBatch->maxElem);
+    for (int i = 0; i < pBatch->nElem; ++i) {
+        pWti->pDeferredMsgs[i] = pBatch->pElem[i].pMsg;
+        pBatch->pElem[i].pMsg = NULL;
+    }
+    pWti->nDeferredMsgs = pBatch->nElem;
+    pBatch->nElem = pBatch->nElemDeq = 0;
+}
+
 /* Delete a batch of processed user objects from the queue, which includes
  * destructing the objects themself. Any entries not marked as finally
  * processed are enqueued again. The new enqueue is necessary because we have a
  * rgerhards, 2009-05-13
  */
-static rsRetVal DeleteProcessedBatch(qqueue_t *pThis, batch_t *pBatch) {
+static rsRetVal DeleteProcessedBatch(qqueue_t *pThis, wti_t *pWti) {
+    batch_t *const pBatch = &pWti->batch;
     int i;
     smsg_t *pMsg;
     int nEnqueued = 0;
@@ -3077,11 +3112,6 @@ static rsRetVal DeleteProcessedBatch(qqueue_t *pThis, batch_t *pBatch) {
         int retried = 0;
         iRet = pThis->qCompleteBatch(pThis, pBatch, &committed, &retried);
         if (iRet != RS_RET_OK) RETiRet;
-        for (i = 0; i < pBatch->nElem; ++i) {
-            pMsg = pBatch->pElem[i].pMsg;
-            msgDestruct(&pMsg);
-            pBatch->pElem[i].pMsg = NULL;
-        }
         /* committed is the physical-record count. It intentionally includes
          * salvaged corrupt records because recovery included those records in
          * iQueueSize; retried counts only decoded messages appended again. */
@@ -3098,7 +3128,7 @@ static rsRetVal DeleteProcessedBatch(qqueue_t *pThis, batch_t *pBatch) {
             qqueueAddOverallQueueSize(added);
         }
         ATOMIC_SUB(&pThis->nLogDeq, committed, &pThis->mutLogDeq);
-        pBatch->nElem = pBatch->nElemDeq = 0;
+        qqueueDeferBatch(pWti);
         pBatch->storeData = NULL;
         RETiRet;
     }
@@ -3116,7 +3146,6 @@ static rsRetVal DeleteProcessedBatch(qqueue_t *pThis, batch_t *pBatch) {
                     localRet);
             }
         }
-        msgDestruct(&pMsg);
     }
 
     DBGPRINTF("DeleteProcessedBatch: we deleted %d objects and enqueued %d objects\n", i - nEnqueued, nEnqueued);
@@ -3125,7 +3154,7 @@ static rsRetVal DeleteProcessedBatch(qqueue_t *pThis, batch_t *pBatch) {
 
     iRet = DeleteBatchFromQStore(pThis, pBatch);
 
-    pBatch->nElem = pBatch->nElemDeq = 0; /* reset batch */  // TODO: more fine init, new fields! 2010-06-14
+    qqueueDeferBatch(pWti);
 
     RETiRet;
 }
@@ -3157,7 +3186,7 @@ static rsRetVal ATTR_NONNULL() DequeueConsumableElements(qqueue_t *const pThis,
     DEFiRet;
 
     nDeleted = pWti->batch.nElemDeq;
-    localRet = DeleteProcessedBatch(pThis, &pWti->batch);
+    localRet = DeleteProcessedBatch(pThis, pWti);
     if (pThis->qCompleteBatch != NULL) CHKiRet(localRet);
 
     nDequeued = nDiscarded = 0;
@@ -3389,6 +3418,7 @@ static rsRetVal ATTR_NONNULL() DequeueConsumableElements(qqueue_t *const pThis,
         pWti->batch.eltState[nDequeued] = BATCH_STATE_RDY;
         ++nDequeued;
         if (nDequeued < iMinDeqBatchSize && getLogicalQueueSize(pThis) == 0) {
+            qqueueDrainDeferredLocked(pThis, pWti);
             while (!qqueueIsShutdownImmediate(pThis) && keep_running && nDequeued < iMinDeqBatchSize &&
                    getLogicalQueueSize(pThis) == 0) {
                 dbgprintf(
@@ -3602,12 +3632,18 @@ static rsRetVal DequeueForConsumer(qqueue_t *pThis, wti_t *pWti, int *const pSki
     ISOBJ_TYPE_assert(pThis, qqueue);
     ISOBJ_TYPE_assert(pWti, wti);
 
+retry_dequeue:
     CHKiRet(DequeueConsumable(pThis, pWti, pSkippedMsgs));
 
     if (pWti->batch.nElem == 0) ABORT_FINALIZE(RS_RET_IDLE);
 
-
 finalize_it:
+    if (iRet != RS_RET_OK && pWti->nDeferredMsgs != 0) {
+        qqueueDrainDeferredLocked(pThis, pWti);
+        /* An enqueue during disposal could not signal us as a waiter yet.
+         * Retest under the mutex before returning IDLE to the wait loop. */
+        if (iRet == RS_RET_IDLE && getLogicalQueueSize(pThis) > 0) goto retry_dequeue;
+    }
     RETiRet;
 }
 
@@ -3631,8 +3667,9 @@ static rsRetVal batchProcessed(qqueue_t *pThis, wti_t *pWti) {
     int iCancelStateSave;
     /* at this spot, we must not be cancelled */
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &iCancelStateSave);
-    DeleteProcessedBatch(pThis, &pWti->batch);
+    DeleteProcessedBatch(pThis, pWti);
     qqueueChkPersist(pThis, pWti->batch.nElemDeq);
+    qqueueDrainDeferredLocked(pThis, pWti);
     pthread_setcancelstate(iCancelStateSave, NULL);
 
     RETiRet;
@@ -3644,7 +3681,7 @@ static rsRetVal batchProcessed(qqueue_t *pThis, wti_t *pWti) {
  * rgerhards, 2008-01-21
  */
 static rsRetVal ConsumerReg(qqueue_t *pThis, wti_t *pWti) {
-    int iCancelStateSave;
+    int iCancelStateSave = PTHREAD_CANCEL_DISABLE;
     int bNeedReLock = 0; /**< do we need to lock the mutex again? */
     int skippedMsgs = 0; /**< did the queue loose any messages (can happen with
                           ** disk queue if .qi file is corrupt */
@@ -3669,6 +3706,7 @@ static rsRetVal ConsumerReg(qqueue_t *pThis, wti_t *pWti) {
     /* we now have a non-idle batch of work, so we can release the queue mutex and process it */
     d_pthread_mutex_unlock(pThis->mut);
     bNeedReLock = 1;
+    qqueueDrainDeferred(pWti);
 
     /* report errors, now that we are outside of queue lock */
     if (skippedMsgs > 0) {
@@ -3695,10 +3733,10 @@ static rsRetVal ConsumerReg(qqueue_t *pThis, wti_t *pWti) {
         srSleep(pThis->iDeqSlowdown / 1000000, pThis->iDeqSlowdown % 1000000);
     }
 
-    /* but now cancellation is no longer permitted */
-    pthread_setcancelstate(iCancelStateSave, NULL);
-
 finalize_it:
+    /* Consumer errors also leave cancellation disabled before taking the
+     * queue mutex. The cancel handler therefore always enters unlocked. */
+    pthread_setcancelstate(iCancelStateSave, NULL);
     DBGPRINTF("regular consumer finished, iret=%d, szlog %d sz phys %d\n", iRet, getLogicalQueueSize(pThis),
               getPhysicalQueueSize(pThis));
 
@@ -3720,7 +3758,7 @@ finalize_it:
  */
 static rsRetVal ConsumerDA(qqueue_t *pThis, wti_t *pWti) {
     int i;
-    int iCancelStateSave;
+    int iCancelStateSave = PTHREAD_CANCEL_DISABLE;
     int bNeedReLock = 0; /**< do we need to lock the mutex again? */
     int skippedMsgs = 0;
     DEFiRet;
@@ -3733,6 +3771,7 @@ static rsRetVal ConsumerDA(qqueue_t *pThis, wti_t *pWti) {
     /* we now have a non-idle batch of work, so we can release the queue mutex and process it */
     d_pthread_mutex_unlock(pThis->mut);
     bNeedReLock = 1;
+    qqueueDrainDeferred(pWti);
 
     /* at this spot, we may be cancelled */
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &iCancelStateSave);
@@ -3766,10 +3805,9 @@ static rsRetVal ConsumerDA(qqueue_t *pThis, wti_t *pWti) {
         pWti->batch.eltState[i] = BATCH_STATE_COMM; /* commited to other queue! */
     }
 
-    /* but now cancellation is no longer permitted */
-    pthread_setcancelstate(iCancelStateSave, NULL);
-
 finalize_it:
+    /* Early errors must also restore the queue-locked cancellation contract. */
+    pthread_setcancelstate(iCancelStateSave, NULL);
     /*	Check the last return state of qqueueEnqMsg. If an error was returned, we acknowledge it only.
      *	Unless the error code is RS_RET_ERR_QUEUE_EMERGENCY, we reset the return state to RS_RET_OK.
      *	Otherwise the Caller functions would run into an infinite Loop trying to enqueue the

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -3063,16 +3063,16 @@ finalize_it:
  * disabled. No other worker, producer, or shutdown path accesses this buffer.
  */
 static void qqueueDrainDeferred(wti_t *const pWti) {
-    for (int i = 0; i < pWti->nDeferredMsgs; ++i) {
-        msgDestruct(&pWti->pDeferredMsgs[i]);
+    for (int i = 0; i < pWti->n_deferred_msgs; ++i) {
+        msgDestruct(&pWti->p_deferred_msgs[i]);
     }
-    pWti->nDeferredMsgs = 0;
+    pWti->n_deferred_msgs = 0;
 }
 
 /* Exceptional idle/minbatch/cleanup path: never retain a completed batch
  * across a condition wait. Recheck queue predicates after reacquiring. */
 static void qqueueDrainDeferredLocked(qqueue_t *const pThis, wti_t *const pWti) {
-    if (pWti->nDeferredMsgs != 0) {
+    if (pWti->n_deferred_msgs != 0) {
         d_pthread_mutex_unlock(pThis->mut);
         qqueueDrainDeferred(pWti);
         qqueueLock(pThis);
@@ -3081,13 +3081,13 @@ static void qqueueDrainDeferredLocked(qqueue_t *const pThis, wti_t *const pWti) 
 
 static void qqueueDeferBatch(wti_t *const pWti) {
     batch_t *const pBatch = &pWti->batch;
-    assert(pWti->nDeferredMsgs == 0);
+    assert(pWti->n_deferred_msgs == 0);
     assert(pBatch->nElem <= pBatch->maxElem);
     for (int i = 0; i < pBatch->nElem; ++i) {
-        pWti->pDeferredMsgs[i] = pBatch->pElem[i].pMsg;
+        pWti->p_deferred_msgs[i] = pBatch->pElem[i].pMsg;
         pBatch->pElem[i].pMsg = NULL;
     }
-    pWti->nDeferredMsgs = pBatch->nElem;
+    pWti->n_deferred_msgs = pBatch->nElem;
     pBatch->nElem = pBatch->nElemDeq = 0;
 }
 
@@ -3638,7 +3638,7 @@ retry_dequeue:
     if (pWti->batch.nElem == 0) ABORT_FINALIZE(RS_RET_IDLE);
 
 finalize_it:
-    if (iRet != RS_RET_OK && pWti->nDeferredMsgs != 0) {
+    if (iRet != RS_RET_OK && pWti->n_deferred_msgs != 0) {
         qqueueDrainDeferredLocked(pThis, pWti);
         /* An enqueue during disposal could not signal us as a waiter yet.
          * Retest under the mutex before returning IDLE to the wait loop. */

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -278,6 +278,8 @@ BEGINobjDestruct(wti) /* be sure to specify the object type also in END and CODE
     }
     /* actual destruction */
     batchFree(&pThis->batch);
+    assert(pThis->nDeferredMsgs == 0);
+    free(pThis->pDeferredMsgs);
     free(pThis->actWrkrInfo);
     pthread_cond_destroy(&pThis->pcondBusy);
     DESTROY_ATOMIC_HELPER_MUT(pThis->mutIsRunning);
@@ -319,6 +321,8 @@ rsRetVal wtiConstructFinalize(wti_t *pThis) {
     /* we now alloc the array for user pointers. We obtain the max from the queue itself. */
     CHKiRet(pThis->pWtp->pfGetDeqBatchSize(pThis->pWtp->pUsr, &iDeqBatchSize));
     CHKiRet(batchInit(&pThis->batch, iDeqBatchSize));
+    CHKmalloc(pThis->pDeferredMsgs = calloc((size_t)iDeqBatchSize, sizeof(smsg_t *)));
+    pThis->nDeferredMsgs = 0;
 
 finalize_it:
     RETiRet;
@@ -340,7 +344,12 @@ static void wtiWorkerCancelCleanup(void *arg) {
     ISOBJ_TYPE_assert(pWtp, wtp);
 
     DBGPRINTF("%s: cancellation cleanup handler called.\n", wtiGetDbgHdr(pThis));
+    /* The consumer releases the queue mutex only around cancel-safe output
+     * work. Restoring or committing its batch, including deferred cleanup,
+     * must use the same mutex as the ordinary callback path. */
+    d_pthread_mutex_lock(pWtp->pmutUsr);
     pWtp->pfObjProcessed(pWtp->pUsr, pThis);
+    d_pthread_mutex_unlock(pWtp->pmutUsr);
     DBGPRINTF("%s: done cancellation cleanup handler.\n", wtiGetDbgHdr(pThis));
 }
 
@@ -442,6 +451,7 @@ PRAGMA_IGNORE_Wempty_body rsRetVal wtiWorker(wti_t *__restrict__ const pThis) {
         /* first check if we are in shutdown process (but evaluate a bit later) */
         terminateRet = wtpChkStopWrkr(pWtp, MUTEX_ALREADY_LOCKED);
         if (terminateRet == RS_RET_TERMINATE_NOW) {
+        terminate_now:
             /* we now need to free the old batch */
             localRet = pWtp->pfObjProcessed(pWtp->pUsr, pThis);
             DBGOPRINT((obj_t *)pThis,
@@ -457,6 +467,11 @@ PRAGMA_IGNORE_Wempty_body rsRetVal wtiWorker(wti_t *__restrict__ const pThis) {
         if (localRet == RS_RET_ERR_QUEUE_EMERGENCY) {
             break; /* end of loop */
         } else if (localRet == RS_RET_IDLE) {
+            /* Even an idle callback can release the queue mutex to dispose
+             * its completed batch. Shutdown may have signalled during that
+             * interval, before this worker registered an idle wait. */
+            terminateRet = wtpChkStopWrkr(pWtp, MUTEX_ALREADY_LOCKED);
+            if (terminateRet == RS_RET_TERMINATE_NOW) goto terminate_now;
             if (terminateRet == RS_RET_TERMINATE_WHEN_IDLE || bInactivityTOOccurred) {
                 if (bInactivityTOOccurred && pWtp->pfIdleTimeout != NULL && pWtp->pWrkr[0] == pThis &&
                     pWtp->pfIdleTimeout(pWtp->pUsr) == RS_RET_RETRY) {

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -278,8 +278,8 @@ BEGINobjDestruct(wti) /* be sure to specify the object type also in END and CODE
     }
     /* actual destruction */
     batchFree(&pThis->batch);
-    assert(pThis->nDeferredMsgs == 0);
-    free(pThis->pDeferredMsgs);
+    assert(pThis->n_deferred_msgs == 0);
+    free(pThis->p_deferred_msgs);
     free(pThis->actWrkrInfo);
     pthread_cond_destroy(&pThis->pcondBusy);
     DESTROY_ATOMIC_HELPER_MUT(pThis->mutIsRunning);
@@ -321,8 +321,8 @@ rsRetVal wtiConstructFinalize(wti_t *pThis) {
     /* we now alloc the array for user pointers. We obtain the max from the queue itself. */
     CHKiRet(pThis->pWtp->pfGetDeqBatchSize(pThis->pWtp->pUsr, &iDeqBatchSize));
     CHKiRet(batchInit(&pThis->batch, iDeqBatchSize));
-    CHKmalloc(pThis->pDeferredMsgs = calloc((size_t)iDeqBatchSize, sizeof(smsg_t *)));
-    pThis->nDeferredMsgs = 0;
+    CHKmalloc(pThis->p_deferred_msgs = calloc((size_t)iDeqBatchSize, sizeof(smsg_t *)));
+    pThis->n_deferred_msgs = 0;
 
 finalize_it:
     RETiRet;

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -84,6 +84,9 @@ struct wti_s {
         actWrkrInfo_t *actWrkrInfo; /* *array* of action wrkr infos for all actions
                           (sized for max nbr of actions in config!) */
         pthread_cond_t pcondBusy; /* condition to wake up the worker, protected by pmutUsr in wtp */
+        /* Queue-local deferred batch cleanup is bounded by batch.maxElem. */
+        smsg_t **pDeferredMsgs;
+        int nDeferredMsgs;
         DEF_ATOMIC_HELPER_MUT(mutIsRunning);
         struct {
             uint8_t script_errno; /* errno-type interface for RainerScript functions */
@@ -104,7 +107,6 @@ static inline int wtiIsShutdownImmediate(const wti_t *const pWti) {
     return ATOMIC_LOAD_32BIT(pWti->pbShutdownImmediate, pWti->pmutShutdownImmediate);
 #endif
 }
-
 
 /* prototypes */
 rsRetVal wtiConstruct(wti_t **ppThis);

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -85,8 +85,8 @@ struct wti_s {
                           (sized for max nbr of actions in config!) */
         pthread_cond_t pcondBusy; /* condition to wake up the worker, protected by pmutUsr in wtp */
         /* Queue-local deferred batch cleanup is bounded by batch.maxElem. */
-        smsg_t **pDeferredMsgs;
-        int nDeferredMsgs;
+        smsg_t **p_deferred_msgs;
+        int n_deferred_msgs;
         DEF_ATOMIC_HELPER_MUT(mutIsRunning);
         struct {
             uint8_t script_errno; /* errno-type interface for RainerScript functions */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -65,6 +65,9 @@ EXTRA_DIST += $(TESTS_PRIFILT_TRAILING_SEPARATOR)
 TESTS_TEMPLATE_PARAMETER_ERRORS = template-parameter-errors.sh
 EXTRA_DIST += $(TESTS_TEMPLATE_PARAMETER_ERRORS)
 
+TESTS_QUEUE_DEFERRED_IDLE_WAKEUP = queue-deferred-idle-wakeup.sh queue-deferred-idle-shutdown.sh
+EXTRA_DIST += $(TESTS_QUEUE_DEFERRED_IDLE_WAKEUP) override_queue_disposal.c
+
 TESTS_SEGQUEUE_TOOL = rsyslog-segqueue-tool.py rsyslog-segqueue-runtime.sh
 EXTRA_DIST += $(TESTS_SEGQUEUE_TOOL)
 
@@ -1210,6 +1213,7 @@ TESTS_MMDARWIN_VALGRIND = \
 	mmdarwin_errmsg_no_sock-vg.sh
 
 TESTS_OMPROG = \
+	queue-fixedarray-outoforder.sh \
 	omprog-defaults.sh \
 	omprog-output-capture.sh \
 	omprog-output-capture-mt.sh \
@@ -2819,6 +2823,13 @@ liboverride_getaddrinfo_la_SOURCES = override_getaddrinfo.c
 liboverride_getaddrinfo_la_CFLAGS =
 liboverride_getaddrinfo_la_LDFLAGS = $(TEST_LIBOVERRIDE_LDFLAGS)
 
+check_LTLIBRARIES += liboverride_queue_disposal.la
+liboverride_queue_disposal_la_SOURCES = override_queue_disposal.c
+liboverride_queue_disposal_la_CPPFLAGS = $(runtime_unit_linkedlist_CPPFLAGS)
+liboverride_queue_disposal_la_CFLAGS =
+liboverride_queue_disposal_la_LDFLAGS = $(TEST_LIBOVERRIDE_LDFLAGS)
+liboverride_queue_disposal_la_LIBADD = $(LIBFASTJSON_LIBS) $(DL_LIBS) $(PTHREADS_LIBS)
+
 if ENABLE_IMPTCP
 check_LTLIBRARIES += liboverride_epoll_ctl.la
 liboverride_epoll_ctl_la_SOURCES = override_epoll_ctl.c
@@ -2958,6 +2969,7 @@ endif # if ENABLE_ELASTICSEARCH_TESTS
 
 if ENABLE_DEFAULT_TESTS
 TESTS += $(TESTS_DEFAULT)
+TESTS += $(TESTS_QUEUE_DEFERRED_IDLE_WAKEUP)
 TESTS += $(TESTS_JSON_OMITIFZERO)
 TESTS += $(TESTS_SEGMENTED_DISK_QUEUE)
 if ENABLE_SEGQUEUE_TOOL

--- a/tests/override_queue_disposal.c
+++ b/tests/override_queue_disposal.c
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Pause the final JSON-root release for one marked message. The main executable
+ * binds msgDestruct internally, so interpose its external libfastjson release
+ * instead. The test never renders or replaces this tree before destruction.
+ * A FIFO handshake gives the test an exact unlocked-disposal/idle interleaving;
+ * poll bounds a missing release and preserves a nonzero daemon failure oracle.
+ */
+#include "config.h"
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+#include <json.h>
+
+static int (*real_put)(struct json_object *);
+static pthread_once_t resolve_once = PTHREAD_ONCE_INIT;
+static int claimed;
+
+static void resolve_put(void) {
+    dlerror();
+    real_put = (int (*)(struct json_object *))dlsym(RTLD_NEXT, "fjson_object_put");
+    if (dlerror() != NULL || real_put == NULL) {
+        fputs("queue disposal hook: cannot resolve fjson_object_put\n", stderr);
+        _exit(2);
+    }
+}
+
+int json_object_put(struct json_object *object) {
+    struct json_object *marker;
+    const char *ready;
+    const char *release;
+    int pipefd;
+    int readyfd;
+    struct pollfd fd;
+    struct timespec started, now;
+    int remaining;
+    int polled;
+    char byte;
+
+    pthread_once(&resolve_once, resolve_put);
+    if (object != NULL && json_object_get_type(object) == json_type_object &&
+        json_object_object_get_ex(object, "queue_disposal_gate", &marker) &&
+        __atomic_exchange_n(&claimed, 1, __ATOMIC_RELAXED) == 0) {
+        ready = getenv("RSYSLOG_QUEUE_DISPOSAL_READY");
+        release = getenv("RSYSLOG_QUEUE_DISPOSAL_RELEASE");
+        if (ready == NULL || release == NULL) _exit(2);
+        pipefd = open(release, O_RDONLY | O_NONBLOCK);
+        readyfd = open(ready, O_WRONLY | O_CREAT | O_EXCL, 0600);
+        if (pipefd < 0 || readyfd < 0 || write(readyfd, "ready\n", 6) != 6 || close(readyfd) != 0) _exit(2);
+        fd.fd = pipefd;
+        fd.events = POLLIN;
+        fd.revents = 0;
+        if (clock_gettime(CLOCK_MONOTONIC, &started) != 0) _exit(2);
+        remaining = 30000;
+        while ((polled = poll(&fd, 1, remaining)) < 0 && errno == EINTR) {
+            /* Shutdown signals the paused worker with SIGTTIN. Keep the
+             * handshake alive without extending its bounded deadline. */
+            if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) _exit(2);
+            remaining = 30000 - (int)((now.tv_sec - started.tv_sec) * 1000 + (now.tv_nsec - started.tv_nsec) / 1000000);
+            if (remaining <= 0) _exit(2);
+        }
+        if (polled != 1 || read(pipefd, &byte, 1) != 1 || close(pipefd) != 0) _exit(2);
+    }
+    return real_put(object);
+}

--- a/tests/queue-deferred-idle-shutdown.sh
+++ b/tests/queue-deferred-idle-shutdown.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Hold the final JSON destructor while the empty-queue worker is unlocked and
+# not registered as a waiter, then request shutdown. The debug marker proves
+# shutdown has set the pool state and sent its wakeup before disposal resumes.
+# Bounded proper termination proves the worker rechecks stop state after this
+# unlock instead of losing shutdown's wakeup. Limits diagnose a deadlock;
+# ordering comes from the FIFO and the post-signal shutdown marker.
+. ${srcdir:=.}/diag.sh init
+skip_platform "AIX" "test requires shared-library interposition"
+skip_ASAN "LD_PRELOAD conflicts with ASan runtime load order"
+check_command_available timeout
+export RSYSLOG_QUEUE_DISPOSAL_READY="$PWD/$RSYSLOG_DYNNAME.ready"
+export RSYSLOG_QUEUE_DISPOSAL_RELEASE="$PWD/$RSYSLOG_DYNNAME.release"
+export RSYSLOG_PRELOAD=.libs/liboverride_queue_disposal.so
+export RSYSLOG_DEBUG="Debug"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
+mkfifo "$RSYSLOG_QUEUE_DISPOSAL_RELEASE"
+generate_conf
+add_conf '
+global(processInternalMessages="off")
+main_queue(queue.type="FixedArray" queue.size="128"
+    queue.workerThreads="1" queue.dequeueBatchSize="1"
+    queue.timeoutShutdown="20000")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+if ($msg contains "msgnum:") then {
+    set $!queue_disposal_gate = "held";
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+startup
+injectmsg 0 1
+wait_file_lines "$RSYSLOG_QUEUE_DISPOSAL_READY" 1 10
+shutdown_immediate
+TB_TEST_TIMEOUT=10 wait_content 'main Q:Reg: waiting .* on worker thread termination' "$RSYSLOG_DEBUGLOG"
+timeout 10 bash -c 'printf "release\n" > "$RSYSLOG_QUEUE_DISPOSAL_RELEASE"' || error_exit 1
+wait_shutdown "" 10
+seq_check 0 0
+exit_test

--- a/tests/queue-deferred-idle-shutdown.sh
+++ b/tests/queue-deferred-idle-shutdown.sh
@@ -5,6 +5,9 @@
 # Bounded proper termination proves the worker rechecks stop state after this
 # unlock instead of losing shutdown's wakeup. Limits diagnose a deadlock;
 # ordering comes from the FIFO and the post-signal shutdown marker.
+#
+# This file is part of rsyslog.
+# Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 skip_platform "AIX" "test requires shared-library interposition"
 skip_ASAN "LD_PRELOAD conflicts with ASan runtime load order"

--- a/tests/queue-deferred-idle-wakeup.sh
+++ b/tests/queue-deferred-idle-wakeup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Pause final msg0 JSON destruction using an external-library interposer.
+# While the worker is outside the queue mutex and not yet a queue waiter,
+# enqueue msg1 and then release the destructor. Successful bounded admission
+# proves destruction is unlocked; output of msg1 proves the idle path retests
+# the queue after disposal instead of losing that enqueue's wakeup. FIFO
+# readiness/release determines ordering; time limits only diagnose a deadlock.
+# The test-only hook cannot coexist with ASan's runtime-first load order.
+. ${srcdir:=.}/diag.sh init
+skip_platform "AIX" "test requires shared-library interposition"
+skip_ASAN "LD_PRELOAD conflicts with ASan runtime load order"
+check_command_available timeout
+export RSYSLOG_QUEUE_DISPOSAL_READY="$PWD/$RSYSLOG_DYNNAME.ready"
+export RSYSLOG_QUEUE_DISPOSAL_RELEASE="$PWD/$RSYSLOG_DYNNAME.release"
+export RSYSLOG_PRELOAD=.libs/liboverride_queue_disposal.so
+mkfifo "$RSYSLOG_QUEUE_DISPOSAL_RELEASE"
+generate_conf
+add_conf '
+global(processInternalMessages="off")
+main_queue(queue.type="FixedArray" queue.size="128"
+    queue.workerThreads="1" queue.dequeueBatchSize="1")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+if ($msg contains "msgnum:") then {
+    if ($msg contains "msgnum:00000000:") then
+        set $!queue_disposal_gate = "held";
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+startup
+injectmsg 0 1
+wait_file_lines "$RSYSLOG_QUEUE_DISPOSAL_READY" 1 10
+# Direct diagtalker permits a strict bound on admission while the destructor
+# remains paused. A queued TCP send alone would not prove admission completed.
+printf 'injectmsg 1 1\n' | timeout 10 "$TESTTOOL_DIR/diagtalker" -p"$IMDIAG_PORT" || error_exit 1
+timeout 10 bash -c 'printf "release\n" > "$RSYSLOG_QUEUE_DISPOSAL_RELEASE"' || error_exit 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 2 10
+shutdown_when_empty
+wait_shutdown
+seq_check 0 1
+exit_test

--- a/tests/queue-deferred-idle-wakeup.sh
+++ b/tests/queue-deferred-idle-wakeup.sh
@@ -6,6 +6,9 @@
 # the queue after disposal instead of losing that enqueue's wakeup. FIFO
 # readiness/release determines ordering; time limits only diagnose a deadlock.
 # The test-only hook cannot coexist with ASan's runtime-first load order.
+#
+# This file is part of rsyslog.
+# Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 skip_platform "AIX" "test requires shared-library interposition"
 skip_ASAN "LD_PRELOAD conflicts with ASan runtime load order"

--- a/tests/queue-fixedarray-outoforder.sh
+++ b/tests/queue-fixedarray-outoforder.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Keep the oldest one-message batch inside a confirmed omprog call while later
+# unequal batches retire and wrap a 128-slot FixedArray many times. The helper
+# announces receipt before blocking on a FIFO; only the test can release it.
+# All later message IDs must reach omfile BEFORE release, proving count-based
+# RAM reclamation does not wait for the oldest batch. After release, exact
+# sequence coverage and proper termination detect overwritten pointers, loss,
+# duplicates, and cleanup errors. JSON trees exercise final reference cleanup.
+# The 120-second omprog timeout is only a hang bound, never synchronization.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=4097
+
+generate_conf
+mkfifo "$RSYSLOG_DYNNAME.release"
+cat > "$RSYSLOG_DYNNAME.helper" <<HELPER
+#!/bin/bash
+printf 'OK\n'
+while IFS= read -r message; do
+    printf '%s\n' "\$message" > "$PWD/$RSYSLOG_DYNNAME.entered"
+    IFS= read -r release < "$PWD/$RSYSLOG_DYNNAME.release"
+    printf 'OK\n'
+done
+HELPER
+chmod +x "$RSYSLOG_DYNNAME.helper"
+add_conf '
+module(load="../plugins/omprog/.libs/omprog")
+main_queue(queue.type="FixedArray" queue.size="128"
+    queue.dequeueBatchSize="31" queue.workerThreads="3"
+    queue.workerThreadMinimumMessages="1")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+if ($msg contains "msgnum:") then {
+    set $!tree = parse_json("{\"nested\":{\"array\":[1,2,3],\"text\":\"payload\"}}");
+    if ($msg contains "msgnum:00000000:") then
+        action(type="omprog" binary="'$PWD'/'$RSYSLOG_DYNNAME'.helper"
+            confirmMessages="on" confirmTimeout="120000"
+            template="outfmt")
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+startup
+injectmsg 0 1
+wait_content '00000000' "$RSYSLOG_DYNNAME.entered"
+injectmsg 1 $((NUMMESSAGES - 1))
+wait_file_lines "$RSYSLOG_OUT_LOG" $((NUMMESSAGES - 1))
+check_not_present '00000000' "$RSYSLOG_OUT_LOG"
+printf 'release\n' > "$RSYSLOG_DYNNAME.release"
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test

--- a/tests/queue-fixedarray-outoforder.sh
+++ b/tests/queue-fixedarray-outoforder.sh
@@ -7,6 +7,9 @@
 # sequence coverage and proper termination detect overwritten pointers, loss,
 # duplicates, and cleanup errors. JSON trees exercise final reference cleanup.
 # The 120-second omprog timeout is only a hang bound, never synchronization.
+#
+# This file is part of rsyslog.
+# Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=4097
 


### PR DESCRIPTION
Completed batches were retired and destroyed while holding the queue mutex, extending producer contention with batch size. This makes FixedArray batch retirement constant-time and destroys completed messages after releasing the mutex. Idle, shutdown, cancellation, and disk-assisted lifecycle behavior is covered by deterministic regression tests.

Each worker can temporarily retain one completed batch's payload references plus a pointer buffer while queue capacity is reused. This is a bounded increase in physical retention; queue admission counts are unchanged.

The benchmark driver checks exact delivery, validates workload inputs and metrics, records checkout/image provenance, pins the image ID, and preserves incomplete results on failure. Image setup, trials, and timeout cleanup have explicit deadlines.

On the frozen 16-sender / 8-input-worker / 4-consumer workload with four million messages, two 11-pair sessions measured about 16.8% shorter work time; the single-producer guardrail was about 1.1% slower. These measurements belong to runtime revision `454b340a1`; later runtime edits only rename two fields. Reproduction details and limitations are in `benchmarks/queue-contention/README.md`.

Validation:
- Final `e3b83f23d`: Ubuntu 26.04 full local check passed, 1,560 pass / 69 skip / 0 fail. An intermittent existing rate-limit HUP test failed once, then passed both a focused retry and the complete rerun.
- Static analyzer: 0 bugs; C source unchanged by subsequent benchmark-only commits.
- Initial runtime validation: targeted ASan 8 pass / 2 preload skips; TSan 10 pass; Clang 21 and GCC 15 builds; mock distcheck.
- Benchmark checks cover malformed metrics, missing images, setup/trial timeouts, partial results, and a small real Docker smoke.
- Current independent local security review passed with complete coverage and no candidates.
- The original hosted mmnormalize HUP TSan failure did not recur in local reproductions or subsequent hosted TSan runs. All final-head hosted checks passed. The macOS arm64 TSan lane passed after retrying a TCP reconnect/session-limit stress failure.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

