### PR TITLE
docs: add dated rejected-engineering-paths catalog

### DIFF
--- a/.agent/skills/rsyslog-performance/SKILL.md
+++ b/.agent/skills/rsyslog-performance/SKILL.md
@@ -56,8 +56,12 @@ measurement time.
 
 Retain a candidate only when both independent sessions meet the declared
 target and every guardrail. Revert neutral, noisy, unsafe, overly complex, or
-questionable changes. Record rejected candidates because they prevent repeated
-low-value work.
+questionable changes. Record rejected candidates in
+[doc/ai/rejected_engineering_paths.md](../../../doc/ai/rejected_engineering_paths.md)
+using the [`rsyslog_rejected_paths`](../rsyslog_rejected_paths/SKILL.md)
+skill so later sessions do not retry the same path. Consult that catalog
+before proposing queue wakeup, allocator-off-lock, or disk-queue descriptor
+experiments.
 
 ## Validate and report
 
@@ -78,7 +82,9 @@ Report:
 
 For a concise example of evidence that shaped this workflow, read
 [campaign-lessons.md](references/campaign-lessons.md). Keep component-specific
-commands and detailed results in that subsystem's benchmark directory.
+commands and detailed results in that subsystem's benchmark directory. The
+dated abandon/retry policy lives in the rejected-paths catalog, not in this
+skill.
 
 ## Extend the method
 

--- a/.agent/skills/rsyslog-performance/references/campaign-lessons.md
+++ b/.agent/skills/rsyslog-performance/references/campaign-lessons.md
@@ -1,5 +1,10 @@
 # Campaign lessons
 
+Abandoned candidates from this and later campaigns belong in
+[doc/ai/rejected_engineering_paths.md](../../../../doc/ai/rejected_engineering_paths.md)
+with `recorded`, `last_reviewed`, and `stale_after` dates. This file stays a
+short transferable-methods note, not the retry/do-not-retry log.
+
 The first evidence source was the segmented disk queue and DA spill/drain
 campaign in `benchmarks/segmented-diskqueue/`.
 

--- a/.agent/skills/rsyslog_module/SKILL.md
+++ b/.agent/skills/rsyslog_module/SKILL.md
@@ -18,6 +18,9 @@ This skill captures the essential technical patterns for authoring and maintaini
 
 ### 1. Concurrency & Locking
 Rsyslog v8 has a high-concurrency worker model.
+- Before changing queue mutex hold time, worker wakeup, or list-node
+  allocation, consult
+  [doc/ai/rejected_engineering_paths.md](../../../doc/ai/rejected_engineering_paths.md).
 - **Shared State (`pData`)**: Mutable state shared across workers MUST be protected by a mutex in `pData`.
 - **Per-Worker State (`WID`)**: Never share `wrkrInstanceData_t`.
 - **Belt and Suspenders**:

--- a/.agent/skills/rsyslog_rejected_paths/SKILL.md
+++ b/.agent/skills/rsyslog_rejected_paths/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: rsyslog_rejected_paths
+description: Consult and update the dated catalog of tried-and-abandoned rsyslog engineering paths so agents do not repeat rejected queue, diskqueue, or similar designs. Use before proposing performance or locking experiments, when parking a candidate, or when checking whether old benchmark advice is stale.
+---
+
+# Rejected engineering paths
+
+Canonical log:
+
+[doc/ai/rejected_engineering_paths.md](../../../doc/ai/rejected_engineering_paths.md)
+
+Read that file before inventing a "clever" follow-up in an area it already
+covers. Do not treat subsystem READMEs or chat memory as the substitute.
+
+## When to use
+
+- Planning a performance, locking, wakeup, allocator, or disk-queue change
+- A user asks to retry waiter targeting, LinkedList enqueue prealloc, or
+  another idea that sounds familiar
+- A campaign or PR is **not** being pursued and the reason should survive
+  the session
+- An entry's dates look old and you need to know if it is still binding
+
+## Agent rules
+
+1. **Search first.** Match on `area`, `id`, and a short description of the
+   idea. If it is the same design, stop and cite the entry instead of
+   reimplementing it.
+2. **Honor status.** `rejected` means do not merge that design without new
+   evidence. `parked` means do not treat an open PR as approved hygiene.
+   `measurement-rejected` means fix the harness before claiming a product
+   result. `superseded` means follow the later retained work.
+3. **Check dates before citing numbers.** If today is after `stale_after`,
+   or `last_reviewed` / `catalog_updated` is older than
+   `default_review_horizon_days` (180), say the evidence is historical.
+   Do not quote old ratios as current. Re-measure only when `reopen_if` is
+   met and the user wants the attempt.
+4. **Do not revive on principle.** "Generally better practice" is not enough
+   when the catalog records complexity, leak surface, or a missed target.
+5. **Record new dead ends in the same change** when you abandon a candidate
+   after measurement or review. Fill every template field, set `recorded`
+   and `last_reviewed` to today, set `stale_after` to today plus
+   `default_binding_horizon_days` (540) unless a shorter horizon is clearly
+   justified, and bump `catalog_updated`.
+6. **Keep evidence elsewhere.** Point to tracked benchmark JSON, README
+   sections, or PR URLs. Do not paste host paths, raw logs, or large tables
+   into the catalog.
+7. **Update, do not fork.** If an entry is wrong or superseded, edit it and
+   refresh `last_reviewed`. Do not add a second overlapping id.
+
+## Related skills
+
+- `rsyslog-performance`: how to measure; this skill is what not to retry
+- `rsyslog_module`: concurrency patterns; still consult the catalog for
+  queue/wakeup experiments
+- `rsyslog_commit`: catalog edits are agent/internal docs, not ChangeLog

--- a/.agent/skills/rsyslog_rejected_paths/agents/openai.yaml
+++ b/.agent/skills/rsyslog_rejected_paths/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "rsyslog Rejected Engineering Paths"
+  short_description: "Avoid repeating dated, already-abandoned designs"
+  default_prompt: "Use $rsyslog_rejected_paths before retrying a performance or locking idea, and update the catalog when a candidate is abandoned."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ To ensure consistency and high-quality contributions, AI agents SHOULD use the f
 | [`rsyslog_module`](.agent/skills/rsyslog_module/SKILL.md) | Technical patterns for concurrency and module authoring. |
 | [`rsyslog_config`](.agent/skills/rsyslog_config/SKILL.md) | Dual-frontend config architecture (RainerScript + YAML) and parity rules. |
 | [`rsyslog-performance`](.agent/skills/rsyslog-performance/SKILL.md) | Evidence-based, safety-preserving runtime performance optimization. |
+| [`rsyslog_rejected_paths`](.agent/skills/rsyslog_rejected_paths/SKILL.md) | Dated catalog of tried-and-abandoned designs; consult before retrying. |
 | [`rsyslog_issue_triage`](.agent/skills/rsyslog_issue_triage/SKILL.md) | GitHub issue backlog triage, clustering, closure comments, and local evidence boards. |
 | [`rsyslog_continuous_issue_session`](.agent/skills/rsyslog_continuous_issue_session/SKILL.md) | Long-running issue-fix sessions with a rolling active PR set, validation gates, babysitting, cleanup, and automatic refill from the local issue cache. |
 | [`rsyslog_commit`](.agent/skills/rsyslog_commit/SKILL.md) | Compliant commit messages and branching policies. |
@@ -52,6 +53,11 @@ after formatting if you already validated the code immediately before.
 - **Architecture**: Microkernel core (`runtime/`) + Loadable Plugins (`plugins/`)
 - **Metadata**: Every module directory contains `MODULE_METADATA.yaml`.
 - **Knowledge Base**: `doc/ai/` contains canonical patterns for RAG ingestion.
+- **Rejected paths**: [`doc/ai/rejected_engineering_paths.md`](./doc/ai/rejected_engineering_paths.md)
+  records what was tried, the result, and why it was not pursued, with
+  `recorded` / `last_reviewed` / `stale_after` dates. Use the
+  [`rsyslog_rejected_paths`](.agent/skills/rsyslog_rejected_paths/SKILL.md)
+  skill before repeating a familiar optimization or locking experiment.
 - **Security Triage**: [`doc/ai/security_triage_rubric.md`](./doc/ai/security_triage_rubric.md)
   defines how AI agents must distinguish confirmed issues from potential
   issues, hardening, and invalid findings before using security severity or CWE
@@ -104,7 +110,7 @@ validation as the final validation gate when container tooling is available.
   and untracked files, so it is safer than manually inspecting only
   `origin/main...HEAD` during active local work.
 - Agent-documentation and skill-only edits, limited to files such as
-  `AGENTS.md`, `AGENTS.local.md`, `.agent/skills/**`, or `.codex/skills/**`,
+  `AGENTS.md`, `AGENTS.local.md`, `.agent/skills/**`, `.codex/skills/**`,
   do not require a full local CI container run or static analyzer. Validate
   them with text review, targeted command-snippet checks when useful, and the
   relevant documentation/style checks. If the same change also touches code,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,11 @@ validation as the final validation gate when container tooling is available.
   relevant documentation/style checks. If the same change also touches code,
   tests, workflows, build files, or scripts, validate those touched areas via
   the container-testing skill.
+- Internal `doc/ai/**` catalogs that are not Sphinx inputs share this exception
+  because they affect agent guidance only, not runtime behavior, tests,
+  workflows, build files, or rendered documentation. Validate them with text,
+  link, and YAML checks; use the full validation path when a change also
+  touches an in-scope runtime or documentation input.
 - User-facing documentation edits that affect rendered Sphinx docs under
   `doc/source/**`, or Sphinx support files for that tree, should run a
   high-concurrency docs build instead of local runtime CI:

--- a/doc/AGENTS.md
+++ b/doc/AGENTS.md
@@ -8,11 +8,12 @@ AI agents working on documentation MUST use the standardized skills in `.agent/s
 
 - **Doc**: Use [`rsyslog_doc`](../.agent/skills/rsyslog_doc/SKILL.md) for metadata blocks, summary slices, and Sphinx validation.
 - **Dist**: Use [`rsyslog_doc_dist`](../.agent/skills/rsyslog_doc_dist/SKILL.md) for `doc/Makefile.am` synchronization.
+- **Rejected paths**: Use [`rsyslog_rejected_paths`](../.agent/skills/rsyslog_rejected_paths/SKILL.md) when recording or consulting abandoned designs in `doc/ai/rejected_engineering_paths.md`.
 - **Commit**: Use [`rsyslog_commit`](../.agent/skills/rsyslog_commit/SKILL.md) for doc-specific commit trailers.
 
 ## Subtree Specifics
 
-- **Knowledge Base**: `doc/ai/` contains canonical guides for Mermaid, Terminology, and authoring.
+- **Knowledge Base**: `doc/ai/` contains canonical guides for Mermaid, Terminology, authoring, and the dated rejected-paths catalog.
 - **Prompting**: Use `ai/rsyslog_code_doc_builder/base_prompt.txt` for tone and style guidance.
 - **Build**: Use `./doc/tools/build-doc-linux.sh --clean --format html` for validation.
 

--- a/doc/ai/AGENTS.md
+++ b/doc/ai/AGENTS.md
@@ -7,6 +7,7 @@ This file defines specific guidelines for AI assistants working on the documenta
 - **Authoring Guidelines:** [`doc/ai/authoring_guidelines.md`](./authoring_guidelines.md)
 - **Structure and Paths:** [`doc/ai/structure_and_paths.md`](./structure_and_paths.md)
 - **Terminology:** [`doc/ai/terminology.md`](./terminology.md)
+- **Rejected engineering paths:** [`doc/ai/rejected_engineering_paths.md`](./rejected_engineering_paths.md)
 - **Security Triage Rubric:** [`doc/ai/security_triage_rubric.md`](./security_triage_rubric.md)
 - **Project Threat Model:** [`doc/security/project-threat-model.md`](../security/project-threat-model.md)
 - **Threat-Model Routing:** [`doc/security/threat-model-components.json`](../security/threat-model-components.json)

--- a/doc/ai/README.md
+++ b/doc/ai/README.md
@@ -13,6 +13,7 @@
 | `mermaid_rules.md` | Diagram syntax rules |
 | `terminology.md` | Canonical rsyslog vocabulary |
 | `security_triage_rubric.md` | Security finding proof, severity, and hardening classification rules |
+| `rejected_engineering_paths.md` | Dated tried/result/stop log so abandoned designs are not retried |
 | `../security/project-threat-model.md` | Versioned project threat model, trust boundaries, and security invariants |
 | `../security/threat-model-components.json` | Machine-readable path routing for local PR security reviews |
 | `chunking_and_embeddings.md` | RAG extraction schema and chunk structure |

--- a/doc/ai/rejected_engineering_paths.md
+++ b/doc/ai/rejected_engineering_paths.md
@@ -1,0 +1,224 @@
+# Rejected and parked engineering paths
+
+catalog_updated: 2026-09-10
+default_review_horizon_days: 180
+default_binding_horizon_days: 540
+
+This is the canonical log of approaches that were tried, measured or
+reviewed, and then **not pursued**. It exists so agents and humans do not
+reopen the same dead ends from first principles.
+
+It is not a performance leaderboard and not a substitute for the
+[`rsyslog-performance`](../../.agent/skills/rsyslog-performance/SKILL.md)
+measurement contract. Component benchmark READMEs and tracked JSON remain
+the detailed evidence. This file stores the **decision**: what, result,
+why we stopped, and when that decision becomes stale.
+
+## How to read dates
+
+Every catalog and entry date is ISO-8601 (`YYYY-MM-DD`).
+
+| Field | Meaning |
+| --- | --- |
+| `catalog_updated` | Last add, edit, or status change in this file |
+| `recorded` | When the attempt was concluded |
+| `last_reviewed` | Last time a human or agent confirmed the write-up still matches the evidence |
+| `stale_after` | After this date the entry is **historical**, not binding |
+
+Default horizons from `catalog_updated` / `recorded`:
+
+- Re-read (`default_review_horizon_days`): 180 days
+- Stop treating as current evidence (`default_binding_horizon_days`): 540 days
+
+An entry is **stalled or too old** when any of these is true:
+
+- today is after `stale_after`
+- `last_reviewed` is more than `default_review_horizon_days` before today
+- `catalog_updated` is more than `default_review_horizon_days` before today
+  and no newer entry exists in the touched area
+- the compared revisions, compiler, or host class no longer match current
+  `main` in a way that could change the result
+
+Stale does **not** mean "try it again immediately". It means: do not cite the
+old ratio as current fact. Re-measure under the performance skill before
+reviving the idea, and only if `reopen_if` is actually met.
+
+## Status values
+
+| Status | Meaning |
+| --- | --- |
+| `rejected` | Do not merge or retry the same design without new evidence |
+| `parked` | Code or a PR may exist; not accepted as the next step |
+| `measurement-rejected` | The *benchmark design* was invalid; the product idea is untested |
+| `superseded` | A later retained change replaced this line of work |
+
+## Entry template
+
+Copy this block when adding a path. Keep IDs stable (`area-short-name`).
+Do not store hostnames, home directories, or raw logs here.
+
+```yaml
+id:
+status: rejected | parked | measurement-rejected | superseded
+recorded: YYYY-MM-DD
+last_reviewed: YYYY-MM-DD
+stale_after: YYYY-MM-DD
+area:
+tried:
+result:
+why_stopped:
+evidence:
+reopen_if:
+```
+
+## Entries
+
+### queue-waiter-targeting
+
+```yaml
+id: queue-waiter-targeting
+status: rejected
+recorded: 2026-09-05
+last_reviewed: 2026-09-10
+stale_after: 2028-02-27
+area: runtime/queue.c wti/wtp wakeup
+tried: >
+  Direct idle-worker wakeup ("waiter targeting"), including a reservation-cap
+  variant, on the FixedArray main-queue contention screen.
+result: >
+  Isolated multi-producer lifecycle screens were about 23% slower than the
+  untargeted baseline (median ratios about 1.229 and 1.230, one session each).
+why_stopped: >
+  Throughput regressed. Extra wakeup policy complexity was not justified.
+  Later retained work was deferred msgDestruct plus O(1) FixedArray retirement,
+  not waiter targeting.
+evidence:
+  - benchmarks/queue-contention/README.md (Measured results, 2026-09-05)
+reopen_if: >
+  A new profile shows idle-worker selection as the dominant contended cost on
+  current main, with a design that does not add lock hold or false wakeups,
+  and two independent sessions beat the declared improvement target without
+  a low-contention regression.
+```
+
+### queue-ll-enq-prealloc
+
+```yaml
+id: queue-ll-enq-prealloc
+status: parked
+recorded: 2026-09-10
+last_reviewed: 2026-09-10
+stale_after: 2028-03-03
+area: runtime/queue.c LinkedList qqueueEnqMsg
+tried: >
+  malloc LinkedList enqueue cells before taking the queue mutex in
+  qqueueEnqMsg only (not MultiEnq). Cells were handed to qAdd only after
+  flow-control waits so a per-queue pEnqNode slot could not be overwritten.
+  PR https://github.com/rsyslog/rsyslog/pull/7577
+result: >
+  On a shared WSL host (cpuset 0-15 of 28 CPUs), Direct main queue plus
+  LinkedList action queue (1e6 msgs, 16 connections, 8+8 workers): two
+  sessions, median after/before 1.022 and 1.034, MAD 0.034 and 0.029.
+  Declared 5% improvement target missed; 5% regression guardrail held.
+  Low-contention guardrail median 0.978. Review found two leak classes
+  (publish-before-wait; abort before consume) that were then fixed in the PR.
+why_stopped: >
+  No wall-clock win on the path the patch actually changes. Alloc happens
+  before discard/full decisions, so overload pays malloc+free for messages
+  that never enqueue. Per-queue pEnqNode is easy to leak again if a later
+  wait is added after handoff. Incomplete (MultiEnq still allocates under
+  the lock). Not accepted as "better practice" hygiene in queue.c.
+evidence:
+  - this conversation's local paired sessions vs main 135fb6cfb and
+    PR HEAD c9fbcfeb9 (2026-09-09/10); method in the performance skill
+  - https://github.com/rsyslog/rsyslog/pull/7577
+reopen_if: >
+  A finished design allocates only when enqueue will proceed, has no
+  queue-object side channel, covers MultiEnq, and two independent sessions
+  meet the declared target on a LinkedList EnqMsg workload. Do not revive
+  the current PR solely as style.
+```
+
+### diskqueue-persistent-read-descriptor
+
+```yaml
+id: diskqueue-persistent-read-descriptor
+status: rejected
+recorded: 2026-07-16
+last_reviewed: 2026-09-10
+stale_after: 2028-01-07
+area: runtime segmented disk queue / DA
+tried: Persistent validated read descriptor reuse to cut open/close syscalls.
+result: >
+  Open/close counts fell, but batch-1024 end-to-end and drain gains stayed
+  below the 10% acceptance threshold.
+why_stopped: Local syscall win did not meet the campaign's end-to-end bar.
+evidence:
+  - benchmarks/segmented-diskqueue/results/campaign-2026-07.json
+  - .agent/skills/rsyslog-performance/references/campaign-lessons.md
+reopen_if: >
+  A workload where open/close dominates end-to-end time (not 1024-message
+  batches on this host class) is measured under the same paired protocol.
+```
+
+### diskqueue-reserved-record-header-alloc
+
+```yaml
+id: diskqueue-reserved-record-header-alloc
+status: rejected
+recorded: 2026-07-16
+last_reviewed: 2026-09-10
+stale_after: 2028-01-07
+area: runtime segmented disk queue / DA
+tried: Reserved record-header allocation headroom.
+result: Two sessions were noisy; no repeatable gain above the threshold.
+why_stopped: Inconclusive under the campaign noise rules; not retained.
+evidence:
+  - benchmarks/segmented-diskqueue/results/campaign-2026-07.json
+reopen_if: Repeatable paired sessions on current main beat the declared target.
+```
+
+### diskqueue-reuse-encoded-payload-on-rotation
+
+```yaml
+id: diskqueue-reuse-encoded-payload-on-rotation
+status: rejected
+recorded: 2026-07-16
+last_reviewed: 2026-09-10
+stale_after: 2028-01-07
+area: runtime segmented disk queue / DA
+tried: Reuse the encoded payload across segment rotation.
+result: Pilot and rerun changed direction with high dispersion.
+why_stopped: Unstable effect; rotation rewrite not kept.
+evidence:
+  - benchmarks/segmented-diskqueue/results/campaign-2026-07.json
+reopen_if: Independent sessions agree on the same side of the target with MAD
+  below the campaign inconclusive limit.
+```
+
+### diskqueue-timed-restart-replay-benchmark
+
+```yaml
+id: diskqueue-timed-restart-replay-benchmark
+status: measurement-rejected
+recorded: 2026-07-16
+last_reviewed: 2026-09-10
+stale_after: 2028-01-07
+area: benchmarks/segmented-diskqueue
+tried: >
+  A timed clean restart/replay screen for segmented and DA queues.
+result: >
+  Safe designs either left action-owned records outside the tested queue,
+  blocked clean shutdown, suppressed DA transfer, or added another
+  persistent queue that confounded the metric.
+why_stopped: >
+  The benchmark could not isolate the intended cost. Functional restart and
+  DA retry tests remain the guardrail; do not publish a confounded timer.
+evidence:
+  - benchmarks/segmented-diskqueue/README.md
+  - benchmarks/segmented-diskqueue/results/campaign-2026-07.json
+    (guardrails.restart_replay)
+reopen_if: >
+  A harness owns exactly one queue, preserves DA transfer, and still has
+  deterministic ready/complete oracles without extra persistent queues.
+```

--- a/runtime/AGENTS.md
+++ b/runtime/AGENTS.md
@@ -51,6 +51,13 @@ collection, and process orchestration).
   when you modify reusable primitives.
 
 ## Coordination & documentation
+- Before changing queue locking, waiter wakeup, or enqueue allocation
+  timing, read
+  [`doc/ai/rejected_engineering_paths.md`](../doc/ai/rejected_engineering_paths.md)
+  and the
+  [`rsyslog_rejected_paths`](../.agent/skills/rsyslog_rejected_paths/SKILL.md)
+  skill. Do not revive a dated `rejected` or `parked` design without
+  meeting its `reopen_if` conditions and refreshing measurements.
 - Notify module owners (via metadata or review notes) when adjusting
   `module-template.h`, initialization flows, or statistics surfaces consumed by
   plugins.


### PR DESCRIPTION
## Summary
- There was no single dated log of what we tried, how it behaved, and why we stopped. Lessons lived in chat, `campaign-lessons.md`, and benchmark READMEs.
- This adds `doc/ai/rejected_engineering_paths.md` with `recorded`, `last_reviewed`, and `stale_after` on every entry, plus `reopen_if` so stale numbers are not treated as current fact.
- Agent skill `rsyslog_rejected_paths` and pointers from `AGENTS.md`, performance/module skills, and `runtime/AGENTS.md` tell agents to consult and update that catalog instead of retrying waiter targeting, LinkedList EnqMsg prealloc, or the known disk-queue dead ends.

## Test plan
- [x] `devtools/local-validation-plan.sh --run` classified **internal-doc-only** (no container CI / Sphinx).
- [ ] Skim the catalog dates and first three entries for accuracy.
- [ ] Confirm agents hitting queue/wakeup work would see the new skill from `AGENTS.md`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

