### PR TITLE
packaging: restore daily-stable baseline builds

### DIFF
--- a/.github/opensuse-leap160-daily-stable-policy.yml
+++ b/.github/opensuse-leap160-daily-stable-policy.yml
@@ -38,13 +38,11 @@
     {
       "name": "0001-fix-RainerScript-replace-heap-buffer-overflow.patch",
       "sha256": "465e3fbeaa800f22fe674481d1482a26dd584695b6325ff1fb3c5d904ea1d4d2",
-      "upstream_commit": "667e3f61aec5ee02c5c2ee6f0f8accf6fe4301a9",
       "reason": "Already present in current main's replace() sizing pass."
     },
     {
       "name": "0001-gtls-guard-early-debug-level-lookup.patch",
       "sha256": "4eeeb6fa3b26a0b319119724c0f8f8b5c232ed26385cdb9b4d8f8b6e8f3218fb",
-      "upstream_commit": "d6684c589d718cba6b70dcd10a2336902ebf2d10",
       "reason": "Already present in current main's early GnuTLS initialization guard."
     }
   ]

--- a/.github/opensuse-leap160-daily-stable-policy.yml
+++ b/.github/opensuse-leap160-daily-stable-policy.yml
@@ -34,6 +34,18 @@
       "name": "0001-rsyslogd-fix-rsyslog-mmpstrucdata-stack-overflow.patch",
       "sha256": "9102ebba992cb7a7c4dd408ed097f28a938b160800c2ec74fcfe8735e2c56fd9",
       "reason": "Superseded by current main's dynamically allocated structured-data parser value buffer."
+    },
+    {
+      "name": "0001-fix-RainerScript-replace-heap-buffer-overflow.patch",
+      "sha256": "465e3fbeaa800f22fe674481d1482a26dd584695b6325ff1fb3c5d904ea1d4d2",
+      "upstream_commit": "667e3f61aec5ee02c5c2ee6f0f8accf6fe4301a9",
+      "reason": "Already present in current main's replace() sizing pass."
+    },
+    {
+      "name": "0001-gtls-guard-early-debug-level-lookup.patch",
+      "sha256": "4eeeb6fa3b26a0b319119724c0f8f8b5c232ed26385cdb9b4d8f8b6e8f3218fb",
+      "upstream_commit": "d6684c589d718cba6b70dcd10a2336902ebf2d10",
+      "reason": "Already present in current main's early GnuTLS initialization guard."
     }
   ]
 }

--- a/.github/ubuntu-daily-stable-26.04-policy.yml
+++ b/.github/ubuntu-daily-stable-26.04-policy.yml
@@ -5,6 +5,10 @@
       "reason": "Ubuntu 26.04 carries the 2 GiB imfile timeout increase that current upstream already includes with later test updates."
     },
     {
+      "patch": "Skip-imfile-logrotate-async.sh.patch",
+      "reason": "Ubuntu's skip predates current main's deterministic inotify logrotate regression test, which replaced the flaky timing assumptions."
+    },
+    {
       "patch": "gnusort-in-tests.patch",
       "reason": "Ubuntu 26.04 carries an armhf GNU sort test workaround whose patch context is superseded by later upstream testbench changes."
     },

--- a/.github/workflows/alpine324_daily_stable.yml
+++ b/.github/workflows/alpine324_daily_stable.yml
@@ -153,16 +153,22 @@ jobs:
           baseline_dir="$RUNNER_TEMP/alpine-aports"
           baseline_fetched=false
           for attempt in 1 2 3; do
-            rm -rf "$baseline_dir"
-            if timeout 90s git clone --depth 1 --branch "$ALPINE_BRANCH" \
-              --filter=blob:none --sparse \
-              https://gitlab.alpinelinux.org/alpine/aports.git "$baseline_dir"; then
-              if timeout 90s git -C "$baseline_dir" sparse-checkout set main/rsyslog; then
-                baseline_fetched=true
-                break
+            for baseline_remote in \
+              https://gitlab.alpinelinux.org/alpine/aports.git \
+              https://github.com/alpinelinux/aports.git; do
+              rm -rf "$baseline_dir"
+              if timeout 90s git clone --depth 1 --branch "$ALPINE_BRANCH" \
+                --filter=blob:none --sparse "$baseline_remote" "$baseline_dir"; then
+                if timeout 90s git -C "$baseline_dir" sparse-checkout set main/rsyslog; then
+                  baseline_fetched=true
+                  break
+                fi
               fi
+              echo "::warning::Alpine baseline fetch failed from $baseline_remote (attempt $attempt/3)"
+            done
+            if [ "$baseline_fetched" = true ]; then
+              break
             fi
-            echo "::warning::Alpine baseline fetch failed (attempt $attempt/3)"
             [ "$attempt" -eq 3 ] || sleep "$((attempt * 15))"
           done
           [ "$baseline_fetched" = true ] || {

--- a/devtools/release/rpm-daily-stable.sh
+++ b/devtools/release/rpm-daily-stable.sh
@@ -238,8 +238,27 @@ PY
   while IFS= read -r source_url; do
     case "$source_url" in
       http://*|https://*)
-        curl --fail --location --retry 4 --retry-delay 5 \
-          --output "$sources_dir/${source_url##*/}" "$source_url"
+        source_file="$sources_dir/${source_url##*/}"
+        source_tmp="$(mktemp "$sources_dir/.source.XXXXXX")"
+        if ! curl --fail --location --retry 4 --retry-delay 5 --connect-timeout 20 \
+          --output "$source_tmp" "$source_url"; then
+          case "$source_url" in
+            https://archive.apache.org/dist/*)
+              fallback_url="https://downloads.apache.org/${source_url#https://archive.apache.org/dist/}"
+              echo "warning: retrying unavailable Apache archive source via $fallback_url" >&2
+              if ! curl --fail --location --retry 4 --retry-delay 5 --connect-timeout 20 \
+                --output "$source_tmp" "$fallback_url"; then
+                rm -f "$source_tmp"
+                exit 1
+              fi
+              ;;
+            *)
+              rm -f "$source_tmp"
+              exit 1
+              ;;
+          esac
+        fi
+        mv "$source_tmp" "$source_file"
         ;;
     esac
   done < <(

--- a/devtools/release/rpm-daily-stable.sh
+++ b/devtools/release/rpm-daily-stable.sh
@@ -249,12 +249,12 @@ PY
               if ! curl --fail --location --retry 4 --retry-delay 5 --connect-timeout 20 \
                 --output "$source_tmp" "$fallback_url"; then
                 rm -f "$source_tmp"
-                exit 1
+                return 1
               fi
               ;;
             *)
               rm -f "$source_tmp"
-              exit 1
+              return 1
               ;;
           esac
         fi


### PR DESCRIPTION
## Summary

Repairs the four automated daily-stable package archive failures by making
baseline preparation explicit and fail-closed:

- records the two openSUSE downstream patch hashes and current-main commits;
- accepts Ubuntu's obsolete imfile async-logrotate test-skip patch;
- retries Alpine's official GitHub aports mirror after GitLab is unavailable;
- retries Apache archive sources through `downloads.apache.org`, staging files
  in a temporary path before atomic promotion.

## Evidence

- Alpine's GitLab and GitHub `3.24-stable` heads matched exactly.
- The openSUSE patch validator passed against the current source RPM.
- EL10 source preparation downloaded the Qpid source with the expected SHA-512.
- The Debian and RPM patch-policy checks passed.

## Validation

`actionlint`, `zizmor`, `shellcheck`, policy parsing, patch-policy tests, and
the security delta review passed. Three full Ubuntu 26.04 `-j60` container
runs each hit different unrelated timing-sensitive test flakes; every failed
case was rerun successfully in a fresh Ubuntu 26.04 container. Hosted PR CI
remains the authoritative full-suite gate.

Closes https://github.com/rsyslog/rsyslog/issues/7551
Closes https://github.com/rsyslog/rsyslog/issues/7582
Closes https://github.com/rsyslog/rsyslog/issues/7584
Closes https://github.com/rsyslog/rsyslog/issues/7585


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rsyslog/rsyslog/pull/7586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

